### PR TITLE
Fix online audio replay cache retention

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -144,6 +144,8 @@ dependencies {
     implementation("androidx.media3:media3-session:$media3_version")
     implementation("androidx.media3:media3-ui:$media3_version")
     implementation("androidx.media3:media3-common:$media3_version")
+    implementation("androidx.media3:media3-datasource:$media3_version")
+    implementation("androidx.media3:media3-database:$media3_version")
 
     // Room
     implementation("androidx.room:room-runtime:$room_version")

--- a/app/src/main/java/com/asmr/player/playback/PlaybackMediaCache.kt
+++ b/app/src/main/java/com/asmr/player/playback/PlaybackMediaCache.kt
@@ -1,0 +1,35 @@
+package com.asmr.player.playback
+
+import android.content.Context
+import androidx.media3.database.StandaloneDatabaseProvider
+import androidx.media3.datasource.cache.LeastRecentlyUsedCacheEvictor
+import androidx.media3.datasource.cache.SimpleCache
+import java.io.File
+
+object PlaybackMediaCache {
+    private const val CACHE_DIR_NAME = "playback_media_cache"
+    private const val MAX_CACHE_BYTES = 256L * 1024L * 1024L
+
+    @Volatile
+    private var cache: SimpleCache? = null
+
+    fun getInstance(context: Context): SimpleCache {
+        cache?.let { return it }
+        return synchronized(this) {
+            cache?.let { return@synchronized it }
+            val directory = File(context.cacheDir, CACHE_DIR_NAME).apply { mkdirs() }
+            SimpleCache(
+                directory,
+                LeastRecentlyUsedCacheEvictor(MAX_CACHE_BYTES),
+                StandaloneDatabaseProvider(context.applicationContext)
+            ).also { cache = it }
+        }
+    }
+
+    fun release() {
+        synchronized(this) {
+            cache?.release()
+            cache = null
+        }
+    }
+}

--- a/app/src/main/java/com/asmr/player/playback/RoutingPlaybackDataSource.kt
+++ b/app/src/main/java/com/asmr/player/playback/RoutingPlaybackDataSource.kt
@@ -1,0 +1,59 @@
+package com.asmr.player.playback
+
+import android.net.Uri
+import androidx.media3.common.util.UnstableApi
+import androidx.media3.datasource.DataSource
+import androidx.media3.datasource.DataSpec
+import androidx.media3.datasource.TransferListener
+import com.asmr.player.util.isOnlineTrackPath
+
+@UnstableApi
+class RoutingPlaybackDataSource(
+    private val upstream: DataSource,
+    private val cached: DataSource,
+    private val shouldUseCache: (Uri) -> Boolean = { uri -> isOnlineTrackPath(uri.toString()) }
+) : DataSource {
+    private var activeDataSource: DataSource? = null
+
+    override fun addTransferListener(transferListener: TransferListener) {
+        upstream.addTransferListener(transferListener)
+        cached.addTransferListener(transferListener)
+    }
+
+    override fun open(dataSpec: DataSpec): Long {
+        val selected = if (shouldUseCache(dataSpec.uri)) cached else upstream
+        activeDataSource = selected
+        return selected.open(dataSpec)
+    }
+
+    override fun read(buffer: ByteArray, offset: Int, length: Int): Int {
+        val current = activeDataSource ?: throw IllegalStateException("DataSource is not opened")
+        return current.read(buffer, offset, length)
+    }
+
+    override fun getUri(): Uri? = activeDataSource?.uri
+
+    override fun getResponseHeaders(): Map<String, List<String>> =
+        activeDataSource?.responseHeaders ?: emptyMap()
+
+    override fun close() {
+        val current = activeDataSource
+        activeDataSource = null
+        current?.close()
+    }
+
+    @UnstableApi
+    class Factory(
+        private val upstreamFactory: DataSource.Factory,
+        private val cachedFactory: DataSource.Factory,
+        private val shouldUseCache: (Uri) -> Boolean = { uri -> isOnlineTrackPath(uri.toString()) }
+    ) : DataSource.Factory {
+        override fun createDataSource(): DataSource {
+            return RoutingPlaybackDataSource(
+                upstream = upstreamFactory.createDataSource(),
+                cached = cachedFactory.createDataSource(),
+                shouldUseCache = shouldUseCache
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/asmr/player/service/PlaybackService.kt
+++ b/app/src/main/java/com/asmr/player/service/PlaybackService.kt
@@ -19,9 +19,11 @@ import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.exoplayer.source.DefaultMediaSourceFactory
 import androidx.media3.datasource.DefaultDataSource
 import androidx.media3.datasource.DefaultHttpDataSource
+import androidx.media3.datasource.FileDataSource
 import androidx.media3.datasource.ResolvingDataSource
 import androidx.media3.session.MediaSession
 import androidx.media3.session.MediaSessionService
+import androidx.media3.datasource.cache.CacheDataSource
 import com.asmr.player.MainActivity
 import com.asmr.player.data.local.db.AppDatabase
 import com.asmr.player.data.local.db.entities.TrackPlaybackProgressEntity
@@ -38,6 +40,8 @@ import com.asmr.player.playback.BalanceAudioProcessor
 import com.asmr.player.playback.ChannelModeAudioProcessor
 import com.asmr.player.playback.FadingPlayer
 import com.asmr.player.playback.GraphicEqualizerAudioProcessor
+import com.asmr.player.playback.PlaybackMediaCache
+import com.asmr.player.playback.RoutingPlaybackDataSource
 import com.asmr.player.playback.StereoFftAnalyzer
 import com.asmr.player.playback.StereoOrbitAudioProcessor
 import com.asmr.player.playback.StereoPcmRingBuffer
@@ -159,7 +163,7 @@ class PlaybackService : MediaSessionService() {
             override fun onTransferEnd(source: DataSource, dataSpec: DataSpec, isNetwork: Boolean) {}
         }
 
-        val dataSourceFactory = DefaultDataSource.Factory(
+        val upstreamDataSourceFactory = DefaultDataSource.Factory(
             this,
             ResolvingDataSource.Factory(httpFactory) { dataSpec ->
                 val uri = dataSpec.uri
@@ -185,6 +189,17 @@ class PlaybackService : MediaSessionService() {
         ).apply {
             setTransferListener(transferListener)
         }
+
+        val cacheDataSourceFactory = CacheDataSource.Factory()
+            .setCache(PlaybackMediaCache.getInstance(applicationContext))
+            .setCacheReadDataSourceFactory(FileDataSource.Factory())
+            .setUpstreamDataSourceFactory(upstreamDataSourceFactory)
+            .setFlags(CacheDataSource.FLAG_IGNORE_CACHE_ON_ERROR)
+
+        val dataSourceFactory = RoutingPlaybackDataSource.Factory(
+            upstreamFactory = upstreamDataSourceFactory,
+            cachedFactory = cacheDataSourceFactory
+        )
 
         exoPlayer = ExoPlayer.Builder(this)
             .setRenderersFactory(
@@ -660,6 +675,7 @@ class PlaybackService : MediaSessionService() {
             release()
             mediaSession = null
         }
+        runCatching { PlaybackMediaCache.release() }
         super.onDestroy()
     }
 


### PR DESCRIPTION
## Summary
- add Media3 playback cache for online audio replay
- route only online playback through CacheDataSource
- keep existing DLsite header/cookie injection and traffic stats behavior

## Verification
- ./gradlew :app:compileDebugKotlin