### PR TITLE
feat: add independent in-app volume controls

### DIFF
--- a/app/src/main/java/com/asmr/player/MainActivity.kt
+++ b/app/src/main/java/com/asmr/player/MainActivity.kt
@@ -1,6 +1,7 @@
 package com.asmr.player
 
 import android.os.Bundle
+import android.view.KeyEvent
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.BackHandler
 import androidx.activity.compose.setContent
@@ -147,6 +148,12 @@ import kotlinx.coroutines.flow.map
 import androidx.compose.foundation.border
 import androidx.compose.foundation.BorderStroke
 import androidx.media3.common.MediaItem
+import androidx.lifecycle.lifecycleScope
+import com.asmr.player.data.settings.SettingsRepository
+import com.asmr.player.playback.AppVolume
+import com.asmr.player.ui.common.AppVolumeVerticalSlider
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
 
 private enum class OverlaySheet {
     Queue,
@@ -161,6 +168,12 @@ class MainActivity : ComponentActivity() {
     @Inject
     lateinit var settingsDataStore: SettingsDataStore
 
+    @Inject
+    lateinit var settingsRepository: SettingsRepository
+
+    private val volumeKeyEventTick = MutableStateFlow(0L)
+    private var volumeKeyEventSeq = 0L
+
     @OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3WindowSizeClassApi::class)
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -171,6 +184,7 @@ class MainActivity : ComponentActivity() {
             val context = LocalContext.current
             val playerViewModel: PlayerViewModel = hiltViewModel()
             val libraryViewModel: LibraryViewModel = hiltViewModel()
+            val volumeKeyTick by volumeKeyEventTick.asStateFlow().collectAsState()
             val themeMediaSource by remember(playerViewModel) {
                 playerViewModel.playback
                     .map { it.currentMediaItem.toThemeMediaSource() }
@@ -329,7 +343,8 @@ class MainActivity : ComponentActivity() {
                         coverPreviewMode = coverPreviewMode,
                         lyricsPageSettings = lyricsPageSettings,
                         forceImmersive = showSplash,
-                        baseStaticHue = baseStaticHue
+                        baseStaticHue = baseStaticHue,
+                        volumeKeyEventTick = volumeKeyTick
                     )
 
                     if (showSplash) {
@@ -385,6 +400,21 @@ class MainActivity : ComponentActivity() {
             }
         }
     }
+
+    override fun dispatchKeyEvent(event: KeyEvent): Boolean {
+        val isVolumeKey = event.keyCode == KeyEvent.KEYCODE_VOLUME_UP || event.keyCode == KeyEvent.KEYCODE_VOLUME_DOWN
+        if (!isVolumeKey) return super.dispatchKeyEvent(event)
+
+        if (event.action == KeyEvent.ACTION_DOWN) {
+            val delta = if (event.keyCode == KeyEvent.KEYCODE_VOLUME_UP) AppVolume.StepPercent else -AppVolume.StepPercent
+            lifecycleScope.launch {
+                settingsRepository.adjustAppVolumePercent(delta)
+            }
+            volumeKeyEventSeq += 1L
+            volumeKeyEventTick.value = volumeKeyEventSeq
+        }
+        return true
+    }
 }
 
 @Composable
@@ -408,7 +438,8 @@ fun MainContainer(
     coverPreviewMode: CoverPreviewMode,
     lyricsPageSettings: LyricsPageSettings,
     forceImmersive: Boolean,
-    baseStaticHue: HuePalette
+    baseStaticHue: HuePalette,
+    volumeKeyEventTick: Long
 ) {
     val navController = rememberNavController()
     val navigator = remember(navController) { AppNavigator(navController) }
@@ -435,8 +466,14 @@ fun MainContainer(
     val drawerStatusViewModel: DrawerStatusViewModel = hiltViewModel()
     val statisticsViewModel: StatisticsViewModel = hiltViewModel()
     val bulkProgress by libraryViewModel.bulkProgress.collectAsState()
+    val appVolumePercent by playerViewModel.appVolumePercent.collectAsState()
     var showManualRjDialog by remember { mutableStateOf(false) }
     var manualRjInput by remember { mutableStateOf("") }
+    var showHardwareVolumeOverlay by remember { mutableStateOf(false) }
+    var hardwareVolumeOverlayInteracting by remember { mutableStateOf(false) }
+    var hardwareVolumeOverlayHoldTick by remember { mutableLongStateOf(0L) }
+    var lastHandledVolumeKeyTick by remember { mutableLongStateOf(0L) }
+    var lastNonZeroAppVolumePercent by rememberSaveable { mutableIntStateOf(AppVolume.DefaultPercent) }
     
     val configuration = LocalConfiguration.current
     val isLandscape = configuration.orientation == Configuration.ORIENTATION_LANDSCAPE
@@ -447,6 +484,8 @@ fun MainContainer(
     val immersivePlayer = forceImmersive || currentRoute == "now_playing" || currentRoute == "lyrics"
 
     LaunchedEffect(currentRoute) {
+        showHardwareVolumeOverlay = false
+        hardwareVolumeOverlayInteracting = false
         val last = lastRouteForTouchBlock
         val seq = ++touchBlockSeq
         if (last != null && currentRoute != null && last != currentRoute) {
@@ -542,6 +581,38 @@ fun MainContainer(
     val topBarContentColor = colorScheme.onSurface
     
     val drawerContainerColor = if (colorScheme.isDark) Color(0xFF121212) else Color.White
+
+    LaunchedEffect(appVolumePercent) {
+        if (appVolumePercent > 0) {
+            lastNonZeroAppVolumePercent = appVolumePercent
+        }
+    }
+
+    LaunchedEffect(volumeKeyEventTick) {
+        if (volumeKeyEventTick <= 0L) return@LaunchedEffect
+        if (volumeKeyEventTick == lastHandledVolumeKeyTick) return@LaunchedEffect
+        lastHandledVolumeKeyTick = volumeKeyEventTick
+        if (currentRoute == "now_playing") {
+            showHardwareVolumeOverlay = false
+            return@LaunchedEffect
+        }
+        showHardwareVolumeOverlay = true
+        hardwareVolumeOverlayHoldTick = volumeKeyEventTick
+    }
+
+    LaunchedEffect(showHardwareVolumeOverlay, hardwareVolumeOverlayHoldTick, hardwareVolumeOverlayInteracting, currentRoute) {
+        if (!showHardwareVolumeOverlay) return@LaunchedEffect
+        if (currentRoute == "now_playing") {
+            showHardwareVolumeOverlay = false
+            return@LaunchedEffect
+        }
+        if (hardwareVolumeOverlayInteracting) return@LaunchedEffect
+        val snapshot = hardwareVolumeOverlayHoldTick
+        delay(2_000)
+        if (!hardwareVolumeOverlayInteracting && hardwareVolumeOverlayHoldTick == snapshot) {
+            showHardwareVolumeOverlay = false
+        }
+    }
 
     BackHandler(drawerState.isOpen) {
         scope.launch { drawerState.close() }
@@ -1159,6 +1230,7 @@ fun MainContainer(
                     if (globalDynamicHueEnabled) {
                         NowPlayingScreen(
                             windowSizeClass = windowSizeClass,
+                            hardwareVolumeEventTick = volumeKeyEventTick,
                             onBack = { navController.popBackStack() },
                             onOpenLyrics = { navController.navigateSingleTop("lyrics") },
                             onShowQueue = onShowQueue,
@@ -1184,6 +1256,7 @@ fun MainContainer(
                     } else {
                         NowPlayingScreen(
                             windowSizeClass = windowSizeClass,
+                            hardwareVolumeEventTick = volumeKeyEventTick,
                             onBack = { navController.popBackStack() },
                             onOpenLyrics = { navController.navigateSingleTop("lyrics") },
                             onShowQueue = onShowQueue,
@@ -1404,6 +1477,43 @@ fun MainContainer(
                 )
             }
 
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(end = 18.dp),
+                contentAlignment = Alignment.CenterEnd
+            ) {
+                AnimatedVisibility(
+                    visible = showHardwareVolumeOverlay,
+                    enter = fadeIn(animationSpec = tween(140)) + slideInHorizontally(animationSpec = tween(180)) { it / 3 },
+                    exit = fadeOut(animationSpec = tween(160)) + slideOutHorizontally(animationSpec = tween(180)) { it / 3 }
+                ) {
+                    HardwareVolumeOverlay(
+                        volumePercent = appVolumePercent,
+                        onVolumeChange = {
+                            playerViewModel.setAppVolumePercent(it)
+                            hardwareVolumeOverlayHoldTick += 1L
+                        },
+                        onToggleMute = {
+                            if (appVolumePercent > 0) {
+                                playerViewModel.setAppVolumePercent(0)
+                            } else {
+                                playerViewModel.setAppVolumePercent(
+                                    lastNonZeroAppVolumePercent.coerceAtLeast(AppVolume.StepPercent)
+                                )
+                            }
+                            hardwareVolumeOverlayHoldTick += 1L
+                        },
+                        onInteractionActiveChanged = { active ->
+                            hardwareVolumeOverlayInteracting = active
+                            if (!active) {
+                                hardwareVolumeOverlayHoldTick += 1L
+                            }
+                        }
+                    )
+                }
+            }
+
             NonTouchableAppMessageOverlay(messages = visibleMessages)
         }
 
@@ -1455,6 +1565,56 @@ fun MainContainer(
 
 }
 
+}
+
+@Composable
+private fun HardwareVolumeOverlay(
+    volumePercent: Int,
+    onVolumeChange: (Int) -> Unit,
+    onToggleMute: () -> Unit,
+    onInteractionActiveChanged: (Boolean) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val colorScheme = AsmrTheme.colorScheme
+    val accentColor = colorScheme.primary
+
+    Surface(
+        modifier = modifier,
+        shape = RoundedCornerShape(22.dp),
+        color = colorScheme.surface.copy(alpha = if (colorScheme.isDark) 0.92f else 0.96f),
+        contentColor = colorScheme.onSurface,
+        shadowElevation = if (colorScheme.isDark) 0.dp else 10.dp,
+        tonalElevation = 0.dp
+    ) {
+        Column(
+            modifier = Modifier
+                .width(88.dp)
+                .padding(horizontal = 14.dp, vertical = 18.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(10.dp)
+        ) {
+            Icon(
+                imageVector = if (volumePercent == 0) Icons.Default.VolumeOff else Icons.Default.VolumeUp,
+                contentDescription = null,
+                tint = accentColor,
+                modifier = Modifier
+                    .size(20.dp)
+                    .clickable(onClick = onToggleMute)
+            )
+            AppVolumeVerticalSlider(
+                valuePercent = volumePercent,
+                onValueChange = onVolumeChange,
+                accentColor = accentColor,
+                onInteractionActiveChanged = onInteractionActiveChanged
+            )
+            Text(
+                text = "${AppVolume.clampPercent(volumePercent)}%",
+                style = MaterialTheme.typography.labelLarge,
+                color = colorScheme.onSurface,
+                fontWeight = FontWeight.SemiBold
+            )
+        }
+    }
 }
 
 @Stable

--- a/app/src/main/java/com/asmr/player/data/settings/SettingsDataStore.kt
+++ b/app/src/main/java/com/asmr/player/data/settings/SettingsDataStore.kt
@@ -11,6 +11,8 @@ import androidx.datastore.preferences.preferencesDataStore
 val Context.settingsDataStore by preferencesDataStore(name = "settings")
 
 object SettingsKeys {
+    val APP_VOLUME_PERCENT = intPreferencesKey("app_volume_percent")
+
     val EQ_ENABLED = booleanPreferencesKey("eq_enabled")
     fun eqBandLevel(index: Int) = intPreferencesKey("eq_band_$index")
 

--- a/app/src/main/java/com/asmr/player/data/settings/SettingsRepository.kt
+++ b/app/src/main/java/com/asmr/player/data/settings/SettingsRepository.kt
@@ -1,6 +1,7 @@
 package com.asmr.player.data.settings
 
 import android.content.Context
+import com.asmr.player.playback.AppVolume
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
@@ -14,6 +15,10 @@ import kotlinx.coroutines.withContext
 class SettingsRepository @Inject constructor(
     @ApplicationContext private val context: Context
 ) {
+    val appVolumePercent: Flow<Int> = context.settingsDataStore.data.map { prefs ->
+        AppVolume.clampPercent(prefs[SettingsKeys.APP_VOLUME_PERCENT] ?: AppVolume.DefaultPercent)
+    }
+
     val libraryViewMode: Flow<Int> = context.settingsDataStore.data.map { prefs ->
         prefs[SettingsKeys.LIBRARY_VIEW_MODE] ?: 0
     }
@@ -235,6 +240,26 @@ class SettingsRepository @Inject constructor(
     suspend fun setPlayMode(mode: Int) {
         withContext(Dispatchers.IO) {
             context.settingsDataStore.edit { it[SettingsKeys.PLAY_MODE] = mode }
+        }
+    }
+
+    suspend fun setAppVolumePercent(percent: Int) {
+        withContext(Dispatchers.IO) {
+            context.settingsDataStore.edit {
+                it[SettingsKeys.APP_VOLUME_PERCENT] = AppVolume.clampPercent(percent)
+            }
+        }
+    }
+
+    suspend fun adjustAppVolumePercent(deltaPercent: Int): Int {
+        return withContext(Dispatchers.IO) {
+            var updated = AppVolume.DefaultPercent
+            context.settingsDataStore.edit {
+                val current = AppVolume.clampPercent(it[SettingsKeys.APP_VOLUME_PERCENT] ?: AppVolume.DefaultPercent)
+                updated = AppVolume.adjustPercent(current, deltaPercent)
+                it[SettingsKeys.APP_VOLUME_PERCENT] = updated
+            }
+            updated
         }
     }
 

--- a/app/src/main/java/com/asmr/player/playback/AppVolume.kt
+++ b/app/src/main/java/com/asmr/player/playback/AppVolume.kt
@@ -1,0 +1,26 @@
+package com.asmr.player.playback
+
+object AppVolume {
+    const val MinPercent = 0
+    const val NormalMaxPercent = 100
+    const val MaxPercent = 300
+    const val DefaultPercent = 100
+    const val StepPercent = 5
+
+    fun clampPercent(percent: Int): Int = percent.coerceIn(MinPercent, MaxPercent)
+
+    fun adjustPercent(percent: Int, deltaPercent: Int): Int = clampPercent(percent + deltaPercent)
+
+    fun basePlayerVolume(percent: Int): Float {
+        return (clampPercent(percent).coerceAtMost(NormalMaxPercent) / 100f).coerceIn(0f, 1f)
+    }
+
+    fun gainMultiplier(percent: Int): Float {
+        val clamped = clampPercent(percent)
+        return if (clamped <= NormalMaxPercent) 1f else (clamped / 100f).coerceIn(1f, 3f)
+    }
+
+    fun visualFraction(percent: Int): Float {
+        return (clampPercent(percent).coerceAtMost(NormalMaxPercent) / 100f).coerceIn(0f, 1f)
+    }
+}

--- a/app/src/main/java/com/asmr/player/playback/AsmrRenderersFactory.kt
+++ b/app/src/main/java/com/asmr/player/playback/AsmrRenderersFactory.kt
@@ -10,6 +10,7 @@ import androidx.media3.exoplayer.audio.DefaultAudioSink
 class AsmrRenderersFactory(
     context: Context,
     private val graphicEqualizerAudioProcessor: GraphicEqualizerAudioProcessor,
+    private val gainAudioProcessor: GainAudioProcessor,
     private val balanceAudioProcessor: BalanceAudioProcessor,
     private val stereoOrbitAudioProcessor: StereoOrbitAudioProcessor,
     private val channelModeAudioProcessor: ChannelModeAudioProcessor,
@@ -25,6 +26,7 @@ class AsmrRenderersFactory(
             .setAudioProcessors(
                 arrayOf(
                     spectrumTapAudioProcessor,
+                    gainAudioProcessor,
                     graphicEqualizerAudioProcessor,
                     channelModeAudioProcessor,
                     stereoOrbitAudioProcessor,

--- a/app/src/main/java/com/asmr/player/playback/FadingPlayer.kt
+++ b/app/src/main/java/com/asmr/player/playback/FadingPlayer.kt
@@ -16,25 +16,33 @@ class FadingPlayer(
 ) : ForwardingPlayer(delegate) {
 
     private var pendingSwitchFadeIn: Boolean = false
+    private var baseVolume: Float = 1f
+    private var fadeVolume: Float = 1f
 
     private val transitionListener = object : Player.Listener {
         override fun onMediaItemTransition(mediaItem: MediaItem?, reason: Int) {
             if (!pendingSwitchFadeIn) return
             pendingSwitchFadeIn = false
-            volumeFader.fadeTo(delegate, 1f, switchFadeInMs)
+            volumeFader.fadeTo(this@FadingPlayer, 1f, switchFadeInMs)
         }
     }
 
     init {
         delegate.addListener(transitionListener)
+        syncOutputVolume()
+    }
+
+    fun setBaseVolume(volume: Float) {
+        baseVolume = volume.coerceIn(0f, 1f)
+        syncOutputVolume()
     }
 
     override fun play() {
         pendingSwitchFadeIn = false
         volumeFader.cancel()
-        delegate.volume = 0f
+        volume = 0f
         delegate.play()
-        volumeFader.fadeTo(delegate, 1f, playFadeMs)
+        volumeFader.fadeTo(this, 1f, playFadeMs)
     }
 
     override fun pause() {
@@ -43,7 +51,7 @@ class FadingPlayer(
             delegate.pause()
             return
         }
-        volumeFader.fadeTo(delegate, 0f, pauseFadeMs) {
+        volumeFader.fadeTo(this, 0f, pauseFadeMs) {
             delegate.pause()
         }
     }
@@ -64,13 +72,24 @@ class FadingPlayer(
             return
         }
         val beforeIndex = delegate.currentMediaItemIndex
-        volumeFader.fadeTo(delegate, 0f, switchFadeOutMs) {
+        volumeFader.fadeTo(this, 0f, switchFadeOutMs) {
             seekAction()
             val afterIndex = delegate.currentMediaItemIndex
             if (afterIndex == beforeIndex) {
                 pendingSwitchFadeIn = false
-                volumeFader.fadeTo(delegate, 1f, switchFadeInMs)
+                volumeFader.fadeTo(this, 1f, switchFadeInMs)
             }
         }
+    }
+
+    override fun getVolume(): Float = fadeVolume
+
+    override fun setVolume(volume: Float) {
+        fadeVolume = volume.coerceIn(0f, 1f)
+        syncOutputVolume()
+    }
+
+    private fun syncOutputVolume() {
+        delegate.volume = (baseVolume * fadeVolume).coerceIn(0f, 1f)
     }
 }

--- a/app/src/main/java/com/asmr/player/playback/PlayerConnection.kt
+++ b/app/src/main/java/com/asmr/player/playback/PlayerConnection.kt
@@ -20,6 +20,7 @@ import com.asmr.player.service.PlaybackService
 import com.asmr.player.domain.model.Album
 import com.asmr.player.domain.model.Track
 import com.asmr.player.util.MessageManager
+import com.asmr.player.playback.AppVolume
 import dagger.hilt.android.qualifiers.ApplicationContext
 import com.asmr.player.util.NetworkMeteredChecker
 import kotlinx.coroutines.CoroutineScope
@@ -28,12 +29,14 @@ import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.suspendCancellableCoroutine
@@ -75,6 +78,9 @@ class PlayerConnection @Inject constructor(
     private var didRestorePlaybackState: Boolean = false
     private val meteredWarnedMediaIds = LinkedHashSet<String>()
     private var lastMeteredWarnAtMs: Long = 0L
+
+    val appVolumePercent: StateFlow<Int> = settingsRepository.appVolumePercent
+        .stateIn(scope, SharingStarted.Eagerly, AppVolume.DefaultPercent)
 
     init {
         scope.launch {
@@ -544,6 +550,18 @@ class PlayerConnection @Inject constructor(
         val c = controller ?: return
         val cmd = androidx.media3.session.SessionCommand(action, android.os.Bundle.EMPTY)
         c.sendCustomCommand(cmd, args)
+    }
+
+    fun setAppVolumePercent(percent: Int) {
+        scope.launch {
+            settingsRepository.setAppVolumePercent(percent)
+        }
+    }
+
+    fun adjustAppVolumePercent(deltaPercent: Int) {
+        scope.launch {
+            settingsRepository.adjustAppVolumePercent(deltaPercent)
+        }
     }
 
     private fun updateQueue() {

--- a/app/src/main/java/com/asmr/player/service/PlaybackService.kt
+++ b/app/src/main/java/com/asmr/player/service/PlaybackService.kt
@@ -37,6 +37,8 @@ import com.asmr.player.playback.AsmrRenderersFactory
 import com.asmr.player.playback.BalanceAudioProcessor
 import com.asmr.player.playback.ChannelModeAudioProcessor
 import com.asmr.player.playback.FadingPlayer
+import com.asmr.player.playback.GainAudioProcessor
+import com.asmr.player.playback.AppVolume
 import com.asmr.player.playback.GraphicEqualizerAudioProcessor
 import com.asmr.player.playback.StereoFftAnalyzer
 import com.asmr.player.playback.StereoOrbitAudioProcessor
@@ -70,7 +72,9 @@ class PlaybackService : MediaSessionService() {
 
     private var mediaSession: MediaSession? = null
     private lateinit var exoPlayer: ExoPlayer
+    private lateinit var sessionPlayer: FadingPlayer
     private val graphicEqualizerAudioProcessor = GraphicEqualizerAudioProcessor()
+    private val gainAudioProcessor = GainAudioProcessor()
     private val balanceAudioProcessor = BalanceAudioProcessor()
     private val stereoOrbitAudioProcessor = StereoOrbitAudioProcessor()
     private val channelModeAudioProcessor = ChannelModeAudioProcessor()
@@ -191,6 +195,7 @@ class PlaybackService : MediaSessionService() {
                 AsmrRenderersFactory(
                     this,
                     graphicEqualizerAudioProcessor,
+                    gainAudioProcessor,
                     balanceAudioProcessor,
                     stereoOrbitAudioProcessor,
                     channelModeAudioProcessor,
@@ -210,9 +215,8 @@ class PlaybackService : MediaSessionService() {
             .build()
 
         spectrumAnalyzer.start()
-        startEffectLoops()
 
-        val sessionPlayer = FadingPlayer(
+        sessionPlayer = FadingPlayer(
             delegate = exoPlayer,
             volumeFader = volumeFader,
             playFadeMs = 1000L,
@@ -220,6 +224,7 @@ class PlaybackService : MediaSessionService() {
             switchFadeOutMs = 250L,
             switchFadeInMs = 250L
         )
+        startEffectLoops()
         mediaSession = MediaSession.Builder(this, sessionPlayer)
             .setSessionActivity(createContentIntent())
             .setCallback(object : MediaSession.Callback {
@@ -611,12 +616,18 @@ class PlaybackService : MediaSessionService() {
     private fun startEffectLoops() {
         effectApplyJob?.cancel()
         effectApplyJob = serviceScope.launch {
-            combine(audioEffectController.equalizerSettings, sessionSettings) { global, session ->
-                session ?: global
-            }.collect { settings ->
+            combine(
+                audioEffectController.equalizerSettings,
+                sessionSettings,
+                settingsRepository.appVolumePercent
+            ) { global, session, appVolumePercent ->
+                (session ?: global) to appVolumePercent
+            }.collect { (settings, appVolumePercent) ->
                 lastEffectiveSettings = settings
                 graphicEqualizerAudioProcessor.setEnabled(settings.enabled)
                 graphicEqualizerAudioProcessor.setBandLevels(settings.bandLevels)
+                sessionPlayer.setBaseVolume(AppVolume.basePlayerVolume(appVolumePercent))
+                gainAudioProcessor.setGain(AppVolume.gainMultiplier(appVolumePercent))
                 val stereoEnabled = settings.stereoEnabled
                 val panActive = stereoEnabled && (settings.orbitEnabled || settings.orbitAzimuthDeg != 0f)
                 balanceAudioProcessor.setBalance(if (stereoEnabled && !panActive) settings.balance else 0f)

--- a/app/src/main/java/com/asmr/player/ui/common/AppVolumeUi.kt
+++ b/app/src/main/java/com/asmr/player/ui/common/AppVolumeUi.kt
@@ -1,0 +1,219 @@
+package com.asmr.player.ui.common
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.gestures.Orientation
+import androidx.compose.foundation.gestures.draggable
+import androidx.compose.foundation.gestures.rememberDraggableState
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.width
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.layout.onSizeChanged
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.unit.dp
+import com.asmr.player.playback.AppVolume
+import kotlin.math.roundToInt
+import androidx.compose.foundation.gestures.detectTapGestures
+
+@Composable
+fun AppVolumeSlider(
+    valuePercent: Int,
+    onValueChange: (Int) -> Unit,
+    modifier: Modifier = Modifier,
+    accentColor: Color,
+    onInteractionActiveChanged: ((Boolean) -> Unit)? = null,
+    enabled: Boolean = true
+) {
+    AppVolumeTrack(
+        valuePercent = valuePercent,
+        onValueChange = onValueChange,
+        modifier = modifier
+            .fillMaxWidth()
+            .height(28.dp),
+        accentColor = accentColor,
+        orientation = Orientation.Horizontal,
+        onInteractionActiveChanged = onInteractionActiveChanged,
+        enabled = enabled
+    )
+}
+
+@Composable
+fun AppVolumeVerticalSlider(
+    valuePercent: Int,
+    onValueChange: (Int) -> Unit,
+    accentColor: Color,
+    modifier: Modifier = Modifier,
+    onInteractionActiveChanged: ((Boolean) -> Unit)? = null,
+    enabled: Boolean = true
+) {
+    AppVolumeTrack(
+        valuePercent = valuePercent,
+        onValueChange = onValueChange,
+        modifier = modifier
+            .width(26.dp)
+            .height(180.dp),
+        accentColor = accentColor,
+        orientation = Orientation.Vertical,
+        onInteractionActiveChanged = onInteractionActiveChanged,
+        enabled = enabled
+    )
+}
+
+@Composable
+private fun AppVolumeTrack(
+    valuePercent: Int,
+    onValueChange: (Int) -> Unit,
+    modifier: Modifier,
+    accentColor: Color,
+    orientation: Orientation,
+    onInteractionActiveChanged: ((Boolean) -> Unit)?,
+    enabled: Boolean
+) {
+    val clampedValue = remember(valuePercent) { AppVolume.clampPercent(valuePercent) }
+    var dragPercent by remember(orientation) { mutableFloatStateOf(clampedValue.toFloat()) }
+    var isDragging by remember(orientation) { androidx.compose.runtime.mutableStateOf(false) }
+    var lastDispatchedPercent by remember(orientation) { mutableIntStateOf(clampedValue) }
+    var trackLengthPx by remember(orientation) { mutableFloatStateOf(240f) }
+
+    LaunchedEffect(clampedValue, isDragging) {
+        if (!isDragging) {
+            dragPercent = clampedValue.toFloat()
+            lastDispatchedPercent = clampedValue
+        }
+    }
+
+    val draggableState = rememberDraggableState { delta ->
+        val range = AppVolume.MaxPercent.toFloat()
+        val scaleMultiplier = if (orientation == Orientation.Vertical) 2.25f else 2.45f
+        val scale = trackLengthPx.coerceAtLeast(1f) * scaleMultiplier
+        val percentDelta = (delta / scale) * range
+        if (kotlin.math.abs(percentDelta) < 0.01f) return@rememberDraggableState
+        dragPercent = if (orientation == Orientation.Horizontal) {
+            dragPercent + percentDelta
+        } else {
+            dragPercent - percentDelta
+        }
+        val next = AppVolume.clampPercent(dragPercent.roundToInt())
+        if (next != lastDispatchedPercent) {
+            lastDispatchedPercent = next
+            onValueChange(next)
+        }
+    }
+
+    Box(
+        modifier = modifier
+            .onSizeChanged { size ->
+                trackLengthPx = if (orientation == Orientation.Horizontal) {
+                    size.width.toFloat()
+                } else {
+                    size.height.toFloat()
+                }
+            }
+            .pointerInput(enabled, clampedValue, orientation) {
+                if (!enabled) return@pointerInput
+                detectTapGestures { offset ->
+                    if (clampedValue > AppVolume.NormalMaxPercent) return@detectTapGestures
+                    val fraction = if (orientation == Orientation.Horizontal) {
+                        (offset.x / size.width.toFloat().coerceAtLeast(1f)).coerceIn(0f, 1f)
+                    } else {
+                        (1f - offset.y / size.height.toFloat().coerceAtLeast(1f)).coerceIn(0f, 1f)
+                    }
+                    onValueChange((fraction * AppVolume.NormalMaxPercent).roundToInt())
+                }
+            }
+            .draggable(
+                state = draggableState,
+                orientation = orientation,
+                enabled = enabled,
+                onDragStarted = {
+                    dragPercent = clampedValue.toFloat()
+                    lastDispatchedPercent = clampedValue
+                    isDragging = true
+                    onInteractionActiveChanged?.invoke(true)
+                },
+                onDragStopped = {
+                    isDragging = false
+                    onInteractionActiveChanged?.invoke(false)
+                }
+            )
+    ) {
+        Canvas(modifier = Modifier.matchParentSize()) {
+            val thumbRadius = 8.dp.toPx()
+            val stroke = if (orientation == Orientation.Horizontal) 4.dp.toPx() else 6.dp.toPx()
+            val displayPercent = if (isDragging) {
+                dragPercent.coerceIn(AppVolume.MinPercent.toFloat(), AppVolume.MaxPercent.toFloat())
+            } else {
+                clampedValue.toFloat()
+            }
+            val visualFraction = (displayPercent.coerceAtMost(AppVolume.NormalMaxPercent.toFloat()) / AppVolume.NormalMaxPercent.toFloat())
+                .coerceIn(0f, 1f)
+
+            if (orientation == Orientation.Horizontal) {
+                val centerY = size.height / 2f
+                val startX = thumbRadius
+                val endX = (size.width - thumbRadius).coerceAtLeast(startX)
+                val progressX = startX + (endX - startX) * visualFraction
+
+                drawLine(
+                    color = accentColor.copy(alpha = 0.2f),
+                    start = Offset(startX, centerY),
+                    end = Offset(endX, centerY),
+                    strokeWidth = stroke,
+                    cap = StrokeCap.Round
+                )
+                if (progressX > startX) {
+                    drawLine(
+                        color = accentColor,
+                        start = Offset(startX, centerY),
+                        end = Offset(progressX, centerY),
+                        strokeWidth = stroke,
+                        cap = StrokeCap.Round
+                    )
+                }
+                drawCircle(
+                    color = accentColor,
+                    radius = thumbRadius,
+                    center = Offset(progressX, centerY)
+                )
+            } else {
+                val centerX = size.width / 2f
+                val top = thumbRadius
+                val bottom = (size.height - thumbRadius).coerceAtLeast(top)
+                val activeY = bottom - (bottom - top) * visualFraction
+
+                drawLine(
+                    color = accentColor.copy(alpha = 0.18f),
+                    start = Offset(centerX, bottom),
+                    end = Offset(centerX, top),
+                    strokeWidth = stroke,
+                    cap = StrokeCap.Round
+                )
+                if (activeY < bottom) {
+                    drawLine(
+                        color = accentColor,
+                        start = Offset(centerX, bottom),
+                        end = Offset(centerX, activeY),
+                        strokeWidth = stroke,
+                        cap = StrokeCap.Round
+                    )
+                }
+                drawCircle(
+                    color = accentColor,
+                    radius = thumbRadius,
+                    center = Offset(centerX, activeY)
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/asmr/player/ui/player/NowPlayingScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/player/NowPlayingScreen.kt
@@ -5,7 +5,6 @@ import android.content.Context
 import android.content.ContextWrapper
 import android.content.pm.ActivityInfo
 import android.content.res.Configuration
-import android.media.AudioManager
 import android.os.SystemClock
 import android.view.LayoutInflater
 import androidx.activity.compose.BackHandler
@@ -73,6 +72,8 @@ import androidx.media3.ui.PlayerView
 import com.asmr.player.R
 import com.asmr.player.data.settings.CoverPreviewMode
 import com.asmr.player.ui.common.AsmrAsyncImage
+import com.asmr.player.ui.common.AppVolumeSlider
+import com.asmr.player.playback.AppVolume
 import com.asmr.player.playback.PlaybackSnapshot
 import com.asmr.player.ui.common.EqualizerPanel
 import com.asmr.player.ui.common.rememberComputedDominantColorCenterWeighted
@@ -96,6 +97,7 @@ import kotlinx.coroutines.launch
 @OptIn(ExperimentalFoundationApi::class, ExperimentalMaterial3Api::class)
 fun NowPlayingScreen(
     windowSizeClass: WindowSizeClass,
+    hardwareVolumeEventTick: Long,
     onBack: () -> Unit,
     onOpenLyrics: () -> Unit,
     onShowQueue: () -> Unit,
@@ -869,7 +871,12 @@ fun NowPlayingScreen(
                         onPrimaryColor = onAccentColor
                     )
 
-                    VolumeControl(modifier = Modifier.fillMaxWidth(), accentColor = accentColor)
+                    VolumeControl(
+                        modifier = Modifier.fillMaxWidth(),
+                        accentColor = accentColor,
+                        viewModel = viewModel,
+                        hardwareVolumeEventTick = hardwareVolumeEventTick
+                    )
                 }
             }
         }
@@ -1683,27 +1690,31 @@ private fun normalizeSingleLineText(text: String): String {
 
 @Composable
 @OptIn(ExperimentalFoundationApi::class)
-private fun VolumeControl(modifier: Modifier = Modifier, accentColor: Color) {
-    val context = LocalContext.current
-    val audioManager = remember(context) {
-        context.getSystemService(Context.AUDIO_SERVICE) as AudioManager
-    }
-    val maxVolume = remember(audioManager) { audioManager.getStreamMaxVolume(AudioManager.STREAM_MUSIC).coerceAtLeast(1) }
+private fun VolumeControl(
+    modifier: Modifier = Modifier,
+    accentColor: Color,
+    viewModel: PlayerViewModel,
+    hardwareVolumeEventTick: Long
+) {
     var expanded by rememberSaveable { mutableStateOf(false) }
-    var volume by remember { mutableIntStateOf(audioManager.getStreamVolume(AudioManager.STREAM_MUSIC).coerceIn(0, maxVolume)) }
-    var lastNonZeroVolume by remember { mutableIntStateOf(volume.coerceAtLeast(1)) }
+    val volume by viewModel.appVolumePercent.collectAsState()
+    var lastNonZeroVolume by rememberSaveable { mutableIntStateOf(AppVolume.DefaultPercent) }
     var lastInteractionAt by remember { mutableLongStateOf(0L) }
 
-    fun refreshVolumeFromSystem() {
-        volume = audioManager.getStreamVolume(AudioManager.STREAM_MUSIC).coerceIn(0, maxVolume)
+    LaunchedEffect(volume) {
         if (volume > 0) lastNonZeroVolume = volume
     }
 
+    LaunchedEffect(hardwareVolumeEventTick) {
+        if (hardwareVolumeEventTick <= 0L) return@LaunchedEffect
+        expanded = true
+        lastInteractionAt = SystemClock.elapsedRealtime()
+    }
+
     fun setVolume(newVolume: Int) {
-        val v = newVolume.coerceIn(0, maxVolume)
-        volume = v
-        if (v > 0) lastNonZeroVolume = v
-        audioManager.setStreamVolume(AudioManager.STREAM_MUSIC, v, 0)
+        val next = AppVolume.clampPercent(newVolume)
+        if (next > 0) lastNonZeroVolume = next
+        viewModel.setAppVolumePercent(next)
     }
 
     LaunchedEffect(expanded, lastInteractionAt) {
@@ -1733,15 +1744,13 @@ private fun VolumeControl(modifier: Modifier = Modifier, accentColor: Color) {
                     .padding(vertical = 6.dp)
                     .combinedClickable(
                         onClick = {
-                            refreshVolumeFromSystem()
                             if (volume > 0) {
                                 setVolume(0)
                             } else {
-                                setVolume(lastNonZeroVolume.coerceIn(1, maxVolume))
+                                setVolume(lastNonZeroVolume.coerceAtLeast(AppVolume.StepPercent))
                             }
                         },
                         onLongClick = {
-                            refreshVolumeFromSystem()
                             expanded = true
                             lastInteractionAt = SystemClock.elapsedRealtime()
                         }
@@ -1782,11 +1791,10 @@ private fun VolumeControl(modifier: Modifier = Modifier, accentColor: Color) {
                             .size(20.dp)
                             .combinedClickable(
                                 onClick = {
-                                    refreshVolumeFromSystem()
                                     if (volume > 0) {
                                         setVolume(0)
                                     } else {
-                                        setVolume(lastNonZeroVolume.coerceIn(1, maxVolume))
+                                        setVolume(lastNonZeroVolume.coerceAtLeast(AppVolume.StepPercent))
                                     }
                                     lastInteractionAt = SystemClock.elapsedRealtime()
                                 },
@@ -1801,27 +1809,25 @@ private fun VolumeControl(modifier: Modifier = Modifier, accentColor: Color) {
                     )
                     Spacer(modifier = Modifier.weight(1f))
                     Text(
-                        text = "${(volume.toFloat() / maxVolume.toFloat() * 100f).roundToInt()}%",
+                        text = "${AppVolume.clampPercent(volume)}%",
                         style = MaterialTheme.typography.bodySmall,
                         color = colorScheme.textTertiary
                     )
                 }
 
-                Slider(
-                    value = volume.toFloat(),
-                    onValueChange = { v ->
-                        val newVol = v.roundToInt().coerceIn(0, maxVolume)
+                AppVolumeSlider(
+                    valuePercent = volume,
+                    onValueChange = { newVol ->
                         if (newVol != volume) {
                             setVolume(newVol)
                         }
                         lastInteractionAt = SystemClock.elapsedRealtime()
                     },
-                    valueRange = 0f..maxVolume.toFloat(),
-                    colors = SliderDefaults.colors(
-                        thumbColor = accentColor,
-                        activeTrackColor = accentColor,
-                        inactiveTrackColor = accentColor.copy(alpha = 0.2f)
-                    )
+                    modifier = Modifier.fillMaxWidth(),
+                    accentColor = accentColor,
+                    onInteractionActiveChanged = {
+                        lastInteractionAt = SystemClock.elapsedRealtime()
+                    }
                 )
             }
         }

--- a/app/src/main/java/com/asmr/player/ui/player/playerviewmodel.kt
+++ b/app/src/main/java/com/asmr/player/ui/player/playerviewmodel.kt
@@ -41,6 +41,7 @@ import com.asmr.player.data.repository.SliceOverlapException
 import com.asmr.player.data.settings.EqualizerSettings
 import com.asmr.player.data.settings.AsmrPreset
 import com.asmr.player.playback.SlicePlaybackController
+import com.asmr.player.playback.AppVolume
 
 import com.asmr.player.util.MessageManager
 import kotlin.math.roundToLong
@@ -93,6 +94,9 @@ class PlayerViewModel @Inject constructor(
 
     val sleepTimerLastDurationMin: StateFlow<Int> = settingsRepository.sleepTimerLastDurationMin
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), 30)
+
+    val appVolumePercent: StateFlow<Int> = playerConnection.appVolumePercent
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), AppVolume.DefaultPercent)
 
     private val _sessionEqualizer = MutableStateFlow<EqualizerSettings?>(null)
     val sessionEqualizer: StateFlow<EqualizerSettings> = combine(
@@ -243,6 +247,14 @@ class PlayerViewModel @Inject constructor(
     }
 
     fun togglePlayPause() = playerConnection.togglePlayPause()
+
+    fun setAppVolumePercent(percent: Int) {
+        playerConnection.setAppVolumePercent(percent)
+    }
+
+    fun adjustAppVolumePercent(deltaPercent: Int) {
+        playerConnection.adjustAppVolumePercent(deltaPercent)
+    }
 
     fun toggleFloatingLyrics() {
         viewModelScope.launch {


### PR DESCRIPTION
## Summary
- add independent in-app volume controls decoupled from system media volume
- support hardware-key volume overlays outside now playing and sync now playing controls
- extend in-app volume range above 100% with gain processing and persist volume state

## Testing
- ./gradlew :app:compileDebugKotlin