### PR TITLE
Add global cover motion browsing

### DIFF
--- a/app/src/main/java/com/asmr/player/MainActivity.kt
+++ b/app/src/main/java/com/asmr/player/MainActivity.kt
@@ -190,6 +190,7 @@ class MainActivity : ComponentActivity() {
             val staticHueArgb by settingsDataStore.staticHueArgb.collectAsState(initial = null)
             val coverBackgroundEnabled by settingsDataStore.coverBackgroundEnabled.collectAsState(initial = true)
             val coverBackgroundClarity by settingsDataStore.coverBackgroundClarity.collectAsState(initial = 0.35f)
+            val coverMotionEnabled by settingsDataStore.coverMotionEnabled.collectAsState(initial = false)
             val neutral = remember(mode) { neutralPaletteForMode(mode) }
             val cacheManager = remember(context.applicationContext) {
                 dagger.hilt.android.EntryPointAccessors.fromApplication(
@@ -322,6 +323,7 @@ class MainActivity : ComponentActivity() {
                         globalDynamicHueEnabled = globalDynamicHueEnabled,
                         coverBackgroundEnabled = coverBackgroundEnabled,
                         coverBackgroundClarity = coverBackgroundClarity,
+                        coverMotionEnabled = coverMotionEnabled,
                         forceImmersive = showSplash,
                         baseStaticHue = baseStaticHue
                     )
@@ -399,6 +401,7 @@ fun MainContainer(
     globalDynamicHueEnabled: Boolean,
     coverBackgroundEnabled: Boolean,
     coverBackgroundClarity: Float,
+    coverMotionEnabled: Boolean,
     forceImmersive: Boolean,
     baseStaticHue: HuePalette
 ) {
@@ -1165,7 +1168,8 @@ fun MainContainer(
                             },
                             viewModel = playerViewModel,
                             coverBackgroundEnabled = coverBackgroundEnabled,
-                            coverBackgroundClarity = coverBackgroundClarity
+                            coverBackgroundClarity = coverBackgroundClarity,
+                            coverMotionEnabled = coverMotionEnabled
                         )
                     } else {
                         NowPlayingScreen(
@@ -1189,7 +1193,8 @@ fun MainContainer(
                             },
                             viewModel = playerViewModel,
                             coverBackgroundEnabled = coverBackgroundEnabled,
-                            coverBackgroundClarity = coverBackgroundClarity
+                            coverBackgroundClarity = coverBackgroundClarity,
+                            coverMotionEnabled = coverMotionEnabled
                         )
                     }
                 }
@@ -1200,7 +1205,8 @@ fun MainContainer(
                             onSeekTo = { pos -> playerViewModel.seekTo(pos) },
                             playerViewModel = playerViewModel,
                             coverBackgroundEnabled = coverBackgroundEnabled,
-                            coverBackgroundClarity = coverBackgroundClarity
+                            coverBackgroundClarity = coverBackgroundClarity,
+                            coverMotionEnabled = coverMotionEnabled
                         )
                     } else {
                         LyricsPage(
@@ -1208,7 +1214,8 @@ fun MainContainer(
                             onSeekTo = { pos -> playerViewModel.seekTo(pos) },
                             playerViewModel = playerViewModel,
                             coverBackgroundEnabled = coverBackgroundEnabled,
-                            coverBackgroundClarity = coverBackgroundClarity
+                            coverBackgroundClarity = coverBackgroundClarity,
+                            coverMotionEnabled = coverMotionEnabled
                         )
                     }
                 }

--- a/app/src/main/java/com/asmr/player/data/local/datastore/SettingsDataStore.kt
+++ b/app/src/main/java/com/asmr/player/data/local/datastore/SettingsDataStore.kt
@@ -21,6 +21,7 @@ class SettingsDataStore @Inject constructor(
     private val staticHueArgbDarkKey = intPreferencesKey("static_hue_argb_dark")
     private val coverBackgroundEnabledKey = booleanPreferencesKey("cover_background_enabled")
     private val coverBackgroundClarityKey = floatPreferencesKey("cover_background_clarity")
+    private val coverMotionEnabledKey = booleanPreferencesKey("cover_motion_enabled")
     private val recentAlbumsPanelExpandedKey = booleanPreferencesKey("recent_albums_panel_expanded")
 
     val theme: Flow<String> = context.settingsDataStore.data.map { it[themeKey] ?: "system" }
@@ -41,6 +42,7 @@ class SettingsDataStore @Inject constructor(
     }
     val coverBackgroundEnabled: Flow<Boolean> = context.settingsDataStore.data.map { it[coverBackgroundEnabledKey] ?: true }
     val coverBackgroundClarity: Flow<Float> = context.settingsDataStore.data.map { it[coverBackgroundClarityKey] ?: 0.35f }
+    val coverMotionEnabled: Flow<Boolean> = context.settingsDataStore.data.map { it[coverMotionEnabledKey] ?: false }
     val recentAlbumsPanelExpanded: Flow<Boolean> = context.settingsDataStore.data.map { it[recentAlbumsPanelExpandedKey] ?: true }
 
     suspend fun setTheme(theme: String) {
@@ -74,6 +76,10 @@ class SettingsDataStore @Inject constructor(
 
     suspend fun setCoverBackgroundClarity(clarity: Float) {
         context.settingsDataStore.edit { it[coverBackgroundClarityKey] = clarity }
+    }
+
+    suspend fun setCoverMotionEnabled(enabled: Boolean) {
+        context.settingsDataStore.edit { it[coverMotionEnabledKey] = enabled }
     }
 
     suspend fun setRecentAlbumsPanelExpanded(expanded: Boolean) {

--- a/app/src/main/java/com/asmr/player/ui/player/CoverArtworkBackground.kt
+++ b/app/src/main/java/com/asmr/player/ui/player/CoverArtworkBackground.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.blur
 import androidx.compose.ui.graphics.Color
@@ -27,6 +28,7 @@ fun CoverArtworkBackground(
     clarity: Float,
     overlayBaseColor: Color,
     tintBaseColor: Color,
+    artworkAlignment: Alignment = Alignment.Center,
     isDark: Boolean = true
 ) {
     if (!enabled) return
@@ -62,6 +64,7 @@ fun CoverArtworkBackground(
             contentDescription = null,
             modifier = Modifier.fillMaxSize().then(artworkModifier),
             contentScale = ContentScale.Crop,
+            alignment = artworkAlignment,
             alpha = style.artworkAlpha,
             loading = {},
         )

--- a/app/src/main/java/com/asmr/player/ui/player/CoverArtworkEdgeBlend.kt
+++ b/app/src/main/java/com/asmr/player/ui/player/CoverArtworkEdgeBlend.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.blur
 import androidx.compose.ui.draw.clip
@@ -29,7 +30,8 @@ fun CoverArtworkEdgeBlend(
     artworkModel: Any?,
     blendColor: Color,
     modifier: Modifier = Modifier,
-    cornerRadius: Dp = 28.dp
+    cornerRadius: Dp = 28.dp,
+    artworkAlignment: Alignment = Alignment.Center
 ) {
     val shape = remember(cornerRadius) { RoundedCornerShape(cornerRadius) }
     val blurDp = 32.dp
@@ -70,6 +72,7 @@ fun CoverArtworkEdgeBlend(
                 }
                 .then(blurModifier),
             contentScale = ContentScale.Crop,
+            alignment = artworkAlignment,
             placeholder = {},
             loading = {},
         )
@@ -107,6 +110,7 @@ fun CoverArtworkEdgeBlend(
                     }
                 },
             contentScale = ContentScale.Crop,
+            alignment = artworkAlignment,
             placeholderCornerRadius = cornerRadius.value.toInt(),
         )
     }

--- a/app/src/main/java/com/asmr/player/ui/player/CoverMotion.kt
+++ b/app/src/main/java/com/asmr/player/ui/player/CoverMotion.kt
@@ -1,0 +1,493 @@
+package com.asmr.player.ui.player
+
+import android.content.Context
+import android.hardware.Sensor
+import android.hardware.SensorEvent
+import android.hardware.SensorEventListener
+import android.hardware.SensorManager
+import android.view.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.BiasAlignment
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalLifecycleOwner
+import androidx.compose.ui.platform.LocalView
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import kotlin.math.abs
+import kotlin.math.asin
+import kotlin.math.sign
+import kotlin.math.sqrt
+
+private const val COVER_MOTION_DEAD_ZONE_DEGREES = 3f
+private const val COVER_MOTION_FULL_TRAVEL_DEGREES = 8f
+private const val COVER_MOTION_LOW_PASS_FACTOR = 0.14f
+private const val MIN_VECTOR_MAGNITUDE = 0.001f
+
+internal data class CoverMotionState(
+    val horizontalBias: Float = 0f,
+    val verticalBias: Float = 0f
+) {
+    companion object {
+        val Center = CoverMotionState()
+    }
+}
+
+internal data class CoverMotionAngles(
+    val horizontalDegrees: Float,
+    val verticalDegrees: Float
+)
+
+internal data class ScreenTiltDegrees(
+    val horizontal: Float,
+    val vertical: Float
+)
+
+internal data class ScreenOrientationBasis(
+    val rightWorld: FloatArray,
+    val upWorld: FloatArray,
+    val forwardWorld: FloatArray
+)
+
+@Composable
+internal fun rememberCoverMotionState(
+    enabled: Boolean,
+    resetKey: Any? = Unit
+): CoverMotionState {
+    val context = LocalContext.current
+    val lifecycleOwner = LocalLifecycleOwner.current
+    val view = LocalView.current
+    val displayRotation = view.display?.rotation ?: Surface.ROTATION_0
+    val sensorManager = remember(context) {
+        context.getSystemService(Context.SENSOR_SERVICE) as? SensorManager
+    }
+    val rotationVectorSensor = remember(sensorManager) {
+        sensorManager?.getDefaultSensor(Sensor.TYPE_ROTATION_VECTOR)
+    }
+    val gravitySensor = remember(sensorManager) {
+        sensorManager?.getDefaultSensor(Sensor.TYPE_GRAVITY)
+    }
+    val selectedSensor = rotationVectorSensor ?: gravitySensor
+    val motionState: MutableState<CoverMotionState> = remember {
+        mutableStateOf(CoverMotionState.Center)
+    }
+
+    DisposableEffect(enabled, sensorManager, selectedSensor, lifecycleOwner, displayRotation, resetKey) {
+        if (!enabled || sensorManager == null || selectedSensor == null) {
+            motionState.value = CoverMotionState.Center
+            return@DisposableEffect onDispose { motionState.value = CoverMotionState.Center }
+        }
+
+        var registered = false
+        var referenceBasis: ScreenOrientationBasis? = null
+        var referenceTilt: ScreenTiltDegrees? = null
+        var previousAngles: CoverMotionAngles? = null
+        var smoothedState = CoverMotionState.Center
+        lateinit var listener: SensorEventListener
+
+        fun reset() {
+            referenceBasis = null
+            referenceTilt = null
+            previousAngles = null
+            smoothedState = CoverMotionState.Center
+            motionState.value = CoverMotionState.Center
+        }
+
+        fun register() {
+            if (registered) return
+            registered = sensorManager.registerListener(
+                listener,
+                selectedSensor,
+                SensorManager.SENSOR_DELAY_GAME
+            )
+            if (!registered) reset()
+        }
+
+        fun unregister() {
+            if (!registered) return
+            sensorManager.unregisterListener(listener)
+            registered = false
+        }
+
+        listener = object : SensorEventListener {
+            override fun onSensorChanged(event: SensorEvent?) {
+                val values = event?.values ?: return
+                val targetState = when (selectedSensor.type) {
+                    Sensor.TYPE_ROTATION_VECTOR -> {
+                        val basis = screenOrientationBasisFromRotationVector(values, displayRotation)
+                        if (basis == null) {
+                            previousAngles = null
+                            smoothedState = CoverMotionState.Center
+                            motionState.value = CoverMotionState.Center
+                            return
+                        }
+                        val reference = referenceBasis
+                        if (reference == null) {
+                            referenceBasis = basis
+                            previousAngles = CoverMotionAngles(0f, 0f)
+                            smoothedState = CoverMotionState.Center
+                            motionState.value = CoverMotionState.Center
+                            return
+                        }
+                        val rawAngles = relativeAnglesFromReference(current = basis, reference = reference)
+                        val continuousAngles = previousAngles
+                            ?.let { unwrapAngles(previous = it, current = rawAngles) }
+                            ?: rawAngles
+                        previousAngles = continuousAngles
+                        coverMotionStateFromAngles(continuousAngles)
+                    }
+
+                    Sensor.TYPE_GRAVITY -> {
+                        val tilt = screenTiltDegreesFromGravity(values, displayRotation)
+                        if (tilt == null) {
+                            smoothedState = CoverMotionState.Center
+                            motionState.value = CoverMotionState.Center
+                            return
+                        }
+                        val reference = referenceTilt
+                        if (reference == null) {
+                            referenceTilt = tilt
+                            smoothedState = CoverMotionState.Center
+                            motionState.value = CoverMotionState.Center
+                            return
+                        }
+                        coverMotionStateFromAngles(
+                            CoverMotionAngles(
+                                horizontalDegrees = tilt.horizontal - reference.horizontal,
+                                verticalDegrees = tilt.vertical - reference.vertical
+                            )
+                        )
+                    }
+
+                    else -> return
+                }
+
+                smoothedState = lowPassCoverMotionState(
+                    previous = smoothedState,
+                    target = targetState,
+                    factor = COVER_MOTION_LOW_PASS_FACTOR
+                )
+                motionState.value = smoothedState
+            }
+
+            override fun onAccuracyChanged(sensor: Sensor?, accuracy: Int) = Unit
+        }
+
+        val observer = LifecycleEventObserver { _, event ->
+            when (event) {
+                Lifecycle.Event.ON_RESUME -> {
+                    reset()
+                    register()
+                }
+
+                Lifecycle.Event.ON_PAUSE -> {
+                    unregister()
+                    reset()
+                }
+
+                else -> Unit
+            }
+        }
+
+        lifecycleOwner.lifecycle.addObserver(observer)
+        if (lifecycleOwner.lifecycle.currentState.isAtLeast(Lifecycle.State.RESUMED)) {
+            register()
+        }
+
+        onDispose {
+            lifecycleOwner.lifecycle.removeObserver(observer)
+            unregister()
+            reset()
+        }
+    }
+
+    return motionState.value
+}
+
+internal fun CoverMotionState.toAlignment(): Alignment {
+    return BiasAlignment(horizontalBias = horizontalBias, verticalBias = verticalBias)
+}
+
+internal fun screenOrientationBasisFromRotationVector(
+    rotationVector: FloatArray,
+    displayRotation: Int
+): ScreenOrientationBasis? {
+    if (rotationVector.isEmpty() || rotationVector.any { !it.isFinite() }) return null
+    val rotationMatrix = FloatArray(9)
+    runCatching {
+        SensorManager.getRotationMatrixFromVector(rotationMatrix, rotationVector)
+    }.getOrNull() ?: return null
+    return screenOrientationBasisFromRotationMatrix(rotationMatrix, displayRotation)
+}
+
+internal fun screenOrientationBasisFromRotationMatrix(
+    rotationMatrix: FloatArray,
+    displayRotation: Int
+): ScreenOrientationBasis? {
+    if (rotationMatrix.size < 9) return null
+    return ScreenOrientationBasis(
+        rightWorld = normalizeVector(
+            transformVector(
+                rotationMatrix = rotationMatrix,
+                vector = screenRightAxisInDeviceCoordinates(displayRotation)
+            )
+        ) ?: return null,
+        upWorld = normalizeVector(
+            transformVector(
+                rotationMatrix = rotationMatrix,
+                vector = screenUpAxisInDeviceCoordinates(displayRotation)
+            )
+        ) ?: return null,
+        forwardWorld = normalizeVector(
+            transformVector(
+                rotationMatrix = rotationMatrix,
+                vector = floatArrayOf(0f, 0f, 1f)
+            )
+        ) ?: return null
+    )
+}
+
+internal fun relativeAnglesFromReference(
+    current: ScreenOrientationBasis,
+    reference: ScreenOrientationBasis
+): CoverMotionAngles {
+    val rotationVector = relativeRotationVectorWorld(current = current, reference = reference)
+        ?: return CoverMotionAngles(horizontalDegrees = 0f, verticalDegrees = 0f)
+    val horizontal = Math.toDegrees(dot(rotationVector, reference.upWorld).toDouble()).toFloat()
+    val vertical = Math.toDegrees((-dot(rotationVector, reference.rightWorld)).toDouble()).toFloat()
+    return CoverMotionAngles(horizontalDegrees = horizontal, verticalDegrees = vertical)
+}
+
+internal fun screenTiltDegreesFromGravity(
+    gravityDevice: FloatArray,
+    displayRotation: Int
+): ScreenTiltDegrees? {
+    if (gravityDevice.size < 3 || gravityDevice.any { !it.isFinite() }) return null
+    val gravityScreen = remapGravityToScreenCoordinates(gravityDevice, displayRotation)
+    val magnitude = vectorMagnitude(gravityScreen)
+    if (!magnitude.isFinite() || magnitude < MIN_VECTOR_MAGNITUDE) return null
+
+    val normalizedX = (gravityScreen[0] / magnitude).coerceIn(-1f, 1f)
+    val normalizedZ = (gravityScreen[2] / magnitude).coerceIn(-1f, 1f)
+    if (!normalizedX.isFinite() || !normalizedZ.isFinite()) return null
+    return ScreenTiltDegrees(
+        horizontal = Math.toDegrees(asin(normalizedX.toDouble())).toFloat(),
+        vertical = Math.toDegrees(asin((-normalizedZ).toDouble())).toFloat()
+    )
+}
+
+internal fun remapGravityToScreenCoordinates(
+    gravityDevice: FloatArray,
+    displayRotation: Int
+): FloatArray {
+    val x = gravityDevice[0]
+    val y = gravityDevice[1]
+    val z = gravityDevice[2]
+    return when (displayRotation) {
+        Surface.ROTATION_0 -> floatArrayOf(x, y, z)
+        Surface.ROTATION_90 -> floatArrayOf(-y, x, z)
+        Surface.ROTATION_180 -> floatArrayOf(-x, -y, z)
+        Surface.ROTATION_270 -> floatArrayOf(y, -x, z)
+        else -> floatArrayOf(x, y, z)
+    }
+}
+
+internal fun coverMotionStateFromAngles(angles: CoverMotionAngles): CoverMotionState {
+    return CoverMotionState(
+        horizontalBias = mapDegreesToBias(angles.horizontalDegrees),
+        verticalBias = mapDegreesToBias(angles.verticalDegrees)
+    )
+}
+
+internal fun mapDegreesToBias(
+    degrees: Float,
+    deadZoneDegrees: Float = COVER_MOTION_DEAD_ZONE_DEGREES,
+    fullTravelDegrees: Float = COVER_MOTION_FULL_TRAVEL_DEGREES
+): Float {
+    if (!degrees.isFinite()) return 0f
+    val safeFullTravel = maxOf(fullTravelDegrees, deadZoneDegrees + 0.001f)
+    val magnitude = abs(degrees)
+    if (magnitude <= deadZoneDegrees) return 0f
+    val normalized = ((magnitude - deadZoneDegrees) / (safeFullTravel - deadZoneDegrees))
+        .coerceIn(0f, 1f)
+    return normalized * sign(degrees)
+}
+
+internal fun lowPassCoverMotionState(
+    previous: CoverMotionState,
+    target: CoverMotionState,
+    factor: Float
+): CoverMotionState {
+    val clampedFactor = factor.coerceIn(0f, 1f)
+    return CoverMotionState(
+        horizontalBias = lerpBias(previous.horizontalBias, target.horizontalBias, clampedFactor),
+        verticalBias = lerpBias(previous.verticalBias, target.verticalBias, clampedFactor)
+    )
+}
+
+internal fun unwrapAngles(
+    previous: CoverMotionAngles,
+    current: CoverMotionAngles
+): CoverMotionAngles {
+    return CoverMotionAngles(
+        horizontalDegrees = unwrapAngleDegrees(previous.horizontalDegrees, current.horizontalDegrees),
+        verticalDegrees = unwrapAngleDegrees(previous.verticalDegrees, current.verticalDegrees)
+    )
+}
+
+internal fun unwrapAngleDegrees(previousDegrees: Float, currentDegrees: Float): Float {
+    val previousWrapped = wrapDegrees(previousDegrees)
+    var delta = currentDegrees - previousWrapped
+    if (delta > 180f) delta -= 360f
+    if (delta < -180f) delta += 360f
+    return previousDegrees + delta
+}
+
+internal fun wrapDegrees(degrees: Float): Float {
+    var wrapped = degrees % 360f
+    if (wrapped <= -180f) wrapped += 360f
+    if (wrapped > 180f) wrapped -= 360f
+    return wrapped
+}
+
+private fun screenRightAxisInDeviceCoordinates(displayRotation: Int): FloatArray {
+    return when (displayRotation) {
+        Surface.ROTATION_0 -> floatArrayOf(1f, 0f, 0f)
+        Surface.ROTATION_90 -> floatArrayOf(0f, -1f, 0f)
+        Surface.ROTATION_180 -> floatArrayOf(-1f, 0f, 0f)
+        Surface.ROTATION_270 -> floatArrayOf(0f, 1f, 0f)
+        else -> floatArrayOf(1f, 0f, 0f)
+    }
+}
+
+private fun screenUpAxisInDeviceCoordinates(displayRotation: Int): FloatArray {
+    return when (displayRotation) {
+        Surface.ROTATION_0 -> floatArrayOf(0f, 1f, 0f)
+        Surface.ROTATION_90 -> floatArrayOf(1f, 0f, 0f)
+        Surface.ROTATION_180 -> floatArrayOf(0f, -1f, 0f)
+        Surface.ROTATION_270 -> floatArrayOf(-1f, 0f, 0f)
+        else -> floatArrayOf(0f, 1f, 0f)
+    }
+}
+
+private fun transformVector(rotationMatrix: FloatArray, vector: FloatArray): FloatArray {
+    return floatArrayOf(
+        rotationMatrix[0] * vector[0] + rotationMatrix[1] * vector[1] + rotationMatrix[2] * vector[2],
+        rotationMatrix[3] * vector[0] + rotationMatrix[4] * vector[1] + rotationMatrix[5] * vector[2],
+        rotationMatrix[6] * vector[0] + rotationMatrix[7] * vector[1] + rotationMatrix[8] * vector[2]
+    )
+}
+
+private fun relativeRotationVectorWorld(
+    current: ScreenOrientationBasis,
+    reference: ScreenOrientationBasis
+): FloatArray? {
+    val relativeMatrix = multiplyMatrices(
+        left = basisToMatrix(current),
+        right = transposeMatrix(basisToMatrix(reference))
+    )
+    return rotationVectorFromMatrix(relativeMatrix)
+}
+
+private fun basisToMatrix(basis: ScreenOrientationBasis): FloatArray {
+    return floatArrayOf(
+        basis.rightWorld[0], basis.upWorld[0], basis.forwardWorld[0],
+        basis.rightWorld[1], basis.upWorld[1], basis.forwardWorld[1],
+        basis.rightWorld[2], basis.upWorld[2], basis.forwardWorld[2]
+    )
+}
+
+private fun transposeMatrix(matrix: FloatArray): FloatArray {
+    return floatArrayOf(
+        matrix[0], matrix[3], matrix[6],
+        matrix[1], matrix[4], matrix[7],
+        matrix[2], matrix[5], matrix[8]
+    )
+}
+
+private fun multiplyMatrices(left: FloatArray, right: FloatArray): FloatArray {
+    return floatArrayOf(
+        left[0] * right[0] + left[1] * right[3] + left[2] * right[6],
+        left[0] * right[1] + left[1] * right[4] + left[2] * right[7],
+        left[0] * right[2] + left[1] * right[5] + left[2] * right[8],
+        left[3] * right[0] + left[4] * right[3] + left[5] * right[6],
+        left[3] * right[1] + left[4] * right[4] + left[5] * right[7],
+        left[3] * right[2] + left[4] * right[5] + left[5] * right[8],
+        left[6] * right[0] + left[7] * right[3] + left[8] * right[6],
+        left[6] * right[1] + left[7] * right[4] + left[8] * right[7],
+        left[6] * right[2] + left[7] * right[5] + left[8] * right[8]
+    )
+}
+
+private fun rotationVectorFromMatrix(matrix: FloatArray): FloatArray? {
+    val trace = (matrix[0] + matrix[4] + matrix[8]).coerceIn(-1f, 3f)
+    val cosTheta = ((trace - 1f) / 2f).coerceIn(-1f, 1f)
+    val theta = kotlin.math.acos(cosTheta)
+    if (!theta.isFinite() || theta < 1e-4f) {
+        return floatArrayOf(0f, 0f, 0f)
+    }
+
+    val axisRaw = floatArrayOf(
+        matrix[7] - matrix[5],
+        matrix[2] - matrix[6],
+        matrix[3] - matrix[1]
+    )
+    val axis = normalizeVector(axisRaw)
+    if (axis != null) {
+        return floatArrayOf(
+            axis[0] * theta,
+            axis[1] * theta,
+            axis[2] * theta
+        )
+    }
+
+    val x = sqrt(maxOf(0f, (matrix[0] + 1f) * 0.5f))
+    val y = sqrt(maxOf(0f, (matrix[4] + 1f) * 0.5f))
+    val z = sqrt(maxOf(0f, (matrix[8] + 1f) * 0.5f))
+    val fallbackAxis = normalizeVector(
+        floatArrayOf(
+            x * signOrOne(matrix[7] - matrix[5]),
+            y * signOrOne(matrix[2] - matrix[6]),
+            z * signOrOne(matrix[3] - matrix[1])
+        )
+    ) ?: return null
+    return floatArrayOf(
+        fallbackAxis[0] * theta,
+        fallbackAxis[1] * theta,
+        fallbackAxis[2] * theta
+    )
+}
+
+private fun normalizeVector(vector: FloatArray): FloatArray? {
+    val magnitude = vectorMagnitude(vector)
+    if (!magnitude.isFinite() || magnitude < MIN_VECTOR_MAGNITUDE) return null
+    return floatArrayOf(
+        vector[0] / magnitude,
+        vector[1] / magnitude,
+        vector[2] / magnitude
+    )
+}
+
+private fun vectorMagnitude(vector: FloatArray): Float {
+    return sqrt(
+        vector[0] * vector[0] +
+            vector[1] * vector[1] +
+            vector[2] * vector[2]
+    )
+}
+
+private fun dot(a: FloatArray, b: FloatArray): Float {
+    return a[0] * b[0] + a[1] * b[1] + a[2] * b[2]
+}
+
+private fun signOrOne(value: Float): Float {
+    return if (value < 0f) -1f else 1f
+}
+
+private fun lerpBias(previous: Float, target: Float, factor: Float): Float {
+    return (previous + ((target - previous) * factor)).coerceIn(-1f, 1f)
+}

--- a/app/src/main/java/com/asmr/player/ui/player/LyricsPage.kt
+++ b/app/src/main/java/com/asmr/player/ui/player/LyricsPage.kt
@@ -65,6 +65,7 @@ fun LyricsPage(
     playerViewModel: PlayerViewModel,
     coverBackgroundEnabled: Boolean,
     coverBackgroundClarity: Float,
+    coverMotionEnabled: Boolean,
     viewModel: LyricsViewModel = hiltViewModel()
 ) {
     val uiState by viewModel.uiState.collectAsState()
@@ -83,6 +84,10 @@ fun LyricsPage(
     )
     val configuration = LocalConfiguration.current
     val isLandscape = configuration.orientation == Configuration.ORIENTATION_LANDSCAPE
+    val coverMotionState = rememberCoverMotionState(
+        enabled = coverBackgroundEnabled && coverMotionEnabled,
+        resetKey = playback.currentMediaItem?.mediaId
+    )
 
     Box(modifier = Modifier.fillMaxSize()) {
         CoverArtworkBackground(
@@ -91,6 +96,7 @@ fun LyricsPage(
             clarity = coverBackgroundClarity,
             overlayBaseColor = colorScheme.background,
             tintBaseColor = dominantColor,
+            artworkAlignment = coverMotionState.toAlignment(),
             isDark = colorScheme.isDark
         )
 

--- a/app/src/main/java/com/asmr/player/ui/player/NowPlayingScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/player/NowPlayingScreen.kt
@@ -103,6 +103,7 @@ fun NowPlayingScreen(
     viewModel: PlayerViewModel,
     coverBackgroundEnabled: Boolean,
     coverBackgroundClarity: Float,
+    coverMotionEnabled: Boolean,
     lyricsViewModel: LyricsViewModel = hiltViewModel()
 ) {
     val playback by viewModel.playback.collectAsState()
@@ -197,6 +198,11 @@ fun NowPlayingScreen(
     val useSplitLayout = heightClass != WindowHeightSizeClass.Compact && isLandscape
     val player = viewModel.playerOrNull()
     val videoAspectRatio = rememberPlayerVideoAspectRatio(player)
+    val coverMotionState = rememberCoverMotionState(
+        enabled = coverMotionEnabled && !isVideo,
+        resetKey = item?.mediaId
+    )
+    val coverMotionAlignment = coverMotionState.toAlignment()
 
     Box(
         modifier = Modifier.fillMaxSize()
@@ -215,6 +221,7 @@ fun NowPlayingScreen(
                 clarity = coverBackgroundClarity,
                 overlayBaseColor = colorScheme.background,
                 tintBaseColor = accentColor,
+                artworkAlignment = coverMotionAlignment,
                 isDark = colorScheme.isDark
             )
         }
@@ -309,7 +316,8 @@ fun NowPlayingScreen(
                                 onOpenLyrics = onOpenLyrics,
                                 edgeBlendEnabled = false,
                                 edgeBlendColor = if (coverBackgroundEnabled) accentColor else colorScheme.background,
-                                videoBackdropColor = videoBackdropColor
+                                videoBackdropColor = videoBackdropColor,
+                                artworkAlignment = coverMotionAlignment
                             )
                         }
                         
@@ -522,7 +530,8 @@ fun NowPlayingScreen(
                                 onOpenLyrics = onOpenLyrics,
                                 edgeBlendEnabled = false,
                                 edgeBlendColor = if (coverBackgroundEnabled) accentColor else colorScheme.background,
-                                videoBackdropColor = videoBackdropColor
+                                videoBackdropColor = videoBackdropColor,
+                                artworkAlignment = coverMotionAlignment
                             )
                         }
 
@@ -769,7 +778,8 @@ fun NowPlayingScreen(
                                 onOpenLyrics = onOpenLyrics,
                                 edgeBlendEnabled = false,
                                 edgeBlendColor = if (coverBackgroundEnabled) accentColor else colorScheme.background,
-                                videoBackdropColor = videoBackdropColor
+                                videoBackdropColor = videoBackdropColor,
+                                artworkAlignment = coverMotionAlignment
                             )
                         }
                     }
@@ -1053,7 +1063,8 @@ private fun ArtworkBox(
     onOpenLyrics: () -> Unit,
     edgeBlendEnabled: Boolean,
     edgeBlendColor: Color,
-    videoBackdropColor: Color
+    videoBackdropColor: Color,
+    artworkAlignment: Alignment = Alignment.Center
 ) {
     val shape = RoundedCornerShape(28.dp)
     val hasArtwork = metadata?.artworkUri != null
@@ -1107,7 +1118,8 @@ private fun ArtworkBox(
                         CoverArtworkEdgeBlend(
                             artworkModel = artwork,
                             blendColor = edgeBlendColor,
-                            modifier = Modifier.fillMaxSize()
+                            modifier = Modifier.fillMaxSize(),
+                            artworkAlignment = artworkAlignment
                         )
                     } else {
                         DiscPlaceholder(modifier = Modifier.fillMaxSize(), cornerRadius = 28)
@@ -1117,6 +1129,7 @@ private fun ArtworkBox(
                         model = metadata?.artworkUri,
                         contentDescription = null,
                         contentScale = ContentScale.Crop,
+                        alignment = artworkAlignment,
                         placeholderCornerRadius = 28,
                         modifier = Modifier.fillMaxSize(),
                     )

--- a/app/src/main/java/com/asmr/player/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/settings/SettingsScreen.kt
@@ -73,6 +73,7 @@ fun SettingsScreen(
     val staticHueArgbDark by viewModel.staticHueArgbDark.collectAsState()
     val coverBackgroundEnabled by viewModel.coverBackgroundEnabled.collectAsState()
     val coverBackgroundClarity by viewModel.coverBackgroundClarity.collectAsState()
+    val coverMotionEnabled by viewModel.coverMotionEnabled.collectAsState()
     val updateState by viewModel.updateState.collectAsState()
     val scanRoots by libraryViewModel.scanRoots.collectAsState()
     val bulkProgress by libraryViewModel.bulkProgress.collectAsState()
@@ -337,6 +338,11 @@ fun SettingsScreen(
                     text = "播放页/歌词页封面背景",
                     checked = coverBackgroundEnabled,
                     onCheckedChange = viewModel::setCoverBackgroundEnabled
+                )
+                SettingsToggleRow(
+                    text = "封面随手机转动查看完整图片",
+                    checked = coverMotionEnabled,
+                    onCheckedChange = viewModel::setCoverMotionEnabled
                 )
                 if (coverBackgroundEnabled) {
                     key("cover_background_clarity_slider") {

--- a/app/src/main/java/com/asmr/player/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/asmr/player/ui/settings/SettingsViewModel.kt
@@ -72,6 +72,9 @@ class SettingsViewModel @Inject constructor(
     val coverBackgroundClarity: StateFlow<Float> = settingsDataStore.coverBackgroundClarity
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), 0.35f)
 
+    val coverMotionEnabled: StateFlow<Boolean> = settingsDataStore.coverMotionEnabled
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), false)
+
     private val updateClient = GitHubUpdateClient(okHttpClient)
     private val _updateState = MutableStateFlow<AppUpdateState>(AppUpdateState.Idle)
     val updateState = _updateState.asStateFlow()
@@ -103,6 +106,10 @@ class SettingsViewModel @Inject constructor(
 
     fun setCoverBackgroundClarity(clarity: Float) {
         viewModelScope.launch { settingsDataStore.setCoverBackgroundClarity(clarity) }
+    }
+
+    fun setCoverMotionEnabled(enabled: Boolean) {
+        viewModelScope.launch { settingsDataStore.setCoverMotionEnabled(enabled) }
     }
 
     fun checkUpdate() {

--- a/app/src/test/java/com/asmr/player/ui/player/CoverMotionTest.kt
+++ b/app/src/test/java/com/asmr/player/ui/player/CoverMotionTest.kt
@@ -1,0 +1,210 @@
+package com.asmr.player.ui.player
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+import kotlin.math.cos
+import kotlin.math.sin
+
+class CoverMotionTest {
+
+    @Test
+    fun zeroAnglesMapToCenteredBias() {
+        val state = coverMotionStateFromAngles(CoverMotionAngles(0f, 0f))
+
+        assertEquals(0f, state.horizontalBias, 0.0001f)
+        assertEquals(0f, state.verticalBias, 0.0001f)
+    }
+
+    @Test
+    fun yawMapsToHorizontalBias() {
+        val angles = relativeAnglesFromReference(
+            current = rotateBasisY(REFERENCE_BASIS, 12f),
+            reference = REFERENCE_BASIS
+        )
+        val state = coverMotionStateFromAngles(angles)
+
+        assertEquals(12f, angles.horizontalDegrees, 0.25f)
+        assertEquals(0f, angles.verticalDegrees, 0.25f)
+        assertEquals(1f, state.horizontalBias, 0.001f)
+    }
+
+    @Test
+    fun pitchMapsToVerticalBias() {
+        val angles = relativeAnglesFromReference(
+            current = rotateBasisX(REFERENCE_BASIS, 12f),
+            reference = REFERENCE_BASIS
+        )
+        val state = coverMotionStateFromAngles(angles)
+
+        assertEquals(0f, angles.horizontalDegrees, 0.25f)
+        assertEquals(-12f, angles.verticalDegrees, 0.25f)
+        assertEquals(-1f, state.verticalBias, 0.001f)
+    }
+
+    @Test
+    fun yawAndPitchCombineIntoDiagonalBias() {
+        val angles = relativeAnglesFromReference(
+            current = rotateBasisY(rotateBasisX(REFERENCE_BASIS, 12f), 12f),
+            reference = REFERENCE_BASIS
+        )
+        val state = coverMotionStateFromAngles(angles)
+
+        assertEquals(12f, angles.horizontalDegrees, 0.5f)
+        assertEquals(-12f, angles.verticalDegrees, 0.5f)
+        assertEquals(1f, state.horizontalBias, 0.02f)
+        assertEquals(-1f, state.verticalBias, 0.02f)
+    }
+
+    @Test
+    fun unwrapAcrossPlusMinus179StaysContinuous() {
+        assertEquals(181f, unwrapAngleDegrees(179f, -179f), 0.0001f)
+        assertEquals(-181f, unwrapAngleDegrees(-179f, 179f), 0.0001f)
+    }
+
+    @Test
+    fun valuesInsideDeadZoneStayCentered() {
+        assertEquals(0f, mapDegreesToBias(2.9f), 0.0001f)
+        assertEquals(0f, mapDegreesToBias(-2.9f), 0.0001f)
+    }
+
+    @Test
+    fun degreesPastFullTravelClampToUnitBias() {
+        assertEquals(1f, mapDegreesToBias(24f), 0.0001f)
+        assertEquals(-1f, mapDegreesToBias(-24f), 0.0001f)
+    }
+
+    @Test
+    fun gravityFallbackStillUsesTiltMapping() {
+        val portrait = screenTiltDegreesFromGravity(
+            gravityDevice = floatArrayOf(sinDeg(12f), -cosDeg(12f), 0f),
+            displayRotation = android.view.Surface.ROTATION_0
+        )!!
+        val state = coverMotionStateFromAngles(
+            CoverMotionAngles(
+                horizontalDegrees = portrait.horizontal,
+                verticalDegrees = portrait.vertical
+            )
+        )
+
+        assertEquals(12f, portrait.horizontal, 0.25f)
+        assertEquals(0f, portrait.vertical, 0.25f)
+        assertEquals(1f, state.horizontalBias, 0.001f)
+    }
+
+    @Test
+    fun gravityFallbackRemapsLandscapeTiltToSameScreenDirection() {
+        val portrait = screenTiltDegreesFromGravity(
+            gravityDevice = floatArrayOf(sinDeg(12f), -cosDeg(12f), 0f),
+            displayRotation = android.view.Surface.ROTATION_0
+        )!!
+        val landscape = screenTiltDegreesFromGravity(
+            gravityDevice = floatArrayOf(-cosDeg(12f), -sinDeg(12f), 0f),
+            displayRotation = android.view.Surface.ROTATION_90
+        )!!
+
+        assertEquals(portrait.horizontal, landscape.horizontal, 0.25f)
+        assertEquals(portrait.vertical, landscape.vertical, 0.25f)
+    }
+
+    @Test
+    fun flatReferenceTiltRightThenReturnFlatReCenters() {
+        val flatReference = ScreenOrientationBasis(
+            rightWorld = floatArrayOf(1f, 0f, 0f),
+            upWorld = floatArrayOf(0f, 1f, 0f),
+            forwardWorld = floatArrayOf(0f, 0f, 1f)
+        )
+        val tilted = rotateBasisY(flatReference, 12f)
+
+        val tiltedAngles = relativeAnglesFromReference(
+            current = tilted,
+            reference = flatReference
+        )
+        val returnedAngles = relativeAnglesFromReference(
+            current = flatReference,
+            reference = flatReference
+        )
+
+        assertEquals(12f, tiltedAngles.horizontalDegrees, 0.25f)
+        assertEquals(0f, returnedAngles.horizontalDegrees, 0.0001f)
+        assertEquals(0f, returnedAngles.verticalDegrees, 0.0001f)
+    }
+
+    @Test
+    fun invalidSensorInputsAreRejectedByPureHelpers() {
+        val invalidRotationVector = screenOrientationBasisFromRotationVector(
+            rotationVector = floatArrayOf(Float.NaN, 0f, 0f, 1f),
+            displayRotation = android.view.Surface.ROTATION_0
+        )
+        val invalidGravity = screenTiltDegreesFromGravity(
+            gravityDevice = floatArrayOf(Float.NaN, 0f, 0f),
+            displayRotation = android.view.Surface.ROTATION_0
+        )
+
+        assertNull(invalidRotationVector)
+        assertNull(invalidGravity)
+    }
+
+    private fun rotateBasisX(basis: ScreenOrientationBasis, degrees: Float): ScreenOrientationBasis {
+        return rotateBasis(
+            basis = basis,
+            matrix = floatArrayOf(
+                1f, 0f, 0f,
+                0f, cosDeg(degrees), -sinDeg(degrees),
+                0f, sinDeg(degrees), cosDeg(degrees)
+            )
+        )
+    }
+
+    private fun rotateBasisY(basis: ScreenOrientationBasis, degrees: Float): ScreenOrientationBasis {
+        return rotateBasis(
+            basis = basis,
+            matrix = floatArrayOf(
+                cosDeg(degrees), 0f, sinDeg(degrees),
+                0f, 1f, 0f,
+                -sinDeg(degrees), 0f, cosDeg(degrees)
+            )
+        )
+    }
+
+    private fun rotateBasis(basis: ScreenOrientationBasis, matrix: FloatArray): ScreenOrientationBasis {
+        return ScreenOrientationBasis(
+            rightWorld = normalize(transform(matrix, basis.rightWorld)),
+            upWorld = normalize(transform(matrix, basis.upWorld)),
+            forwardWorld = normalize(transform(matrix, basis.forwardWorld))
+        )
+    }
+
+    private fun normalize(vector: FloatArray): FloatArray {
+        val magnitude = kotlin.math.sqrt(
+            vector[0] * vector[0] +
+                vector[1] * vector[1] +
+                vector[2] * vector[2]
+        )
+        return floatArrayOf(
+            vector[0] / magnitude,
+            vector[1] / magnitude,
+            vector[2] / magnitude
+        )
+    }
+
+    private fun transform(matrix: FloatArray, vector: FloatArray): FloatArray {
+        return floatArrayOf(
+            matrix[0] * vector[0] + matrix[1] * vector[1] + matrix[2] * vector[2],
+            matrix[3] * vector[0] + matrix[4] * vector[1] + matrix[5] * vector[2],
+            matrix[6] * vector[0] + matrix[7] * vector[1] + matrix[8] * vector[2]
+        )
+    }
+
+    private fun sinDeg(degrees: Float): Float = sin(Math.toRadians(degrees.toDouble())).toFloat()
+
+    private fun cosDeg(degrees: Float): Float = cos(Math.toRadians(degrees.toDouble())).toFloat()
+
+    private companion object {
+        val REFERENCE_BASIS = ScreenOrientationBasis(
+            rightWorld = floatArrayOf(1f, 0f, 0f),
+            upWorld = floatArrayOf(0f, 1f, 0f),
+            forwardWorld = floatArrayOf(0f, 0f, 1f)
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- add a global cover motion switch for lyrics and now playing surfaces
- use rotation-vector based relative pose browsing with gravity tilt fallback
- support aligned cover panning for lyrics background, now playing background, and artwork container
- fix the flat-on-open pose issue that could leave the cover stuck at one side

## Verification
- ./gradlew :app:compileDebugKotlin
- unit test compilation remains blocked by the existing SearchScreenChromeTest errors