### PR TITLE
Add drag and motion cover preview modes

### DIFF
--- a/app/src/main/java/com/asmr/player/MainActivity.kt
+++ b/app/src/main/java/com/asmr/player/MainActivity.kt
@@ -123,6 +123,7 @@ import com.asmr.player.ui.player.QueueSheetContent
 import com.asmr.player.ui.player.SleepTimerSheetContent
 
 import com.asmr.player.data.local.datastore.SettingsDataStore
+import com.asmr.player.data.settings.CoverPreviewMode
 import com.asmr.player.util.MessageManager
 import com.asmr.player.ui.common.NonTouchableAppMessageOverlay
 import com.asmr.player.ui.common.VisibleAppMessage
@@ -190,7 +191,7 @@ class MainActivity : ComponentActivity() {
             val staticHueArgb by settingsDataStore.staticHueArgb.collectAsState(initial = null)
             val coverBackgroundEnabled by settingsDataStore.coverBackgroundEnabled.collectAsState(initial = true)
             val coverBackgroundClarity by settingsDataStore.coverBackgroundClarity.collectAsState(initial = 0.35f)
-            val coverMotionEnabled by settingsDataStore.coverMotionEnabled.collectAsState(initial = false)
+            val coverPreviewMode by settingsDataStore.coverPreviewMode.collectAsState(initial = CoverPreviewMode.Disabled)
             val neutral = remember(mode) { neutralPaletteForMode(mode) }
             val cacheManager = remember(context.applicationContext) {
                 dagger.hilt.android.EntryPointAccessors.fromApplication(
@@ -323,7 +324,7 @@ class MainActivity : ComponentActivity() {
                         globalDynamicHueEnabled = globalDynamicHueEnabled,
                         coverBackgroundEnabled = coverBackgroundEnabled,
                         coverBackgroundClarity = coverBackgroundClarity,
-                        coverMotionEnabled = coverMotionEnabled,
+                        coverPreviewMode = coverPreviewMode,
                         forceImmersive = showSplash,
                         baseStaticHue = baseStaticHue
                     )
@@ -401,7 +402,7 @@ fun MainContainer(
     globalDynamicHueEnabled: Boolean,
     coverBackgroundEnabled: Boolean,
     coverBackgroundClarity: Float,
-    coverMotionEnabled: Boolean,
+    coverPreviewMode: CoverPreviewMode,
     forceImmersive: Boolean,
     baseStaticHue: HuePalette
 ) {
@@ -542,9 +543,14 @@ fun MainContainer(
         scope.launch { drawerState.close() }
     }
 
+    val drawerGesturesEnabled = remember(currentRoute, coverPreviewMode) {
+        val dragPreviewRoute = currentRoute == "now_playing" || currentRoute == "lyrics"
+        !(dragPreviewRoute && coverPreviewMode == CoverPreviewMode.Drag)
+    }
+
     ModalNavigationDrawer(
         drawerState = drawerState,
-        gesturesEnabled = true,
+        gesturesEnabled = drawerGesturesEnabled,
         drawerContent = {
             Box(
                 modifier = Modifier
@@ -1169,7 +1175,7 @@ fun MainContainer(
                             viewModel = playerViewModel,
                             coverBackgroundEnabled = coverBackgroundEnabled,
                             coverBackgroundClarity = coverBackgroundClarity,
-                            coverMotionEnabled = coverMotionEnabled
+                            coverPreviewMode = coverPreviewMode
                         )
                     } else {
                         NowPlayingScreen(
@@ -1194,7 +1200,7 @@ fun MainContainer(
                             viewModel = playerViewModel,
                             coverBackgroundEnabled = coverBackgroundEnabled,
                             coverBackgroundClarity = coverBackgroundClarity,
-                            coverMotionEnabled = coverMotionEnabled
+                            coverPreviewMode = coverPreviewMode
                         )
                     }
                 }
@@ -1206,7 +1212,7 @@ fun MainContainer(
                             playerViewModel = playerViewModel,
                             coverBackgroundEnabled = coverBackgroundEnabled,
                             coverBackgroundClarity = coverBackgroundClarity,
-                            coverMotionEnabled = coverMotionEnabled
+                            coverPreviewMode = coverPreviewMode
                         )
                     } else {
                         LyricsPage(
@@ -1215,7 +1221,7 @@ fun MainContainer(
                             playerViewModel = playerViewModel,
                             coverBackgroundEnabled = coverBackgroundEnabled,
                             coverBackgroundClarity = coverBackgroundClarity,
-                            coverMotionEnabled = coverMotionEnabled
+                            coverPreviewMode = coverPreviewMode
                         )
                     }
                 }

--- a/app/src/main/java/com/asmr/player/data/local/datastore/SettingsDataStore.kt
+++ b/app/src/main/java/com/asmr/player/data/local/datastore/SettingsDataStore.kt
@@ -2,6 +2,7 @@ package com.asmr.player.data.local.datastore
 
 import android.content.Context
 import androidx.datastore.preferences.core.*
+import com.asmr.player.data.settings.CoverPreviewMode
 import com.asmr.player.data.settings.settingsDataStore
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.flow.Flow
@@ -21,7 +22,7 @@ class SettingsDataStore @Inject constructor(
     private val staticHueArgbDarkKey = intPreferencesKey("static_hue_argb_dark")
     private val coverBackgroundEnabledKey = booleanPreferencesKey("cover_background_enabled")
     private val coverBackgroundClarityKey = floatPreferencesKey("cover_background_clarity")
-    private val coverMotionEnabledKey = booleanPreferencesKey("cover_motion_enabled")
+    private val coverPreviewModeKey = stringPreferencesKey("cover_preview_mode")
     private val recentAlbumsPanelExpandedKey = booleanPreferencesKey("recent_albums_panel_expanded")
 
     val theme: Flow<String> = context.settingsDataStore.data.map { it[themeKey] ?: "system" }
@@ -42,7 +43,9 @@ class SettingsDataStore @Inject constructor(
     }
     val coverBackgroundEnabled: Flow<Boolean> = context.settingsDataStore.data.map { it[coverBackgroundEnabledKey] ?: true }
     val coverBackgroundClarity: Flow<Float> = context.settingsDataStore.data.map { it[coverBackgroundClarityKey] ?: 0.35f }
-    val coverMotionEnabled: Flow<Boolean> = context.settingsDataStore.data.map { it[coverMotionEnabledKey] ?: false }
+    val coverPreviewMode: Flow<CoverPreviewMode> = context.settingsDataStore.data.map {
+        CoverPreviewMode.fromStorageValue(it[coverPreviewModeKey])
+    }
     val recentAlbumsPanelExpanded: Flow<Boolean> = context.settingsDataStore.data.map { it[recentAlbumsPanelExpandedKey] ?: true }
 
     suspend fun setTheme(theme: String) {
@@ -78,8 +81,8 @@ class SettingsDataStore @Inject constructor(
         context.settingsDataStore.edit { it[coverBackgroundClarityKey] = clarity }
     }
 
-    suspend fun setCoverMotionEnabled(enabled: Boolean) {
-        context.settingsDataStore.edit { it[coverMotionEnabledKey] = enabled }
+    suspend fun setCoverPreviewMode(mode: CoverPreviewMode) {
+        context.settingsDataStore.edit { it[coverPreviewModeKey] = mode.storageValue }
     }
 
     suspend fun setRecentAlbumsPanelExpanded(expanded: Boolean) {

--- a/app/src/main/java/com/asmr/player/data/settings/CoverPreviewMode.kt
+++ b/app/src/main/java/com/asmr/player/data/settings/CoverPreviewMode.kt
@@ -1,0 +1,13 @@
+package com.asmr.player.data.settings
+
+enum class CoverPreviewMode(val storageValue: String) {
+    Disabled("disabled"),
+    Drag("drag"),
+    Motion("motion");
+
+    companion object {
+        fun fromStorageValue(value: String?): CoverPreviewMode {
+            return entries.firstOrNull { it.storageValue == value } ?: Disabled
+        }
+    }
+}

--- a/app/src/main/java/com/asmr/player/ui/player/CoverDragPreview.kt
+++ b/app/src/main/java/com/asmr/player/ui/player/CoverDragPreview.kt
@@ -1,0 +1,122 @@
+package com.asmr.player.ui.player
+
+import android.view.Surface
+import androidx.compose.foundation.gestures.awaitEachGesture
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.BiasAlignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.input.pointer.positionChanged
+import androidx.compose.ui.platform.LocalView
+import kotlin.math.abs
+
+@Stable
+internal class CoverDragPreviewState {
+    var horizontalBias by mutableFloatStateOf(0f)
+        private set
+
+    var verticalBias by mutableFloatStateOf(0f)
+        private set
+
+    fun reset() {
+        horizontalBias = 0f
+        verticalBias = 0f
+    }
+
+    fun dragBy(deltaX: Float, deltaY: Float, containerWidthPx: Float, containerHeightPx: Float) {
+        horizontalBias = dragBiasAfterDelta(
+            currentBias = horizontalBias,
+            deltaPx = deltaX,
+            containerPx = containerWidthPx
+        )
+        verticalBias = dragBiasAfterDelta(
+            currentBias = verticalBias,
+            deltaPx = deltaY,
+            containerPx = containerHeightPx
+        )
+    }
+}
+
+@Composable
+internal fun rememberCoverDragPreviewState(
+    enabled: Boolean,
+    resetKey: Any? = Unit
+): CoverDragPreviewState {
+    val state = remember { CoverDragPreviewState() }
+    val displayRotation = LocalView.current.display?.rotation ?: Surface.ROTATION_0
+
+    LaunchedEffect(enabled, resetKey, displayRotation) {
+        state.reset()
+    }
+
+    return state
+}
+
+internal fun CoverDragPreviewState.toAlignment(): Alignment {
+    return BiasAlignment(horizontalBias = horizontalBias, verticalBias = verticalBias)
+}
+
+internal fun Modifier.coverDragPreviewGesture(
+    enabled: Boolean,
+    state: CoverDragPreviewState,
+    minPointers: Int
+): Modifier {
+    return pointerInput(enabled, state, minPointers) {
+        if (!enabled) return@pointerInput
+        awaitEachGesture {
+            var dragging = false
+            while (true) {
+                val event = awaitPointerEvent()
+                val pressed = event.changes.filter { it.pressed }
+                if (pressed.isEmpty()) break
+                if (pressed.any { change -> change.isConsumed }) continue
+                if (!dragging) {
+                    if (pressed.size < minPointers) continue
+                    dragging = true
+                }
+                if (pressed.size < minPointers) break
+
+                var deltaX = 0f
+                var deltaY = 0f
+                pressed.forEach { change ->
+                    deltaX += change.position.x - change.previousPosition.x
+                    deltaY += change.position.y - change.previousPosition.y
+                }
+                deltaX /= pressed.size.toFloat()
+                deltaY /= pressed.size.toFloat()
+                if (abs(deltaX) <= 0.01f && abs(deltaY) <= 0.01f) continue
+
+                state.dragBy(
+                    deltaX = deltaX,
+                    deltaY = deltaY,
+                    containerWidthPx = size.width.toFloat(),
+                    containerHeightPx = size.height.toFloat()
+                )
+                pressed.forEach { change ->
+                    if (change.positionChanged()) {
+                        change.consume()
+                    }
+                }
+            }
+        }
+    }
+}
+
+internal fun dragBiasAfterDelta(
+    currentBias: Float,
+    deltaPx: Float,
+    containerPx: Float
+): Float {
+    if (!currentBias.isFinite() || !deltaPx.isFinite() || !containerPx.isFinite() || containerPx <= 1f) {
+        return currentBias.coerceIn(-1f, 1f)
+    }
+    val normalizedDelta = (deltaPx * 2f) / containerPx
+    return (currentBias + normalizedDelta).coerceIn(-1f, 1f)
+}

--- a/app/src/main/java/com/asmr/player/ui/player/LyricsPage.kt
+++ b/app/src/main/java/com/asmr/player/ui/player/LyricsPage.kt
@@ -57,6 +57,7 @@ import com.asmr.player.ui.common.rememberDominantColorCenterWeighted
 
 import android.content.res.Configuration
 import androidx.compose.ui.platform.LocalConfiguration
+import com.asmr.player.data.settings.CoverPreviewMode
 
 @Composable
 fun LyricsPage(
@@ -65,7 +66,7 @@ fun LyricsPage(
     playerViewModel: PlayerViewModel,
     coverBackgroundEnabled: Boolean,
     coverBackgroundClarity: Float,
-    coverMotionEnabled: Boolean,
+    coverPreviewMode: CoverPreviewMode,
     viewModel: LyricsViewModel = hiltViewModel()
 ) {
     val uiState by viewModel.uiState.collectAsState()
@@ -84,19 +85,38 @@ fun LyricsPage(
     )
     val configuration = LocalConfiguration.current
     val isLandscape = configuration.orientation == Configuration.ORIENTATION_LANDSCAPE
+    val useDragPreview = coverBackgroundEnabled && coverPreviewMode == CoverPreviewMode.Drag
+    val useMotionPreview = coverBackgroundEnabled && coverPreviewMode == CoverPreviewMode.Motion
     val coverMotionState = rememberCoverMotionState(
-        enabled = coverBackgroundEnabled && coverMotionEnabled,
+        enabled = useMotionPreview,
         resetKey = playback.currentMediaItem?.mediaId
     )
+    val coverDragPreviewState = rememberCoverDragPreviewState(
+        enabled = useDragPreview,
+        resetKey = playback.currentMediaItem?.mediaId
+    )
+    val artworkAlignment = when {
+        useDragPreview -> coverDragPreviewState.toAlignment()
+        useMotionPreview -> coverMotionState.toAlignment()
+        else -> Alignment.Center
+    }
 
-    Box(modifier = Modifier.fillMaxSize()) {
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .coverDragPreviewGesture(
+                enabled = useDragPreview,
+                state = coverDragPreviewState,
+                minPointers = 2
+            )
+    ) {
         CoverArtworkBackground(
             artworkModel = artwork,
             enabled = coverBackgroundEnabled,
             clarity = coverBackgroundClarity,
             overlayBaseColor = colorScheme.background,
             tintBaseColor = dominantColor,
-            artworkAlignment = coverMotionState.toAlignment(),
+            artworkAlignment = artworkAlignment,
             isDark = colorScheme.isDark
         )
 

--- a/app/src/main/java/com/asmr/player/ui/player/NowPlayingScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/player/NowPlayingScreen.kt
@@ -71,6 +71,7 @@ import androidx.media3.common.Player
 import androidx.media3.common.VideoSize
 import androidx.media3.ui.PlayerView
 import com.asmr.player.R
+import com.asmr.player.data.settings.CoverPreviewMode
 import com.asmr.player.ui.common.AsmrAsyncImage
 import com.asmr.player.playback.PlaybackSnapshot
 import com.asmr.player.ui.common.EqualizerPanel
@@ -103,7 +104,7 @@ fun NowPlayingScreen(
     viewModel: PlayerViewModel,
     coverBackgroundEnabled: Boolean,
     coverBackgroundClarity: Float,
-    coverMotionEnabled: Boolean,
+    coverPreviewMode: CoverPreviewMode,
     lyricsViewModel: LyricsViewModel = hiltViewModel()
 ) {
     val playback by viewModel.playback.collectAsState()
@@ -198,11 +199,21 @@ fun NowPlayingScreen(
     val useSplitLayout = heightClass != WindowHeightSizeClass.Compact && isLandscape
     val player = viewModel.playerOrNull()
     val videoAspectRatio = rememberPlayerVideoAspectRatio(player)
+    val useDragPreview = coverPreviewMode == CoverPreviewMode.Drag && !isVideo
+    val useMotionPreview = coverPreviewMode == CoverPreviewMode.Motion && !isVideo
     val coverMotionState = rememberCoverMotionState(
-        enabled = coverMotionEnabled && !isVideo,
+        enabled = useMotionPreview,
         resetKey = item?.mediaId
     )
-    val coverMotionAlignment = coverMotionState.toAlignment()
+    val coverDragPreviewState = rememberCoverDragPreviewState(
+        enabled = useDragPreview,
+        resetKey = item?.mediaId
+    )
+    val coverPreviewAlignment = when {
+        useDragPreview -> coverDragPreviewState.toAlignment()
+        useMotionPreview -> coverMotionState.toAlignment()
+        else -> Alignment.Center
+    }
 
     Box(
         modifier = Modifier.fillMaxSize()
@@ -221,7 +232,7 @@ fun NowPlayingScreen(
                 clarity = coverBackgroundClarity,
                 overlayBaseColor = colorScheme.background,
                 tintBaseColor = accentColor,
-                artworkAlignment = coverMotionAlignment,
+                artworkAlignment = coverPreviewAlignment,
                 isDark = colorScheme.isDark
             )
         }
@@ -308,7 +319,11 @@ fun NowPlayingScreen(
                         horizontalAlignment = Alignment.CenterHorizontally,
                         verticalArrangement = Arrangement.spacedBy(16.dp)
                     ) {
-                        Box(modifier = Modifier.widthIn(max = 420.dp).aspectRatio(if (isVideo) videoAspectRatio else 1f)) {
+                        Box(
+                            modifier = Modifier
+                                .widthIn(max = 420.dp)
+                                .aspectRatio(if (isVideo) videoAspectRatio else 1f)
+                        ) {
                             ArtworkBox(
                                 isVideo = isVideo,
                                 metadata = metadata,
@@ -317,7 +332,9 @@ fun NowPlayingScreen(
                                 edgeBlendEnabled = false,
                                 edgeBlendColor = if (coverBackgroundEnabled) accentColor else colorScheme.background,
                                 videoBackdropColor = videoBackdropColor,
-                                artworkAlignment = coverMotionAlignment
+                                artworkAlignment = coverPreviewAlignment,
+                                dragPreviewEnabled = useDragPreview,
+                                dragPreviewState = coverDragPreviewState
                             )
                         }
                         
@@ -531,7 +548,9 @@ fun NowPlayingScreen(
                                 edgeBlendEnabled = false,
                                 edgeBlendColor = if (coverBackgroundEnabled) accentColor else colorScheme.background,
                                 videoBackdropColor = videoBackdropColor,
-                                artworkAlignment = coverMotionAlignment
+                                artworkAlignment = coverPreviewAlignment,
+                                dragPreviewEnabled = useDragPreview,
+                                dragPreviewState = coverDragPreviewState
                             )
                         }
 
@@ -779,7 +798,9 @@ fun NowPlayingScreen(
                                 edgeBlendEnabled = false,
                                 edgeBlendColor = if (coverBackgroundEnabled) accentColor else colorScheme.background,
                                 videoBackdropColor = videoBackdropColor,
-                                artworkAlignment = coverMotionAlignment
+                                artworkAlignment = coverPreviewAlignment,
+                                dragPreviewEnabled = useDragPreview,
+                                dragPreviewState = coverDragPreviewState
                             )
                         }
                     }
@@ -1064,13 +1085,21 @@ private fun ArtworkBox(
     edgeBlendEnabled: Boolean,
     edgeBlendColor: Color,
     videoBackdropColor: Color,
-    artworkAlignment: Alignment = Alignment.Center
+    artworkAlignment: Alignment = Alignment.Center,
+    dragPreviewEnabled: Boolean = false,
+    dragPreviewState: CoverDragPreviewState? = null,
+    modifier: Modifier = Modifier
 ) {
     val shape = RoundedCornerShape(28.dp)
     val hasArtwork = metadata?.artworkUri != null
     Box(
-        modifier = Modifier
+        modifier = modifier
             .fillMaxSize()
+            .coverDragPreviewGesture(
+                enabled = dragPreviewEnabled && dragPreviewState != null,
+                state = dragPreviewState ?: CoverDragPreviewState(),
+                minPointers = 2
+            )
             .clip(shape)
             .background(if (isVideo) videoBackdropColor else Color.Transparent)
             .then(if (hasArtwork && !edgeBlendEnabled) Modifier.shadow(12.dp, shape) else Modifier)

--- a/app/src/main/java/com/asmr/player/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/settings/SettingsScreen.kt
@@ -27,6 +27,7 @@ import androidx.compose.material.icons.filled.FolderOpen
 import androidx.compose.material.icons.filled.FormatAlignCenter
 import androidx.compose.material.icons.filled.FormatAlignLeft
 import androidx.compose.material.icons.filled.FormatAlignRight
+import androidx.compose.material.icons.filled.Info
 import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material.icons.filled.Sync
 import androidx.compose.material3.*
@@ -40,14 +41,19 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.window.Popup
+import androidx.compose.ui.window.PopupProperties
 import androidx.core.content.ContextCompat
 import androidx.core.content.FileProvider
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.asmr.player.BuildConfig
+import com.asmr.player.data.settings.CoverPreviewMode
 import com.asmr.player.data.settings.FloatingLyricsSettings
 import com.asmr.player.ui.library.BulkPhase
 import com.asmr.player.ui.library.LibraryViewModel
@@ -73,15 +79,24 @@ fun SettingsScreen(
     val staticHueArgbDark by viewModel.staticHueArgbDark.collectAsState()
     val coverBackgroundEnabled by viewModel.coverBackgroundEnabled.collectAsState()
     val coverBackgroundClarity by viewModel.coverBackgroundClarity.collectAsState()
-    val coverMotionEnabled by viewModel.coverMotionEnabled.collectAsState()
+    val coverPreviewMode by viewModel.coverPreviewMode.collectAsState()
     val updateState by viewModel.updateState.collectAsState()
     val scanRoots by libraryViewModel.scanRoots.collectAsState()
     val bulkProgress by libraryViewModel.bulkProgress.collectAsState()
     val isGlobalSyncRunning by libraryViewModel.isGlobalSyncRunning.collectAsState()
     val context = LocalContext.current
     val colorScheme = AsmrTheme.colorScheme
+    val segmentedButtonColors = SegmentedButtonDefaults.colors(
+        activeContainerColor = colorScheme.primarySoft,
+        activeContentColor = if (colorScheme.isDark) colorScheme.onPrimaryContainer else colorScheme.primaryStrong,
+        activeBorderColor = colorScheme.primaryStrong,
+        inactiveContainerColor = Color.Transparent,
+        inactiveContentColor = colorScheme.onSurfaceVariant,
+        inactiveBorderColor = MaterialTheme.colorScheme.outline.copy(alpha = 0.4f)
+    )
     
     var overlayGranted by remember { mutableStateOf(Settings.canDrawOverlays(context)) }
+    var activeTipKey by remember { mutableStateOf<String?>(null) }
     val overlayLauncher = rememberLauncherForActivityResult(ActivityResultContracts.StartActivityForResult()) {
         overlayGranted = Settings.canDrawOverlays(context)
     }
@@ -339,11 +354,52 @@ fun SettingsScreen(
                     checked = coverBackgroundEnabled,
                     onCheckedChange = viewModel::setCoverBackgroundEnabled
                 )
+                /*
                 SettingsToggleRow(
                     text = "封面随手机转动查看完整图片",
                     checked = coverMotionEnabled,
                     onCheckedChange = viewModel::setCoverMotionEnabled
                 )
+                */
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Text("背景封面预览方式", style = MaterialTheme.typography.bodyMedium)
+                    PreviewModeInfoTip(
+                        active = activeTipKey == "cover_preview_mode",
+                        onToggle = {
+                            activeTipKey = if (activeTipKey == "cover_preview_mode") null else "cover_preview_mode"
+                        }
+                    )
+                    Spacer(modifier = Modifier.weight(1f))
+                    SingleChoiceSegmentedButtonRow {
+                        SegmentedButton(
+                            selected = coverPreviewMode == CoverPreviewMode.Disabled,
+                            onClick = { viewModel.setCoverPreviewMode(CoverPreviewMode.Disabled) },
+                            shape = SegmentedButtonDefaults.itemShape(index = 0, count = 3),
+                            colors = segmentedButtonColors,
+                            icon = {},
+                            label = { Text("关闭") }
+                        )
+                        SegmentedButton(
+                            selected = coverPreviewMode == CoverPreviewMode.Drag,
+                            onClick = { viewModel.setCoverPreviewMode(CoverPreviewMode.Drag) },
+                            shape = SegmentedButtonDefaults.itemShape(index = 1, count = 3),
+                            colors = segmentedButtonColors,
+                            icon = {},
+                            label = { Text("滑动") }
+                        )
+                        SegmentedButton(
+                            selected = coverPreviewMode == CoverPreviewMode.Motion,
+                            onClick = { viewModel.setCoverPreviewMode(CoverPreviewMode.Motion) },
+                            shape = SegmentedButtonDefaults.itemShape(index = 2, count = 3),
+                            colors = segmentedButtonColors,
+                            icon = {},
+                            label = { Text("转动") }
+                        )
+                    }
+                }
                 if (coverBackgroundEnabled) {
                     key("cover_background_clarity_slider") {
                         DeferredCommitSettingsSliderRow(
@@ -422,6 +478,7 @@ fun SettingsScreen(
                                 selected = floatingSettings.align == 0,
                                 onClick = { viewModel.updateFloatingLyricsSettings(floatingSettings.copy(align = 0)) },
                                 shape = SegmentedButtonDefaults.itemShape(index = 0, count = 3),
+                                colors = segmentedButtonColors,
                                 icon = {},
                                 label = { Icon(Icons.AutoMirrored.Filled.FormatAlignLeft, null) }
                             )
@@ -429,6 +486,7 @@ fun SettingsScreen(
                                 selected = floatingSettings.align == 1,
                                 onClick = { viewModel.updateFloatingLyricsSettings(floatingSettings.copy(align = 1)) },
                                 shape = SegmentedButtonDefaults.itemShape(index = 1, count = 3),
+                                colors = segmentedButtonColors,
                                 icon = {},
                                 label = { Icon(Icons.Default.FormatAlignCenter, null) }
                             )
@@ -436,6 +494,7 @@ fun SettingsScreen(
                                 selected = floatingSettings.align == 2,
                                 onClick = { viewModel.updateFloatingLyricsSettings(floatingSettings.copy(align = 2)) },
                                 shape = SegmentedButtonDefaults.itemShape(index = 2, count = 3),
+                                colors = segmentedButtonColors,
                                 icon = {},
                                 label = { Icon(Icons.AutoMirrored.Filled.FormatAlignRight, null) }
                             )
@@ -790,4 +849,75 @@ private fun ThemeColorDot(color: Color?, selected: Boolean, onClick: () -> Unit)
             .border(borderWidth, borderColor, CircleShape)
             .clickable(onClick = onClick)
     )
+}
+
+@Composable
+private fun PreviewModeInfoTip(active: Boolean, onToggle: () -> Unit) {
+    val density = LocalDensity.current
+    val offset = with(density) { IntOffset(0, 26.dp.roundToPx()) }
+
+    Surface(
+        shape = CircleShape,
+        color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.7f)
+    ) {
+        Box {
+            IconButton(
+                onClick = onToggle,
+                modifier = Modifier.size(22.dp)
+            ) {
+                Icon(
+                    imageVector = Icons.Default.Info,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.size(14.dp)
+                )
+            }
+            if (active) {
+                Popup(
+                    alignment = Alignment.TopStart,
+                    offset = offset,
+                    onDismissRequest = onToggle,
+                    properties = PopupProperties(
+                        focusable = true,
+                        dismissOnBackPress = true,
+                        dismissOnClickOutside = true
+                    )
+                ) {
+                    Surface(
+                        shape = RoundedCornerShape(10.dp),
+                        tonalElevation = 6.dp,
+                        shadowElevation = 10.dp,
+                        color = MaterialTheme.colorScheme.surface.copy(alpha = 0.96f),
+                        border = androidx.compose.foundation.BorderStroke(
+                            width = 1.dp,
+                            color = MaterialTheme.colorScheme.outline.copy(alpha = 0.2f)
+                        )
+                    ) {
+                        Column(
+                            modifier = Modifier.widthIn(max = 260.dp).padding(12.dp),
+                            verticalArrangement = Arrangement.spacedBy(6.dp)
+                        ) {
+                            Text(
+                                text = "背景封面预览方式",
+                                style = MaterialTheme.typography.titleSmall,
+                                fontWeight = FontWeight.SemiBold
+                            )
+                            Text(
+                                text = "关闭：背景与封面保持居中静止",
+                                style = MaterialTheme.typography.bodySmall
+                            )
+                            Text(
+                                text = "滑动：播放页封面与歌词页背景都使用双指拖动预览，且会临时屏蔽左侧菜单侧滑",
+                                style = MaterialTheme.typography.bodySmall
+                            )
+                            Text(
+                                text = "转动：通过转动手机预览封面其他区域",
+                                style = MaterialTheme.typography.bodySmall
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
 }

--- a/app/src/main/java/com/asmr/player/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/asmr/player/ui/settings/SettingsViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.viewModelScope
 import com.asmr.player.BuildConfig
 import com.asmr.player.data.local.datastore.SettingsDataStore
 import com.asmr.player.data.remote.update.GitHubUpdateClient
+import com.asmr.player.data.settings.CoverPreviewMode
 import com.asmr.player.data.remote.update.UpdateRelease
 import com.asmr.player.data.settings.FloatingLyricsSettings
 import com.asmr.player.data.settings.SettingsRepository
@@ -72,8 +73,8 @@ class SettingsViewModel @Inject constructor(
     val coverBackgroundClarity: StateFlow<Float> = settingsDataStore.coverBackgroundClarity
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), 0.35f)
 
-    val coverMotionEnabled: StateFlow<Boolean> = settingsDataStore.coverMotionEnabled
-        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), false)
+    val coverPreviewMode: StateFlow<CoverPreviewMode> = settingsDataStore.coverPreviewMode
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), CoverPreviewMode.Disabled)
 
     private val updateClient = GitHubUpdateClient(okHttpClient)
     private val _updateState = MutableStateFlow<AppUpdateState>(AppUpdateState.Idle)
@@ -108,8 +109,8 @@ class SettingsViewModel @Inject constructor(
         viewModelScope.launch { settingsDataStore.setCoverBackgroundClarity(clarity) }
     }
 
-    fun setCoverMotionEnabled(enabled: Boolean) {
-        viewModelScope.launch { settingsDataStore.setCoverMotionEnabled(enabled) }
+    fun setCoverPreviewMode(mode: CoverPreviewMode) {
+        viewModelScope.launch { settingsDataStore.setCoverPreviewMode(mode) }
     }
 
     fun checkUpdate() {

--- a/app/src/test/java/com/asmr/player/ui/player/CoverDragPreviewTest.kt
+++ b/app/src/test/java/com/asmr/player/ui/player/CoverDragPreviewTest.kt
@@ -1,0 +1,76 @@
+package com.asmr.player.ui.player
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class CoverDragPreviewTest {
+
+    @Test
+    fun dragStartsCentered() {
+        val state = CoverDragPreviewState()
+
+        assertEquals(0f, state.horizontalBias, 0.0001f)
+        assertEquals(0f, state.verticalBias, 0.0001f)
+    }
+
+    @Test
+    fun horizontalDragMapsToHorizontalBias() {
+        val state = CoverDragPreviewState()
+
+        state.dragBy(
+            deltaX = 50f,
+            deltaY = 0f,
+            containerWidthPx = 200f,
+            containerHeightPx = 400f
+        )
+
+        assertEquals(0.5f, state.horizontalBias, 0.0001f)
+        assertEquals(0f, state.verticalBias, 0.0001f)
+    }
+
+    @Test
+    fun verticalDragMapsToVerticalBias() {
+        val state = CoverDragPreviewState()
+
+        state.dragBy(
+            deltaX = 0f,
+            deltaY = 100f,
+            containerWidthPx = 400f,
+            containerHeightPx = 400f
+        )
+
+        assertEquals(0f, state.horizontalBias, 0.0001f)
+        assertEquals(0.5f, state.verticalBias, 0.0001f)
+    }
+
+    @Test
+    fun dragClampStopsAtBounds() {
+        val state = CoverDragPreviewState()
+
+        state.dragBy(
+            deltaX = 400f,
+            deltaY = -400f,
+            containerWidthPx = 200f,
+            containerHeightPx = 200f
+        )
+
+        assertEquals(1f, state.horizontalBias, 0.0001f)
+        assertEquals(-1f, state.verticalBias, 0.0001f)
+    }
+
+    @Test
+    fun resetReturnsToCenter() {
+        val state = CoverDragPreviewState()
+
+        state.dragBy(
+            deltaX = 60f,
+            deltaY = 40f,
+            containerWidthPx = 240f,
+            containerHeightPx = 160f
+        )
+        state.reset()
+
+        assertEquals(0f, state.horizontalBias, 0.0001f)
+        assertEquals(0f, state.verticalBias, 0.0001f)
+    }
+}


### PR DESCRIPTION
## Summary
- replace the old cover motion toggle with a three-mode cover preview setting: 关闭 / 滑动 / 转动
- add double-finger drag preview for now playing artwork/background and lyrics background
- keep motion preview support, block drawer edge gestures on now playing and lyrics when drag mode is active, and theme the related segmented controls

## Testing
- ./gradlew :app:compileDebugKotlin