### PR TITLE
feat: add lyrics settings group and lyrics page styling

### DIFF
--- a/app/src/main/java/com/asmr/player/MainActivity.kt
+++ b/app/src/main/java/com/asmr/player/MainActivity.kt
@@ -124,6 +124,7 @@ import com.asmr.player.ui.player.SleepTimerSheetContent
 
 import com.asmr.player.data.local.datastore.SettingsDataStore
 import com.asmr.player.data.settings.CoverPreviewMode
+import com.asmr.player.data.settings.LyricsPageSettings
 import com.asmr.player.util.MessageManager
 import com.asmr.player.ui.common.NonTouchableAppMessageOverlay
 import com.asmr.player.ui.common.VisibleAppMessage
@@ -192,6 +193,7 @@ class MainActivity : ComponentActivity() {
             val coverBackgroundEnabled by settingsDataStore.coverBackgroundEnabled.collectAsState(initial = true)
             val coverBackgroundClarity by settingsDataStore.coverBackgroundClarity.collectAsState(initial = 0.35f)
             val coverPreviewMode by settingsDataStore.coverPreviewMode.collectAsState(initial = CoverPreviewMode.Disabled)
+            val lyricsPageSettings by settingsDataStore.lyricsPageSettings.collectAsState(initial = LyricsPageSettings())
             val neutral = remember(mode) { neutralPaletteForMode(mode) }
             val cacheManager = remember(context.applicationContext) {
                 dagger.hilt.android.EntryPointAccessors.fromApplication(
@@ -325,6 +327,7 @@ class MainActivity : ComponentActivity() {
                         coverBackgroundEnabled = coverBackgroundEnabled,
                         coverBackgroundClarity = coverBackgroundClarity,
                         coverPreviewMode = coverPreviewMode,
+                        lyricsPageSettings = lyricsPageSettings,
                         forceImmersive = showSplash,
                         baseStaticHue = baseStaticHue
                     )
@@ -403,6 +406,7 @@ fun MainContainer(
     coverBackgroundEnabled: Boolean,
     coverBackgroundClarity: Float,
     coverPreviewMode: CoverPreviewMode,
+    lyricsPageSettings: LyricsPageSettings,
     forceImmersive: Boolean,
     baseStaticHue: HuePalette
 ) {
@@ -1212,7 +1216,8 @@ fun MainContainer(
                             playerViewModel = playerViewModel,
                             coverBackgroundEnabled = coverBackgroundEnabled,
                             coverBackgroundClarity = coverBackgroundClarity,
-                            coverPreviewMode = coverPreviewMode
+                            coverPreviewMode = coverPreviewMode,
+                            lyricsPageSettings = lyricsPageSettings
                         )
                     } else {
                         LyricsPage(
@@ -1221,7 +1226,8 @@ fun MainContainer(
                             playerViewModel = playerViewModel,
                             coverBackgroundEnabled = coverBackgroundEnabled,
                             coverBackgroundClarity = coverBackgroundClarity,
-                            coverPreviewMode = coverPreviewMode
+                            coverPreviewMode = coverPreviewMode,
+                            lyricsPageSettings = lyricsPageSettings
                         )
                     }
                 }

--- a/app/src/main/java/com/asmr/player/data/local/datastore/SettingsDataStore.kt
+++ b/app/src/main/java/com/asmr/player/data/local/datastore/SettingsDataStore.kt
@@ -3,6 +3,7 @@ package com.asmr.player.data.local.datastore
 import android.content.Context
 import androidx.datastore.preferences.core.*
 import com.asmr.player.data.settings.CoverPreviewMode
+import com.asmr.player.data.settings.LyricsPageSettings
 import com.asmr.player.data.settings.settingsDataStore
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.flow.Flow
@@ -23,6 +24,11 @@ class SettingsDataStore @Inject constructor(
     private val coverBackgroundEnabledKey = booleanPreferencesKey("cover_background_enabled")
     private val coverBackgroundClarityKey = floatPreferencesKey("cover_background_clarity")
     private val coverPreviewModeKey = stringPreferencesKey("cover_preview_mode")
+    private val lyricsPageFontSizeKey = floatPreferencesKey("lyrics_page_font_size")
+    private val lyricsPageStrokeWidthKey = floatPreferencesKey("lyrics_page_stroke_width")
+    private val lyricsPageLineHeightMultiplierKey = floatPreferencesKey("lyrics_page_line_height_multiplier")
+    private val lyricsPageAlignKey = intPreferencesKey("lyrics_page_align")
+    private val lyricsPageDisplayAreaModeKey = intPreferencesKey("lyrics_page_display_area_mode")
     private val recentAlbumsPanelExpandedKey = booleanPreferencesKey("recent_albums_panel_expanded")
 
     val theme: Flow<String> = context.settingsDataStore.data.map { it[themeKey] ?: "system" }
@@ -45,6 +51,15 @@ class SettingsDataStore @Inject constructor(
     val coverBackgroundClarity: Flow<Float> = context.settingsDataStore.data.map { it[coverBackgroundClarityKey] ?: 0.35f }
     val coverPreviewMode: Flow<CoverPreviewMode> = context.settingsDataStore.data.map {
         CoverPreviewMode.fromStorageValue(it[coverPreviewModeKey])
+    }
+    val lyricsPageSettings: Flow<LyricsPageSettings> = context.settingsDataStore.data.map { prefs ->
+        LyricsPageSettings(
+            fontSizeSp = prefs[lyricsPageFontSizeKey] ?: 21f,
+            strokeWidthSp = prefs[lyricsPageStrokeWidthKey] ?: 0.1f,
+            lineHeightMultiplier = prefs[lyricsPageLineHeightMultiplierKey] ?: 1.5f,
+            align = prefs[lyricsPageAlignKey] ?: 0,
+            displayAreaMode = prefs[lyricsPageDisplayAreaModeKey] ?: 0
+        )
     }
     val recentAlbumsPanelExpanded: Flow<Boolean> = context.settingsDataStore.data.map { it[recentAlbumsPanelExpandedKey] ?: true }
 
@@ -83,6 +98,16 @@ class SettingsDataStore @Inject constructor(
 
     suspend fun setCoverPreviewMode(mode: CoverPreviewMode) {
         context.settingsDataStore.edit { it[coverPreviewModeKey] = mode.storageValue }
+    }
+
+    suspend fun setLyricsPageSettings(settings: LyricsPageSettings) {
+        context.settingsDataStore.edit {
+            it[lyricsPageFontSizeKey] = settings.fontSizeSp
+            it[lyricsPageStrokeWidthKey] = settings.strokeWidthSp
+            it[lyricsPageLineHeightMultiplierKey] = settings.lineHeightMultiplier
+            it[lyricsPageAlignKey] = settings.align
+            it[lyricsPageDisplayAreaModeKey] = settings.displayAreaMode
+        }
     }
 
     suspend fun setRecentAlbumsPanelExpanded(expanded: Boolean) {

--- a/app/src/main/java/com/asmr/player/data/settings/LyricsPageSettings.kt
+++ b/app/src/main/java/com/asmr/player/data/settings/LyricsPageSettings.kt
@@ -1,0 +1,9 @@
+package com.asmr.player.data.settings
+
+data class LyricsPageSettings(
+    val fontSizeSp: Float = 21f,
+    val strokeWidthSp: Float = 0.1f,
+    val lineHeightMultiplier: Float = 1.5f,
+    val align: Int = 0, // 0: Left, 1: Center, 2: Right
+    val displayAreaMode: Int = 0 // 0: Full, 1: Top Quarter, 2: Middle Quarter, 3: Bottom Quarter
+)

--- a/app/src/main/java/com/asmr/player/ui/player/AppleLyricsView.kt
+++ b/app/src/main/java/com/asmr/player/ui/player/AppleLyricsView.kt
@@ -1,31 +1,64 @@
 package com.asmr.player.ui.player
 
+import android.os.SystemClock
 import androidx.compose.animation.animateColorAsState
-import androidx.compose.animation.core.*
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.AnimationVector1D
+import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
-import androidx.compose.runtime.*
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableLongStateOf
+import androidx.compose.runtime.mutableStateMapOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.graphicsLayer
-import androidx.compose.ui.platform.LocalConfiguration
-import androidx.compose.ui.graphics.Shadow
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Shadow
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.graphics.luminance
+import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
+import androidx.compose.ui.input.nestedscroll.NestedScrollSource
+import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.rememberTextMeasurer
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.Constraints
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.asmr.player.data.settings.LyricsPageSettings
 import com.asmr.player.ui.theme.AsmrTheme
 import com.asmr.player.util.SubtitleEntry
 import com.asmr.player.util.SubtitleIndexFinder
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlin.math.absoluteValue
+import kotlin.math.roundToInt
 
 @Composable
 internal fun AppleLyricsView(
@@ -36,333 +69,441 @@ internal fun AppleLyricsView(
     colors: LyricReadableColors,
     modifier: Modifier = Modifier,
     isLandscape: Boolean = false,
-    contentPadding: PaddingValues = PaddingValues(0.dp)
+    settings: LyricsPageSettings = LyricsPageSettings()
 ) {
     val indexFinder = remember(lyrics) { SubtitleIndexFinder(lyrics) }
     val activeIndex = remember(currentPosition, indexFinder) {
         indexFinder.findActiveIndex(currentPosition)
     }
-
     val listState = rememberLazyListState()
-
-    // Store per-item translation offsets
-    // Key: Item Index, Value: Animatable OffsetY
+    val density = LocalDensity.current
+    val itemOuterVerticalPadding = 0.dp
+    val itemInnerVerticalPadding = if (isLandscape) 2.dp else 3.dp
+    val itemOuterHorizontalPadding = if (isLandscape) 10.dp else 14.dp
+    val itemInnerHorizontalPadding = if (isLandscape) 8.dp else 10.dp
+    val fontSize = settings.fontSizeSp.sp
+    val wrappedLineHeight = (settings.fontSizeSp * 1.2f).sp
+    val fontSizePx = with(density) { fontSize.toPx() }
+    val itemSpacingPx = fontSizePx * 0.2f * settings.lineHeightMultiplier.coerceAtLeast(0.1f)
+    val nominalItemHeightPx = with(density) {
+        wrappedLineHeight.toPx() + itemInnerVerticalPadding.toPx() * 2f + itemOuterVerticalPadding.toPx() * 2f + itemSpacingPx
+    }
+    val strokeWidthPx = with(density) { settings.strokeWidthSp.sp.toPx() }
+    val textAlign = remember(settings.align) { lyricTextAlign(settings.align) }
+    val baseLyricTextStyle = MaterialTheme.typography.titleLarge
     val itemOffsets = remember { mutableStateMapOf<Int, Animatable<Float, AnimationVector1D>>() }
-
-    // Configuration for the "Focus Area" (slightly below center)
-    val focusRatio = 0.4f // 40% from top (so 60% space below? No, usually slightly below center means top is ~40-45%)
-    // Apple Music is actually often around 30-40% from top. User said "near middle but slightly below".
-    // Let's interpret "slightly below center" as the *highlight* is at ~55%?
-    // User: "located in visual focus area (near middle but slightly below)".
-    // Let's try 0.45f (45% from top).
-
-    // Track the previous active index to detect changes
-    // Use rememberSaveable to persist state across configuration changes (orientation)
-    var previousIndex by remember { mutableIntStateOf(activeIndex) }
-    
-    // Use a key that changes on orientation or activeIndex to force update if needed
-    // Actually, if we rotate, AppleLyricsView is recomposed.
-    // If activeIndex is correct, listState.scrollToItem should be called.
-    // But current logic only scrolls if (activeIndex != previousIndex).
-    // On rotation, previousIndex is re-initialized to activeIndex (because of remember { mutableIntStateOf(activeIndex) }).
-    // So activeIndex == previousIndex.
-    // So the LaunchedEffect(activeIndex) block is SKIPPED (except for initial check, but activeIndex == previousIndex).
-    
-    // We need to force scroll to activeIndex on first composition (or orientation change).
-    // We use a key that includes configuration to trigger on rotation.
-    val configuration = LocalConfiguration.current
-    LaunchedEffect(Unit, configuration) {
-         if (activeIndex >= 0 && lyrics.isNotEmpty()) {
-              // Wait a frame for layout to be ready so we can get viewport height
-              // But we can't easily wait for layout in LaunchedEffect(Unit).
-              // We can just try to scroll.
-              // A negative offset puts it towards the top/center.
-              // To be precise, we need viewportHeight.
-              
-              // We can use a simple approximate offset for now, or just rely on the fact 
-              // that on rotation, we want to re-snap.
-              
-              // Let's force a "refresh" of the position logic by resetting previousIndex?
-              // No, that would trigger animation. We want snap.
-              
-              // Correct fix:
-              // Just call scrollToItem with a reasonable offset.
-              // Since we don't know the exact pixel height yet, maybe just index is enough?
-              // But we want it centered (or at focusRatio).
-              // If we just scroll to index, it goes to top.
-              // We need offset.
-              
-              // Retry scrolling after a short delay to allow layout?
-              // Or better: Observe layout changes?
-              
-              // Simple fix: Just update previousIndex to -1 so the main effect runs?
-              // If we set previousIndex = -1, the main effect sees activeIndex != previousIndex.
-              // It will trigger the "Large Jump" or "Small Jump" logic.
-              // If it triggers "Small Jump" (Wave), it might look weird on rotation.
-              // If abs > 2, it snaps.
-              // So if we force previousIndex = -1, it will likely be > 2 diff?
-              // No, activeIndex might be 0 or 1.
-              
-              // Let's just manually scroll here.
-              listState.scrollToItem(activeIndex, -200) // -200px is roughly a good offset
-              
-              // Ensure highlight state is correct by resetting previousIndex
-              // This forces the next update to be seen as a change if needed, 
-              // or just ensures we are in sync.
-              // Actually, if we rotate, previousIndex is initialized to activeIndex.
-              // So no wave animation triggers. This is correct.
-              // But we want to ensure scroll position is correct.
-         }
-    }
-
-    // Clear offsets when lyrics change to avoid memory leaks or incorrect offsets
-    LaunchedEffect(lyrics) {
-        itemOffsets.clear()
-    }
-
-    LaunchedEffect(activeIndex) {
-        if (activeIndex != previousIndex && activeIndex >= 0 && lyrics.isNotEmpty()) {
-            // 1. Calculate the Snap
-            // We want to center the NEW activeIndex at `viewportHeight * focusRatio`
-            val layoutInfo = listState.layoutInfo
-            val viewportHeight = layoutInfo.viewportSize.height
-            
-            // We can't know the exact size of the new item if it's not visible.
-            // But if we are scrolling sequentially, it's likely just below or nearby.
-            // If it's a large jump (seek), we just snap without wave.
-            
-            if ((activeIndex - previousIndex).absoluteValue > 2) {
-                // Large jump: just scroll smoothly or snap
-                listState.scrollToItem(activeIndex, -(viewportHeight * focusRatio).toInt())
-                previousIndex = activeIndex
-                return@LaunchedEffect
+    val textMeasurer = rememberTextMeasurer()
+    var previousActiveIndex by remember { mutableIntStateOf(activeIndex) }
+    var autoFocusSuspended by remember { mutableStateOf(false) }
+    var lastUserScrollAt by remember { mutableLongStateOf(0L) }
+    var pendingAnimatedRefocus by remember { mutableStateOf(false) }
+    val nestedScrollConnection = remember {
+        object : NestedScrollConnection {
+            override fun onPreScroll(available: Offset, source: NestedScrollSource): Offset {
+                if (available.y != 0f) {
+                    autoFocusSuspended = true
+                    lastUserScrollAt = SystemClock.uptimeMillis()
+                    pendingAnimatedRefocus = false
+                }
+                return Offset.Zero
             }
-
-            // Small jump: Perform Wave
-            // Check if we actually NEED to scroll.
-            // If the item is already above the focus point (and we are near top), we might not need to scroll.
-            // But for consistency, we try to scroll to focus point, and LazyColumn clamps it.
-            val currentItemInfo = layoutInfo.visibleItemsInfo.find { it.index == previousIndex }
-            
-            // Fallback height if not visible (estimate)
-            val estimatedHeight = currentItemInfo?.size ?: 100 
-            
-            // Calculate target scroll offset
-            // We want activeIndex to be at targetY
-            val targetY = (viewportHeight * focusRatio).toInt()
-            
-            // Execute Snap
-            listState.scrollToItem(activeIndex, -targetY)
-            
-            // Calculate how much we ACTUALLY scrolled (visually)
-            // If we were at top (offset 0), and we called scrollToItem(0, -targetY),
-            // LazyColumn stays at offset 0. So visual shift is 0.
-            // We need to know the visual shift to apply the inverse translation.
-            
-            // We can compare the position of a stable item?
-            // Or simpler: We know where 'previousIndex' was.
-            // previousIndex was at 'previousItemInfo.offset'.
-            // Now, where is 'previousIndex'?
-            // We need to wait for layout? No, scrollToItem happens instantly in state, but layout info updates later?
-            // Actually, scrollToItem requests a scroll. The layout info might not update until next frame.
-            // BUT, we need to set offsets NOW.
-            
-            // Let's assume the standard behavior:
-            // We WANT the previous item to stay visually where it was.
-            // The previous item was at `currentItemInfo.offset`.
-            // After scroll, where WILL it be?
-            // We moved `activeIndex` to `targetY`.
-            // `previousIndex` is `activeIndex - 1` (if moving down).
-            // So `previousIndex` will be at `targetY - previousItemHeight`.
-            // So the shift is `(targetY - previousItemHeight) - currentItemInfo.offset`.
-            // Wait, if we are at the top and don't scroll, `targetY` is not reached.
-            
-            // Better approach:
-            // Don't calculate shift. Just define the animation:
-            // "Everything moves UP by one row height".
-            // So we shift everything DOWN by one row height, and animate to 0.
-            // EXCEPT if we are at the top and didn't scroll.
-            // How to detect if we scrolled?
-            // If `activeIndex` is small (e.g. < 5), we might be clamping.
-            
-            // Heuristic:
-            // If `activeIndex` is 0, we are at top.
-            // If `activeIndex` increases, but we are still filling the top space...
-            
-            val jumpDelta = if (currentItemInfo != null) {
-                 currentItemInfo.size.toFloat()
-            } else {
-                 estimatedHeight.toFloat()
-            }
-            
-            // Only apply wave if we are "in the flow". 
-            // If we are at the very top (e.g. index 0 -> 1), and both are visible without scrolling...
-            // Visual check: is `currentItemInfo.offset` already < targetY?
-            // If current item was at 100px, and targetY is 500px.
-            // We don't scroll. The item just changes color.
-            // But user wants "wave" even then?
-            // "When lyrics switch... move up... from top of visible list".
-            // If list doesn't scroll, items don't move up physically.
-            // So we shouldn't translate them down.
-            
-            // We only translate if the list content SCROLLED underneath.
-            // If we are just highlighting next line, and list is static, no translation needed?
-            // User: "Move up... based on current highlighted line height... sequential wave".
-            // This implies the list ALWAYS moves up?
-            // "Lyrics always maintain vertical alignment and stable reading rhythm".
-            // "Highlight switch has 'lifted to focus' feeling".
-            
-            // If we are at the top, and we switch 0 -> 1.
-            // Item 0 is at top. Item 1 is below it.
-            // If we keep Item 1 at its position (below top), it's not "lifted to focus".
-            // Unless "Focus" implies scrolling.
-            // But if we can't scroll (clamped), we can't lift it to the physical screen center.
-            // In that case, we just highlight.
-            // So: Only apply offset if we actually scrolled.
-            
-            // How to know if we scrolled?
-            // We can check `listState.firstVisibleItemIndex` and `scrollOffset` before and after?
-            // But `scrollToItem` is async-ish in effect?
-            // No, `scrollToItem` updates the state immediately for the next measure pass.
-            
-            // Let's rely on the visual position check.
-            // If the item (previous active) was ALREADY above or at the target focus area, we probably scrolled.
-            // If it was well above (e.g. at top 0), and target is 500, we definitely didn't scroll UP.
-            // We only scroll if the new item is BELOW the target.
-            
-            // Simplified Logic:
-            // Always apply the offset animation logic, BUT...
-            // If we are clamped at top, `scrollToItem` won't move the items.
-            // So if we apply `translationY = jumpDelta`, we will push items DOWN visually, while they stay physically in place.
-            // Then they slide UP to their original place.
-            // This looks like they moved down then up. Bad.
-            // We want them to appear static, then move up.
-            // This implies they must physically move up (scroll) to cancel the translation.
-            
-            // So we ONLY apply translation if `scrollToItem` successfully moved the list.
-            // Since we can't easily know the result of `scrollToItem` before it happens...
-            // We can predict clamping.
-            // Total height of items 0..activeIndex?
-            // Too complex.
-            
-            // Workaround:
-            // Only apply wave if `activeIndex > 3` (heuristic) OR if we know we are past the fold.
-            // Or, observe `listState` snapshot.
-            
-            // Let's just allow the wave for indices > 0, but dampen it if we are near top?
-            // Actually, if we are at top, `previousIndex=0` is at `topPad`.
-            // `topPad` is small now.
-            // So `previousIndex` is at ~0.
-            // `targetY` is ~500.
-            // If we switch 0 -> 1. 1 is at ~50.
-            // We want 1 to be at ~500? No, we want 1 to be at ~50 (clamped).
-            // So we call `scrollToItem(1, -500)`. LazyColumn clamps to 0.
-            // Item 1 stays at ~50.
-            // If we apply translation, it jumps.
-            
-            // So: Check if `currentItemInfo.offset` is significantly smaller than `targetY`.
-            // If `currentItemInfo.offset < targetY - currentItemInfo.size`, it means we are "above" the focus zone.
-            // In this case, we likely won't scroll (or scroll very little).
-            // So we should NOT apply the full jump delta.
-            
-            val currentOffset = currentItemInfo?.offset ?: 0
-            val shouldAnimateWave = currentOffset >= (targetY - (currentItemInfo?.size ?: 0) * 2) 
-            // Heuristic: If we are close to the target Y (within 2 rows), we assume we are in "scrolling mode".
-            // If we are way above (offset 0 vs target 500), we are in "top clamp mode".
-            
-            if (shouldAnimateWave) {
-                 val visibleIndices = listState.layoutInfo.visibleItemsInfo.map { it.index }
-                 visibleIndices.forEach { index ->
-                     val anim = itemOffsets.getOrPut(index) { Animatable(0f, Float.VectorConverter) }
-                     anim.snapTo(jumpDelta)
-                 }
-                 
-                 val firstVisible = visibleIndices.minOrNull() ?: 0
-                 visibleIndices.forEach { index ->
-                     val anim = itemOffsets[index] ?: return@forEach
-                     val rowDelay = (index - firstVisible) * 40
-                     launch {
-                         anim.animateTo(
-                             targetValue = 0f,
-                             animationSpec = tween(
-                                 durationMillis = 500,
-                                 delayMillis = rowDelay,
-                                 easing = FastOutSlowInEasing
-                             )
-                         )
-                     }
-                 }
-            }
-        } else if (lyrics.isNotEmpty() && activeIndex >= 0 && previousIndex == -1) {
-             // Initial load scroll
-             val viewportHeight = listState.layoutInfo.viewportSize.height
-             val targetY = (viewportHeight * focusRatio).toInt()
-             listState.scrollToItem(activeIndex, -targetY)
         }
-        
-        previousIndex = activeIndex
     }
 
-    Box(modifier = modifier) {
-        LazyColumn(
-            state = listState,
-            modifier = Modifier.fillMaxSize(),
-            contentPadding = contentPadding,
-            horizontalAlignment = Alignment.CenterHorizontally
+    BoxWithConstraints(modifier = modifier) {
+        val viewportHeightPx = with(density) { maxHeight.toPx() }
+        val estimatedViewportHeightPx = when (settings.displayAreaMode) {
+            1, 2, 3 -> viewportHeightPx * 0.25f
+            else -> viewportHeightPx
+        }
+        val effectiveVisibleLines = calculateRuntimeMaxVisibleLines(
+            viewportHeightPx = estimatedViewportHeightPx,
+            lineBlockHeightPx = nominalItemHeightPx
+        ).coerceAtLeast(1) + 1
+        val targetWindowRange = remember(lyrics.size, activeIndex, effectiveVisibleLines) {
+            targetLyricsWindowRange(
+                totalCount = lyrics.size,
+                activeIndex = activeIndex,
+                visibleItemCount = effectiveVisibleLines
+            )
+        }
+        val itemTextMaxWidthPx = with(density) {
+            (maxWidth - itemOuterHorizontalPadding * 2 - itemInnerHorizontalPadding * 2).toPx().toInt().coerceAtLeast(1)
+        }
+        val measurementStyle = remember(baseLyricTextStyle, fontSize, wrappedLineHeight, textAlign) {
+            baseLyricTextStyle.copy(
+                fontWeight = FontWeight.Bold,
+                fontSize = fontSize,
+                lineHeight = wrappedLineHeight,
+                textAlign = textAlign
+            )
+        }
+        val lyricItemHeightsPx = remember(
+            lyrics,
+            itemTextMaxWidthPx,
+            measurementStyle,
+            nominalItemHeightPx,
+            itemSpacingPx,
+            itemInnerVerticalPadding,
+            itemOuterVerticalPadding,
+            density
         ) {
-            itemsIndexed(
-                items = lyrics,
-                key = { _, entry -> entry.startMs },
-                contentType = { _, _ -> "appleLyricLine" }
-            ) { index, entry ->
-                val isActive = index == activeIndex
-                val targetScale = 1.0f // Unified scale for active and inactive
-                val scale by animateFloatAsState(targetScale, animationSpec = tween(400))
-
-                val targetAlpha = if (isActive) 1f else if (AsmrTheme.colorScheme.isDark) 0.76f else 0.72f
-                val alpha by animateFloatAsState(targetAlpha, animationSpec = tween(400))
-
-                val targetColor = if (isActive) colors.activeText else colors.inactiveText
-                val color by animateColorAsState(targetColor, animationSpec = tween(400))
-                val targetFontWeight = if (isActive) FontWeight.ExtraBold else FontWeight.Bold
-                val fontSize = if (isLandscape) 22.sp else 24.sp
-                val shadow = if (isActive) {
-                    Shadow(
-                        color = colors.accentEmphasis.copy(alpha = if (AsmrTheme.colorScheme.isDark) 0.40f else 0.24f),
-                        offset = Offset.Zero,
-                        blurRadius = if (isLandscape) 14f else 18f
-                    )
-                } else null
-
-                val offsetAnim = itemOffsets[index]
-                val translationY = offsetAnim?.value ?: 0f
-
-                Text(
-                    text = entry.text,
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(horizontal = if (isLandscape) 10.dp else 14.dp, vertical = 2.dp)
-                        .graphicsLayer {
-                            this.translationY = translationY
-                            this.scaleX = scale
-                            this.scaleY = scale
-                            this.alpha = alpha
-                        }
-                        .clickable {
-                            onSeekTo(entry.startMs) 
-                            onOpenLyrics()
-                        }
-                        .padding(horizontal = if (isLandscape) 8.dp else 10.dp, vertical = if (isLandscape) 6.dp else 8.dp),
-                    style = MaterialTheme.typography.titleLarge.copy(
-                        fontWeight = targetFontWeight,
-                        fontSize = fontSize,
-                        textAlign = TextAlign.Center,
-                        lineHeight = if (isLandscape) 30.sp else 34.sp,
-                        shadow = shadow
-                    ),
-                    color = color
+            val innerVerticalPaddingPx = with(density) { itemInnerVerticalPadding.toPx() }
+            val outerVerticalPaddingPx = with(density) { itemOuterVerticalPadding.toPx() }
+            lyrics.map { entry ->
+                measuredLyricItemHeight(
+                    entry = entry,
+                    textMeasurer = textMeasurer,
+                    measurementStyle = measurementStyle,
+                    maxTextWidthPx = itemTextMaxWidthPx,
+                    nominalItemHeightPx = nominalItemHeightPx,
+                    innerVerticalPaddingPx = innerVerticalPaddingPx,
+                    outerVerticalPaddingPx = outerVerticalPaddingPx,
+                    itemSpacingPx = itemSpacingPx
                 )
             }
         }
+        val measuredWindowHeightPx = remember(
+            targetWindowRange,
+            lyricItemHeightsPx,
+            nominalItemHeightPx
+        ) {
+            measuredWindowHeight(
+                targetRange = targetWindowRange,
+                lyricItemHeightsPx = lyricItemHeightsPx,
+                nominalItemHeightPx = nominalItemHeightPx
+            )
+        }
+        val activeItemHeightPx = remember(
+            activeIndex,
+            lyricItemHeightsPx,
+            nominalItemHeightPx
+        ) {
+            lyricItemHeightsPx.getOrNull(activeIndex) ?: nominalItemHeightPx
+        }
+        val waveDurationMillis = 500
+        val viewportLayout = remember(settings, viewportHeightPx, nominalItemHeightPx, measuredWindowHeightPx) {
+            buildLyricsViewportLayout(
+                settings = settings,
+                viewportHeightPx = viewportHeightPx,
+                nominalItemHeightPx = nominalItemHeightPx,
+                measuredWindowHeightPx = measuredWindowHeightPx
+            )
+        }
+        val viewportWindowHeightDp = with(density) { viewportLayout.viewportWindowHeightPx.toDp() }
+        val viewportTopOffsetDp = with(density) { viewportLayout.viewportTopOffsetPx.toDp() }
+        val centeredActiveTopPx = ((viewportLayout.viewportWindowHeightPx - activeItemHeightPx) / 2f).coerceAtLeast(0f)
+        val centeredActiveBottomDp = viewportWindowHeightDp / 2f
+        LaunchedEffect(lastUserScrollAt, autoFocusSuspended) {
+            if (autoFocusSuspended) {
+                val scheduledAt = lastUserScrollAt
+                delay(2000)
+                if (autoFocusSuspended && lastUserScrollAt == scheduledAt && !listState.isScrollInProgress) {
+                    autoFocusSuspended = false
+                    pendingAnimatedRefocus = true
+                }
+            }
+        }
+
+        LaunchedEffect(activeIndex, autoFocusSuspended) {
+            if (lyrics.isEmpty() || activeIndex < 0 || autoFocusSuspended) return@LaunchedEffect
+
+            val targetScrollOffset = -centeredActiveTopPx.roundToInt()
+            var didReposition = false
+            val indexDelta = activeIndex - previousActiveIndex
+            val shouldPlayWave = indexDelta != 0 && indexDelta.absoluteValue <= 2
+            val movementDeltaPx = if (shouldPlayWave) {
+                accumulatedCenterShiftPx(
+                    lyricItemHeightsPx = lyricItemHeightsPx,
+                    fromIndex = previousActiveIndex,
+                    toIndex = activeIndex,
+                    nominalItemHeightPx = nominalItemHeightPx
+                )
+            } else {
+                0f
+            }
+            val affectedIndices = if (shouldPlayWave) {
+                (
+                    listState.layoutInfo.visibleItemsInfo.map { it.index } +
+                        targetLyricsWindowRange(
+                            totalCount = lyrics.size,
+                            activeIndex = activeIndex,
+                            visibleItemCount = effectiveVisibleLines
+                        ).toList()
+                    ).distinct().sorted()
+            } else {
+                emptyList()
+            }
+
+            if (shouldPlayWave) {
+                affectedIndices.forEach { index ->
+                    val anim = itemOffsets.getOrPut(index) { Animatable(0f) }
+                    anim.snapTo(movementDeltaPx)
+                }
+            }
+
+            if (listState.layoutInfo.visibleItemsInfo.any { it.index == activeIndex }) {
+                val activeItemInfo = listState.layoutInfo.visibleItemsInfo.first { it.index == activeIndex }
+                val activeTopPx = activeItemInfo.offset.toFloat()
+                val isPinnedAtTop = listState.firstVisibleItemIndex == 0 && listState.firstVisibleItemScrollOffset == 0
+                if (!(isPinnedAtTop && activeTopPx <= centeredActiveTopPx)) {
+                    val desiredTopPx = centeredActiveTopPx
+                    if (kotlin.math.abs(activeTopPx - desiredTopPx) > 1f) {
+                        if (pendingAnimatedRefocus) {
+                            listState.animateScrollToItem(activeIndex, targetScrollOffset)
+                        } else {
+                            listState.scrollToItem(activeIndex, targetScrollOffset)
+                        }
+                        didReposition = true
+                    }
+                }
+            } else {
+                if (pendingAnimatedRefocus) {
+                    listState.animateScrollToItem(activeIndex, targetScrollOffset)
+                } else {
+                    listState.scrollToItem(activeIndex, targetScrollOffset)
+                }
+                didReposition = true
+            }
+
+            if (didReposition && shouldPlayWave) {
+                val firstVisible = affectedIndices.minOrNull() ?: 0
+                affectedIndices.forEach { index ->
+                    val anim = itemOffsets[index] ?: return@forEach
+                    val rowDelay = (index - firstVisible) * 40
+                    launch {
+                        anim.animateTo(
+                            targetValue = 0f,
+                            animationSpec = tween(
+                                durationMillis = waveDurationMillis,
+                                delayMillis = rowDelay,
+                                easing = FastOutSlowInEasing
+                            )
+                        )
+                    }
+                }
+            }
+            pendingAnimatedRefocus = false
+            previousActiveIndex = activeIndex
+        }
+
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(viewportWindowHeightDp)
+                .offset(y = viewportTopOffsetDp)
+                .clip(RoundedCornerShape(12.dp))
+        ) {
+            LazyColumn(
+                state = listState,
+                modifier = Modifier
+                    .fillMaxSize()
+                    .nestedScroll(nestedScrollConnection),
+                horizontalAlignment = Alignment.CenterHorizontally,
+                contentPadding = PaddingValues(
+                    bottom = centeredActiveBottomDp
+                )
+            ) {
+                itemsIndexed(
+                    items = lyrics,
+                    key = { _, entry -> entry.startMs },
+                    contentType = { _, _ -> "appleLyricLine" }
+                ) { index, entry ->
+                    val isActive = index == activeIndex
+                    val scale by animateFloatAsState(
+                        targetValue = 1f,
+                        animationSpec = tween(400),
+                        label = "lyricScale"
+                    )
+                    val alpha by animateFloatAsState(
+                        targetValue = if (isActive) 1f else if (AsmrTheme.colorScheme.isDark) 0.76f else 0.72f,
+                        animationSpec = tween(400),
+                        label = "lyricAlpha"
+                    )
+                    val color by animateColorAsState(
+                        targetValue = if (isActive) colors.activeText else colors.inactiveText,
+                        animationSpec = tween(400),
+                        label = "lyricColor"
+                    )
+                    val shadow = if (isActive) {
+                        Shadow(
+                            color = colors.accentEmphasis.copy(alpha = if (AsmrTheme.colorScheme.isDark) 0.40f else 0.24f),
+                            offset = Offset.Zero,
+                            blurRadius = if (isLandscape) 14f else 18f
+                        )
+                    } else {
+                        null
+                    }
+
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(
+                                start = itemOuterHorizontalPadding,
+                                top = itemOuterVerticalPadding,
+                                end = itemOuterHorizontalPadding,
+                                bottom = itemOuterVerticalPadding + with(density) { itemSpacingPx.toDp() }
+                            )
+                            .graphicsLayer {
+                                this.translationY = itemOffsets[index]?.value ?: 0f
+                                this.scaleX = scale
+                                this.scaleY = scale
+                                this.alpha = alpha
+                            }
+                            .clickable {
+                                onSeekTo(entry.startMs)
+                                onOpenLyrics()
+                            }
+                            .padding(horizontal = itemInnerHorizontalPadding, vertical = itemInnerVerticalPadding)
+                    ) {
+                        val shadowColor = remember(color) { lyricShadowColor(color) }
+                        LyricLineText(
+                            text = entry.text,
+                            color = color,
+                            shadowColor = shadowColor,
+                            strokeWidthPx = strokeWidthPx,
+                            style = MaterialTheme.typography.titleLarge.copy(
+                                fontWeight = if (isActive) FontWeight.ExtraBold else FontWeight.Bold,
+                                fontSize = fontSize,
+                                lineHeight = wrappedLineHeight,
+                                textAlign = textAlign,
+                                shadow = shadow
+                            ),
+                            textAlign = textAlign
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+private fun targetLyricsWindowRange(
+    totalCount: Int,
+    activeIndex: Int,
+    visibleItemCount: Int
+): IntRange {
+    if (totalCount <= 0 || visibleItemCount <= 0) return IntRange.EMPTY
+    val safeActiveIndex = activeIndex.coerceIn(0, totalCount - 1)
+    val itemsAbove = (visibleItemCount - 1) / 2
+    val itemsBelow = visibleItemCount - 1 - itemsAbove
+    var start = (safeActiveIndex - itemsAbove).coerceAtLeast(0)
+    var end = (safeActiveIndex + itemsBelow).coerceAtMost(totalCount - 1)
+    val missing = visibleItemCount - (end - start + 1)
+    if (missing > 0) {
+        start = (start - missing).coerceAtLeast(0)
+        end = (start + visibleItemCount - 1).coerceAtMost(totalCount - 1)
+    }
+    return start..end
+}
+
+private fun measuredWindowHeight(
+    targetRange: IntRange,
+    lyricItemHeightsPx: List<Float>,
+    nominalItemHeightPx: Float
+): Float {
+    if (targetRange.isEmpty()) return 0f
+    return targetRange.sumOf { index ->
+        lyricItemHeightsPx.getOrNull(index)?.toDouble() ?: nominalItemHeightPx.toDouble()
+    }.toFloat()
+}
+
+private fun accumulatedCenterShiftPx(
+    lyricItemHeightsPx: List<Float>,
+    fromIndex: Int,
+    toIndex: Int,
+    nominalItemHeightPx: Float
+): Float {
+    if (fromIndex == toIndex) return 0f
+    val step = if (toIndex > fromIndex) 1 else -1
+    var distancePx = 0f
+    var currentIndex = fromIndex
+    while (currentIndex != toIndex) {
+        val nextIndex = currentIndex + step
+        val currentHeight = lyricItemHeightsPx.getOrNull(currentIndex) ?: nominalItemHeightPx
+        val nextHeight = lyricItemHeightsPx.getOrNull(nextIndex) ?: nominalItemHeightPx
+        distancePx += (currentHeight + nextHeight) / 2f * step
+        currentIndex = nextIndex
+    }
+    return distancePx
+}
+
+private fun measuredLyricItemHeight(
+    entry: SubtitleEntry?,
+    textMeasurer: androidx.compose.ui.text.TextMeasurer,
+    measurementStyle: TextStyle,
+    maxTextWidthPx: Int,
+    nominalItemHeightPx: Float,
+    innerVerticalPaddingPx: Float,
+    outerVerticalPaddingPx: Float,
+    itemSpacingPx: Float
+): Float {
+    if (entry == null) return nominalItemHeightPx
+    val textLayout = textMeasurer.measure(
+        text = AnnotatedString(entry.text),
+        style = measurementStyle,
+        constraints = Constraints(maxWidth = maxTextWidthPx)
+    )
+    return textLayout.size.height +
+        innerVerticalPaddingPx * 2f +
+        outerVerticalPaddingPx * 2f +
+        itemSpacingPx
+}
+
+private fun lyricShadowColor(textColor: Color): Color {
+    return if (textColor.luminance() > 0.5f) {
+        Color.Black.copy(alpha = 0.9f)
+    } else {
+        Color.White.copy(alpha = 0.9f)
+    }
+}
+
+@Composable
+private fun LyricLineText(
+    text: String,
+    color: Color,
+    shadowColor: Color,
+    strokeWidthPx: Float,
+    style: TextStyle,
+    textAlign: TextAlign
+) {
+    val effectiveShadow = remember(style.shadow, shadowColor, strokeWidthPx) {
+        lyricTextShadow(
+            baseShadow = style.shadow,
+            shadowColor = shadowColor,
+            shadowStrengthPx = strokeWidthPx
+        )
+    }
+    Text(
+        text = text,
+        modifier = Modifier.fillMaxWidth(),
+        style = style.copy(shadow = effectiveShadow),
+        color = color,
+        textAlign = textAlign
+    )
+}
+
+private fun lyricTextShadow(
+    baseShadow: Shadow?,
+    shadowColor: Color,
+    shadowStrengthPx: Float
+): Shadow? {
+    val lyricShadow = if (shadowStrengthPx > 0f) {
+        Shadow(
+            color = shadowColor.copy(alpha = 0.95f),
+            offset = Offset.Zero,
+            blurRadius = shadowStrengthPx * 2.4f
+        )
+    } else {
+        null
+    }
+    return when {
+        baseShadow == null -> lyricShadow
+        lyricShadow == null -> baseShadow
+        else -> Shadow(
+            color = lyricShadow.color,
+            offset = baseShadow.offset,
+            blurRadius = maxOf(baseShadow.blurRadius, lyricShadow.blurRadius)
+        )
     }
 }

--- a/app/src/main/java/com/asmr/player/ui/player/LyricReadableColors.kt
+++ b/app/src/main/java/com/asmr/player/ui/player/LyricReadableColors.kt
@@ -45,14 +45,10 @@ internal fun rememberLyricReadableColors(
         } else {
             colorScheme.textPrimary
         }
-        val inactiveAlpha = if (coverBackgroundEnabled) {
-            if (activeText.luminance() > 0.5f) 0.60f else 0.54f
-        } else if (colorScheme.isDark) {
-            0.54f
-        } else {
-            0.50f
-        }
-        val inactiveText = activeText.copy(alpha = inactiveAlpha)
+        val inactiveText = inactiveLyricTextColor(
+            activeText = activeText,
+            fallback = colorScheme.textSecondary
+        )
 
         LyricReadableColors(
             activeText = activeText,
@@ -60,6 +56,21 @@ internal fun rememberLyricReadableColors(
             accentEmphasis = accentColor.copy(alpha = emphasisAlpha),
             activeContainer = accentColor.copy(alpha = containerAlpha).compositeOver(containerBase)
         )
+    }
+}
+
+private fun inactiveLyricTextColor(
+    activeText: Color,
+    fallback: Color
+): Color {
+    val lightGrayCandidate = Color(0xFFD7DCE4)
+    val darkGrayCandidate = Color(0xFF58606C)
+    return if (activeText.luminance() > 0.5f) {
+        lightGrayCandidate
+    } else if (activeText.luminance() < 0.2f) {
+        darkGrayCandidate
+    } else {
+        fallback
     }
 }
 

--- a/app/src/main/java/com/asmr/player/ui/player/LyricsPage.kt
+++ b/app/src/main/java/com/asmr/player/ui/player/LyricsPage.kt
@@ -7,57 +7,35 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.itemsIndexed
-import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.KeyboardArrowDown
-import androidx.compose.material3.Button
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
-import androidx.compose.material3.FilledTonalButton
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.collectAsState
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.graphicsLayer
-import androidx.compose.ui.platform.LocalDensity
-import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.graphics.Shadow
 import androidx.compose.ui.geometry.Offset
 import androidx.hilt.navigation.compose.hiltViewModel
-import com.asmr.player.util.SubtitleEntry
-import com.asmr.player.util.SubtitleIndexFinder
-import com.asmr.player.ui.common.smoothScrollToIndex
-import kotlinx.coroutines.delay
-
-import androidx.compose.foundation.background
 import com.asmr.player.ui.theme.AsmrTheme
 import com.asmr.player.ui.common.rememberDominantColorCenterWeighted
 
 import android.content.res.Configuration
 import androidx.compose.ui.platform.LocalConfiguration
 import com.asmr.player.data.settings.CoverPreviewMode
+import com.asmr.player.data.settings.LyricsPageSettings
 
 @Composable
 fun LyricsPage(
@@ -67,6 +45,7 @@ fun LyricsPage(
     coverBackgroundEnabled: Boolean,
     coverBackgroundClarity: Float,
     coverPreviewMode: CoverPreviewMode,
+    lyricsPageSettings: LyricsPageSettings,
     viewModel: LyricsViewModel = hiltViewModel()
 ) {
     val uiState by viewModel.uiState.collectAsState()
@@ -153,8 +132,6 @@ fun LyricsPage(
             }
 
             BoxWithConstraints(modifier = Modifier.fillMaxSize()) {
-                val topPad = 0.dp // No top padding as requested
-                val bottomPad = maxHeight * 0.6f
                 AppleLyricsView(
                     lyrics = uiState.lyrics,
                     currentPosition = position,
@@ -162,7 +139,7 @@ fun LyricsPage(
                     colors = lyricColors,
                     modifier = Modifier.fillMaxSize(),
                     isLandscape = isLandscape,
-                    contentPadding = PaddingValues(top = topPad, bottom = bottomPad)
+                    settings = lyricsPageSettings
                 )
             }
         }

--- a/app/src/main/java/com/asmr/player/ui/player/LyricsPageLayout.kt
+++ b/app/src/main/java/com/asmr/player/ui/player/LyricsPageLayout.kt
@@ -1,0 +1,53 @@
+package com.asmr.player.ui.player
+
+import androidx.compose.ui.text.style.TextAlign
+import com.asmr.player.data.settings.LyricsPageSettings
+import kotlin.math.floor
+import kotlin.math.max
+
+internal data class LyricsViewportLayout(
+    val nominalItemHeightPx: Float,
+    val viewportWindowHeightPx: Float,
+    val viewportTopOffsetPx: Float
+)
+
+internal fun buildLyricsViewportLayout(
+    settings: LyricsPageSettings,
+    viewportHeightPx: Float,
+    nominalItemHeightPx: Float,
+    measuredWindowHeightPx: Float = 0f
+): LyricsViewportLayout {
+    val quarterHeightPx = (viewportHeightPx * 0.25f).coerceAtLeast(nominalItemHeightPx)
+    val requestedWindowHeightPx = when (settings.displayAreaMode) {
+        1, 2, 3 -> quarterHeightPx
+        else -> viewportHeightPx
+    }
+    val viewportWindowHeightPx = maxOf(requestedWindowHeightPx, measuredWindowHeightPx.coerceAtMost(requestedWindowHeightPx))
+        .coerceAtMost(viewportHeightPx)
+        .coerceAtLeast(nominalItemHeightPx)
+    val viewportTopOffsetPx = when (settings.displayAreaMode) {
+        1 -> 0f
+        2 -> ((viewportHeightPx - viewportWindowHeightPx) / 2f).coerceAtLeast(0f)
+        3 -> (viewportHeightPx - viewportWindowHeightPx).coerceAtLeast(0f)
+        else -> 0f
+    }
+    return LyricsViewportLayout(
+        nominalItemHeightPx = nominalItemHeightPx,
+        viewportWindowHeightPx = viewportWindowHeightPx,
+        viewportTopOffsetPx = viewportTopOffsetPx
+    )
+}
+
+internal fun calculateRuntimeMaxVisibleLines(
+    viewportHeightPx: Float,
+    lineBlockHeightPx: Float
+): Int {
+    if (viewportHeightPx <= 0f || lineBlockHeightPx <= 0f) return 1
+    return max(1, floor(viewportHeightPx / lineBlockHeightPx).toInt())
+}
+
+internal fun lyricTextAlign(align: Int): TextAlign = when (align) {
+    0 -> TextAlign.Start
+    2 -> TextAlign.End
+    else -> TextAlign.Center
+}

--- a/app/src/main/java/com/asmr/player/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/settings/SettingsScreen.kt
@@ -11,8 +11,8 @@ import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.collectIsDraggedAsState
-import androidx.compose.foundation.border
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
@@ -40,6 +40,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.font.FontWeight
@@ -55,6 +56,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import com.asmr.player.BuildConfig
 import com.asmr.player.data.settings.CoverPreviewMode
 import com.asmr.player.data.settings.FloatingLyricsSettings
+import com.asmr.player.data.settings.LyricsPageSettings
 import com.asmr.player.ui.library.BulkPhase
 import com.asmr.player.ui.library.LibraryViewModel
 import com.asmr.player.ui.theme.AsmrTheme
@@ -72,6 +74,7 @@ fun SettingsScreen(
 ) {
     val floatingLyricsEnabled by viewModel.floatingLyricsEnabled.collectAsState()
     val floatingSettings by viewModel.floatingLyricsSettings.collectAsState()
+    val lyricsPageSettings by viewModel.lyricsPageSettings.collectAsState()
     val dynamicPlayerHueEnabled by viewModel.dynamicPlayerHueEnabled.collectAsState()
     val themeMode by viewModel.themeMode.collectAsState()
     val staticHueArgb by viewModel.staticHueArgb.collectAsState()
@@ -84,6 +87,8 @@ fun SettingsScreen(
     val scanRoots by libraryViewModel.scanRoots.collectAsState()
     val bulkProgress by libraryViewModel.bulkProgress.collectAsState()
     val isGlobalSyncRunning by libraryViewModel.isGlobalSyncRunning.collectAsState()
+    val configuration = LocalConfiguration.current
+    val density = LocalDensity.current
     val context = LocalContext.current
     val colorScheme = AsmrTheme.colorScheme
     val segmentedButtonColors = SegmentedButtonDefaults.colors(
@@ -120,7 +125,6 @@ fun SettingsScreen(
 
     // 屏幕尺寸判断
     val isCompact = windowSizeClass.widthSizeClass == WindowWidthSizeClass.Compact
-
     Scaffold(
         contentWindowInsets = WindowInsets.navigationBars,
         containerColor = Color.Transparent,
@@ -417,131 +421,133 @@ fun SettingsScreen(
                 }
 
                 // 悬浮歌词
-                item(key = "group:floating_lyrics") {
-                    SettingsGroup(title = "悬浮歌词") {
-                SettingsToggleRow(
-                    text = "开启悬浮歌词",
-                    checked = floatingLyricsEnabled,
-                    onCheckedChange = { viewModel.setFloatingLyricsEnabled(it) }
-                )
-
-                if (!overlayGranted && floatingLyricsEnabled) {
-                    OutlinedButton(
-                        onClick = {
-                            val intent = Intent(
-                                Settings.ACTION_MANAGE_OVERLAY_PERMISSION,
-                                Uri.parse("package:${context.packageName}")
-                            )
-                            overlayLauncher.launch(intent)
-                        },
-                        modifier = Modifier.fillMaxWidth(),
-                        colors = ButtonDefaults.outlinedButtonColors()
-                    ) {
-                        Text("授权悬浮窗权限")
-                    }
-                }
-
-                if (floatingLyricsEnabled && overlayGranted) {
-                    // 字体大小
-                    SettingsSliderRow(
-                        text = "字体大小: ${floatingSettings.size.toInt()}",
-                        value = floatingSettings.size,
-                        range = 12f..32f,
-                        onValueChange = { viewModel.updateFloatingLyricsSettings(floatingSettings.copy(size = it)) }
-                    )
-
-                    // 背景透明度
-                    SettingsSliderRow(
-                        text = "背景透明度: ${(floatingSettings.opacity * 100).toInt()}%",
-                        value = floatingSettings.opacity,
-                        range = 0f..1f,
-                        onValueChange = { viewModel.updateFloatingLyricsSettings(floatingSettings.copy(opacity = it)) }
-                    )
-
-                    // 垂直位置
-                    SettingsSliderRow(
-                        text = "垂直位置 (Y轴)",
-                        value = floatingSettings.yOffset.toFloat(),
-                        range = 0f..2000f,
-                        onValueChange = { viewModel.updateFloatingLyricsSettings(floatingSettings.copy(yOffset = it.toInt())) }
-                    )
-
-                    // 对齐方式
-                    Row(
-                        modifier = Modifier.fillMaxWidth(),
-                        verticalAlignment = Alignment.CenterVertically
-                    ) {
-                        Text("对齐方式", style = MaterialTheme.typography.bodyMedium)
-                        Spacer(modifier = Modifier.weight(1f))
-                        SingleChoiceSegmentedButtonRow {
-                            SegmentedButton(
-                                selected = floatingSettings.align == 0,
-                                onClick = { viewModel.updateFloatingLyricsSettings(floatingSettings.copy(align = 0)) },
-                                shape = SegmentedButtonDefaults.itemShape(index = 0, count = 3),
-                                colors = segmentedButtonColors,
-                                icon = {},
-                                label = { Icon(Icons.AutoMirrored.Filled.FormatAlignLeft, null) }
-                            )
-                            SegmentedButton(
-                                selected = floatingSettings.align == 1,
-                                onClick = { viewModel.updateFloatingLyricsSettings(floatingSettings.copy(align = 1)) },
-                                shape = SegmentedButtonDefaults.itemShape(index = 1, count = 3),
-                                colors = segmentedButtonColors,
-                                icon = {},
-                                label = { Icon(Icons.Default.FormatAlignCenter, null) }
-                            )
-                            SegmentedButton(
-                                selected = floatingSettings.align == 2,
-                                onClick = { viewModel.updateFloatingLyricsSettings(floatingSettings.copy(align = 2)) },
-                                shape = SegmentedButtonDefaults.itemShape(index = 2, count = 3),
-                                colors = segmentedButtonColors,
-                                icon = {},
-                                label = { Icon(Icons.AutoMirrored.Filled.FormatAlignRight, null) }
-                            )
-                        }
-                    }
-
-                    val presetColors = remember {
-                        listOf(
-                            0xFFFFFFFF.toInt(),
-                            0xFFFFEB3B.toInt(),
-                            0xFF00E5FF.toInt(),
-                            0xFF69F0AE.toInt(),
-                            0xFFFF4081.toInt()
+                item(key = "group:lyrics") {
+                    SettingsGroup(title = "歌词") {
+                        LyricsPageSettingsSection(
+                            settings = lyricsPageSettings,
+                            segmentedButtonColors = segmentedButtonColors,
+                            onSettingsChange = { next -> viewModel.updateLyricsPageSettings(next) }
                         )
-                    }
-                    Column(modifier = Modifier.fillMaxWidth(), verticalArrangement = Arrangement.spacedBy(10.dp)) {
-                        Text("歌词颜色", style = MaterialTheme.typography.bodyMedium)
-                        Row(horizontalArrangement = Arrangement.spacedBy(12.dp), verticalAlignment = Alignment.CenterVertically) {
-                            presetColors.forEach { c ->
-                                val selected = floatingSettings.color == c
-                                Box(
-                                    modifier = Modifier
-                                        .size(30.dp)
-                                        .clip(CircleShape)
-                                        .background(Color(c))
-                                        .border(
-                                            width = if (selected) 2.dp else 1.dp,
-                                            color = if (selected) colorScheme.primary else colorScheme.onSurface.copy(alpha = 0.25f),
-                                            shape = CircleShape
-                                        )
-                                        .clickable { viewModel.updateFloatingLyricsSettings(floatingSettings.copy(color = c)) }
-                                )
+
+                        HorizontalDivider(color = MaterialTheme.colorScheme.outline.copy(alpha = 0.18f))
+
+                        Text("悬浮歌词", style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.SemiBold)
+                        SettingsToggleRow(
+                            text = "开启悬浮歌词",
+                            checked = floatingLyricsEnabled,
+                            onCheckedChange = { viewModel.setFloatingLyricsEnabled(it) }
+                        )
+
+                        if (!overlayGranted && floatingLyricsEnabled) {
+                            OutlinedButton(
+                                onClick = {
+                                    val intent = Intent(
+                                        Settings.ACTION_MANAGE_OVERLAY_PERMISSION,
+                                        Uri.parse("package:${context.packageName}")
+                                    )
+                                    overlayLauncher.launch(intent)
+                                },
+                                modifier = Modifier.fillMaxWidth(),
+                                colors = ButtonDefaults.outlinedButtonColors()
+                            ) {
+                                Text("授权悬浮窗权限")
                             }
                         }
+
+                        if (floatingLyricsEnabled && overlayGranted) {
+                            SettingsSliderRow(
+                                text = "字体大小: ${floatingSettings.size.toInt()}",
+                                value = floatingSettings.size,
+                                range = 12f..32f,
+                                onValueChange = { viewModel.updateFloatingLyricsSettings(floatingSettings.copy(size = it)) }
+                            )
+
+                            SettingsSliderRow(
+                                text = "背景透明度: ${(floatingSettings.opacity * 100).toInt()}%",
+                                value = floatingSettings.opacity,
+                                range = 0f..1f,
+                                onValueChange = { viewModel.updateFloatingLyricsSettings(floatingSettings.copy(opacity = it)) }
+                            )
+
+                            SettingsSliderRow(
+                                text = "垂直位置 (Y轴)",
+                                value = floatingSettings.yOffset.toFloat(),
+                                range = 0f..2000f,
+                                onValueChange = { viewModel.updateFloatingLyricsSettings(floatingSettings.copy(yOffset = it.toInt())) }
+                            )
+
+                            Row(
+                                modifier = Modifier.fillMaxWidth(),
+                                verticalAlignment = Alignment.CenterVertically
+                            ) {
+                                Text("对齐方式", style = MaterialTheme.typography.bodyMedium)
+                                Spacer(modifier = Modifier.weight(1f))
+                                SingleChoiceSegmentedButtonRow {
+                                    SegmentedButton(
+                                        selected = floatingSettings.align == 0,
+                                        onClick = { viewModel.updateFloatingLyricsSettings(floatingSettings.copy(align = 0)) },
+                                        shape = SegmentedButtonDefaults.itemShape(index = 0, count = 3),
+                                        colors = segmentedButtonColors,
+                                        icon = {},
+                                        label = { Icon(Icons.AutoMirrored.Filled.FormatAlignLeft, null) }
+                                    )
+                                    SegmentedButton(
+                                        selected = floatingSettings.align == 1,
+                                        onClick = { viewModel.updateFloatingLyricsSettings(floatingSettings.copy(align = 1)) },
+                                        shape = SegmentedButtonDefaults.itemShape(index = 1, count = 3),
+                                        colors = segmentedButtonColors,
+                                        icon = {},
+                                        label = { Icon(Icons.Default.FormatAlignCenter, null) }
+                                    )
+                                    SegmentedButton(
+                                        selected = floatingSettings.align == 2,
+                                        onClick = { viewModel.updateFloatingLyricsSettings(floatingSettings.copy(align = 2)) },
+                                        shape = SegmentedButtonDefaults.itemShape(index = 2, count = 3),
+                                        colors = segmentedButtonColors,
+                                        icon = {},
+                                        label = { Icon(Icons.AutoMirrored.Filled.FormatAlignRight, null) }
+                                    )
+                                }
+                            }
+
+                            val presetColors = remember {
+                                listOf(
+                                    0xFFFFFFFF.toInt(),
+                                    0xFFFFEB3B.toInt(),
+                                    0xFF00E5FF.toInt(),
+                                    0xFF69F0AE.toInt(),
+                                    0xFFFF4081.toInt()
+                                )
+                            }
+                            Column(modifier = Modifier.fillMaxWidth(), verticalArrangement = Arrangement.spacedBy(10.dp)) {
+                                Text("歌词颜色", style = MaterialTheme.typography.bodyMedium)
+                                Row(horizontalArrangement = Arrangement.spacedBy(12.dp), verticalAlignment = Alignment.CenterVertically) {
+                                    presetColors.forEach { c ->
+                                        val selected = floatingSettings.color == c
+                                        Box(
+                                            modifier = Modifier
+                                                .size(30.dp)
+                                                .clip(CircleShape)
+                                                .background(Color(c))
+                                                .border(
+                                                    width = if (selected) 2.dp else 1.dp,
+                                                    color = if (selected) colorScheme.primary else colorScheme.onSurface.copy(alpha = 0.25f),
+                                                    shape = CircleShape
+                                                )
+                                                .clickable { viewModel.updateFloatingLyricsSettings(floatingSettings.copy(color = c)) }
+                                        )
+                                    }
+                                }
+                            }
+
+                            SettingsToggleRow(
+                                text = "点击穿透(锁定位置)",
+                                checked = !floatingSettings.touchable,
+                                onCheckedChange = { viewModel.updateFloatingLyricsSettings(floatingSettings.copy(touchable = !it)) }
+                            )
+                        }
                     }
-
-                    // 点击穿透
-                    SettingsToggleRow(
-                        text = "点击穿透 (锁定位置)",
-                        checked = !floatingSettings.touchable,
-                        onCheckedChange = { viewModel.updateFloatingLyricsSettings(floatingSettings.copy(touchable = !it)) }
-                    )
                 }
-            }
-
-                }
-
                 item(key = "group:about_update") {
                     SettingsGroup(title = "关于") {
                         val isDark = AsmrTheme.colorScheme.isDark
@@ -705,6 +711,108 @@ fun SettingsScreen(
                 }
             }
         )
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun LyricsPageSettingsSection(
+    settings: LyricsPageSettings,
+    segmentedButtonColors: SegmentedButtonColors,
+    onSettingsChange: (LyricsPageSettings) -> Unit
+) {
+    Text("歌词页", style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.SemiBold)
+    SettingsSliderRow(
+        text = "字体大小: ${settings.fontSizeSp.toInt()}sp",
+        value = settings.fontSizeSp,
+        range = 18f..36f,
+        onValueChange = { onSettingsChange(settings.copy(fontSizeSp = it)) }
+    )
+    SettingsSliderRow(
+        text = "字体阴影: ${"%.1f".format(settings.strokeWidthSp)}sp",
+        value = settings.strokeWidthSp,
+        range = 0f..3f,
+        onValueChange = { onSettingsChange(settings.copy(strokeWidthSp = it)) }
+    )
+    SettingsSliderRow(
+        text = "行间距: ${"%.2f".format(settings.lineHeightMultiplier)}x",
+        value = settings.lineHeightMultiplier,
+        range = 0.1f..3.0f,
+        onValueChange = { onSettingsChange(settings.copy(lineHeightMultiplier = it)) }
+    )
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Text("显示区域", style = MaterialTheme.typography.bodyMedium)
+        Spacer(modifier = Modifier.weight(1f))
+        SingleChoiceSegmentedButtonRow {
+            SegmentedButton(
+                selected = settings.displayAreaMode == 0,
+                onClick = { onSettingsChange(settings.copy(displayAreaMode = 0)) },
+                shape = SegmentedButtonDefaults.itemShape(index = 0, count = 4),
+                colors = segmentedButtonColors,
+                icon = {},
+                label = { Text("全屏") }
+            )
+            SegmentedButton(
+                selected = settings.displayAreaMode == 1,
+                onClick = { onSettingsChange(settings.copy(displayAreaMode = 1)) },
+                shape = SegmentedButtonDefaults.itemShape(index = 1, count = 4),
+                colors = segmentedButtonColors,
+                icon = {},
+                label = { Text("上1/4") }
+            )
+            SegmentedButton(
+                selected = settings.displayAreaMode == 2,
+                onClick = { onSettingsChange(settings.copy(displayAreaMode = 2)) },
+                shape = SegmentedButtonDefaults.itemShape(index = 2, count = 4),
+                colors = segmentedButtonColors,
+                icon = {},
+                label = { Text("中1/4") }
+            )
+            SegmentedButton(
+                selected = settings.displayAreaMode == 3,
+                onClick = { onSettingsChange(settings.copy(displayAreaMode = 3)) },
+                shape = SegmentedButtonDefaults.itemShape(index = 3, count = 4),
+                colors = segmentedButtonColors,
+                icon = {},
+                label = { Text("下1/4") }
+            )
+        }
+    }
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Text("对齐方式", style = MaterialTheme.typography.bodyMedium)
+        Spacer(modifier = Modifier.weight(1f))
+        SingleChoiceSegmentedButtonRow {
+            SegmentedButton(
+                selected = settings.align == 0,
+                onClick = { onSettingsChange(settings.copy(align = 0)) },
+                shape = SegmentedButtonDefaults.itemShape(index = 0, count = 3),
+                colors = segmentedButtonColors,
+                icon = {},
+                label = { Icon(Icons.AutoMirrored.Filled.FormatAlignLeft, null) }
+            )
+            SegmentedButton(
+                selected = settings.align == 1,
+                onClick = { onSettingsChange(settings.copy(align = 1)) },
+                shape = SegmentedButtonDefaults.itemShape(index = 1, count = 3),
+                colors = segmentedButtonColors,
+                icon = {},
+                label = { Icon(Icons.Default.FormatAlignCenter, null) }
+            )
+            SegmentedButton(
+                selected = settings.align == 2,
+                onClick = { onSettingsChange(settings.copy(align = 2)) },
+                shape = SegmentedButtonDefaults.itemShape(index = 2, count = 3),
+                colors = segmentedButtonColors,
+                icon = {},
+                label = { Icon(Icons.AutoMirrored.Filled.FormatAlignRight, null) }
+            )
+        }
     }
 }
 

--- a/app/src/main/java/com/asmr/player/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/asmr/player/ui/settings/SettingsViewModel.kt
@@ -8,6 +8,7 @@ import com.asmr.player.data.remote.update.GitHubUpdateClient
 import com.asmr.player.data.settings.CoverPreviewMode
 import com.asmr.player.data.remote.update.UpdateRelease
 import com.asmr.player.data.settings.FloatingLyricsSettings
+import com.asmr.player.data.settings.LyricsPageSettings
 import com.asmr.player.data.settings.SettingsRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
@@ -52,6 +53,9 @@ class SettingsViewModel @Inject constructor(
     val floatingLyricsSettings: StateFlow<FloatingLyricsSettings> = settingsRepository.floatingLyricsSettings
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), FloatingLyricsSettings())
 
+    val lyricsPageSettings: StateFlow<LyricsPageSettings> = settingsDataStore.lyricsPageSettings
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), LyricsPageSettings())
+
     val dynamicPlayerHueEnabled: StateFlow<Boolean> = settingsDataStore.dynamicPlayerHueEnabled
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), false)
 
@@ -87,6 +91,10 @@ class SettingsViewModel @Inject constructor(
 
     fun updateFloatingLyricsSettings(settings: FloatingLyricsSettings) {
         viewModelScope.launch { settingsRepository.updateFloatingLyricsSettings(settings) }
+    }
+
+    fun updateLyricsPageSettings(settings: LyricsPageSettings) {
+        viewModelScope.launch { settingsDataStore.setLyricsPageSettings(settings) }
     }
 
     fun setDynamicPlayerHueEnabled(enabled: Boolean) {

--- a/app/src/test/java/com/asmr/player/data/settings/LyricsPageSettingsTest.kt
+++ b/app/src/test/java/com/asmr/player/data/settings/LyricsPageSettingsTest.kt
@@ -1,0 +1,18 @@
+package com.asmr.player.data.settings
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class LyricsPageSettingsTest {
+    @Test
+    fun defaults_matchExpectedLyricsPagePresentation() {
+        val settings = LyricsPageSettings()
+
+        assertEquals(24f, settings.fontSizeSp, 0.001f)
+        assertEquals(0f, settings.strokeWidthSp, 0.001f)
+        assertEquals(1.4f, settings.lineHeightMultiplier, 0.001f)
+        assertEquals(6, settings.maxVisibleLines)
+        assertEquals(1, settings.align)
+        assertEquals(0.5f, settings.centerPositionFraction, 0.001f)
+    }
+}

--- a/app/src/test/java/com/asmr/player/ui/player/LyricsPageLayoutTest.kt
+++ b/app/src/test/java/com/asmr/player/ui/player/LyricsPageLayoutTest.kt
@@ -1,0 +1,41 @@
+package com.asmr.player.ui.player
+
+import androidx.compose.ui.text.style.TextAlign
+import com.asmr.player.data.settings.LyricsPageSettings
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class LyricsPageLayoutTest {
+    @Test
+    fun runtimeMaxVisibleLines_isBoundedByViewportHeight() {
+        assertEquals(5, calculateRuntimeMaxVisibleLines(viewportHeightPx = 520f, lineBlockHeightPx = 100f))
+        assertEquals(1, calculateRuntimeMaxVisibleLines(viewportHeightPx = 0f, lineBlockHeightPx = 100f))
+        assertEquals(1, calculateRuntimeMaxVisibleLines(viewportHeightPx = 520f, lineBlockHeightPx = 0f))
+    }
+
+    @Test
+    fun viewportLayout_clampsVisibleLinesAndTopOffset() {
+        val layout = buildLyricsViewportLayout(
+            settings = LyricsPageSettings(
+                maxVisibleLines = 9,
+                centerPositionFraction = 0.9f
+            ),
+            viewportHeightPx = 640f,
+            lineBlockHeightPx = 100f
+        )
+
+        assertEquals(6, layout.runtimeMaxVisibleLines)
+        assertEquals(6, layout.effectiveVisibleLines)
+        assertEquals(600f, layout.viewportWindowHeightPx, 0.001f)
+        assertTrue(layout.viewportTopOffsetPx in 0f..40f)
+    }
+
+    @Test
+    fun lyricTextAlign_mapsStoredValues() {
+        assertEquals(TextAlign.Start, lyricTextAlign(0))
+        assertEquals(TextAlign.Center, lyricTextAlign(1))
+        assertEquals(TextAlign.End, lyricTextAlign(2))
+        assertEquals(TextAlign.Center, lyricTextAlign(999))
+    }
+}


### PR DESCRIPTION
## Summary
- add a dedicated lyrics settings group and move floating lyrics settings into it
- add persisted lyrics page style settings and wire them through settings, activity, and lyrics page
- update lyrics page rendering, display area modes, scrolling focus behavior, tests, and text shadow styling

## Verification
- ./gradlew :app:compileDebugKotlin