### PR TITLE
fix: 修复平板横屏搜索页最近听过开关错位

### DIFF
--- a/app/src/main/java/com/asmr/player/ui/library/LibraryScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/LibraryScreen.kt
@@ -159,7 +159,7 @@ internal const val LIBRARY_CHROME_TAG = "library_chrome"
 internal const val LIBRARY_SEARCH_INPUT_TAG = "library_search_input"
 internal const val LIBRARY_SORT_BUTTON_TAG = "library_sort_button"
 internal const val LIBRARY_FILTER_BUTTON_TAG = "library_filter_button"
-private val LibraryChromeContentGap = 12.dp
+private val LibraryChromeContentGap = 20.dp
 private val LibraryChromeCollapseOvershoot = 12.dp
 
 @Composable

--- a/app/src/main/java/com/asmr/player/ui/search/SearchScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/search/SearchScreen.kt
@@ -19,6 +19,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListState
@@ -101,6 +102,7 @@ internal const val SEARCH_PREV_BUTTON_TAG = "search_prev_button"
 internal const val SEARCH_NEXT_BUTTON_TAG = "search_next_button"
 internal const val SEARCH_PAGINATION_SPINNER_TAG = "search_pagination_spinner"
 internal const val SEARCH_CHROME_TAG = "search_chrome"
+private val SearchChromeContentGap = 16.dp
 
 private fun stableAlbumKey(album: Album): String {
     val id = album.rjCode.ifBlank { album.workId }.trim()
@@ -178,7 +180,7 @@ fun SearchScreen(
         success != null -> with(androidx.compose.ui.platform.LocalDensity.current) { 120.dp.toPx() }
         else -> with(androidx.compose.ui.platform.LocalDensity.current) { 80.dp.toPx() }
     }
-    val topPadding = with(androidx.compose.ui.platform.LocalDensity.current) { chromeVisibleHeightPx.toDp() }
+    val topPadding = with(androidx.compose.ui.platform.LocalDensity.current) { chromeVisibleHeightPx.toDp() } + SearchChromeContentGap
 
     fun scrollResultsToTop() {
         scope.launch {
@@ -518,13 +520,9 @@ internal fun SearchChrome(
             onSearchSubmit = onSearchSubmit,
             onPurchasedOnlySelected = onPurchasedOnlySelected,
             onOrderSelected = onOrderSelected,
-            onLocaleSelected = onLocaleSelected
+            onLocaleSelected = onLocaleSelected,
+            rightPanelToggle = rightPanelToggle
         )
-
-        if (rightPanelToggle != null) {
-            Spacer(modifier = Modifier.height(8.dp))
-            rightPanelToggle(Modifier.size(50.dp))
-        }
         if (showPagination) {
             SearchPaginationHeader(
                 page = page,
@@ -552,7 +550,8 @@ internal fun SearchToolbar(
     onSearchSubmit: () -> Unit,
     onPurchasedOnlySelected: () -> Unit,
     onOrderSelected: (SearchSortOption) -> Unit,
-    onLocaleSelected: (String) -> Unit
+    onLocaleSelected: (String) -> Unit,
+    rightPanelToggle: (@Composable (Modifier) -> Unit)? = null
 ) {
     val colorScheme = AsmrTheme.colorScheme
     var scopeMenuExpanded by remember { mutableStateOf(false) }
@@ -710,6 +709,10 @@ internal fun SearchToolbar(
                 onSearch = { onSearchSubmit() }
             )
         )
+        if (rightPanelToggle != null) {
+            Spacer(modifier = Modifier.width(8.dp))
+            rightPanelToggle(Modifier.size(50.dp))
+        }
     }
 }
 


### PR DESCRIPTION
## 变更内容
- 修复平板横屏模式下，在线搜索页右侧最近听过面板开关被挤压后错位的问题
- 将在线搜索页的右侧面板开关与搜索栏保持同一行布局
- 增大在线搜索页内容列表与分页栏之间的顶部间距
- 增大本地库内容列表与搜索栏之间的顶部间距

## 验证
- 运行 ./gradlew :app:compileDebugKotlin 通过