### PR TITLE
Implement collapsible top chrome for library views

### DIFF
--- a/app/src/main/java/com/asmr/player/ui/common/CollapsibleHeader.kt
+++ b/app/src/main/java/com/asmr/player/ui/common/CollapsibleHeader.kt
@@ -1,0 +1,77 @@
+package com.asmr.player.ui.common
+
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
+import androidx.compose.ui.input.nestedscroll.NestedScrollSource
+import androidx.compose.ui.unit.Velocity
+
+internal const val COLLAPSIBLE_HEADER_STATE_EXPANDED = "expanded"
+internal const val COLLAPSIBLE_HEADER_STATE_PARTIAL = "partial"
+internal const val COLLAPSIBLE_HEADER_STATE_COLLAPSED = "collapsed"
+
+@Stable
+class CollapsibleHeaderState {
+    var heightPx by mutableFloatStateOf(0f)
+        private set
+
+    var offsetPx by mutableFloatStateOf(0f)
+        private set
+
+    val nestedScrollConnection: NestedScrollConnection = object : NestedScrollConnection {
+        override fun onPostScroll(
+            consumed: Offset,
+            available: Offset,
+            source: NestedScrollSource
+        ): Offset {
+            onScrollDelta(consumed.y)
+            return Offset.Zero
+        }
+
+        override suspend fun onPostFling(consumed: Velocity, available: Velocity): Velocity {
+            if (heightPx <= 0f) return Velocity.Zero
+            if (offsetPx > -heightPx * 0.5f) {
+                expand()
+            } else {
+                collapse()
+            }
+            return Velocity.Zero
+        }
+    }
+
+    val collapseFraction: Float
+        get() = if (heightPx <= 0f) 0f else (-offsetPx / heightPx).coerceIn(0f, 1f)
+
+    fun updateHeight(heightPx: Float) {
+        if (heightPx <= 0f) return
+        this.heightPx = heightPx
+        offsetPx = offsetPx.coerceIn(-heightPx, 0f)
+    }
+
+    fun onScrollDelta(deltaY: Float) {
+        if (heightPx <= 0f || deltaY == 0f) return
+        offsetPx = (offsetPx + deltaY).coerceIn(-heightPx, 0f)
+    }
+
+    fun expand() {
+        offsetPx = 0f
+    }
+
+    fun collapse() {
+        if (heightPx <= 0f) return
+        offsetPx = -heightPx
+    }
+}
+
+@androidx.compose.runtime.Composable
+fun rememberCollapsibleHeaderState(): CollapsibleHeaderState = remember { CollapsibleHeaderState() }
+
+internal fun collapsibleHeaderUiState(collapseFraction: Float): String = when {
+    collapseFraction <= 0.01f -> COLLAPSIBLE_HEADER_STATE_EXPANDED
+    collapseFraction >= 0.99f -> COLLAPSIBLE_HEADER_STATE_COLLAPSED
+    else -> COLLAPSIBLE_HEADER_STATE_PARTIAL
+}

--- a/app/src/main/java/com/asmr/player/ui/library/AlbumDetailScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/AlbumDetailScreen.kt
@@ -8,6 +8,7 @@ import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.animation.core.spring
 import androidx.compose.animation.fadeIn
@@ -19,6 +20,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.foundation.layout.*
@@ -47,15 +49,20 @@ import androidx.compose.foundation.gestures.detectTransformGestures
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalLifecycleOwner
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.stateDescription
 import androidx.compose.ui.state.ToggleableState
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.viewinterop.AndroidView
@@ -101,6 +108,7 @@ import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.launch
 
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.zIndex
 import com.asmr.player.ui.common.rememberDominantColor
@@ -109,6 +117,8 @@ import com.asmr.player.ui.common.DiscPlaceholder
 import com.asmr.player.ui.common.AsmrAsyncImage
 import com.asmr.player.ui.common.AsmrShimmerPlaceholder
 import com.asmr.player.ui.common.CvChipsFlow
+import com.asmr.player.ui.common.collapsibleHeaderUiState
+import com.asmr.player.ui.common.rememberCollapsibleHeaderState
 import com.asmr.player.ui.theme.AsmrTheme
 import com.asmr.player.ui.common.LocalBottomOverlayPadding
 import com.asmr.player.ui.theme.AsmrPlayerTheme
@@ -125,6 +135,9 @@ private enum class OnlineDownloadSource {
     AsmrOne,
     DlsitePlay
 }
+
+private val AlbumDetailTabContentGap = 12.dp
+private val AlbumDetailTabCollapseOvershoot = 10.dp
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -228,11 +241,33 @@ fun AlbumDetailScreen(
                     )
                     var localPreviewFile by remember { mutableStateOf<LocalTreeUiEntry.File?>(null) }
                     var onlinePreviewFile by remember { mutableStateOf<AsmrTreeUiEntry.File?>(null) }
+                    val tabChromeState = rememberCollapsibleHeaderState()
+                    val animatedTabChromeOffsetPx by animateFloatAsState(
+                        targetValue = tabChromeState.offsetPx,
+                        animationSpec = spring(
+                            dampingRatio = Spring.DampingRatioNoBouncy,
+                            stiffness = Spring.StiffnessMediumLow
+                        ),
+                        label = "albumDetailTabChromeOffset"
+                    )
+                    val tabChromeVisibleHeight = if (tabChromeState.heightPx > 0f) {
+                        with(LocalDensity.current) {
+                            (tabChromeState.heightPx + tabChromeState.offsetPx)
+                                .coerceIn(0f, tabChromeState.heightPx)
+                                .toDp()
+                        }
+                    } else {
+                        56.dp
+                    }
+                    val tabContentTopPadding = tabChromeVisibleHeight + AlbumDetailTabContentGap
     
                     LaunchedEffect(model.rjCode, model.dlsiteWorkno, model.localAlbum?.id, selectedTab) {
                         if (selectedTab != 0 && model.dlsiteInfo == null && model.dlsiteWorkno.isNotBlank()) {
                             viewModel.ensureDlsiteLoaded()
                         }
+                    }
+                    LaunchedEffect(selectedTab) {
+                        tabChromeState.expand()
                     }
     
                     Column(modifier = Modifier.fillMaxSize()) {
@@ -272,109 +307,6 @@ fun AlbumDetailScreen(
                     }
                     
                     val tabTitles = remember { listOf("本地", "DL", "DL Play") }
-                    val tabDockOffset = 10.dp
-                    val tabLift = 6.dp
-                    val tabContainerShape = RoundedCornerShape(18.dp)
-                    val tabItemShape = RoundedCornerShape(14.dp)
-                    val tabBarIsDark = colorScheme.isDark
-                    BoxWithConstraints(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(horizontal = 12.dp, vertical = 10.dp)
-                            .zIndex(1f)
-                    ) {
-                        val count = tabTitles.size
-                        val segmentGap = 4.dp
-                        val segmentPadding = 4.dp
-                        val segmentHeight = 36.dp
-                        val segmentTopPadding = tabDockOffset - tabLift
-                        val innerWidth = maxWidth - segmentPadding * 2
-                        val itemWidth = (innerWidth - segmentGap * (count - 1)) / count
-                        val density = LocalDensity.current
-                        val highlightX by animateDpAsState(
-                            targetValue = segmentPadding + (itemWidth + segmentGap) * selectedTab,
-                            animationSpec = spring(
-                                dampingRatio = Spring.DampingRatioNoBouncy,
-                                stiffness = Spring.StiffnessMediumLow
-                            ),
-                            label = "albumDetailTabHighlightX"
-                        )
-                        Surface(
-                            modifier = Modifier.matchParentSize(),
-                            color = if (tabBarIsDark) {
-                                colorScheme.surface.copy(alpha = 0.28f)
-                            } else {
-                                colorScheme.surface.copy(alpha = 0.86f)
-                            },
-                            contentColor = colorScheme.textPrimary,
-                            shape = tabContainerShape,
-                            tonalElevation = 0.dp,
-                            shadowElevation = 0.dp
-                        ) { }
-                        Box(modifier = Modifier.fillMaxWidth().padding(top = segmentTopPadding)) {
-                            Surface(
-                                modifier = Modifier
-                                    .offset {
-                                        val px = with(density) { highlightX.roundToPx() }
-                                        IntOffset(px, 0)
-                                    }
-                                    .width(itemWidth)
-                                    .height(segmentHeight)
-                                    .zIndex(0f)
-                                    .border(
-                                        width = 1.dp,
-                                        color = if (tabBarIsDark) {
-                                            Color.White.copy(alpha = 0.18f)
-                                        } else {
-                                            Color.Black.copy(alpha = 0.10f)
-                                        },
-                                        shape = tabItemShape
-                                    ),
-                                color = colorScheme.surface,
-                                contentColor = colorScheme.textPrimary,
-                                shape = tabItemShape,
-                                tonalElevation = 0.dp,
-                                shadowElevation = 10.dp
-                            ) { }
-                            Row(
-                                modifier = Modifier
-                                    .fillMaxWidth()
-                                    .padding(4.dp)
-                                    .zIndex(1f),
-                                horizontalArrangement = Arrangement.spacedBy(4.dp),
-                                verticalAlignment = Alignment.CenterVertically
-                            ) {
-                                tabTitles.forEachIndexed { index, title ->
-                                    val selected = selectedTab == index
-                                    Box(
-                                        modifier = Modifier
-                                            .width(itemWidth)
-                                            .height(segmentHeight)
-                                            .clip(tabItemShape)
-                                            .clickable(
-                                                indication = null,
-                                                interactionSource = remember { MutableInteractionSource() }
-                                            ) {
-                                                selectedTab = index
-                                                userSelectedTab = true
-                                            }
-                                            .padding(horizontal = 10.dp),
-                                        contentAlignment = Alignment.Center
-                                    ) {
-                                        Text(
-                                            title,
-                                            modifier = Modifier.offset(y = (-3).dp),
-                                            color = if (selected) colorScheme.textPrimary else colorScheme.textSecondary,
-                                            style = MaterialTheme.typography.titleSmall.copy(fontWeight = if (selected) FontWeight.ExtraBold else FontWeight.Medium),
-                                            maxLines = 1,
-                                            overflow = TextOverflow.Ellipsis
-                                        )
-                                    }
-                                }
-                            }
-                        }
-                    }
-
                     LaunchedEffect(selectedTab, model.rjCode, model.dlsiteWorkno) {
                         when (selectedTab) {
                             1 -> {
@@ -385,16 +317,19 @@ fun AlbumDetailScreen(
                         }
                     }
 
-                    Surface(
+                    Box(
                         modifier = Modifier
                             .fillMaxSize()
-                            .zIndex(0f),
-                        color = colorScheme.surface,
-                        shape = RectangleShape,
-                        tonalElevation = 0.dp,
-                        shadowElevation = 0.dp
+                            .clipToBounds()
+                            .zIndex(0f)
                     ) {
-                        Box(modifier = Modifier.fillMaxSize().padding(top = tabDockOffset)) {
+                        Surface(
+                            modifier = Modifier.fillMaxSize(),
+                            color = Color.Transparent,
+                            shape = RectangleShape,
+                            tonalElevation = 0.dp,
+                            shadowElevation = 0.dp
+                        ) {
                             AnimatedContent(
                                 targetState = selectedTab,
                                 transitionSpec = {
@@ -429,6 +364,8 @@ fun AlbumDetailScreen(
                                                 onPersistScroll = { index, offset ->
                                                     viewModel.persistListScrollPosition("scroll:$localTreeStateKey", index, offset)
                                                 },
+                                                topContentPadding = tabContentTopPadding,
+                                                chromeState = tabChromeState,
                                                 album = local,
                                                 header = headerContent,
                                                 onPlayTracks = onPlayTracks,
@@ -516,6 +453,8 @@ fun AlbumDetailScreen(
                                         treeStateKey = "tree:asmrOne:${model.rjCode.trim().uppercase()}",
                                         treeInitialExpanded = viewModel.getTreeExpanded("tree:asmrOne:${model.rjCode.trim().uppercase()}"),
                                         treeWasInitialized = viewModel.isTreeInitialized("tree:asmrOne:${model.rjCode.trim().uppercase()}"),
+                                        topContentPadding = tabContentTopPadding,
+                                        chromeState = tabChromeState,
                                         onPersistTreeState = { expanded ->
                                             val rj = model.rjCode.trim().uppercase()
                                             viewModel.persistTreeState("tree:asmrOne:$rj", expanded)
@@ -548,6 +487,8 @@ fun AlbumDetailScreen(
                                         treeStateKey = "tree:dlsitePlay:${model.baseRjCode.ifBlank { model.rjCode }.trim().uppercase()}",
                                         treeInitialExpanded = viewModel.getTreeExpanded("tree:dlsitePlay:${model.baseRjCode.ifBlank { model.rjCode }.trim().uppercase()}"),
                                         treeWasInitialized = viewModel.isTreeInitialized("tree:dlsitePlay:${model.baseRjCode.ifBlank { model.rjCode }.trim().uppercase()}"),
+                                        topContentPadding = tabContentTopPadding,
+                                        chromeState = tabChromeState,
                                         onPersistTreeState = { expanded ->
                                             val rj = model.baseRjCode.ifBlank { model.rjCode }.trim().uppercase()
                                             viewModel.persistTreeState("tree:dlsitePlay:$rj", expanded)
@@ -560,6 +501,18 @@ fun AlbumDetailScreen(
                                 }
                             }
                         }
+                        AlbumDetailTabChrome(
+                            modifier = Modifier.align(Alignment.TopCenter),
+                            titles = tabTitles,
+                            selectedTab = selectedTab,
+                            animatedOffsetPx = animatedTabChromeOffsetPx,
+                            collapseFraction = tabChromeState.collapseFraction,
+                            onMeasured = { tabChromeState.updateHeight(it.height.toFloat()) },
+                            onTabSelected = { index ->
+                                selectedTab = index
+                                userSelectedTab = true
+                            }
+                        )
                     }
                 }
 
@@ -656,6 +609,154 @@ fun AlbumDetailScreen(
                             text = state.message,
                             color = MaterialTheme.colorScheme.error
                         )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun AlbumDetailTabChrome(
+    modifier: Modifier = Modifier,
+    titles: List<String>,
+    selectedTab: Int,
+    animatedOffsetPx: Float,
+    collapseFraction: Float,
+    onMeasured: (IntSize) -> Unit,
+    onTabSelected: (Int) -> Unit
+) {
+    val colorScheme = AsmrTheme.colorScheme
+    val isDark = colorScheme.isDark
+    val tabContainerShape = RoundedCornerShape(26.dp)
+    val tabItemShape = RoundedCornerShape(18.dp)
+    val collapseOvershootPx = with(LocalDensity.current) { AlbumDetailTabCollapseOvershoot.toPx() }
+
+    BoxWithConstraints(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 8.dp)
+            .onSizeChanged(onMeasured)
+            .graphicsLayer {
+                translationY = animatedOffsetPx -
+                    (collapseFraction.coerceIn(0f, 1f) * collapseOvershootPx)
+                alpha = 1f - (collapseFraction.coerceIn(0f, 1f) * 0.08f)
+            }
+            .semantics { stateDescription = collapsibleHeaderUiState(collapseFraction) }
+            .zIndex(1f)
+    ) {
+        val count = titles.size.coerceAtLeast(1)
+        val segmentGap = 6.dp
+        val segmentPadding = 6.dp
+        val segmentHeight = 42.dp
+        val slotWidth = (maxWidth - (segmentPadding * 2) - (segmentGap * (count - 1))) / count
+        val highlightX by animateDpAsState(
+            targetValue = (slotWidth + segmentGap) * selectedTab,
+            animationSpec = spring(
+                dampingRatio = Spring.DampingRatioNoBouncy,
+                stiffness = Spring.StiffnessMediumLow
+            ),
+            label = "albumDetailTabHighlightX"
+        )
+
+        Surface(
+            modifier = Modifier
+                .fillMaxWidth()
+                .shadow(
+                    elevation = if (isDark) 12.dp else 8.dp,
+                    shape = tabContainerShape,
+                    spotColor = if (isDark) Color.Black.copy(alpha = 0.8f) else Color.Black.copy(alpha = 0.25f),
+                    ambientColor = if (isDark) Color.Black.copy(alpha = 0.8f) else Color.Black.copy(alpha = 0.25f)
+                )
+                .then(
+                    if (isDark) {
+                        Modifier.border(
+                            width = 1.dp,
+                            color = Color.White.copy(alpha = 0.2f),
+                            shape = tabContainerShape
+                        )
+                    } else {
+                        Modifier
+                    }
+                ),
+            color = if (isDark) {
+                colorScheme.surface.copy(alpha = 0.96f)
+            } else {
+                colorScheme.surface.copy(alpha = 0.96f)
+            },
+            contentColor = colorScheme.textPrimary,
+            shape = tabContainerShape,
+            tonalElevation = 0.dp,
+            shadowElevation = 0.dp
+        ) {
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(segmentPadding)
+            ) {
+                Box(
+                    modifier = Modifier
+                        .offset(x = highlightX)
+                        .width(slotWidth)
+                        .height(segmentHeight)
+                        .clip(tabItemShape)
+                        .background(
+                            color = if (isDark) {
+                                colorScheme.primary.copy(alpha = 0.22f)
+                            } else {
+                                colorScheme.primary.copy(alpha = 0.12f)
+                            },
+                            shape = tabItemShape
+                        )
+                        .border(
+                            width = 1.dp,
+                            color = if (isDark) {
+                                colorScheme.primary.copy(alpha = 0.28f)
+                            } else {
+                                colorScheme.primary.copy(alpha = 0.18f)
+                            },
+                            shape = tabItemShape
+                        )
+                )
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(segmentGap),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    titles.forEachIndexed { index, title ->
+                        val selected = selectedTab == index
+                        Box(
+                            modifier = Modifier
+                                .width(slotWidth)
+                                .height(segmentHeight)
+                                .clip(tabItemShape)
+                                .clickable(
+                                    indication = null,
+                                    interactionSource = remember { MutableInteractionSource() }
+                                ) { onTabSelected(index) }
+                                .padding(horizontal = 4.dp),
+                            contentAlignment = Alignment.Center
+                        ) {
+                            Text(
+                                text = title,
+                                modifier = Modifier.fillMaxWidth(),
+                                color = if (selected) {
+                                    if (isDark) {
+                                        colorScheme.primary
+                                    } else {
+                                        colorScheme.primary
+                                    }
+                                } else {
+                                    colorScheme.textSecondary
+                                },
+                                style = MaterialTheme.typography.titleSmall.copy(
+                                    fontWeight = if (selected) FontWeight.ExtraBold else FontWeight.Medium
+                                ),
+                                textAlign = androidx.compose.ui.text.style.TextAlign.Center,
+                                maxLines = 1,
+                                overflow = TextOverflow.Ellipsis
+                            )
+                        }
                     }
                 }
             }
@@ -1473,6 +1574,8 @@ private fun AlbumLocalTab(
     onPersistTreeState: (List<String>) -> Unit,
     initialScroll: Pair<Int, Int>,
     onPersistScroll: (Int, Int) -> Unit,
+    topContentPadding: Dp,
+    chromeState: com.asmr.player.ui.common.CollapsibleHeaderState,
     album: Album,
     header: @Composable () -> Unit,
     onPlayTracks: (Album, List<Track>, Track) -> Unit,
@@ -1511,6 +1614,11 @@ private fun AlbumLocalTab(
         snapshotFlow { listState.firstVisibleItemIndex to listState.firstVisibleItemScrollOffset }
             .distinctUntilChanged()
             .collect { (idx, off) -> onPersistScroll(idx, off) }
+    }
+    LaunchedEffect(listState.firstVisibleItemIndex, listState.firstVisibleItemScrollOffset) {
+        if (listState.firstVisibleItemIndex == 0 && listState.firstVisibleItemScrollOffset == 0) {
+            chromeState.expand()
+        }
     }
 
     val subtitleTrackIds by produceState(
@@ -1569,9 +1677,11 @@ private fun AlbumLocalTab(
     }
 
     LazyColumn(
-        modifier = Modifier.fillMaxSize(),
+        modifier = Modifier
+            .fillMaxSize()
+            .nestedScroll(chromeState.nestedScrollConnection),
         state = listState,
-        contentPadding = PaddingValues(bottom = LocalBottomOverlayPadding.current)
+        contentPadding = PaddingValues(top = topContentPadding, bottom = LocalBottomOverlayPadding.current)
     ) {
         item { header() }
         if (treeResult.entries.isEmpty()) {
@@ -3424,6 +3534,8 @@ private fun AlbumDlsiteInfoTab(
     treeStateKey: String,
     treeInitialExpanded: List<String>,
     treeWasInitialized: Boolean,
+    topContentPadding: Dp,
+    chromeState: com.asmr.player.ui.common.CollapsibleHeaderState,
     onPersistTreeState: (List<String>) -> Unit,
     initialScroll: Pair<Int, Int>,
     onPersistScroll: (Int, Int) -> Unit,
@@ -3454,10 +3566,17 @@ private fun AlbumDlsiteInfoTab(
             .distinctUntilChanged()
             .collect { (idx, off) -> onPersistScroll(idx, off) }
     }
+    LaunchedEffect(listState.firstVisibleItemIndex, listState.firstVisibleItemScrollOffset) {
+        if (listState.firstVisibleItemIndex == 0 && listState.firstVisibleItemScrollOffset == 0) {
+            chromeState.expand()
+        }
+    }
     LazyColumn(
-        modifier = Modifier.fillMaxSize(),
+        modifier = Modifier
+            .fillMaxSize()
+            .nestedScroll(chromeState.nestedScrollConnection),
         state = listState,
-        contentPadding = PaddingValues(bottom = LocalBottomOverlayPadding.current)
+        contentPadding = PaddingValues(top = topContentPadding, bottom = LocalBottomOverlayPadding.current)
     ) {
         item { header() }
         if (dlsiteInfo == null && isLoading) {
@@ -3797,6 +3916,8 @@ private fun AlbumDlsitePlayTreeTab(
     treeStateKey: String,
     treeInitialExpanded: List<String>,
     treeWasInitialized: Boolean,
+    topContentPadding: Dp,
+    chromeState: com.asmr.player.ui.common.CollapsibleHeaderState,
     onPersistTreeState: (List<String>) -> Unit,
     initialScroll: Pair<Int, Int>,
     onPersistScroll: (Int, Int) -> Unit,
@@ -3844,6 +3965,11 @@ private fun AlbumDlsitePlayTreeTab(
                 onPersistScroll(persistedIndex, off)
             }
     }
+    LaunchedEffect(listState.firstVisibleItemIndex, listState.firstVisibleItemScrollOffset) {
+        if (listState.firstVisibleItemIndex == 0 && listState.firstVisibleItemScrollOffset == 0) {
+            chromeState.expand()
+        }
+    }
 
     val rj = rjCode.trim().uppercase()
     val leafTracks = remember(tree) { flattenAsmrOneTracksForUi(tree) }
@@ -3857,9 +3983,11 @@ private fun AlbumDlsitePlayTreeTab(
     val treeResult = remember(tree, expanded.toList()) { flattenAsmrOneTreeForUi(tree, expanded.toSet()) }
 
     LazyColumn(
-        modifier = Modifier.fillMaxSize(),
+        modifier = Modifier
+            .fillMaxSize()
+            .nestedScroll(chromeState.nestedScrollConnection),
         state = listState,
-        contentPadding = PaddingValues(bottom = LocalBottomOverlayPadding.current)
+        contentPadding = PaddingValues(top = topContentPadding, bottom = LocalBottomOverlayPadding.current)
     ) {
         item { header() }
         item {

--- a/app/src/main/java/com/asmr/player/ui/library/LibraryScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/LibraryScreen.kt
@@ -2,6 +2,9 @@ package com.asmr.player.ui.library
 
 import android.content.Intent
 import androidx.activity.compose.BackHandler
+import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.layout.Box
@@ -132,6 +135,7 @@ import androidx.compose.material3.Card
 import androidx.compose.ui.draw.blur
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.text.style.TextOverflow
 import com.asmr.player.ui.common.AsmrAsyncImage
 import androidx.paging.LoadState
@@ -141,8 +145,22 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.stateDescription
 import com.asmr.player.ui.common.CustomSearchBar
 import com.asmr.player.ui.common.ActionButton
+import com.asmr.player.ui.common.collapsibleHeaderUiState
+import com.asmr.player.ui.common.rememberCollapsibleHeaderState
+
+internal const val LIBRARY_CHROME_TAG = "library_chrome"
+internal const val LIBRARY_SEARCH_INPUT_TAG = "library_search_input"
+internal const val LIBRARY_SORT_BUTTON_TAG = "library_sort_button"
+internal const val LIBRARY_FILTER_BUTTON_TAG = "library_filter_button"
+private val LibraryChromeContentGap = 12.dp
+private val LibraryChromeCollapseOvershoot = 12.dp
 
 @Composable
 private fun LibraryActionItem(
@@ -237,6 +255,18 @@ fun LibraryScreen(
     var showAlbumActions by remember { mutableStateOf(false) }
     var showDeleteConfirm by remember { mutableStateOf(false) }
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    val chromeState = rememberCollapsibleHeaderState()
+    val animatedChromeOffsetPx by animateFloatAsState(
+        targetValue = chromeState.offsetPx,
+        animationSpec = tween(durationMillis = 220, easing = FastOutSlowInEasing),
+        label = "libraryChromeOffset"
+    )
+    val chromeVisibleHeightPx = if (chromeState.heightPx > 0f) {
+        (chromeState.heightPx + animatedChromeOffsetPx).coerceIn(0f, chromeState.heightPx)
+    } else {
+        with(LocalDensity.current) { 80.dp.toPx() }
+    }
+    val topPadding = with(LocalDensity.current) { chromeVisibleHeightPx.toDp() } + LibraryChromeContentGap
 
     LaunchedEffect(isTrackList) {
         if (!isTrackList) {
@@ -250,6 +280,25 @@ fun LibraryScreen(
     LaunchedEffect(showDeleteConfirm, actionAlbum) {
         if (showDeleteConfirm && (actionAlbum == null || actionAlbum?.id?.let { it <= 0L } == true)) {
             showDeleteConfirm = false
+        }
+    }
+    LaunchedEffect(mode) {
+        chromeState.expand()
+    }
+    LaunchedEffect(listState.firstVisibleItemIndex, listState.firstVisibleItemScrollOffset, mode) {
+        if ((mode == 0 || mode == 2) &&
+            listState.firstVisibleItemIndex == 0 &&
+            listState.firstVisibleItemScrollOffset == 0
+        ) {
+            chromeState.expand()
+        }
+    }
+    LaunchedEffect(gridState.firstVisibleItemIndex, gridState.firstVisibleItemScrollOffset, mode) {
+        if (mode == 1 &&
+            gridState.firstVisibleItemIndex == 0 &&
+            gridState.firstVisibleItemScrollOffset == 0
+        ) {
+            chromeState.expand()
         }
     }
 
@@ -442,8 +491,10 @@ fun LibraryScreen(
                                 } else if (isTrackList) {
                                     LazyColumn(
                                         state = listState,
-                                        modifier = Modifier.fillMaxSize(),
-                                        contentPadding = PaddingValues(top = 80.dp, bottom = 8.dp)
+                                        modifier = Modifier
+                                            .fillMaxSize()
+                                            .nestedScroll(chromeState.nestedScrollConnection),
+                                        contentPadding = PaddingValues(top = topPadding, bottom = 8.dp)
                                             .withAddedBottomPadding(LocalBottomOverlayPadding.current)
                                     ) {
                                         val headerCount = pagedTrackAlbumHeaders.itemCount
@@ -608,8 +659,10 @@ fun LibraryScreen(
                                     LazyVerticalStaggeredGrid(
                                         columns = StaggeredGridCells.Adaptive(150.dp),
                                         state = gridState,
-                                        modifier = Modifier.fillMaxSize(),
-                                        contentPadding = PaddingValues(top = 80.dp, start = 16.dp, end = 16.dp, bottom = 16.dp)
+                                        modifier = Modifier
+                                            .fillMaxSize()
+                                            .nestedScroll(chromeState.nestedScrollConnection),
+                                        contentPadding = PaddingValues(top = topPadding, start = 16.dp, end = 16.dp, bottom = 16.dp)
                                             .withAddedBottomPadding(LocalBottomOverlayPadding.current),
                                         verticalItemSpacing = 16.dp,
                                         horizontalArrangement = Arrangement.spacedBy(16.dp)
@@ -660,8 +713,10 @@ fun LibraryScreen(
                                     )
                                     LazyColumn(
                                         state = listState,
-                                        modifier = Modifier.fillMaxSize(),
-                                        contentPadding = PaddingValues(top = 80.dp, bottom = 8.dp)
+                                        modifier = Modifier
+                                            .fillMaxSize()
+                                            .nestedScroll(chromeState.nestedScrollConnection),
+                                        contentPadding = PaddingValues(top = topPadding, bottom = 8.dp)
                                             .withAddedBottomPadding(LocalBottomOverlayPadding.current)
                                     ) {
                                         items(
@@ -683,107 +738,30 @@ fun LibraryScreen(
                                     }
                                 }
 
-                                Row(
-                                    modifier = Modifier
-                                        .align(Alignment.TopCenter)
-                                        .fillMaxWidth()
-                                        .padding(horizontal = 16.dp, vertical = 8.dp),
-                                    verticalAlignment = Alignment.CenterVertically
-                                ) {
-                                    CustomSearchBar(
-                                        value = searchText,
-                                        onValueChange = {
-                                            searchText = it
-                                            viewModel.setSearchQuery(it)
-                                        },
-                                        placeholder = "社团 / CV / 标签...",
-                                        modifier = Modifier.weight(1f),
-                                        leadingIcon = {
-                                            Icon(
-                                                imageVector = Icons.Default.Search,
-                                                contentDescription = null,
-                                                tint = colorScheme.onSurfaceVariant
-                                            )
-                                        },
-                                        trailingIcon = if (searchText.isNotBlank()) {
-                                            {
-                                                IconButton(
-                                                    onClick = {
-                                                        searchText = ""
-                                                        viewModel.setSearchQuery("")
-                                                    },
-                                                    modifier = Modifier.size(24.dp)
-                                                ) {
-                                                    Icon(
-                                                        imageVector = Icons.Default.Close,
-                                                        contentDescription = null,
-                                                        tint = colorScheme.onSurfaceVariant
-                                                    )
-                                                }
-                                            }
-                                        } else null
-                                    )
-                                    Spacer(modifier = Modifier.width(12.dp))
-                                    Box {
-                                        ActionButton(
-                                            icon = Icons.Default.SwapVert,
-                                            onClick = { sortMenuExpanded = true }
-                                        )
-                                        MaterialTheme(
-                                            colorScheme = materialColorScheme.copy(
-                                                surface = dynamicContainerColor,
-                                                surfaceContainer = dynamicContainerColor
-                                            )
-                                        ) {
-                                            DropdownMenu(
-                                                expanded = sortMenuExpanded,
-                                                onDismissRequest = { sortMenuExpanded = false },
-                                                modifier = Modifier.background(dynamicContainerColor)
-                                            ) {
-                                                DropdownMenuItem(
-                                                    text = { Text("最近") },
-                                                    onClick = {
-                                                        sortMenuExpanded = false
-                                                        viewModel.setSort(LibrarySort.LastPlayedDesc)
-                                                    }
-                                                )
-                                                HorizontalDivider(
-                                                    modifier = Modifier.padding(horizontal = 8.dp),
-                                                    thickness = 0.5.dp,
-                                                    color = materialColorScheme.outlineVariant.copy(alpha = 0.3f)
-                                                )
-                                                DropdownMenuItem(
-                                                    text = { Text("最近加入") },
-                                                    onClick = {
-                                                        sortMenuExpanded = false
-                                                        viewModel.setSort(LibrarySort.AddedDesc)
-                                                    }
-                                                )
-                                                HorizontalDivider(
-                                                    modifier = Modifier.padding(horizontal = 8.dp),
-                                                    thickness = 0.5.dp,
-                                                    color = materialColorScheme.outlineVariant.copy(alpha = 0.3f)
-                                                )
-                                                DropdownMenuItem(
-                                                    text = { Text("标题") },
-                                                    onClick = {
-                                                        sortMenuExpanded = false
-                                                        viewModel.setSort(LibrarySort.TitleAsc)
-                                                    }
-                                                )
-                                            }
-                                        }
-                                    }
-                                    Spacer(modifier = Modifier.width(8.dp))
-                                    ActionButton(
-                                        icon = Icons.Default.FilterList,
-                                        onClick = onOpenFilterScreen
-                                    )
-                                    if (rightPanelToggle != null) {
-                                        Spacer(modifier = Modifier.width(8.dp))
-                                        rightPanelToggle(Modifier.size(50.dp))
-                                    }
-                                }
+                                LibraryChrome(
+                                    modifier = Modifier.align(Alignment.TopCenter),
+                                    searchText = searchText,
+                                    onSearchTextChange = {
+                                        searchText = it
+                                        viewModel.setSearchQuery(it)
+                                    },
+                                    onClearSearch = {
+                                        searchText = ""
+                                        viewModel.setSearchQuery("")
+                                    },
+                                    sortMenuExpanded = sortMenuExpanded,
+                                    onSortMenuExpandedChange = { sortMenuExpanded = it },
+                                    onSortLastPlayed = { viewModel.setSort(LibrarySort.LastPlayedDesc) },
+                                    onSortAdded = { viewModel.setSort(LibrarySort.AddedDesc) },
+                                    onSortTitle = { viewModel.setSort(LibrarySort.TitleAsc) },
+                                    onOpenFilterScreen = onOpenFilterScreen,
+                                    rightPanelToggle = rightPanelToggle,
+                                    dynamicContainerColor = dynamicContainerColor,
+                                    materialColorScheme = materialColorScheme,
+                                    chromeOffsetPx = animatedChromeOffsetPx,
+                                    collapseFraction = chromeState.collapseFraction,
+                                    onMeasured = { chromeState.updateHeight(it.height.toFloat()) }
+                                )
                             }
                         }
                     }
@@ -963,6 +941,137 @@ fun LibraryScreen(
         }
     }
 
+}
+
+@Composable
+internal fun LibraryChrome(
+    modifier: Modifier = Modifier,
+    searchText: String,
+    onSearchTextChange: (String) -> Unit,
+    onClearSearch: () -> Unit,
+    sortMenuExpanded: Boolean,
+    onSortMenuExpandedChange: (Boolean) -> Unit,
+    onSortLastPlayed: () -> Unit,
+    onSortAdded: () -> Unit,
+    onSortTitle: () -> Unit,
+    onOpenFilterScreen: () -> Unit,
+    rightPanelToggle: (@Composable (Modifier) -> Unit)?,
+    dynamicContainerColor: Color,
+    materialColorScheme: androidx.compose.material3.ColorScheme,
+    chromeOffsetPx: Float,
+    collapseFraction: Float,
+    onMeasured: (IntSize) -> Unit
+) {
+    val colorScheme = AsmrTheme.colorScheme
+    val collapseOvershootPx = with(LocalDensity.current) { LibraryChromeCollapseOvershoot.toPx() }
+
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 8.dp)
+            .onSizeChanged(onMeasured)
+            .graphicsLayer {
+                translationY = chromeOffsetPx - (collapseFraction.coerceIn(0f, 1f) * collapseOvershootPx)
+                alpha = 1f - (collapseFraction.coerceIn(0f, 1f) * 0.1f)
+            }
+            .semantics { stateDescription = collapsibleHeaderUiState(collapseFraction) }
+            .testTag(LIBRARY_CHROME_TAG),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        CustomSearchBar(
+            value = searchText,
+            onValueChange = onSearchTextChange,
+            placeholder = "社团 / CV / 标签...",
+            modifier = Modifier
+                .weight(1f)
+                .testTag(LIBRARY_SEARCH_INPUT_TAG),
+            leadingIcon = {
+                Icon(
+                    imageVector = Icons.Default.Search,
+                    contentDescription = null,
+                    tint = colorScheme.onSurfaceVariant
+                )
+            },
+            trailingIcon = if (searchText.isNotBlank()) {
+                {
+                    IconButton(
+                        onClick = onClearSearch,
+                        modifier = Modifier.size(24.dp)
+                    ) {
+                        Icon(
+                            imageVector = Icons.Default.Close,
+                            contentDescription = null,
+                            tint = colorScheme.onSurfaceVariant
+                        )
+                    }
+                }
+            } else {
+                null
+            }
+        )
+        Spacer(modifier = Modifier.width(12.dp))
+        Box {
+            ActionButton(
+                icon = Icons.Default.SwapVert,
+                onClick = { onSortMenuExpandedChange(true) },
+                modifier = Modifier.testTag(LIBRARY_SORT_BUTTON_TAG)
+            )
+            MaterialTheme(
+                colorScheme = materialColorScheme.copy(
+                    surface = dynamicContainerColor,
+                    surfaceContainer = dynamicContainerColor
+                )
+            ) {
+                DropdownMenu(
+                    expanded = sortMenuExpanded,
+                    onDismissRequest = { onSortMenuExpandedChange(false) },
+                    modifier = Modifier.background(dynamicContainerColor)
+                ) {
+                    DropdownMenuItem(
+                        text = { Text("最近") },
+                        onClick = {
+                            onSortMenuExpandedChange(false)
+                            onSortLastPlayed()
+                        }
+                    )
+                    HorizontalDivider(
+                        modifier = Modifier.padding(horizontal = 8.dp),
+                        thickness = 0.5.dp,
+                        color = materialColorScheme.outlineVariant.copy(alpha = 0.3f)
+                    )
+                    DropdownMenuItem(
+                        text = { Text("最近加入") },
+                        onClick = {
+                            onSortMenuExpandedChange(false)
+                            onSortAdded()
+                        }
+                    )
+                    HorizontalDivider(
+                        modifier = Modifier.padding(horizontal = 8.dp),
+                        thickness = 0.5.dp,
+                        color = materialColorScheme.outlineVariant.copy(alpha = 0.3f)
+                    )
+                    DropdownMenuItem(
+                        text = { Text("标题") },
+                        onClick = {
+                            onSortMenuExpandedChange(false)
+                            onSortTitle()
+                        }
+                    )
+                }
+            }
+        }
+        Spacer(modifier = Modifier.width(8.dp))
+        ActionButton(
+            icon = Icons.Default.FilterList,
+            onClick = onOpenFilterScreen,
+            modifier = Modifier.testTag(LIBRARY_FILTER_BUTTON_TAG)
+        )
+        if (rightPanelToggle != null) {
+            Spacer(modifier = Modifier.width(8.dp))
+            rightPanelToggle(Modifier.size(50.dp))
+        }
+    }
 }
 
 private sealed class TagAssignTarget {

--- a/app/src/main/java/com/asmr/player/ui/search/SearchScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/search/SearchScreen.kt
@@ -1,5 +1,8 @@
 package com.asmr.player.ui.search
 
+import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
@@ -64,15 +67,22 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.stateDescription
+import androidx.compose.ui.layout.onSizeChanged
+import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.asmr.player.domain.model.Album
 import com.asmr.player.ui.common.CustomSearchBar
 import com.asmr.player.ui.common.LocalBottomOverlayPadding
+import com.asmr.player.ui.common.collapsibleHeaderUiState
+import com.asmr.player.ui.common.rememberCollapsibleHeaderState
 import com.asmr.player.ui.common.withAddedBottomPadding
 import com.asmr.player.ui.library.AlbumGridItem
 import com.asmr.player.ui.library.AlbumItem
@@ -90,6 +100,7 @@ internal const val SEARCH_SUBMIT_SPINNER_TAG = "search_submit_spinner"
 internal const val SEARCH_PREV_BUTTON_TAG = "search_prev_button"
 internal const val SEARCH_NEXT_BUTTON_TAG = "search_next_button"
 internal const val SEARCH_PAGINATION_SPINNER_TAG = "search_pagination_spinner"
+internal const val SEARCH_CHROME_TAG = "search_chrome"
 
 private fun stableAlbumKey(album: Album): String {
     val id = album.rjCode.ifBlank { album.workId }.trim()
@@ -122,6 +133,7 @@ fun SearchScreen(
     val scope = rememberCoroutineScope()
     val keyboardController = LocalSoftwareKeyboardController.current
     val isCompact = windowSizeClass.widthSizeClass == WindowWidthSizeClass.Compact
+    val chromeState = rememberCollapsibleHeaderState()
 
     var keywordSyncedFromState by rememberSaveable { mutableStateOf(false) }
     var optionsSyncedFromState by rememberSaveable { mutableStateOf(false) }
@@ -156,6 +168,17 @@ fun SearchScreen(
     val highlightedPage = success?.page ?: 1
     val canGoPrev = success?.canGoPrev == true && success?.isSearching != true
     val canGoNext = success?.canGoNext == true && success?.isSearching != true
+    val animatedChromeOffsetPx by animateFloatAsState(
+        targetValue = chromeState.offsetPx,
+        animationSpec = tween(durationMillis = 220, easing = FastOutSlowInEasing),
+        label = "searchChromeOffset"
+    )
+    val chromeVisibleHeightPx = when {
+        chromeState.heightPx > 0f -> (chromeState.heightPx + animatedChromeOffsetPx).coerceIn(0f, chromeState.heightPx)
+        success != null -> with(androidx.compose.ui.platform.LocalDensity.current) { 120.dp.toPx() }
+        else -> with(androidx.compose.ui.platform.LocalDensity.current) { 80.dp.toPx() }
+    }
+    val topPadding = with(androidx.compose.ui.platform.LocalDensity.current) { chromeVisibleHeightPx.toDp() }
 
     fun scrollResultsToTop() {
         scope.launch {
@@ -196,6 +219,19 @@ fun SearchScreen(
             else -> true
         }
         if (canEnd) pullToRefreshState.endRefresh()
+    }
+    LaunchedEffect(currentPageKey, viewMode) {
+        chromeState.expand()
+    }
+    LaunchedEffect(listState.firstVisibleItemIndex, listState.firstVisibleItemScrollOffset, viewMode) {
+        if (viewMode == 0 && listState.firstVisibleItemIndex == 0 && listState.firstVisibleItemScrollOffset == 0) {
+            chromeState.expand()
+        }
+    }
+    LaunchedEffect(gridState.firstVisibleItemIndex, gridState.firstVisibleItemScrollOffset, viewMode) {
+        if (viewMode != 0 && gridState.firstVisibleItemIndex == 0 && gridState.firstVisibleItemScrollOffset == 0) {
+            chromeState.expand()
+        }
     }
 
     Scaffold(
@@ -248,8 +284,6 @@ fun SearchScreen(
                             .fillMaxWidth()
                     }
                 ) {
-                    val topPadding = if (success != null) 120.dp else 80.dp
-
                     Box(
                         modifier = Modifier
                             .fillMaxSize()
@@ -272,7 +306,9 @@ fun SearchScreen(
                                 if (viewMode == 0) {
                                     LazyColumn(
                                         state = listState,
-                                        modifier = Modifier.fillMaxSize(),
+                                        modifier = Modifier
+                                            .fillMaxSize()
+                                            .nestedScroll(chromeState.nestedScrollConnection),
                                         contentPadding = PaddingValues(top = topPadding, bottom = 8.dp)
                                             .withAddedBottomPadding(LocalBottomOverlayPadding.current)
                                     ) {
@@ -292,7 +328,9 @@ fun SearchScreen(
                                     LazyVerticalStaggeredGrid(
                                         columns = StaggeredGridCells.Adaptive(150.dp),
                                         state = gridState,
-                                        modifier = Modifier.fillMaxSize(),
+                                        modifier = Modifier
+                                            .fillMaxSize()
+                                            .nestedScroll(chromeState.nestedScrollConnection),
                                         contentPadding = PaddingValues(
                                             top = topPadding,
                                             start = 16.dp,
@@ -368,69 +406,135 @@ fun SearchScreen(
                         )
                     }
 
-                    Column(modifier = Modifier.align(Alignment.TopCenter)) {
-                        SearchToolbar(
-                            keyword = keyword,
-                            onKeywordChange = { keyword = it },
-                            selectedOrder = selectedOrder,
-                            purchasedOnly = purchasedOnly,
-                            selectedLocale = selectedLocale,
-                            filterControlsLocked = filterControlsLocked,
-                            searchSubmitLocked = searchSubmitLocked,
-                            showSearchSpinner = showSearchSpinner,
-                            onSearchSubmit = ::submitSearch,
-                            onPurchasedOnlySelected = {
-                                purchasedOnly = true
-                                viewModel.updateSearchOptions(
-                                    order = selectedOrder,
-                                    purchasedOnly = true,
-                                    locale = selectedLocale
-                                )
-                            },
-                            onOrderSelected = { order ->
-                                selectedOrderName = order.name
-                                purchasedOnly = false
-                                viewModel.updateSearchOptions(
-                                    order = order,
-                                    purchasedOnly = false,
-                                    locale = selectedLocale
-                                )
-                            },
-                            onLocaleSelected = { locale ->
-                                selectedLocale = locale
-                                purchasedOnly = false
-                                viewModel.updateSearchOptions(
-                                    order = selectedOrder,
-                                    purchasedOnly = false,
-                                    locale = locale
-                                )
-                            }
-                        )
-
-                        if (rightPanelToggle != null) {
-                            Spacer(modifier = Modifier.height(8.dp))
-                            rightPanelToggle(Modifier.size(50.dp))
-                        }
-                        if (success != null) {
-                            SearchPaginationHeader(
-                                page = highlightedPage,
-                                canGoPrev = canGoPrev,
-                                canGoNext = canGoNext,
-                                controlsLocked = interactionLocked,
-                                showPagingSpinner = showPaginationSpinner,
-                                onPrev = {
-                                    scrollResultsToTop()
-                                    viewModel.prevPage()
-                                },
-                                onNext = {
-                                    scrollResultsToTop()
-                                    viewModel.nextPage()
-                                }
+                    SearchChrome(
+                        modifier = Modifier.align(Alignment.TopCenter),
+                        keyword = keyword,
+                        onKeywordChange = { keyword = it },
+                        selectedOrder = selectedOrder,
+                        purchasedOnly = purchasedOnly,
+                        selectedLocale = selectedLocale,
+                        filterControlsLocked = filterControlsLocked,
+                        searchSubmitLocked = searchSubmitLocked,
+                        showSearchSpinner = showSearchSpinner,
+                        showPagination = success != null,
+                        page = highlightedPage,
+                        canGoPrev = canGoPrev,
+                        canGoNext = canGoNext,
+                        controlsLocked = interactionLocked,
+                        showPagingSpinner = showPaginationSpinner,
+                        rightPanelToggle = rightPanelToggle,
+                        animatedOffsetPx = animatedChromeOffsetPx,
+                        collapseFraction = chromeState.collapseFraction,
+                        onMeasured = { size: IntSize -> chromeState.updateHeight(size.height.toFloat()) },
+                        onSearchSubmit = ::submitSearch,
+                        onPurchasedOnlySelected = {
+                            purchasedOnly = true
+                            viewModel.updateSearchOptions(
+                                order = selectedOrder,
+                                purchasedOnly = true,
+                                locale = selectedLocale
                             )
+                        },
+                        onOrderSelected = { order ->
+                            selectedOrderName = order.name
+                            purchasedOnly = false
+                            viewModel.updateSearchOptions(
+                                order = order,
+                                purchasedOnly = false,
+                                locale = selectedLocale
+                            )
+                        },
+                        onLocaleSelected = { locale ->
+                            selectedLocale = locale
+                            purchasedOnly = false
+                            viewModel.updateSearchOptions(
+                                order = selectedOrder,
+                                purchasedOnly = false,
+                                locale = locale
+                            )
+                        },
+                        onPrev = {
+                            scrollResultsToTop()
+                            viewModel.prevPage()
+                        },
+                        onNext = {
+                            scrollResultsToTop()
+                            viewModel.nextPage()
                         }
-                    }
+                    )
                 }
             }
+        }
+    }
+}
+
+@Composable
+internal fun SearchChrome(
+    modifier: Modifier = Modifier,
+    keyword: String,
+    onKeywordChange: (String) -> Unit,
+    selectedOrder: SearchSortOption,
+    purchasedOnly: Boolean,
+    selectedLocale: String,
+    filterControlsLocked: Boolean,
+    searchSubmitLocked: Boolean,
+    showSearchSpinner: Boolean,
+    showPagination: Boolean,
+    page: Int,
+    canGoPrev: Boolean,
+    canGoNext: Boolean,
+    controlsLocked: Boolean,
+    showPagingSpinner: Boolean,
+    rightPanelToggle: (@Composable (Modifier) -> Unit)?,
+    animatedOffsetPx: Float,
+    collapseFraction: Float,
+    onMeasured: (IntSize) -> Unit,
+    onSearchSubmit: () -> Unit,
+    onPurchasedOnlySelected: () -> Unit,
+    onOrderSelected: (SearchSortOption) -> Unit,
+    onLocaleSelected: (String) -> Unit,
+    onPrev: () -> Unit,
+    onNext: () -> Unit
+) {
+    Column(
+        modifier = modifier
+            .onSizeChanged(onMeasured)
+            .graphicsLayer {
+                translationY = animatedOffsetPx
+                alpha = 1f - (collapseFraction.coerceIn(0f, 1f) * 0.1f)
+            }
+            .semantics { stateDescription = collapsibleHeaderUiState(collapseFraction) }
+            .testTag(SEARCH_CHROME_TAG)
+    ) {
+        SearchToolbar(
+            keyword = keyword,
+            onKeywordChange = onKeywordChange,
+            selectedOrder = selectedOrder,
+            purchasedOnly = purchasedOnly,
+            selectedLocale = selectedLocale,
+            filterControlsLocked = filterControlsLocked,
+            searchSubmitLocked = searchSubmitLocked,
+            showSearchSpinner = showSearchSpinner,
+            onSearchSubmit = onSearchSubmit,
+            onPurchasedOnlySelected = onPurchasedOnlySelected,
+            onOrderSelected = onOrderSelected,
+            onLocaleSelected = onLocaleSelected
+        )
+
+        if (rightPanelToggle != null) {
+            Spacer(modifier = Modifier.height(8.dp))
+            rightPanelToggle(Modifier.size(50.dp))
+        }
+        if (showPagination) {
+            SearchPaginationHeader(
+                page = page,
+                canGoPrev = canGoPrev,
+                canGoNext = canGoNext,
+                controlsLocked = controlsLocked,
+                showPagingSpinner = showPagingSpinner,
+                onPrev = onPrev,
+                onNext = onNext
+            )
         }
     }
 }

--- a/app/src/test/java/com/asmr/player/data/settings/LyricsPageSettingsTest.kt
+++ b/app/src/test/java/com/asmr/player/data/settings/LyricsPageSettingsTest.kt
@@ -8,11 +8,10 @@ class LyricsPageSettingsTest {
     fun defaults_matchExpectedLyricsPagePresentation() {
         val settings = LyricsPageSettings()
 
-        assertEquals(24f, settings.fontSizeSp, 0.001f)
-        assertEquals(0f, settings.strokeWidthSp, 0.001f)
-        assertEquals(1.4f, settings.lineHeightMultiplier, 0.001f)
-        assertEquals(6, settings.maxVisibleLines)
-        assertEquals(1, settings.align)
-        assertEquals(0.5f, settings.centerPositionFraction, 0.001f)
+        assertEquals(21f, settings.fontSizeSp, 0.001f)
+        assertEquals(0.1f, settings.strokeWidthSp, 0.001f)
+        assertEquals(1.5f, settings.lineHeightMultiplier, 0.001f)
+        assertEquals(0, settings.align)
+        assertEquals(0, settings.displayAreaMode)
     }
 }

--- a/app/src/test/java/com/asmr/player/ui/common/CollapsibleHeaderStateTest.kt
+++ b/app/src/test/java/com/asmr/player/ui/common/CollapsibleHeaderStateTest.kt
@@ -1,0 +1,24 @@
+package com.asmr.player.ui.common
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class CollapsibleHeaderStateTest {
+    @Test
+    fun scrollDelta_clampsWithinExpandedAndCollapsedBounds() {
+        val state = CollapsibleHeaderState()
+        state.updateHeight(120f)
+
+        state.onScrollDelta(-200f)
+        assertEquals(-120f, state.offsetPx)
+        assertEquals(1f, state.collapseFraction)
+
+        state.onScrollDelta(50f)
+        assertEquals(-70f, state.offsetPx)
+        assertEquals(COLLAPSIBLE_HEADER_STATE_PARTIAL, collapsibleHeaderUiState(state.collapseFraction))
+
+        state.onScrollDelta(200f)
+        assertEquals(0f, state.offsetPx)
+        assertEquals(COLLAPSIBLE_HEADER_STATE_EXPANDED, collapsibleHeaderUiState(state.collapseFraction))
+    }
+}

--- a/app/src/test/java/com/asmr/player/ui/library/LibraryScreenChromeTest.kt
+++ b/app/src/test/java/com/asmr/player/ui/library/LibraryScreenChromeTest.kt
@@ -1,0 +1,83 @@
+package com.asmr.player.ui.library
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.test.SemanticsMatcher
+import androidx.compose.ui.test.assert
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.asmr.player.ui.common.CollapsibleHeaderState
+import com.asmr.player.ui.theme.AsmrPlayerTheme
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class LibraryScreenChromeTest {
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    @Test
+    fun libraryChrome_collapsesAndExpandsWhileKeepingControlsMounted() {
+        composeRule.mainClock.autoAdvance = false
+        lateinit var chromeState: CollapsibleHeaderState
+
+        composeRule.setContent {
+            chromeState = remember { CollapsibleHeaderState() }
+
+            AsmrPlayerTheme {
+                LibraryChrome(
+                    modifier = Modifier,
+                    searchText = "voice",
+                    onSearchTextChange = {},
+                    onClearSearch = {},
+                    sortMenuExpanded = false,
+                    onSortMenuExpandedChange = {},
+                    onSortLastPlayed = {},
+                    onSortAdded = {},
+                    onSortTitle = {},
+                    onOpenFilterScreen = {},
+                    rightPanelToggle = null,
+                    dynamicContainerColor = MaterialTheme.colorScheme.surface,
+                    materialColorScheme = MaterialTheme.colorScheme,
+                    chromeOffsetPx = chromeState.offsetPx,
+                    collapseFraction = chromeState.collapseFraction,
+                    onMeasured = { chromeState.updateHeight(it.height.toFloat()) }
+                )
+            }
+        }
+
+        composeRule.waitForIdle()
+        composeRule.onNodeWithTag(LIBRARY_CHROME_TAG).assert(
+            SemanticsMatcher.expectValue(SemanticsProperties.StateDescription, "expanded")
+        )
+
+        composeRule.runOnIdle { chromeState.onScrollDelta(-1000f) }
+        composeRule.mainClock.advanceTimeBy(250)
+        composeRule.waitForIdle()
+
+        composeRule.onNodeWithTag(LIBRARY_CHROME_TAG).assert(
+            SemanticsMatcher.expectValue(SemanticsProperties.StateDescription, "collapsed")
+        )
+        composeRule.onNodeWithTag(LIBRARY_SEARCH_INPUT_TAG).assert(
+            SemanticsMatcher.expectValue(SemanticsProperties.TestTag, LIBRARY_SEARCH_INPUT_TAG)
+        )
+        composeRule.onNodeWithTag(LIBRARY_SORT_BUTTON_TAG).assert(
+            SemanticsMatcher.expectValue(SemanticsProperties.TestTag, LIBRARY_SORT_BUTTON_TAG)
+        )
+        composeRule.onNodeWithTag(LIBRARY_FILTER_BUTTON_TAG).assert(
+            SemanticsMatcher.expectValue(SemanticsProperties.TestTag, LIBRARY_FILTER_BUTTON_TAG)
+        )
+
+        composeRule.runOnIdle { chromeState.expand() }
+        composeRule.mainClock.advanceTimeBy(250)
+        composeRule.waitForIdle()
+
+        composeRule.onNodeWithTag(LIBRARY_CHROME_TAG).assert(
+            SemanticsMatcher.expectValue(SemanticsProperties.StateDescription, "expanded")
+        )
+    }
+}

--- a/app/src/test/java/com/asmr/player/ui/player/LyricsPageLayoutTest.kt
+++ b/app/src/test/java/com/asmr/player/ui/player/LyricsPageLayoutTest.kt
@@ -3,7 +3,6 @@ package com.asmr.player.ui.player
 import androidx.compose.ui.text.style.TextAlign
 import com.asmr.player.data.settings.LyricsPageSettings
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class LyricsPageLayoutTest {
@@ -18,17 +17,28 @@ class LyricsPageLayoutTest {
     fun viewportLayout_clampsVisibleLinesAndTopOffset() {
         val layout = buildLyricsViewportLayout(
             settings = LyricsPageSettings(
-                maxVisibleLines = 9,
-                centerPositionFraction = 0.9f
+                displayAreaMode = 2
             ),
             viewportHeightPx = 640f,
-            lineBlockHeightPx = 100f
+            nominalItemHeightPx = 100f
         )
 
-        assertEquals(6, layout.runtimeMaxVisibleLines)
-        assertEquals(6, layout.effectiveVisibleLines)
-        assertEquals(600f, layout.viewportWindowHeightPx, 0.001f)
-        assertTrue(layout.viewportTopOffsetPx in 0f..40f)
+        assertEquals(100f, layout.nominalItemHeightPx, 0.001f)
+        assertEquals(160f, layout.viewportWindowHeightPx, 0.001f)
+        assertEquals(240f, layout.viewportTopOffsetPx, 0.001f)
+    }
+
+    @Test
+    fun viewportLayout_respectsMeasuredWindowWithinRequestedBounds() {
+        val layout = buildLyricsViewportLayout(
+            settings = LyricsPageSettings(displayAreaMode = 1),
+            viewportHeightPx = 640f,
+            nominalItemHeightPx = 100f,
+            measuredWindowHeightPx = 140f
+        )
+
+        assertEquals(140f, layout.viewportWindowHeightPx, 0.001f)
+        assertEquals(0f, layout.viewportTopOffsetPx, 0.001f)
     }
 
     @Test

--- a/app/src/test/java/com/asmr/player/ui/search/SearchScreenChromeTest.kt
+++ b/app/src/test/java/com/asmr/player/ui/search/SearchScreenChromeTest.kt
@@ -6,7 +6,10 @@ import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.test.assertExists
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.test.SemanticsMatcher
+import androidx.compose.ui.test.assert
 import androidx.compose.ui.test.assertIsNotEnabled
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
@@ -14,7 +17,8 @@ import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performImeAction
 import androidx.compose.ui.test.performTextInput
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.asmr.player.ui.theme.AsmrTheme
+import com.asmr.player.ui.common.CollapsibleHeaderState
+import com.asmr.player.ui.theme.AsmrPlayerTheme
 import org.junit.Assert.assertEquals
 import org.junit.Rule
 import org.junit.Test
@@ -32,7 +36,7 @@ class SearchScreenChromeTest {
         composeRule.setContent {
             var keyword by remember { mutableStateOf("") }
 
-            AsmrTheme {
+            AsmrPlayerTheme {
                 SearchToolbar(
                     keyword = keyword,
                     onKeywordChange = { keyword = it },
@@ -65,10 +69,10 @@ class SearchScreenChromeTest {
     @Test
     fun searchPending_disablesChromeAndShowsSearchSpinner() {
         composeRule.setContent {
-            AsmrTheme {
+            AsmrPlayerTheme {
                 Column {
                     SearchToolbar(
-                        keyword = "耳かき",
+                        keyword = "test",
                         onKeywordChange = {},
                         selectedOrder = SearchSortOption.Trend,
                         purchasedOnly = false,
@@ -97,16 +101,18 @@ class SearchScreenChromeTest {
         composeRule.onNodeWithTag(SEARCH_SCOPE_BUTTON_TAG).assertIsNotEnabled()
         composeRule.onNodeWithTag(SEARCH_LANGUAGE_BUTTON_TAG).assertIsNotEnabled()
         composeRule.onNodeWithTag(SEARCH_SUBMIT_BUTTON_TAG).assertIsNotEnabled()
-        composeRule.onNodeWithTag(SEARCH_SUBMIT_SPINNER_TAG).assertExists()
+        composeRule.onNodeWithTag(SEARCH_SUBMIT_SPINNER_TAG).assert(
+            SemanticsMatcher.expectValue(SemanticsProperties.TestTag, SEARCH_SUBMIT_SPINNER_TAG)
+        )
     }
 
     @Test
     fun pagePending_disablesChromeAndShowsPaginationSpinner() {
         composeRule.setContent {
-            AsmrTheme {
+            AsmrPlayerTheme {
                 Column {
                     SearchToolbar(
-                        keyword = "耳かき",
+                        keyword = "test",
                         onKeywordChange = {},
                         selectedOrder = SearchSortOption.Trend,
                         purchasedOnly = false,
@@ -137,6 +143,78 @@ class SearchScreenChromeTest {
         composeRule.onNodeWithTag(SEARCH_SUBMIT_BUTTON_TAG).assertIsNotEnabled()
         composeRule.onNodeWithTag(SEARCH_PREV_BUTTON_TAG).assertIsNotEnabled()
         composeRule.onNodeWithTag(SEARCH_NEXT_BUTTON_TAG).assertIsNotEnabled()
-        composeRule.onNodeWithTag(SEARCH_PAGINATION_SPINNER_TAG).assertExists()
+        composeRule.onNodeWithTag(SEARCH_PAGINATION_SPINNER_TAG).assert(
+            SemanticsMatcher.expectValue(SemanticsProperties.TestTag, SEARCH_PAGINATION_SPINNER_TAG)
+        )
+    }
+
+    @Test
+    fun searchChrome_collapsesAndExpandsWhileKeepingControlsMounted() {
+        composeRule.mainClock.autoAdvance = false
+        lateinit var chromeState: CollapsibleHeaderState
+
+        composeRule.setContent {
+            chromeState = remember { CollapsibleHeaderState() }
+
+            AsmrPlayerTheme {
+                SearchChrome(
+                    modifier = Modifier,
+                    keyword = "RJ123456",
+                    onKeywordChange = {},
+                    selectedOrder = SearchSortOption.Trend,
+                    purchasedOnly = false,
+                    selectedLocale = "ja_JP",
+                    filterControlsLocked = false,
+                    searchSubmitLocked = false,
+                    showSearchSpinner = false,
+                    showPagination = true,
+                    page = 2,
+                    canGoPrev = true,
+                    canGoNext = true,
+                    controlsLocked = false,
+                    showPagingSpinner = false,
+                    rightPanelToggle = null,
+                    animatedOffsetPx = chromeState.offsetPx,
+                    collapseFraction = chromeState.collapseFraction,
+                    onMeasured = { chromeState.updateHeight(it.height.toFloat()) },
+                    onSearchSubmit = {},
+                    onPurchasedOnlySelected = {},
+                    onOrderSelected = {},
+                    onLocaleSelected = {},
+                    onPrev = {},
+                    onNext = {}
+                )
+            }
+        }
+
+        composeRule.waitForIdle()
+        composeRule.onNodeWithTag(SEARCH_CHROME_TAG).assert(
+            SemanticsMatcher.expectValue(SemanticsProperties.StateDescription, "expanded")
+        )
+
+        composeRule.runOnIdle { chromeState.onScrollDelta(-1000f) }
+        composeRule.mainClock.advanceTimeBy(250)
+        composeRule.waitForIdle()
+
+        composeRule.onNodeWithTag(SEARCH_CHROME_TAG).assert(
+            SemanticsMatcher.expectValue(SemanticsProperties.StateDescription, "collapsed")
+        )
+        composeRule.onNodeWithTag(SEARCH_INPUT_TAG).assert(
+            SemanticsMatcher.expectValue(SemanticsProperties.TestTag, SEARCH_INPUT_TAG)
+        )
+        composeRule.onNodeWithTag(SEARCH_PREV_BUTTON_TAG).assert(
+            SemanticsMatcher.expectValue(SemanticsProperties.TestTag, SEARCH_PREV_BUTTON_TAG)
+        )
+        composeRule.onNodeWithTag(SEARCH_NEXT_BUTTON_TAG).assert(
+            SemanticsMatcher.expectValue(SemanticsProperties.TestTag, SEARCH_NEXT_BUTTON_TAG)
+        )
+
+        composeRule.runOnIdle { chromeState.expand() }
+        composeRule.mainClock.advanceTimeBy(250)
+        composeRule.waitForIdle()
+
+        composeRule.onNodeWithTag(SEARCH_CHROME_TAG).assert(
+            SemanticsMatcher.expectValue(SemanticsProperties.StateDescription, "expanded")
+        )
     }
 }


### PR DESCRIPTION
## Summary
- add a shared collapsible header helper for scroll-driven top chrome behavior
- make online search, library, and album detail top controls float and collapse/expand with scroll
- fix outdated tests and add coverage for the collapsible header behavior

## Testing
- ./gradlew compileDebugKotlin