### PR TITLE
fix: polish now playing cover theme behavior

### DIFF
--- a/app/src/androidTest/java/com/asmr/player/ui/common/DominantColorKeyAndroidTest.kt
+++ b/app/src/androidTest/java/com/asmr/player/ui/common/DominantColorKeyAndroidTest.kt
@@ -1,0 +1,48 @@
+package com.asmr.player.ui.common
+
+import androidx.compose.ui.graphics.Color
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class DominantColorKeyAndroidTest {
+
+    @Test
+    fun imageCenterWeightedKey_changesWithBackgroundPolarity() {
+        val lightKey = centerWeightedDominantColorCacheKey(
+            baseKey = "content://album/artwork",
+            centerRegionRatio = 0.62f,
+            defaultColor = Color.White
+        )
+        val darkKey = centerWeightedDominantColorCacheKey(
+            baseKey = "content://album/artwork",
+            centerRegionRatio = 0.62f,
+            defaultColor = Color.Black
+        )
+
+        assertNotEquals(lightKey, darkKey)
+        assertTrue(lightKey.contains("bg=light"))
+        assertTrue(darkKey.contains("bg=dark"))
+    }
+
+    @Test
+    fun videoCenterWeightedKey_changesWithBackgroundPolarity() {
+        val lightKey = centerWeightedVideoFrameDominantColorCacheKey(
+            baseKey = "content://album/video",
+            centerRegionRatio = 0.62f,
+            defaultColor = Color(0xFFF0F4F8)
+        )
+        val darkKey = centerWeightedVideoFrameDominantColorCacheKey(
+            baseKey = "content://album/video",
+            centerRegionRatio = 0.62f,
+            defaultColor = Color(0xFF121212)
+        )
+
+        assertNotEquals(lightKey, darkKey)
+        assertTrue(lightKey.contains("bg=light"))
+        assertTrue(darkKey.contains("bg=dark"))
+    }
+}

--- a/app/src/androidTest/java/com/asmr/player/ui/player/CoverArtworkBackgroundStyleAndroidTest.kt
+++ b/app/src/androidTest/java/com/asmr/player/ui/player/CoverArtworkBackgroundStyleAndroidTest.kt
@@ -1,0 +1,32 @@
+package com.asmr.player.ui.player
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class CoverArtworkBackgroundStyleAndroidTest {
+
+    @Test
+    fun clarity100_hasNoBlur_andLowerOverlayTint() {
+        val lowClarity = coverArtworkBackdropStyle(clarity = 0f, isDark = true)
+        val highClarity = coverArtworkBackdropStyle(clarity = 1f, isDark = true)
+
+        assertEquals(0f, highClarity.blurDp.value, 0.001f)
+        assertTrue(highClarity.overlayAlpha < lowClarity.overlayAlpha)
+        assertTrue(highClarity.tintAlpha < lowClarity.tintAlpha)
+        assertTrue(highClarity.scrimAlpha < lowClarity.scrimAlpha)
+    }
+
+    @Test
+    fun artworkVisibility_increasesAsClarityIncreases() {
+        val lowClarity = coverArtworkBackdropStyle(clarity = 0f, isDark = false)
+        val midClarity = coverArtworkBackdropStyle(clarity = 0.5f, isDark = false)
+        val highClarity = coverArtworkBackdropStyle(clarity = 1f, isDark = false)
+
+        assertTrue(lowClarity.artworkAlpha < midClarity.artworkAlpha)
+        assertTrue(midClarity.artworkAlpha < highClarity.artworkAlpha)
+    }
+}

--- a/app/src/main/java/com/asmr/player/MainActivity.kt
+++ b/app/src/main/java/com/asmr/player/MainActivity.kt
@@ -21,6 +21,7 @@ import android.content.Context
 import android.content.ContextWrapper
 import android.content.pm.ActivityInfo
 import android.content.res.Configuration
+import android.net.Uri
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.core.view.WindowCompat
 import androidx.core.view.WindowInsetsCompat
@@ -138,9 +139,12 @@ import com.asmr.player.ui.theme.dynamicPageContainerColor
 import javax.inject.Inject
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.withTimeoutOrNull
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.map
 
 import androidx.compose.foundation.border
 import androidx.compose.foundation.BorderStroke
+import androidx.media3.common.MediaItem
 
 private enum class OverlaySheet {
     Queue,
@@ -165,7 +169,11 @@ class MainActivity : ComponentActivity() {
             val context = LocalContext.current
             val playerViewModel: PlayerViewModel = hiltViewModel()
             val libraryViewModel: LibraryViewModel = hiltViewModel()
-            val playback by playerViewModel.playback.collectAsState()
+            val themeMediaSource by remember(playerViewModel) {
+                playerViewModel.playback
+                    .map { it.currentMediaItem.toThemeMediaSource() }
+                    .distinctUntilChanged()
+            }.collectAsState(initial = ThemeMediaSource())
             val systemDark = isSystemInDarkTheme()
             val themePref by settingsDataStore.theme.collectAsState(initial = "system")
             val mode = when (themePref.lowercase()) {
@@ -175,16 +183,9 @@ class MainActivity : ComponentActivity() {
                 "system" -> if (systemDark) ThemeMode.Dark else ThemeMode.Light
                 else -> if (systemDark) ThemeMode.Dark else ThemeMode.Light
             }
-            val item = playback.currentMediaItem
-            val metadata = item?.mediaMetadata
-            val artworkUri = metadata?.artworkUri
-            val videoUri = item?.localConfiguration?.uri
-            val uriText = videoUri?.toString().orEmpty()
-            val mimeType = item?.localConfiguration?.mimeType.orEmpty()
-            val ext = uriText.substringBefore('#').substringBefore('?').substringAfterLast('.', "").lowercase()
-            val isVideo = metadata?.extras?.getBoolean("is_video") == true ||
-                mimeType.startsWith("video/") ||
-                ext in setOf("mp4", "m4v", "webm", "mkv", "mov")
+            val artworkUri = themeMediaSource.artworkUri
+            val videoUri = themeMediaSource.videoUri
+            val isVideo = themeMediaSource.isVideo
             val globalDynamicHueEnabled by settingsDataStore.dynamicPlayerHueEnabled.collectAsState(initial = false)
             val staticHueArgb by settingsDataStore.staticHueArgb.collectAsState(initial = null)
             val coverBackgroundEnabled by settingsDataStore.coverBackgroundEnabled.collectAsState(initial = true)
@@ -418,8 +419,11 @@ fun MainContainer(
     var touchBlockSeq by remember { mutableIntStateOf(0) }
     val drawerState = rememberDrawerState(initialValue = DrawerValue.Closed)
     val scope = rememberCoroutineScope()
-    val playback by playerViewModel.playback.collectAsState()
-    val artworkUri = playback.currentMediaItem?.mediaMetadata?.artworkUri
+    val hasCurrentMediaItem by remember(playerViewModel) {
+        playerViewModel.playback
+            .map { it.currentMediaItem != null }
+            .distinctUntilChanged()
+    }.collectAsState(initial = false)
     val drawerStatusViewModel: DrawerStatusViewModel = hiltViewModel()
     val statisticsViewModel: StatisticsViewModel = hiltViewModel()
     val bulkProgress by libraryViewModel.bulkProgress.collectAsState()
@@ -655,7 +659,7 @@ fun MainContainer(
             }
         }
     ) {
-        val miniPlayerVisible = playback.currentMediaItem != null && currentRoute != "now_playing" && currentRoute != "lyrics"
+        val miniPlayerVisible = hasCurrentMediaItem && currentRoute != "now_playing" && currentRoute != "lyrics"
         val rightPanelExpandedFromStore by settingsDataStore.recentAlbumsPanelExpanded.collectAsState(initial = recentAlbumsPanelExpandedInitial)
         val rightPanelExpandedState = remember(settingsDataStore, scope, recentAlbumsPanelExpandedInitial) {
             PersistedBooleanState(initial = recentAlbumsPanelExpandedInitial) { expanded ->
@@ -1869,6 +1873,34 @@ private data class DefaultSystemUiState(
     val lightStatusBars: Boolean,
     val lightNavigationBars: Boolean
 )
+
+private data class ThemeMediaSource(
+    val artworkUri: Uri? = null,
+    val videoUri: Uri? = null,
+    val isVideo: Boolean = false
+)
+
+private fun MediaItem?.toThemeMediaSource(): ThemeMediaSource {
+    val item = this ?: return ThemeMediaSource()
+    val metadata = item.mediaMetadata
+    val artworkUri = metadata.artworkUri
+    val videoUri = item.localConfiguration?.uri
+    val mimeType = item.localConfiguration?.mimeType.orEmpty()
+    val uriText = videoUri?.toString().orEmpty()
+    val fileExtension = uriText
+        .substringBefore('#')
+        .substringBefore('?')
+        .substringAfterLast('.', "")
+        .lowercase()
+    val isVideo = metadata.extras?.getBoolean("is_video") == true ||
+        mimeType.startsWith("video/") ||
+        fileExtension in setOf("mp4", "m4v", "webm", "mkv", "mov")
+    return ThemeMediaSource(
+        artworkUri = artworkUri,
+        videoUri = videoUri,
+        isVideo = isVideo
+    )
+}
 
 private fun Context.findActivity(): Activity? {
     var context = this

--- a/app/src/main/java/com/asmr/player/ui/common/AsmrAsyncImage.kt
+++ b/app/src/main/java/com/asmr/player/ui/common/AsmrAsyncImage.kt
@@ -98,6 +98,13 @@ fun AsmrAsyncImage(
     }
     val progress = crossfade.value.coerceIn(0f, 1f)
     Box {
+        // Keep a measurable anchor even when loading/empty UI intentionally renders nothing.
+        Box(
+            modifier = sizedModifier.graphicsLayer {
+                this.alpha = 0f
+                compositingStrategy = CompositingStrategy.ModulateAlpha
+            }
+        )
         if (state.value == AsmrAsyncImageState.Loading || (fadeIn && progress < 1f)) {
             val loadingAlpha = if (state.value == AsmrAsyncImageState.Loading) 1f else (1f - progress)
             val loadingModifier = if (loadingAlpha >= 0.999f) {

--- a/app/src/main/java/com/asmr/player/ui/common/DominantColor.kt
+++ b/app/src/main/java/com/asmr/player/ui/common/DominantColor.kt
@@ -37,6 +37,30 @@ data class DominantColorResult(
     val fromCache: Boolean
 )
 
+internal fun dominantColorBackgroundPolarity(defaultColor: Color): String {
+    return if (defaultColor.luminance() < 0.5f) "dark" else "light"
+}
+
+internal fun centerWeightedDominantColorCacheKey(
+    baseKey: String,
+    centerRegionRatio: Float,
+    defaultColor: Color
+): String {
+    val regionKey = (centerRegionRatio * 100).toInt().coerceIn(10, 100)
+    val backgroundKey = dominantColorBackgroundPolarity(defaultColor)
+    return "cw:$regionKey:bg=$backgroundKey:$baseKey"
+}
+
+internal fun centerWeightedVideoFrameDominantColorCacheKey(
+    baseKey: String,
+    centerRegionRatio: Float,
+    defaultColor: Color
+): String {
+    val regionKey = (centerRegionRatio * 100).toInt().coerceIn(10, 100)
+    val backgroundKey = dominantColorBackgroundPolarity(defaultColor)
+    return "vf:cw:$regionKey:bg=$backgroundKey:$baseKey"
+}
+
 @Composable
 fun rememberDominantColor(
     model: Any?,
@@ -106,12 +130,16 @@ fun rememberDominantColorCenterWeighted(
         EntryPointAccessors.fromApplication(app, ImageCacheEntryPoint::class.java).imageCacheManager()
     }
     val baseKey = model?.toString().orEmpty()
-    val regionKey = (centerRegionRatio * 100).toInt().coerceIn(10, 100)
-    val key = "cw:$regionKey:$baseKey"
+    val preferDarkBackground = defaultColor.luminance() < 0.5f
+    val key = centerWeightedDominantColorCacheKey(
+        baseKey = baseKey,
+        centerRegionRatio = centerRegionRatio,
+        defaultColor = defaultColor
+    )
     val animatable = remember { Animatable(defaultColor, ColorVectorConverter) }
     val animatedColor = remember { derivedStateOf { animatable.value } }
 
-    LaunchedEffect(key, defaultColor, baseKey) {
+    LaunchedEffect(key, defaultColor, baseKey, preferDarkBackground) {
         if (baseKey.isBlank()) {
             animatable.animateTo(defaultColor, animationSpec = tween(durationMillis = 260, easing = FastOutSlowInEasing))
             return@LaunchedEffect
@@ -134,7 +162,6 @@ fun rememberDominantColorCenterWeighted(
                 val colorInt = runCatching {
                     val palette = Palette.from(bitmap).generate()
                     val hint = computeCenterWeightedHintColorInt(bitmap, centerRegionRatio)
-                    val preferDarkBackground = defaultColor.luminance() < 0.5f
                     pickBestColorInt(
                         palette = palette,
                         fallbackColorInt = defaultColor.toArgb(),
@@ -145,7 +172,6 @@ fun rememberDominantColorCenterWeighted(
 
                 val hsl = FloatArray(3)
                 ColorUtils.colorToHSL(colorInt, hsl)
-                val preferDarkBackground = defaultColor.luminance() < 0.5f
                 adjustHslForUi(hsl, preferDarkBackground)
 
                 Color(ColorUtils.HSLToColor(hsl))
@@ -230,12 +256,16 @@ fun rememberVideoFrameDominantColorCenterWeighted(
 ): State<Color> {
     val context = LocalContext.current
     val baseKey = videoUri?.toString().orEmpty()
-    val regionKey = (centerRegionRatio * 100).toInt().coerceIn(10, 100)
-    val key = "vf:cw:$regionKey:$baseKey"
+    val preferDarkBackground = defaultColor.luminance() < 0.5f
+    val key = centerWeightedVideoFrameDominantColorCacheKey(
+        baseKey = baseKey,
+        centerRegionRatio = centerRegionRatio,
+        defaultColor = defaultColor
+    )
     val animatable = remember { Animatable(defaultColor, ColorVectorConverter) }
     val animatedColor = remember { derivedStateOf { animatable.value } }
 
-    LaunchedEffect(key, defaultColor, baseKey) {
+    LaunchedEffect(key, defaultColor, baseKey, preferDarkBackground) {
         if (baseKey.isBlank()) {
             animatable.animateTo(defaultColor, animationSpec = tween(durationMillis = 260, easing = FastOutSlowInEasing))
             return@LaunchedEffect
@@ -253,7 +283,6 @@ fun rememberVideoFrameDominantColorCenterWeighted(
                     val colorInt = runCatching {
                         val palette = Palette.from(bitmap).generate()
                         val hint = computeCenterWeightedHintColorInt(bitmap, centerRegionRatio)
-                        val preferDarkBackground = defaultColor.luminance() < 0.5f
                         pickBestColorInt(
                             palette = palette,
                             fallbackColorInt = defaultColor.toArgb(),
@@ -264,7 +293,6 @@ fun rememberVideoFrameDominantColorCenterWeighted(
 
                     val hsl = FloatArray(3)
                     ColorUtils.colorToHSL(colorInt, hsl)
-                    val preferDarkBackground = defaultColor.luminance() < 0.5f
                     adjustHslForUi(hsl, preferDarkBackground)
 
                     Color(ColorUtils.HSLToColor(hsl))
@@ -291,12 +319,16 @@ fun rememberComputedDominantColorCenterWeighted(
         EntryPointAccessors.fromApplication(app, ImageCacheEntryPoint::class.java).imageCacheManager()
     }
     val baseKey = model?.toString().orEmpty()
-    val regionKey = (centerRegionRatio * 100).toInt().coerceIn(10, 100)
-    val key = "cw:$regionKey:$baseKey"
+    val preferDarkBackground = defaultColor.luminance() < 0.5f
+    val key = centerWeightedDominantColorCacheKey(
+        baseKey = baseKey,
+        centerRegionRatio = centerRegionRatio,
+        defaultColor = defaultColor
+    )
     val cached = remember(key) { DominantColorCache.get(key) }
     val state = remember(key) { mutableStateOf(DominantColorResult(color = cached, fromCache = cached != null)) }
 
-    LaunchedEffect(key, defaultColor, baseKey) {
+    LaunchedEffect(key, defaultColor, baseKey, preferDarkBackground) {
         if (baseKey.isBlank()) {
             state.value = DominantColorResult(color = null, fromCache = false)
             return@LaunchedEffect
@@ -317,7 +349,6 @@ fun rememberComputedDominantColorCenterWeighted(
                 val colorInt = runCatching {
                     val palette = Palette.from(bitmap).generate()
                     val hint = computeCenterWeightedHintColorInt(bitmap, centerRegionRatio)
-                    val preferDarkBackground = defaultColor.luminance() < 0.5f
                     pickBestColorInt(
                         palette = palette,
                         fallbackColorInt = defaultColor.toArgb(),
@@ -328,7 +359,6 @@ fun rememberComputedDominantColorCenterWeighted(
 
                 val hsl = FloatArray(3)
                 ColorUtils.colorToHSL(colorInt, hsl)
-                val preferDarkBackground = defaultColor.luminance() < 0.5f
                 adjustHslForUi(hsl, preferDarkBackground)
 
                 Color(ColorUtils.HSLToColor(hsl))
@@ -351,12 +381,16 @@ fun rememberComputedVideoFrameDominantColorCenterWeighted(
 ): State<DominantColorResult> {
     val context = LocalContext.current
     val baseKey = videoUri?.toString().orEmpty()
-    val regionKey = (centerRegionRatio * 100).toInt().coerceIn(10, 100)
-    val key = "vf:cw:$regionKey:$baseKey"
+    val preferDarkBackground = defaultColor.luminance() < 0.5f
+    val key = centerWeightedVideoFrameDominantColorCacheKey(
+        baseKey = baseKey,
+        centerRegionRatio = centerRegionRatio,
+        defaultColor = defaultColor
+    )
     val cached = remember(key) { DominantColorCache.get(key) }
     val state = remember(key) { mutableStateOf(DominantColorResult(color = cached, fromCache = cached != null)) }
 
-    LaunchedEffect(key, defaultColor, baseKey) {
+    LaunchedEffect(key, defaultColor, baseKey, preferDarkBackground) {
         if (baseKey.isBlank() || videoUri == null) {
             state.value = DominantColorResult(color = null, fromCache = false)
             return@LaunchedEffect
@@ -371,7 +405,6 @@ fun rememberComputedVideoFrameDominantColorCenterWeighted(
                     val colorInt = runCatching {
                         val palette = Palette.from(bitmap).generate()
                         val hint = computeCenterWeightedHintColorInt(bitmap, centerRegionRatio)
-                        val preferDarkBackground = defaultColor.luminance() < 0.5f
                         pickBestColorInt(
                             palette = palette,
                             fallbackColorInt = defaultColor.toArgb(),
@@ -382,7 +415,6 @@ fun rememberComputedVideoFrameDominantColorCenterWeighted(
 
                     val hsl = FloatArray(3)
                     ColorUtils.colorToHSL(colorInt, hsl)
-                    val preferDarkBackground = defaultColor.luminance() < 0.5f
                     adjustHslForUi(hsl, preferDarkBackground)
 
                     Color(ColorUtils.HSLToColor(hsl))
@@ -409,10 +441,14 @@ fun PrewarmDominantColorCenterWeighted(
         EntryPointAccessors.fromApplication(app, ImageCacheEntryPoint::class.java).imageCacheManager()
     }
     val baseKey = model?.toString().orEmpty()
-    val regionKey = (centerRegionRatio * 100).toInt().coerceIn(10, 100)
-    val key = "cw:$regionKey:$baseKey"
+    val preferDarkBackground = defaultColor.luminance() < 0.5f
+    val key = centerWeightedDominantColorCacheKey(
+        baseKey = baseKey,
+        centerRegionRatio = centerRegionRatio,
+        defaultColor = defaultColor
+    )
 
-    LaunchedEffect(key, defaultColor, baseKey) {
+    LaunchedEffect(key, defaultColor, baseKey, preferDarkBackground) {
         if (baseKey.isBlank()) return@LaunchedEffect
         if (DominantColorCache.get(key) != null) return@LaunchedEffect
 
@@ -430,7 +466,6 @@ fun PrewarmDominantColorCenterWeighted(
                 val colorInt = runCatching {
                     val palette = Palette.from(bitmap).generate()
                     val hint = computeCenterWeightedHintColorInt(bitmap, centerRegionRatio)
-                    val preferDarkBackground = defaultColor.luminance() < 0.5f
                     pickBestColorInt(
                         palette = palette,
                         fallbackColorInt = defaultColor.toArgb(),
@@ -441,7 +476,6 @@ fun PrewarmDominantColorCenterWeighted(
 
                 val hsl = FloatArray(3)
                 ColorUtils.colorToHSL(colorInt, hsl)
-                val preferDarkBackground = defaultColor.luminance() < 0.5f
                 adjustHslForUi(hsl, preferDarkBackground)
 
                 Color(ColorUtils.HSLToColor(hsl))
@@ -460,10 +494,14 @@ fun PrewarmVideoFrameDominantColorCenterWeighted(
 ) {
     val context = LocalContext.current
     val baseKey = videoUri?.toString().orEmpty()
-    val regionKey = (centerRegionRatio * 100).toInt().coerceIn(10, 100)
-    val key = "vf:cw:$regionKey:$baseKey"
+    val preferDarkBackground = defaultColor.luminance() < 0.5f
+    val key = centerWeightedVideoFrameDominantColorCacheKey(
+        baseKey = baseKey,
+        centerRegionRatio = centerRegionRatio,
+        defaultColor = defaultColor
+    )
 
-    LaunchedEffect(key, defaultColor, baseKey) {
+    LaunchedEffect(key, defaultColor, baseKey, preferDarkBackground) {
         if (baseKey.isBlank() || videoUri == null) return@LaunchedEffect
         if (DominantColorCache.get(key) != null) return@LaunchedEffect
 
@@ -474,7 +512,6 @@ fun PrewarmVideoFrameDominantColorCenterWeighted(
                     val colorInt = runCatching {
                         val palette = Palette.from(bitmap).generate()
                         val hint = computeCenterWeightedHintColorInt(bitmap, centerRegionRatio)
-                        val preferDarkBackground = defaultColor.luminance() < 0.5f
                         pickBestColorInt(
                             palette = palette,
                             fallbackColorInt = defaultColor.toArgb(),
@@ -485,7 +522,6 @@ fun PrewarmVideoFrameDominantColorCenterWeighted(
 
                     val hsl = FloatArray(3)
                     ColorUtils.colorToHSL(colorInt, hsl)
-                    val preferDarkBackground = defaultColor.luminance() < 0.5f
                     adjustHslForUi(hsl, preferDarkBackground)
 
                     Color(ColorUtils.HSLToColor(hsl))

--- a/app/src/main/java/com/asmr/player/ui/player/AppleLyricsView.kt
+++ b/app/src/main/java/com/asmr/player/ui/player/AppleLyricsView.kt
@@ -12,33 +12,28 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.blur
-import androidx.compose.ui.draw.scale
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
-import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.graphics.Shadow
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.text.style.TextOverflow
-import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.asmr.player.ui.theme.AsmrTheme
 import com.asmr.player.util.SubtitleEntry
 import com.asmr.player.util.SubtitleIndexFinder
 import kotlinx.coroutines.launch
 import kotlin.math.absoluteValue
 
 @Composable
-fun AppleLyricsView(
+internal fun AppleLyricsView(
     lyrics: List<SubtitleEntry>,
     currentPosition: Long,
     onSeekTo: (Long) -> Unit,
     onOpenLyrics: () -> Unit = {},
-    activeColor: Color = MaterialTheme.colorScheme.primary,
-    inactiveColor: Color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.5f),
+    colors: LyricReadableColors,
     modifier: Modifier = Modifier,
     isLandscape: Boolean = false,
     contentPadding: PaddingValues = PaddingValues(0.dp)
@@ -49,8 +44,6 @@ fun AppleLyricsView(
     }
 
     val listState = rememberLazyListState()
-    val coroutineScope = rememberCoroutineScope()
-    val density = LocalDensity.current
 
     // Store per-item translation offsets
     // Key: Item Index, Value: Animatable OffsetY
@@ -129,8 +122,6 @@ fun AppleLyricsView(
 
     LaunchedEffect(activeIndex) {
         if (activeIndex != previousIndex && activeIndex >= 0 && lyrics.isNotEmpty()) {
-            val isMovingDown = activeIndex > previousIndex
-            
             // 1. Calculate the Snap
             // We want to center the NEW activeIndex at `viewportHeight * focusRatio`
             val layoutInfo = listState.layoutInfo
@@ -151,9 +142,6 @@ fun AppleLyricsView(
             // Check if we actually NEED to scroll.
             // If the item is already above the focus point (and we are near top), we might not need to scroll.
             // But for consistency, we try to scroll to focus point, and LazyColumn clamps it.
-            
-            // Current position of i+1 (if visible)
-            val nextItemInfo = layoutInfo.visibleItemsInfo.find { it.index == activeIndex }
             val currentItemInfo = layoutInfo.visibleItemsInfo.find { it.index == previousIndex }
             
             // Fallback height if not visible (estimate)
@@ -328,40 +316,24 @@ fun AppleLyricsView(
                 contentType = { _, _ -> "appleLyricLine" }
             ) { index, entry ->
                 val isActive = index == activeIndex
-                val isPast = index < activeIndex
-                
-                // Animate visual properties
                 val targetScale = 1.0f // Unified scale for active and inactive
                 val scale by animateFloatAsState(targetScale, animationSpec = tween(400))
-                
-                val targetBlur = if (isActive) 0.dp else 1.5.dp // Slight blur for inactive?
-                // Blur is expensive on Android < 12 (RenderEffect). 
-                // Maybe just alpha/color is enough. Apple Music has blur on background but text is usually sharp, just dim.
-                // Let's skip blur for performance unless requested. User said "Transparency/Color transition".
-                
-                val targetAlpha = if (isActive) 1f else 0.55f
+
+                val targetAlpha = if (isActive) 1f else if (AsmrTheme.colorScheme.isDark) 0.76f else 0.72f
                 val alpha by animateFloatAsState(targetAlpha, animationSpec = tween(400))
 
-                val targetColor = if (isActive) activeColor else inactiveColor
-                // We animate color manually or via animateColorAsState
+                val targetColor = if (isActive) colors.activeText else colors.inactiveText
                 val color by animateColorAsState(targetColor, animationSpec = tween(400))
-                
                 val targetFontWeight = if (isActive) FontWeight.ExtraBold else FontWeight.Bold
                 val fontSize = if (isLandscape) 22.sp else 24.sp
-                
-                // Add shadow for active lyric
                 val shadow = if (isActive) {
-                     Shadow(
-                         color = Color.Black.copy(alpha = 0.6f),
-                         offset = androidx.compose.ui.geometry.Offset(0f, 2f),
-                         blurRadius = 4f
-                     )
+                    Shadow(
+                        color = colors.accentEmphasis.copy(alpha = if (AsmrTheme.colorScheme.isDark) 0.40f else 0.24f),
+                        offset = Offset.Zero,
+                        blurRadius = if (isLandscape) 14f else 18f
+                    )
                 } else null
 
-                // Get the wave offset
-                // We need to observe the Animatable.
-                // Note: itemOffsets is a SnapshotStateMap, so accessing it is state-read.
-                // But the Animatable inside is stable. We need to read `.value`.
                 val offsetAnim = itemOffsets[index]
                 val translationY = offsetAnim?.value ?: 0f
 
@@ -369,22 +341,23 @@ fun AppleLyricsView(
                     text = entry.text,
                     modifier = Modifier
                         .fillMaxWidth()
-                        .padding(vertical = 12.dp, horizontal = 24.dp)
+                        .padding(horizontal = if (isLandscape) 10.dp else 14.dp, vertical = 2.dp)
                         .graphicsLayer {
                             this.translationY = translationY
                             this.scaleX = scale
                             this.scaleY = scale
                             this.alpha = alpha
                         }
-                        .clickable { 
+                        .clickable {
                             onSeekTo(entry.startMs) 
                             onOpenLyrics()
-                        },
+                        }
+                        .padding(horizontal = if (isLandscape) 8.dp else 10.dp, vertical = if (isLandscape) 6.dp else 8.dp),
                     style = MaterialTheme.typography.titleLarge.copy(
                         fontWeight = targetFontWeight,
                         fontSize = fontSize,
                         textAlign = TextAlign.Center,
-                        lineHeight = if (isLandscape) 32.sp else 36.sp,
+                        lineHeight = if (isLandscape) 30.sp else 34.sp,
                         shadow = shadow
                     ),
                     color = color

--- a/app/src/main/java/com/asmr/player/ui/player/CoverArtworkBackground.kt
+++ b/app/src/main/java/com/asmr/player/ui/player/CoverArtworkBackground.kt
@@ -12,13 +12,13 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.blur
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.asComposeRenderEffect
+import androidx.compose.ui.graphics.compositeOver
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.asmr.player.ui.common.AsmrAsyncImage
-import kotlin.math.max
-import kotlin.math.min
+import kotlin.math.pow
 
 @Composable
 fun CoverArtworkBackground(
@@ -30,57 +30,102 @@ fun CoverArtworkBackground(
     isDark: Boolean = true
 ) {
     if (!enabled) return
-    val c = remember(clarity) { min(1f, max(0f, clarity)) }
-    val blurDp: Dp = remember(c) { (2f + (1f - c) * 18f).dp }
-    
-    // 基础图片透明度
-    val alpha = remember(c) { 0.30f * c }
-    
-    // 背景叠加透明度：深色模式下稍微增加基础叠加，确保更暗
-    val overlayAlpha = remember(c, isDark) { 
-        val base = if (isDark) 0.35f else 0.20f
-        base + 0.20f * c 
-    }
-    
-    // 氛围色透明度：深色模式下降低氛围色的权重，防止过亮
-    val tintAlpha = remember(c, isDark) {
-        val maxTint = if (isDark) 0.62f else 0.72f
-        maxTint * (1f - c) + 0.12f * c
-    }
-    
-    Box(modifier = Modifier.fillMaxSize().background(overlayBaseColor))
 
-    val artworkModifier = remember(blurDp) {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+    val style = remember(clarity, isDark) {
+        coverArtworkBackdropStyle(clarity = clarity, isDark = isDark)
+    }
+
+    // Keep the backdrop anchored to the extracted cover hue, but keep the base veil lighter.
+    val baseBackdropColor = remember(style.baseTintAlpha, overlayBaseColor, tintBaseColor) {
+        tintBaseColor.copy(alpha = style.baseTintAlpha).compositeOver(overlayBaseColor)
+    }
+    Box(modifier = Modifier.fillMaxSize().background(baseBackdropColor))
+
+    val artworkModifier = remember(style.blurDp) {
+        if (style.blurDp.value <= 0f) {
+            Modifier
+        } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
             Modifier.graphicsLayer {
-                val blurPx = blurDp.toPx()
+                val blurPx = style.blurDp.toPx()
                 renderEffect = RenderEffect
                     .createBlurEffect(blurPx, blurPx, Shader.TileMode.CLAMP)
                     .asComposeRenderEffect()
             }
         } else {
-            Modifier.blur(blurDp)
+            Modifier.blur(style.blurDp)
         }
     }
+
     if (artworkModel != null) {
         AsmrAsyncImage(
             model = artworkModel,
             contentDescription = null,
             modifier = Modifier.fillMaxSize().then(artworkModifier),
             contentScale = ContentScale.Crop,
-            alpha = alpha,
+            alpha = style.artworkAlpha,
             loading = {},
         )
     }
-    
-    // 叠加层 1: 基础背景色叠加 (Overlay)
-    Box(modifier = Modifier.fillMaxSize().background(overlayBaseColor.copy(alpha = overlayAlpha)))
-    
-    // 叠加层 2: 氛围色/主导色叠加 (Tint)
-    Box(modifier = Modifier.fillMaxSize().background(tintBaseColor.copy(alpha = tintAlpha)))
-    
-    // 叠加层 3: 深色模式额外压暗层 (Scrim) - 确保在任何氛围色下文字都有足够对比度
-    if (isDark) {
-        Box(modifier = Modifier.fillMaxSize().background(Color.Black.copy(alpha = 0.15f)))
+
+    Box(modifier = Modifier.fillMaxSize().background(overlayBaseColor.copy(alpha = style.overlayAlpha)))
+    Box(modifier = Modifier.fillMaxSize().background(tintBaseColor.copy(alpha = style.tintAlpha)))
+
+    if (style.scrimAlpha > 0f) {
+        Box(modifier = Modifier.fillMaxSize().background(Color.Black.copy(alpha = style.scrimAlpha)))
     }
+}
+
+internal data class BackdropStyle(
+    val blurDp: Dp,
+    val baseTintAlpha: Float,
+    val artworkAlpha: Float,
+    val overlayAlpha: Float,
+    val tintAlpha: Float,
+    val scrimAlpha: Float
+)
+
+internal fun coverArtworkBackdropStyle(
+    clarity: Float,
+    isDark: Boolean
+): BackdropStyle {
+    val normalized = clarity.coerceIn(0f, 1f)
+    // Lower clarity should change gently; higher clarity should open up faster.
+    val reveal = normalized.pow(2.15f)
+    return BackdropStyle(
+        blurDp = lerpFloat(
+            start = if (isDark) 30f else 28f,
+            end = 0f,
+            fraction = reveal
+        ).dp,
+        baseTintAlpha = lerpFloat(
+            start = if (isDark) 0.64f else 0.52f,
+            end = if (isDark) 0.12f else 0.04f,
+            fraction = reveal
+        ),
+        artworkAlpha = lerpFloat(
+            start = if (isDark) 0.01f else 0.008f,
+            end = if (isDark) 0.96f else 0.985f,
+            fraction = reveal
+        ),
+        overlayAlpha = lerpFloat(
+            start = if (isDark) 0.12f else 0.07f,
+            end = if (isDark) 0.02f else 0.008f,
+            fraction = reveal
+        ),
+        tintAlpha = lerpFloat(
+            start = if (isDark) 0.10f else 0.08f,
+            end = if (isDark) 0.01f else 0.004f,
+            fraction = reveal
+        ),
+        scrimAlpha = lerpFloat(
+            start = if (isDark) 0.15f else 0.015f,
+            end = if (isDark) 0.018f else 0f,
+            fraction = reveal
+        )
+    )
+}
+
+private fun lerpFloat(start: Float, end: Float, fraction: Float): Float {
+    val t = fraction.coerceIn(0f, 1f)
+    return start + (end - start) * t
 }

--- a/app/src/main/java/com/asmr/player/ui/player/LyricReadableColors.kt
+++ b/app/src/main/java/com/asmr/player/ui/player/LyricReadableColors.kt
@@ -1,0 +1,100 @@
+package com.asmr.player.ui.player
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.compositeOver
+import androidx.compose.ui.graphics.luminance
+import androidx.compose.ui.graphics.toArgb
+import androidx.core.graphics.ColorUtils
+import com.asmr.player.ui.theme.AsmrTheme
+
+@Immutable
+internal data class LyricReadableColors(
+    val activeText: Color,
+    val inactiveText: Color,
+    val accentEmphasis: Color,
+    val activeContainer: Color
+)
+
+@Composable
+internal fun rememberLyricReadableColors(
+    accentColor: Color,
+    coverBackgroundEnabled: Boolean,
+    coverBackgroundClarity: Float
+): LyricReadableColors {
+    val colorScheme = AsmrTheme.colorScheme
+    return remember(accentColor, coverBackgroundEnabled, coverBackgroundClarity, colorScheme) {
+        val emphasisAlpha = if (colorScheme.isDark) 0.82f else 0.68f
+        val containerAlpha = if (colorScheme.isDark) 0.26f else 0.16f
+        val containerBase = colorScheme.surface.copy(alpha = if (colorScheme.isDark) 0.80f else 0.88f)
+        val backdropEstimate = estimateLyricBackdropColor(
+            accentColor = accentColor,
+            backgroundColor = colorScheme.background,
+            coverBackgroundEnabled = coverBackgroundEnabled,
+            coverBackgroundClarity = coverBackgroundClarity,
+            isDark = colorScheme.isDark
+        )
+
+        val activeText = if (coverBackgroundEnabled) {
+            pickReadableLyricTextColor(
+                backdrop = backdropEstimate,
+                fallback = colorScheme.textPrimary
+            )
+        } else {
+            colorScheme.textPrimary
+        }
+        val inactiveAlpha = if (coverBackgroundEnabled) {
+            if (activeText.luminance() > 0.5f) 0.60f else 0.54f
+        } else if (colorScheme.isDark) {
+            0.54f
+        } else {
+            0.50f
+        }
+        val inactiveText = activeText.copy(alpha = inactiveAlpha)
+
+        LyricReadableColors(
+            activeText = activeText,
+            inactiveText = inactiveText,
+            accentEmphasis = accentColor.copy(alpha = emphasisAlpha),
+            activeContainer = accentColor.copy(alpha = containerAlpha).compositeOver(containerBase)
+        )
+    }
+}
+
+private fun estimateLyricBackdropColor(
+    accentColor: Color,
+    backgroundColor: Color,
+    coverBackgroundEnabled: Boolean,
+    coverBackgroundClarity: Float,
+    isDark: Boolean
+): Color {
+    if (!coverBackgroundEnabled) return backgroundColor
+
+    val style = coverArtworkBackdropStyle(
+        clarity = coverBackgroundClarity,
+        isDark = isDark
+    )
+    var estimated = accentColor
+    estimated = backgroundColor.copy(alpha = style.overlayAlpha).compositeOver(estimated)
+    estimated = accentColor.copy(alpha = style.tintAlpha).compositeOver(estimated)
+    if (style.scrimAlpha > 0f) {
+        estimated = Color.Black.copy(alpha = style.scrimAlpha).compositeOver(estimated)
+    }
+    return estimated
+}
+
+private fun pickReadableLyricTextColor(
+    backdrop: Color,
+    fallback: Color
+): Color {
+    val lightCandidate = Color(0xFFF7FAFC)
+    val darkCandidate = Color(0xFF111418)
+    val backdropArgb = backdrop.toArgb()
+    val lightContrast = ColorUtils.calculateContrast(lightCandidate.toArgb(), backdropArgb)
+    val darkContrast = ColorUtils.calculateContrast(darkCandidate.toArgb(), backdropArgb)
+    val best = if (lightContrast >= darkContrast) lightCandidate else darkCandidate
+    val bestContrast = maxOf(lightContrast, darkContrast)
+    return if (bestContrast >= 4.5) best else fallback
+}

--- a/app/src/main/java/com/asmr/player/ui/player/LyricsPage.kt
+++ b/app/src/main/java/com/asmr/player/ui/player/LyricsPage.kt
@@ -76,6 +76,11 @@ fun LyricsPage(
         model = artwork,
         defaultColor = colorScheme.background
     )
+    val lyricColors = rememberLyricReadableColors(
+        accentColor = dominantColor,
+        coverBackgroundEnabled = coverBackgroundEnabled,
+        coverBackgroundClarity = coverBackgroundClarity
+    )
     val configuration = LocalConfiguration.current
     val isLandscape = configuration.orientation == Configuration.ORIENTATION_LANDSCAPE
 
@@ -128,7 +133,7 @@ fun LyricsPage(
                     lyrics = uiState.lyrics,
                     currentPosition = position,
                     onSeekTo = onSeekTo,
-                    activeColor = dominantColor, // Use dominant color
+                    colors = lyricColors,
                     modifier = Modifier.fillMaxSize(),
                     isLandscape = isLandscape,
                     contentPadding = PaddingValues(top = topPad, bottom = bottomPad)

--- a/app/src/main/java/com/asmr/player/ui/player/NowPlayingScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/player/NowPlayingScreen.kt
@@ -143,6 +143,11 @@ fun NowPlayingScreen(
         ),
         label = "nowPlayingAccentColor"
     )
+    val lyricColors = rememberLyricReadableColors(
+        accentColor = accentColor,
+        coverBackgroundEnabled = coverBackgroundEnabled,
+        coverBackgroundClarity = coverBackgroundClarity
+    )
     val onAccentColor = if (accentColor.luminance() > 0.55f) Color.Black else Color.White
     val videoBackdropColor = if (isVideo) {
         if (coverBackgroundEnabled) accentColor else colorScheme.background
@@ -374,7 +379,7 @@ fun NowPlayingScreen(
                                     currentPosition = playback.positionMs,
                                     onSeekTo = { viewModel.seekTo(it) },
                                     onOpenLyrics = onOpenLyrics,
-                                    activeColor = accentColor,
+                                    colors = lyricColors,
                                     modifier = Modifier
                                         .weight(0.70f)
                                         .fillMaxHeight(),
@@ -578,7 +583,7 @@ fun NowPlayingScreen(
                                     currentPosition = playback.positionMs,
                                     onSeekTo = { viewModel.seekTo(it) },
                                     onOpenLyrics = onOpenLyrics,
-                                    activeColor = accentColor,
+                                    colors = lyricColors,
                                     modifier = Modifier
                                         .weight(0.72f)
                                         .fillMaxHeight(),
@@ -774,7 +779,7 @@ fun NowPlayingScreen(
                             lyrics = lyricsState.lyrics,
                             currentPosition = playback.positionMs,
                             onOpenLyrics = onOpenLyrics,
-                            accentColor = accentColor,
+                            colors = lyricColors,
                             modifier = Modifier.fillMaxWidth()
                         )
                     }
@@ -1438,7 +1443,7 @@ private fun SingleLineLyrics(
     lyrics: List<SubtitleEntry>,
     currentPosition: Long,
     onOpenLyrics: () -> Unit,
-    accentColor: Color,
+    colors: LyricReadableColors,
     modifier: Modifier = Modifier,
 ) {
     val sortedLyrics = remember(lyrics) {
@@ -1478,16 +1483,23 @@ private fun SingleLineLyrics(
     Column(
         modifier = modifier
             .clickable { onOpenLyrics() }
-            .padding(horizontal = 16.dp, vertical = 8.dp),
-        verticalArrangement = Arrangement.spacedBy(8.dp),
+            .padding(horizontal = 16.dp, vertical = 4.dp),
+        verticalArrangement = Arrangement.spacedBy(4.dp),
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
         AnimatedLyricLine(
             text = currentText,
             durationMs = lineDuration,
-            color = accentColor,
+            colors = colors,
             fontWeight = FontWeight.ExtraBold,
             modifier = Modifier.fillMaxWidth()
+        )
+        Box(
+            modifier = Modifier
+                .width(52.dp)
+                .height(2.dp)
+                .clip(RoundedCornerShape(percent = 50))
+                .background(colors.accentEmphasis.copy(alpha = if (AsmrTheme.colorScheme.isDark) 0.72f else 0.56f))
         )
     }
 }
@@ -1497,7 +1509,7 @@ private fun SingleLineLyrics(
 private fun AnimatedLyricLine(
     text: String,
     durationMs: Long,
-    color: Color,
+    colors: LyricReadableColors,
     fontWeight: FontWeight,
     modifier: Modifier = Modifier
 ) {
@@ -1507,7 +1519,7 @@ private fun AnimatedLyricLine(
             ContentTransform(
                 targetContentEnter = slideInVertically(animationSpec = tween(600)) { it } + fadeIn(animationSpec = tween(600)),
                 initialContentExit = slideOutVertically(animationSpec = tween(600)) { -it } + fadeOut(animationSpec = tween(600)),
-                sizeTransform = SizeTransform(clip = false)
+                sizeTransform = null
             )
         },
         label = "lyricLine"
@@ -1516,7 +1528,7 @@ private fun AnimatedLyricLine(
             text = target,
             durationMs = durationMs,
             style = MaterialTheme.typography.titleMedium,
-            color = color,
+            colors = colors,
             fontWeight = fontWeight,
             modifier = modifier
         )
@@ -1529,17 +1541,18 @@ private fun SlowMarqueeText(
     text: String,
     durationMs: Long,
     style: androidx.compose.ui.text.TextStyle,
-    color: Color,
+    colors: LyricReadableColors,
     fontWeight: FontWeight,
     modifier: Modifier = Modifier
 ) {
     val singleLine = remember(text) { normalizeSingleLineText(text) }
     val content = singleLine.ifBlank { " " }
-    val shadow = if (AsmrTheme.colorScheme.isDark) {
-        Shadow(color = Color.Black.copy(alpha = 0.6f), offset = Offset(0f, 2f), blurRadius = 4f)
-    } else {
-        Shadow(color = Color.Black.copy(alpha = 0.15f), offset = Offset(0f, 1f), blurRadius = 2f)
-    }
+    val colorScheme = AsmrTheme.colorScheme
+    val shadow = Shadow(
+        color = colors.accentEmphasis.copy(alpha = if (colorScheme.isDark) 0.28f else 0.18f),
+        offset = Offset.Zero,
+        blurRadius = if (colorScheme.isDark) 14f else 10f
+    )
     
     val textMeasurer = androidx.compose.ui.text.rememberTextMeasurer()
     val textLayoutResult = remember(content, style, fontWeight) {
@@ -1600,15 +1613,18 @@ private fun SlowMarqueeText(
                 fontWeight = fontWeight,
                 shadow = shadow
             ),
-            color = color,
+            color = colors.activeText,
             maxLines = 1,
             softWrap = false,
             overflow = TextOverflow.Clip,
             textAlign = TextAlign.Center,
-            modifier = Modifier.basicMarquee(
-                iterations = Int.MAX_VALUE,
-                velocity = finalVelocity.coerceAtLeast(10.dp) // Minimum speed
-            )
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 10.dp, vertical = 2.dp)
+                .basicMarquee(
+                    iterations = Int.MAX_VALUE,
+                    velocity = finalVelocity.coerceAtLeast(10.dp)
+                )
         )
     }
 }

--- a/app/src/main/java/com/asmr/player/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/settings/SettingsScreen.kt
@@ -9,6 +9,8 @@ import android.provider.DocumentsContract
 import android.provider.Settings
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsDraggedAsState
 import androidx.compose.foundation.border
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -31,6 +33,7 @@ import androidx.compose.material3.*
 import androidx.compose.material3.windowsizeclass.WindowSizeClass
 import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
 import androidx.compose.runtime.*
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -52,6 +55,7 @@ import com.asmr.player.ui.theme.AsmrTheme
 import com.asmr.player.ui.common.LocalBottomOverlayPadding
 import com.asmr.player.ui.common.withAddedBottomPadding
 import java.io.File
+import kotlin.math.abs
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -252,7 +256,7 @@ fun SettingsScreen(
                                     Icon(Icons.Default.Delete, contentDescription = null, tint = colorScheme.onSurface)
                                 }
                             }
-                        }
+                            }
                     }
                 }
             }
@@ -335,27 +339,16 @@ fun SettingsScreen(
                     onCheckedChange = viewModel::setCoverBackgroundEnabled
                 )
                 if (coverBackgroundEnabled) {
-                    var editingClarity by remember { mutableFloatStateOf(coverBackgroundClarity.coerceIn(0f, 1f)) }
-                    var clarityDragging by remember { mutableStateOf(false) }
-                    LaunchedEffect(coverBackgroundClarity) {
-                        if (!clarityDragging) {
-                            editingClarity = coverBackgroundClarity.coerceIn(0f, 1f)
-                        }
+                    key("cover_background_clarity_slider") {
+                        DeferredCommitSettingsSliderRow(
+                            committedValue = coverBackgroundClarity,
+                            range = 0f..1f,
+                            textForValue = { value ->
+                                "封面背景清晰度：${(value.coerceIn(0f, 1f) * 100).toInt()}%"
+                            },
+                            onValueCommitted = viewModel::setCoverBackgroundClarity
+                        )
                     }
-                    val percent = (editingClarity * 100).toInt()
-                    SettingsSliderRow(
-                        text = "封面背景清晰度：$percent%",
-                        value = editingClarity,
-                        range = 0f..1f,
-                        onValueChange = {
-                            clarityDragging = true
-                            editingClarity = it.coerceIn(0f, 1f)
-                        },
-                        onValueChangeFinished = {
-                            clarityDragging = false
-                            viewModel.setCoverBackgroundClarity(editingClarity)
-                        }
-                    )
                 }
             }
 
@@ -700,8 +693,10 @@ private fun SettingsSliderRow(
     value: Float,
     range: ClosedFloatingPointRange<Float>,
     onValueChange: (Float) -> Unit,
-    onValueChangeFinished: (() -> Unit)? = null
+    onValueChangeFinished: (() -> Unit)? = null,
+    interactionSource: MutableInteractionSource? = null
 ) {
+    val sliderInteractionSource = interactionSource ?: remember { MutableInteractionSource() }
     Column(modifier = Modifier.fillMaxWidth()) {
         Text(text, style = MaterialTheme.typography.bodyMedium)
         Slider(
@@ -709,9 +704,56 @@ private fun SettingsSliderRow(
             onValueChange = onValueChange,
             valueRange = range,
             onValueChangeFinished = onValueChangeFinished,
+            interactionSource = sliderInteractionSource,
             modifier = Modifier.fillMaxWidth()
         )
     }
+}
+
+@Composable
+private fun DeferredCommitSettingsSliderRow(
+    committedValue: Float,
+    range: ClosedFloatingPointRange<Float>,
+    textForValue: (Float) -> String,
+    onValueCommitted: (Float) -> Unit
+) {
+    val coercedCommittedValue = committedValue.coerceIn(range.start, range.endInclusive)
+    var draftValue by rememberSaveable(range.start, range.endInclusive) {
+        mutableStateOf(coercedCommittedValue)
+    }
+    var pendingCommit by rememberSaveable { mutableStateOf<Float?>(null) }
+    val interactionSource = remember { MutableInteractionSource() }
+    val isDragging by interactionSource.collectIsDraggedAsState()
+
+    LaunchedEffect(coercedCommittedValue, isDragging, pendingCommit) {
+        when {
+            isDragging -> Unit
+            pendingCommit != null -> {
+                if (abs(coercedCommittedValue - pendingCommit!!) <= 0.001f) {
+                    draftValue = coercedCommittedValue
+                    pendingCommit = null
+                }
+            }
+            abs(draftValue - coercedCommittedValue) > 0.001f -> {
+                draftValue = coercedCommittedValue
+            }
+        }
+    }
+
+    SettingsSliderRow(
+        text = textForValue(draftValue),
+        value = draftValue,
+        range = range,
+        onValueChange = { newValue ->
+            draftValue = newValue.coerceIn(range.start, range.endInclusive)
+        },
+        onValueChangeFinished = {
+            val valueToCommit = draftValue.coerceIn(range.start, range.endInclusive)
+            pendingCommit = valueToCommit
+            onValueCommitted(valueToCommit)
+        },
+        interactionSource = interactionSource
+    )
 }
 
 @Composable

--- a/app/src/main/java/com/asmr/player/ui/theme/HueDerivation.kt
+++ b/app/src/main/java/com/asmr/player/ui/theme/HueDerivation.kt
@@ -47,7 +47,7 @@ internal fun deriveHuePalette(
         Color(ColorUtils.blendARGB(primaryArgb, target.toArgb(), strongBlend))
     }
 
-    val onPrimary = bestOnPrimary(primary, fallbackOnPrimary)
+    val onPrimary = bestOnPrimary(primaryStrong, fallbackOnPrimary)
 
     return HuePalette(
         primary = primary,
@@ -70,20 +70,47 @@ internal fun bestOnPrimary(primary: Color, fallback: Color): Color {
 }
 
 internal fun clampPrimaryHslForMode(hsl: FloatArray, mode: ThemeMode) {
+    val hue = ((hsl[0] % 360f) + 360f) % 360f
+    val saturation = hsl[1].coerceIn(0f, 1f)
     val lightnessMin = when (mode) {
-        ThemeMode.Light -> 0.12f
-        ThemeMode.Dark -> 0.18f
-        ThemeMode.SoftDark -> 0.20f
+        ThemeMode.Light -> 0.18f
+        ThemeMode.Dark -> when {
+            hue in 38f..85f -> 0.58f
+            hue in 85f..170f -> 0.54f
+            hue in 170f..260f -> 0.48f
+            else -> 0.52f
+        }
+        ThemeMode.SoftDark -> when {
+            hue in 38f..85f -> 0.54f
+            hue in 85f..170f -> 0.50f
+            hue in 170f..260f -> 0.45f
+            else -> 0.48f
+        }
     }
     val lightnessMax = when (mode) {
-        ThemeMode.Light -> 0.62f
-        ThemeMode.Dark -> 0.70f
-        ThemeMode.SoftDark -> 0.66f
+        ThemeMode.Light -> when {
+            hue in 38f..85f -> if (saturation >= 0.45f) 0.38f else 0.42f
+            hue in 85f..170f -> if (saturation >= 0.45f) 0.40f else 0.44f
+            hue in 170f..260f -> if (saturation >= 0.45f) 0.46f else 0.50f
+            else -> if (saturation >= 0.45f) 0.42f else 0.46f
+        }
+        ThemeMode.Dark -> when {
+            hue in 38f..85f -> 0.74f
+            hue in 85f..170f -> 0.70f
+            hue in 170f..260f -> 0.66f
+            else -> 0.68f
+        }
+        ThemeMode.SoftDark -> when {
+            hue in 38f..85f -> 0.70f
+            hue in 85f..170f -> 0.66f
+            hue in 170f..260f -> 0.62f
+            else -> 0.64f
+        }
     }
     val saturationMax = when (mode) {
-        ThemeMode.Light -> 0.82f
-        ThemeMode.Dark -> 0.80f
-        ThemeMode.SoftDark -> 0.78f
+        ThemeMode.Light -> 0.76f
+        ThemeMode.Dark -> 0.78f
+        ThemeMode.SoftDark -> 0.76f
     }
     hsl[1] = hsl[1].coerceIn(0f, saturationMax)
     hsl[2] = hsl[2].coerceIn(lightnessMin, lightnessMax)


### PR DESCRIPTION
## Summary
- fix cover artwork background rendering and clarity behavior for now playing and lyrics pages
- improve cover-derived theme recalculation and contrast handling across light/dark mode
- smooth lyric presentation and defer clarity slider commits to reduce playback-time drag jank

## Verification
- ./gradlew :app:compileDebugKotlin
