### PR TITLE
fix: stop replaying stale volume overlay events

### DIFF
--- a/app/src/main/java/com/asmr/player/MainActivity.kt
+++ b/app/src/main/java/com/asmr/player/MainActivity.kt
@@ -473,6 +473,7 @@ fun MainContainer(
     var hardwareVolumeOverlayInteracting by remember { mutableStateOf(false) }
     var hardwareVolumeOverlayHoldTick by remember { mutableLongStateOf(0L) }
     var lastHandledVolumeKeyTick by remember { mutableLongStateOf(0L) }
+    var nowPlayingVolumeEventTick by remember { mutableLongStateOf(0L) }
     var lastNonZeroAppVolumePercent by rememberSaveable { mutableIntStateOf(AppVolume.DefaultPercent) }
     
     val configuration = LocalConfiguration.current
@@ -486,6 +487,9 @@ fun MainContainer(
     LaunchedEffect(currentRoute) {
         showHardwareVolumeOverlay = false
         hardwareVolumeOverlayInteracting = false
+        if (currentRoute == "now_playing") {
+            nowPlayingVolumeEventTick = 0L
+        }
         val last = lastRouteForTouchBlock
         val seq = ++touchBlockSeq
         if (last != null && currentRoute != null && last != currentRoute) {
@@ -594,6 +598,7 @@ fun MainContainer(
         lastHandledVolumeKeyTick = volumeKeyEventTick
         if (currentRoute == "now_playing") {
             showHardwareVolumeOverlay = false
+            nowPlayingVolumeEventTick = volumeKeyEventTick
             return@LaunchedEffect
         }
         showHardwareVolumeOverlay = true
@@ -1227,7 +1232,7 @@ fun MainContainer(
                     if (globalDynamicHueEnabled) {
                         NowPlayingScreen(
                             windowSizeClass = windowSizeClass,
-                            hardwareVolumeEventTick = volumeKeyEventTick,
+                            hardwareVolumeEventTick = nowPlayingVolumeEventTick,
                             onBack = { navController.popBackStack() },
                             onOpenLyrics = { navController.navigateSingleTop("lyrics") },
                             onShowQueue = onShowQueue,
@@ -1253,7 +1258,7 @@ fun MainContainer(
                     } else {
                         NowPlayingScreen(
                             windowSizeClass = windowSizeClass,
-                            hardwareVolumeEventTick = volumeKeyEventTick,
+                            hardwareVolumeEventTick = nowPlayingVolumeEventTick,
                             onBack = { navController.popBackStack() },
                             onOpenLyrics = { navController.navigateSingleTop("lyrics") },
                             onShowQueue = onShowQueue,

--- a/app/src/main/java/com/asmr/player/ui/player/NowPlayingScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/player/NowPlayingScreen.kt
@@ -1696,17 +1696,26 @@ private fun VolumeControl(
     viewModel: PlayerViewModel,
     hardwareVolumeEventTick: Long
 ) {
-    var expanded by rememberSaveable { mutableStateOf(false) }
+    var expanded by remember { mutableStateOf(false) }
     val volume by viewModel.appVolumePercent.collectAsState()
-    var lastNonZeroVolume by rememberSaveable { mutableIntStateOf(AppVolume.DefaultPercent) }
+    var lastNonZeroVolume by remember { mutableIntStateOf(AppVolume.DefaultPercent) }
     var lastInteractionAt by remember { mutableLongStateOf(0L) }
+    var hasObservedInitialHardwareVolumeEventTick by remember { mutableStateOf(false) }
+    var lastHandledHardwareVolumeEventTick by remember { mutableLongStateOf(0L) }
 
     LaunchedEffect(volume) {
         if (volume > 0) lastNonZeroVolume = volume
     }
 
     LaunchedEffect(hardwareVolumeEventTick) {
+        if (!hasObservedInitialHardwareVolumeEventTick) {
+            lastHandledHardwareVolumeEventTick = hardwareVolumeEventTick
+            hasObservedInitialHardwareVolumeEventTick = true
+            return@LaunchedEffect
+        }
         if (hardwareVolumeEventTick <= 0L) return@LaunchedEffect
+        if (hardwareVolumeEventTick == lastHandledHardwareVolumeEventTick) return@LaunchedEffect
+        lastHandledHardwareVolumeEventTick = hardwareVolumeEventTick
         expanded = true
         lastInteractionAt = SystemClock.elapsedRealtime()
     }


### PR DESCRIPTION
## Summary
- prevent stale volume overlay events from replaying after state is restored
- keep the overlay state aligned with the latest volume interaction