### PR TITLE
fix: improve drawer and message overlay behavior

### DIFF
--- a/app/src/main/java/com/asmr/player/MainActivity.kt
+++ b/app/src/main/java/com/asmr/player/MainActivity.kt
@@ -618,10 +618,7 @@ fun MainContainer(
         scope.launch { drawerState.close() }
     }
 
-    val drawerGesturesEnabled = remember(currentRoute, coverPreviewMode) {
-        val dragPreviewRoute = currentRoute == "now_playing" || currentRoute == "lyrics"
-        !(dragPreviewRoute && coverPreviewMode == CoverPreviewMode.Drag)
-    }
+    val drawerGesturesEnabled = currentRoute != "now_playing" && currentRoute != "lyrics"
 
     ModalNavigationDrawer(
         drawerState = drawerState,

--- a/app/src/main/java/com/asmr/player/ui/common/AppSnackbar.kt
+++ b/app/src/main/java/com/asmr/player/ui/common/AppSnackbar.kt
@@ -1,29 +1,45 @@
 package com.asmr.player.ui.common
 
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.CheckCircle
 import androidx.compose.material.icons.filled.Error
 import androidx.compose.material.icons.filled.Info
 import androidx.compose.material.icons.filled.Warning
-import androidx.compose.material3.*
+import androidx.compose.material3.Icon
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
-import androidx.compose.animation.core.Animatable
-import androidx.compose.animation.core.LinearEasing
-import androidx.compose.animation.core.tween
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.graphics.compositeOver
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.asmr.player.ui.theme.AsmrTheme
 import com.asmr.player.util.MessageType
 
 @Composable
@@ -35,25 +51,40 @@ fun AppSnackbar(
     durationMs: Long,
     modifier: Modifier = Modifier
 ) {
-    val (icon, color) = when (type) {
-        MessageType.Success -> Icons.Default.CheckCircle to Color(0xFF4CAF50)
-        MessageType.Error -> Icons.Default.Error to Color(0xFFF44336)
-        MessageType.Warning -> Icons.Default.Warning to Color(0xFFFF9800)
-        MessageType.Info -> Icons.Default.Info to Color(0xFF2196F3)
+    val appColors = AsmrTheme.colorScheme
+    val (icon, accentColor) = when (type) {
+        MessageType.Success -> Icons.Default.CheckCircle to Color(0xFF3E9B63)
+        MessageType.Error -> Icons.Default.Error to Color(0xFFD95C4F)
+        MessageType.Warning -> Icons.Default.Warning to Color(0xFFD6942A)
+        MessageType.Info -> Icons.Default.Info to Color(0xFF2F7FB6)
+    }
+    val shape: Shape = RoundedCornerShape(18.dp)
+    val containerColor = if (appColors.isDark) {
+        MaterialTheme.colorScheme.surfaceContainerHigh.copy(alpha = 0.96f)
+    } else {
+        appColors.primarySoft.copy(alpha = 0.10f).compositeOver(MaterialTheme.colorScheme.surface)
+    }
+    val borderColor = if (appColors.isDark) {
+        MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.42f)
+    } else {
+        appColors.primary.copy(alpha = 0.16f)
+    }
+    val countTextColor = if (appColors.isDark) {
+        MaterialTheme.colorScheme.onSurfaceVariant
+    } else {
+        appColors.textSecondary
+    }
+    val progressTrackColor = if (appColors.isDark) {
+        MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.22f)
+    } else {
+        accentColor.copy(alpha = 0.12f).compositeOver(containerColor)
     }
 
-    Surface(
+    Box(
         modifier = modifier
-            .clip(RoundedCornerShape(18.dp))
-            .background(Color.Transparent),
-        color = MaterialTheme.colorScheme.surface.copy(alpha = 0.82f),
-        tonalElevation = 3.dp,
-        shadowElevation = 10.dp,
-        shape = RoundedCornerShape(18.dp),
-        border = androidx.compose.foundation.BorderStroke(
-            width = 1.dp,
-            color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.45f)
-        )
+            .clip(shape)
+            .background(containerColor, shape)
+            .border(1.dp, borderColor, shape)
     ) {
         val progress = remember(messageId) { Animatable(1f) }
         LaunchedEffect(messageId, durationMs) {
@@ -66,43 +97,65 @@ fun AppSnackbar(
                 )
             )
         }
-        Column(modifier = Modifier.fillMaxWidth()) {
+
+        Box(modifier = Modifier.fillMaxWidth()) {
             Row(
                 modifier = Modifier
-                    .padding(horizontal = 14.dp, vertical = 12.dp),
-                verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.spacedBy(12.dp)
+                    .fillMaxWidth()
+                    .padding(bottom = 3.dp)
             ) {
-                Icon(
-                    imageVector = icon,
-                    contentDescription = null,
-                    tint = color,
-                    modifier = Modifier.size(24.dp)
+                Box(
+                    modifier = Modifier
+                        .padding(start = 10.dp, top = 10.dp, bottom = 10.dp)
+                        .width(4.dp)
+                        .heightIn(min = 34.dp)
+                        .clip(RoundedCornerShape(999.dp))
+                        .background(accentColor.copy(alpha = if (appColors.isDark) 0.84f else 0.72f))
                 )
-                Text(
-                    text = message,
-                    style = MaterialTheme.typography.bodyMedium.copy(
-                        fontWeight = FontWeight.Medium,
-                        letterSpacing = 0.3.sp
-                    ),
-                    color = MaterialTheme.colorScheme.onSurface,
-                    maxLines = 3,
-                    overflow = TextOverflow.Ellipsis,
-                    modifier = Modifier.weight(1f, fill = false)
-                )
-                if (count > 1) {
-                    Text(
-                        text = "×$count",
-                        style = MaterialTheme.typography.labelSmall.copy(fontWeight = FontWeight.SemiBold),
-                        color = MaterialTheme.colorScheme.onSurfaceVariant
-                    )
+                Column(modifier = Modifier.fillMaxWidth()) {
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(start = 12.dp, end = 14.dp, top = 12.dp, bottom = 10.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(12.dp)
+                    ) {
+                        Icon(
+                            imageVector = icon,
+                            contentDescription = null,
+                            tint = accentColor,
+                            modifier = Modifier.size(22.dp)
+                        )
+                        androidx.compose.material3.Text(
+                            text = message,
+                            style = MaterialTheme.typography.bodyMedium.copy(
+                                fontWeight = FontWeight.Medium,
+                                letterSpacing = 0.2.sp
+                            ),
+                            color = MaterialTheme.colorScheme.onSurface,
+                            maxLines = 3,
+                            overflow = TextOverflow.Ellipsis,
+                            modifier = Modifier.weight(1f)
+                        )
+                        if (count > 1) {
+                            androidx.compose.material3.Text(
+                                text = "x$count",
+                                style = MaterialTheme.typography.labelSmall.copy(fontWeight = FontWeight.SemiBold),
+                                color = countTextColor
+                            )
+                        }
+                    }
                 }
             }
             LinearProgressIndicator(
                 progress = { progress.value.coerceIn(0f, 1f) },
-                color = color.copy(alpha = 0.85f),
-                trackColor = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.22f),
-                modifier = Modifier.fillMaxWidth().height(2.dp)
+                color = accentColor.copy(alpha = if (appColors.isDark) 0.85f else 0.72f),
+                trackColor = progressTrackColor,
+                modifier = Modifier
+                    .align(Alignment.BottomEnd)
+                    .fillMaxWidth()
+                    .height(3.dp)
+                    .clip(RoundedCornerShape(bottomStart = 18.dp, bottomEnd = 18.dp))
             )
         }
     }
@@ -117,8 +170,6 @@ fun AppSnackbarHost(
         hostState = hostState,
         modifier = modifier,
         snackbar = { data ->
-            // 这里我们解析 message 中的特殊前缀来判断类型，或者直接使用默认
-            // 稍后在 MessageManager 集成时，我们会通过 SnackbarHostState.showSnackbar 传入特定格式的字符串
             val (message, type) = parseSnackbarMessage(data.visuals.message)
             AppSnackbar(
                 messageId = 0L,

--- a/app/src/main/java/com/asmr/player/ui/common/NonTouchableMessageOverlay.kt
+++ b/app/src/main/java/com/asmr/player/ui/common/NonTouchableMessageOverlay.kt
@@ -1,129 +1,46 @@
 package com.asmr.player.ui.common
 
-import android.content.Context
-import android.content.ContextWrapper
-import android.graphics.PixelFormat
-import android.util.Log
-import android.view.Gravity
-import android.view.WindowManager
-import androidx.activity.ComponentActivity
-import androidx.compose.material3.ColorScheme
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Shapes
-import androidx.compose.material3.Typography
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.WindowInsetsSides
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.only
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeDrawing
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.DisposableEffect
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.SideEffect
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.ComposeView
-import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
-import kotlinx.coroutines.delay
+import androidx.compose.ui.zIndex
 
 @Composable
 fun NonTouchableAppMessageOverlay(
     messages: List<VisibleAppMessage>,
     startPadding: Dp = 16.dp,
-    bottomPadding: Dp = 80.dp,
-    colorScheme: ColorScheme = MaterialTheme.colorScheme,
-    typography: Typography = MaterialTheme.typography,
-    shapes: Shapes = MaterialTheme.shapes
+    bottomPadding: Dp = 80.dp
 ) {
-    val context = LocalContext.current
-    val activity = remember(context) { context.findComponentActivity() } ?: return
-    val windowManager = remember(activity) {
-        activity.getSystemService(Context.WINDOW_SERVICE) as WindowManager
+    if (messages.isEmpty()) return
+
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .zIndex(100f),
+        contentAlignment = Alignment.BottomStart
+    ) {
+        AppMessageOverlay(
+            messages = messages,
+            modifier = Modifier
+                .windowInsetsPadding(
+                    WindowInsets.safeDrawing.only(
+                        WindowInsetsSides.Start + WindowInsetsSides.Bottom
+                    )
+                )
+                .padding(
+                    start = startPadding,
+                    bottom = bottomPadding + LocalBottomOverlayPadding.current
+                )
+        )
     }
-
-    var currentMessages by remember { mutableStateOf<List<VisibleAppMessage>>(emptyList()) }
-    SideEffect { currentMessages = messages }
-    val shouldShow = currentMessages.isNotEmpty()
-
-    var currentColorScheme by remember { mutableStateOf(colorScheme) }
-    var currentTypography by remember { mutableStateOf(typography) }
-    var currentShapes by remember { mutableStateOf(shapes) }
-    SideEffect {
-        currentColorScheme = colorScheme
-        currentTypography = typography
-        currentShapes = shapes
-    }
-
-    val overlayView = remember(activity) {
-        ComposeView(activity).apply {
-            setTag(androidx.lifecycle.runtime.R.id.view_tree_lifecycle_owner, activity)
-            setTag(androidx.lifecycle.viewmodel.R.id.view_tree_view_model_store_owner, activity)
-            setTag(androidx.savedstate.R.id.view_tree_saved_state_registry_owner, activity)
-            setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnDetachedFromWindow)
-            setContent {
-                MaterialTheme(
-                    colorScheme = currentColorScheme,
-                    typography = currentTypography,
-                    shapes = currentShapes
-                ) {
-                    if (currentMessages.isNotEmpty()) AppMessageOverlay(messages = currentMessages)
-                }
-            }
-        }
-    }
-
-    DisposableEffect(activity) {
-        onDispose {
-            runCatching {
-                if (overlayView.parent != null) windowManager.removeViewImmediate(overlayView)
-            }
-        }
-    }
-
-    LaunchedEffect(activity, shouldShow, startPadding, bottomPadding) {
-        if (!shouldShow) {
-            runCatching {
-                if (overlayView.parent != null) windowManager.removeViewImmediate(overlayView)
-            }
-            return@LaunchedEffect
-        }
-
-        val density = activity.resources.displayMetrics.density
-        val layoutParams = WindowManager.LayoutParams(
-            WindowManager.LayoutParams.WRAP_CONTENT,
-            WindowManager.LayoutParams.WRAP_CONTENT,
-            WindowManager.LayoutParams.TYPE_APPLICATION_PANEL,
-            WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE or
-                WindowManager.LayoutParams.FLAG_NOT_TOUCHABLE,
-            PixelFormat.TRANSLUCENT
-        ).apply {
-            gravity = Gravity.BOTTOM or Gravity.START
-            x = (startPadding.value * density).toInt()
-            y = (bottomPadding.value * density).toInt()
-        }
-
-        var logged = false
-        while (overlayView.parent == null) {
-            layoutParams.token = activity.window.decorView.windowToken
-            try {
-                windowManager.addView(overlayView, layoutParams)
-            } catch (t: Throwable) {
-                if (!logged) {
-                    Log.w("NonTouchableAppMessageOverlay", "addView failed", t)
-                    logged = true
-                }
-                delay(50)
-            }
-        }
-    }
-}
-
-private fun Context.findComponentActivity(): ComponentActivity? {
-    var c: Context = this
-    while (c is ContextWrapper) {
-        if (c is ComponentActivity) return c
-        c = c.baseContext
-    }
-    return null
 }

--- a/app/src/main/java/com/asmr/player/ui/library/AlbumDetailViewModel.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/AlbumDetailViewModel.kt
@@ -346,13 +346,13 @@ class AlbumDetailViewModel @Inject constructor(
     fun manualSetRjAndSync(input: String) {
         val normalized = Regex("""RJ\d+""", RegexOption.IGNORE_CASE).find(input.trim())?.value?.uppercase().orEmpty()
         if (normalized.isBlank()) {
-            messageManager.showError("请输入有效 RJ 号（如 RJ123456）")
+            messageManager.showError("请输入有效的作品编号")
             return
         }
         val current = _uiState.value as? AlbumDetailUiState.Success
         val local = current?.model?.localAlbum
         if (local == null || local.id <= 0L) {
-            messageManager.showError("仅支持本地库专辑手动绑定 RJ")
+            messageManager.showError("仅支持本地库专辑手动绑定作品编号")
             return
         }
 
@@ -418,7 +418,7 @@ class AlbumDetailViewModel @Inject constructor(
                 messageManager.showSuccess("已绑定 $normalized 并完成云同步")
                 loadAlbum(local.id, normalized, force = true)
             } catch (e: Exception) {
-                messageManager.showError("同步异常：${e.message}")
+                messageManager.showError("同步失败，请稍后重试")
                 loadAlbum(local.id, normalized, force = true)
             } finally {
                 syncCoordinator.end(token)
@@ -444,7 +444,7 @@ class AlbumDetailViewModel @Inject constructor(
                 val rj = current.model.rjCode.ifBlank { local.rjCode.ifBlank { local.workId } }
                 loadAlbum(local.id, rj, force = true)
             } catch (e: Exception) {
-                messageManager.showError("设置封面失败：${e.message}")
+                messageManager.showError("设置封面失败，请检查后重试")
             }
         }
     }
@@ -774,8 +774,7 @@ class AlbumDetailViewModel @Inject constructor(
                 val updated = (_uiState.value as? AlbumDetailUiState.Success)?.model ?: return@launch
                 val updatedWorkno = updated.dlsiteWorkno.trim().uppercase().ifBlank { updated.rjCode.trim().uppercase() }
                 if (token != dlsiteTrialLoadToken || !updatedWorkno.equals(workno, ignoreCase = true)) return@launch
-                val errMsg = e.message?.trim().orEmpty().ifBlank { "未知错误" }
-                messageManager.showError("试听刷新失败：$errMsg")
+                messageManager.showError("试听刷新失败，请稍后重试")
                 _uiState.value = AlbumDetailUiState.Success(model = updated.copy(isLoadingDlsiteTrial = false))
             }
         }
@@ -929,8 +928,7 @@ class AlbumDetailViewModel @Inject constructor(
                 val updatedKey = updated.rjCode.trim().uppercase()
                 if (updatedKey.equals(keyRj, ignoreCase = true)) {
                     if (updated.asmrOneTree.isEmpty()) {
-                        val errMsg = e.message?.trim().orEmpty().ifBlank { "未知错误" }
-                        messageManager.showError("在线资源加载失败：$errMsg")
+                        messageManager.showError("在线资源加载失败，请稍后重试")
                     }
                     if (updated.isLoadingAsmrOne) {
                         _uiState.value = AlbumDetailUiState.Success(model = updated.copy(isLoadingAsmrOne = false))
@@ -999,8 +997,7 @@ class AlbumDetailViewModel @Inject constructor(
                 }
                 val updated = (_uiState.value as? AlbumDetailUiState.Success)?.model ?: return@launch
                 if (pickedResult == null && lastError != null) {
-                    val errMsg = lastError?.message?.trim().orEmpty().ifBlank { "未知错误" }
-                    messageManager.showError("DLsite Play 加载失败：$errMsg")
+                    messageManager.showError("DLsite Play 加载失败，请稍后重试")
                 }
                 _uiState.value = AlbumDetailUiState.Success(
                     model = updated.copy(

--- a/app/src/main/java/com/asmr/player/util/AppErrorMessageFormatter.kt
+++ b/app/src/main/java/com/asmr/player/util/AppErrorMessageFormatter.kt
@@ -1,0 +1,114 @@
+package com.asmr.player.util
+
+object AppErrorMessageFormatter {
+    private val whitespaceRegex = Regex("""\s+""")
+    private val rjSampleRegex = Regex("""[（(]\s*如\s*RJ\d{6,}\s*[)）]""", RegexOption.IGNORE_CASE)
+    private val technicalDetailRegexes = listOf(
+        Regex("""\bHTTP\s*\d{3}\b""", RegexOption.IGNORE_CASE),
+        Regex("""\b[A-Za-z]+Exception\b"""),
+        Regex("""\b[A-Z]{2,}(?:_[A-Z0-9]+)+\b"""),
+        Regex("""\b(error\s*code|errorCode|status\s*code|code)\b""", RegexOption.IGNORE_CASE),
+        Regex("""\b(sockettimeout|timeout|timed out|ioexception|illegalstate|unknownhost|ssl|eof|cancelled|canceled|failed)\b""", RegexOption.IGNORE_CASE),
+        Regex("""\bRJ\d{6,}\b""", RegexOption.IGNORE_CASE)
+    )
+
+    fun sanitize(rawMessage: String, fallback: String = "操作失败，请稍后重试"): String {
+        val normalized = rawMessage
+            .replace(whitespaceRegex, " ")
+            .replace(rjSampleRegex, "")
+            .trim()
+            .trimEnd('：', ':')
+
+        if (normalized.isBlank()) return fallback
+
+        explicitMessage(normalized)?.let { return it }
+        knownTechnicalMessage(normalized)?.let { return it }
+
+        if (hasTechnicalDetails(normalized)) {
+            messagePrefix(normalized)?.let { prefix ->
+                friendlyPrefixMessage(prefix)?.let { return it }
+            }
+            inferCategory(normalized)?.let { return it }
+            return fallback
+        }
+
+        return normalized
+    }
+
+    private fun explicitMessage(message: String): String? {
+        return when {
+            message.startsWith("请输入有效 RJ 号") -> "请输入有效的作品编号"
+            message.startsWith("仅支持本地库专辑手动绑定 RJ") -> "仅支持本地库专辑手动绑定作品编号"
+            else -> null
+        }
+    }
+
+    private fun knownTechnicalMessage(message: String): String? {
+        val lower = message.lowercase()
+        return when {
+            ".m3u8" in lower -> "当前暂不支持在线播放该音频，请先下载后再播放"
+            "401" in lower || "认证" in message || "登录" in message && ("失败" in message || "过期" in message) ->
+                "登录状态已失效，请重新登录后重试"
+            "403" in lower || "访问被拒绝" in message -> "当前访问受限，请稍后再试"
+            "404" in lower || "not found" in lower -> "未找到相关内容，请检查后重试"
+            "429" in lower -> "请求过于频繁，请稍后再试"
+            "500" in lower || "502" in lower || "503" in lower || "504" in lower -> "服务器开小差了，请稍后重试"
+            "timeout" in lower || "timed out" in lower -> "请求超时，请稍后重试"
+            "unknownhost" in lower || "network" in lower || "ioexception" in lower || "网络" in message ->
+                "网络连接失败，请检查网络后重试"
+            else -> null
+        }
+    }
+
+    private fun inferCategory(message: String): String? {
+        return when {
+            "播放" in message -> "播放失败，请稍后重试"
+            "试听" in message -> "试听刷新失败，请稍后重试"
+            "在线资源" in message -> "在线资源加载失败，请稍后重试"
+            "DLsite Play" in message -> "DLsite Play 加载失败，请稍后重试"
+            "封面" in message -> "设置封面失败，请检查后重试"
+            "扫描" in message -> "扫描失败，请检查目录权限后重试"
+            "刷新" in message -> "刷新失败，请稍后重试"
+            "云同步" in message || "同步" in message -> "同步失败，请稍后重试"
+            "删除" in message -> "删除失败，请稍后重试"
+            else -> null
+        }
+    }
+
+    private fun messagePrefix(message: String): String? {
+        val separatorIndex = message.indexOfFirst { it == '：' || it == ':' }
+        if (separatorIndex <= 0) return null
+        return message.substring(0, separatorIndex).trim().takeIf { it.isNotBlank() }
+    }
+
+    private fun friendlyPrefixMessage(prefix: String): String? {
+        val normalizedPrefix = prefix.replace("异常", "失败")
+        return when {
+            "播放" in normalizedPrefix -> "播放失败，请稍后重试"
+            "试听刷新" in normalizedPrefix -> "试听刷新失败，请稍后重试"
+            "在线资源加载" in normalizedPrefix -> "在线资源加载失败，请稍后重试"
+            "DLsite Play 加载" in normalizedPrefix -> "DLsite Play 加载失败，请稍后重试"
+            "设置封面" in normalizedPrefix -> "设置封面失败，请检查后重试"
+            "扫描" in normalizedPrefix -> "扫描失败，请检查目录权限后重试"
+            "目录刷新" in normalizedPrefix || "刷新" in normalizedPrefix -> "刷新失败，请稍后重试"
+            "重扫" in normalizedPrefix -> "重扫失败，请检查目录后重试"
+            "云同步" in normalizedPrefix || "同步" in normalizedPrefix -> "同步失败，请稍后重试"
+            "删除" in normalizedPrefix -> "删除失败，请稍后重试"
+            normalizedPrefix.endsWith("失败") -> "$normalizedPrefix，请稍后重试"
+            else -> null
+        }
+    }
+
+    private fun hasTechnicalDetails(message: String): Boolean {
+        return technicalDetailRegexes.any { it.containsMatchIn(message) } || !containsOnlyReadableChinese(message)
+    }
+
+    private fun containsOnlyReadableChinese(message: String): Boolean {
+        val stripped = message
+            .replace(Regex("""[，。！？；：“”‘’（）()、/\\\-+*#@]"""), "")
+            .replace(Regex("""\d+"""), "")
+            .trim()
+        if (stripped.isBlank()) return false
+        return stripped.all { it.code in 0x4E00..0x9FFF || it.isWhitespace() }
+    }
+}

--- a/app/src/main/java/com/asmr/player/util/MessageManager.kt
+++ b/app/src/main/java/com/asmr/player/util/MessageManager.kt
@@ -35,9 +35,22 @@ class MessageManager @Inject constructor() {
     val messages = _messages.asSharedFlow()
 
     fun showMessage(message: String, type: MessageType = MessageType.Info, durationMs: Long = 3000) {
+        val normalizedMessage = when (type) {
+            MessageType.Error -> AppErrorMessageFormatter.sanitize(message)
+            else -> message.trim()
+        }
+        if (normalizedMessage.isBlank()) return
         val now = System.currentTimeMillis()
         val id = seq.incrementAndGet()
-        _messages.tryEmit(AppMessage(id = id, message = message, type = type, durationMs = durationMs, createdAtMs = now))
+        _messages.tryEmit(
+            AppMessage(
+                id = id,
+                message = normalizedMessage,
+                type = type,
+                durationMs = durationMs,
+                createdAtMs = now
+            )
+        )
     }
 
     fun showSuccess(message: String) = showMessage(message, MessageType.Success)


### PR DESCRIPTION
## Summary
- disable drawer swipe gestures on now playing and lyrics pages only
- move app message overlay into the Compose root so bubbles stay above page content
- normalize error bubble copy to concise Chinese and refine snackbar visuals in light mode
 
## Testing
- ./gradlew :app:compileDebugKotlin\n