### PR TITLE
fix: 添加目录重复性检测和防嵌套导入，修复下载删除确认对话框位置

### DIFF
--- a/app/src/main/java/com/asmr/player/ui/downloads/DownloadsScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/downloads/DownloadsScreen.kt
@@ -167,26 +167,29 @@ fun DownloadsScreen(
                 }
             }
             if (resolved != null) {
-                Box(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .align(Alignment.BottomCenter)
-                        .padding(horizontal = 16.dp, vertical = 16.dp),
-                    contentAlignment = Alignment.BottomCenter
-                ) {
-                    DeleteConfirmBanner(
-                        title = resolved.title,
-                        message = resolved.message,
-                        onConfirm = {
-                            pendingDelete = null
-                            when (action) {
-                                is PendingDeleteAction.Task -> viewModel.deleteTask(action.taskId)
-                                is PendingDeleteAction.Item -> viewModel.deleteItem(action.workId)
+                AlertDialog(
+                    onDismissRequest = { pendingDelete = null },
+                    title = { Text(resolved.title) },
+                    text = { Text(resolved.message) },
+                    confirmButton = {
+                        TextButton(
+                            onClick = {
+                                pendingDelete = null
+                                when (action) {
+                                    is PendingDeleteAction.Task -> viewModel.deleteTask(action.taskId)
+                                    is PendingDeleteAction.Item -> viewModel.deleteItem(action.workId)
+                                }
                             }
-                        },
-                        onDismiss = { pendingDelete = null }
-                    )
-                }
+                        ) {
+                            Text("删除")
+                        }
+                    },
+                    dismissButton = {
+                        TextButton(onClick = { pendingDelete = null }) {
+                            Text("取消")
+                        }
+                    }
+                )
             } else {
                 pendingDelete = null
             }

--- a/app/src/main/java/com/asmr/player/ui/library/libraryviewmodel.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/libraryviewmodel.kt
@@ -729,14 +729,63 @@ class LibraryViewModel @Inject constructor(
     }
 
     fun addScanRoot(uriString: String): Boolean {
+        val existingRoots = scanRootsStore.getRoots()
+        
+        // 检查重复
+        if (existingRoots.contains(uriString)) {
+            messageManager.showInfo("扫描目录已存在")
+            return false
+        }
+        
+        // 检查嵌套：新目录是否是现有目录的子目录
+        val newUri = runCatching { Uri.parse(uriString) }.getOrNull()
+        if (newUri != null) {
+            for (existingRoot in existingRoots) {
+                val existingUri = runCatching { Uri.parse(existingRoot) }.getOrNull() ?: continue
+                
+                // 检查新目录是否是现有目录的子目录
+                if (isSubdirectory(newUri, existingUri)) {
+                    messageManager.showInfo("该目录已被包含在现有扫描目录中")
+                    return false
+                }
+                
+                // 检查现有目录是否是新目录的子目录
+                if (isSubdirectory(existingUri, newUri)) {
+                    messageManager.showInfo("该目录包含了现有的扫描目录，请先移除子目录")
+                    return false
+                }
+            }
+        }
+        
         val added = scanRootsStore.addRoot(uriString)
         _scanRoots.value = runCatching { scanRootsStore.getRoots() }.getOrDefault(emptySet())
         if (added) {
             messageManager.showSuccess("已添加扫描目录")
-        } else {
-            messageManager.showInfo("扫描目录已存在")
         }
         return added
+    }
+    
+    private fun isSubdirectory(child: Uri, parent: Uri): Boolean {
+        // 比较 URI 的路径部分
+        val childPath = child.toString()
+        val parentPath = parent.toString()
+        
+        // 如果是相同的 URI scheme 和 authority
+        if (child.scheme != parent.scheme || child.authority != parent.authority) {
+            return false
+        }
+        
+        // 获取文档树 ID
+        val childTreeId = runCatching { 
+            DocumentsContract.getTreeDocumentId(child) 
+        }.getOrNull() ?: return false
+        
+        val parentTreeId = runCatching { 
+            DocumentsContract.getTreeDocumentId(parent) 
+        }.getOrNull() ?: return false
+        
+        // 检查子目录关系
+        return childTreeId.startsWith(parentTreeId) && childTreeId != parentTreeId
     }
 
     fun removeScanRoot(uriString: String) {


### PR DESCRIPTION
## 修复内容

### 1. 设置页面"添加目录"功能增强
- 添加重复性检测：检查要添加的目录是否已存在
- 添加防嵌套导入：
  - 检测新目录是否是现有目录的子目录
  - 检测现有目录是否是新目录的子目录
  - 使用 DocumentsContract.getTreeDocumentId() 比较 URI 树结构
- 提供清晰的用户提示信息

### 2. 下载管理页面删除确认对话框位置修复
- 将底部的自定义 DeleteConfirmBanner 替换为标准 AlertDialog
- 对话框现在显示在屏幕中央（Material Design 标准位置）
- 保持相同功能：显示标题、消息和确认/取消按钮

## 相关 Issue
- [x] 设置页面的"添加目录"功能中要添加目录重复性检测以及目录防嵌套导入
- [x] 下载管理页面中删除某一个下载任务时弹出的确认窗口应该在顶层且在屏幕中间，而不是在屏幕底部