### PR TITLE
fix: improve theme preset colors per mode\n\n- Light mode: deep/dark …

### DIFF
--- a/app/src/main/java/com/asmr/player/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/settings/SettingsScreen.kt
@@ -290,24 +290,25 @@ fun SettingsScreen(
                         selected = staticHueArgb == null,
                         onClick = { viewModel.setStaticHueArgb(null) }
                     )
-                val isDark = AsmrTheme.colorScheme.isDark
-                val presets = if (isDark) {
+                // 浅色主题用深色调（深红、深蓝、墨綠等），深色/柔和深色主题用高饱和亮色
+                val presets = if (themeMode == "light") {
                     listOf(
-                        Color(0xFF81C784), // Green 300
-                        Color(0xFF64B5F6), // Blue 300
-                        Color(0xFFBA68C8), // Purple 300
-                        Color(0xFFF06292), // Pink 300
-                        Color(0xFFFFB74D), // Orange 300
-                        Color(0xFF4DB6AC)  // Teal 300
+                        Color(0xFF0B3D2E), // 墨綠
+                        Color(0xFF0D47A1), // 深蓝
+                        Color(0xFF880E4F), // 深玫红
+                        Color(0xFF4A148C), // 深紫
+                        Color(0xFF7B1A1A), // 深砖红
+                        Color(0xFF004D40)  // 深青綠
                     )
                 } else {
+                    // dark / soft_dark：饱和度稍高的亮色，在暗背景上清晰醒目
                     listOf(
-                        Color(0xFF2E7D32), // Green 700
-                        Color(0xFF3E75C3), // Custom Blue
-                        Color(0xFF8E24AA), // Purple 600
-                        Color(0xFFD81B60), // Pink 600
-                        Color(0xFFFF8F00), // Orange 800
-                        Color(0xFF00897B)  // Teal 600
+                        Color(0xFF29B6F6), // 亮天蓝
+                        Color(0xFF26C17A), // 亮翠綠
+                        Color(0xFF7C4DFF), // 亮紫罗兰
+                        Color(0xFFFF5252), // 亮珊瑚红
+                        Color(0xFFFFCA28), // 亮琥珀黄
+                        Color(0xFF26C7C7)  // 亮青色
                     )
                 }
                 presets.forEach { c ->


### PR DESCRIPTION
## 变更说明

### 问题
当前三种主题模式下提供的可选主题色不够合理：
- 浅色主题下颜色偏亮/饱和，在白色背景上辨识度不足
- 深色主题下颜色偏暗，在深色背景上不够醒目

### 解决方案
重新设计两套主题色预设，并从 `isDark` 布尔判断改为 `themeMode` 字符串精确匹配：

| 主题模式 | 预设色方向 | 颜色 |
|---|---|---|
| `light`（浅色） | 深色调，白底高对比 | 墨绿、深蓝、深玫红、深紫、深砖红、深青绿 |
| `dark` / `soft_dark` | 高饱和亮色，暗底清晰醒目 | 亮天蓝、亮翠绿、亮紫罗兰、亮珊瑚红、亮琥珀黄、亮青色 |

### 文件变更
- `ui/settings/SettingsScreen.kt`：替换主题色预设列表

### 遗留问题
- [ ] 封面主色作为主题色时切换明暗主题，颜色搭配仍需优化