### PR TITLE
fix: avoid distortion when app volume exceeds 100%

### DIFF
--- a/app/src/main/java/com/asmr/player/playback/AppVolume.kt
+++ b/app/src/main/java/com/asmr/player/playback/AppVolume.kt
@@ -1,5 +1,8 @@
 package com.asmr.player.playback
 
+import kotlin.math.log10
+import kotlin.math.roundToInt
+
 object AppVolume {
     const val MinPercent = 0
     const val NormalMaxPercent = 100
@@ -18,6 +21,12 @@ object AppVolume {
     fun gainMultiplier(percent: Int): Float {
         val clamped = clampPercent(percent)
         return if (clamped <= NormalMaxPercent) 1f else (clamped / 100f).coerceIn(1f, 3f)
+    }
+
+    fun boostGainMb(percent: Int): Int {
+        val multiplier = gainMultiplier(percent)
+        if (multiplier <= 1f) return 0
+        return (20f * log10(multiplier) * 100f).roundToInt().coerceAtLeast(0)
     }
 
     fun visualFraction(percent: Int): Float {

--- a/app/src/main/java/com/asmr/player/playback/AppVolumeBoostController.kt
+++ b/app/src/main/java/com/asmr/player/playback/AppVolumeBoostController.kt
@@ -1,0 +1,63 @@
+package com.asmr.player.playback
+
+import android.media.audiofx.LoudnessEnhancer
+import android.util.Log
+
+class AppVolumeBoostController {
+    private var audioSessionId: Int = 0
+    private var boostGainMb: Int = 0
+    private var enhancer: LoudnessEnhancer? = null
+
+    fun setAudioSessionId(audioSessionId: Int) {
+        if (this.audioSessionId == audioSessionId) return
+        this.audioSessionId = audioSessionId
+        releaseEnhancer()
+        ensureEnhancer()
+    }
+
+    fun setVolumePercent(percent: Int) {
+        val nextBoostGainMb = AppVolume.boostGainMb(percent)
+        if (boostGainMb == nextBoostGainMb) return
+        boostGainMb = nextBoostGainMb
+        applyBoost()
+    }
+
+    fun release() {
+        releaseEnhancer()
+    }
+
+    private fun ensureEnhancer() {
+        if (audioSessionId <= 0 || boostGainMb <= 0 || enhancer != null) return
+        enhancer = runCatching { LoudnessEnhancer(audioSessionId) }
+            .onFailure {
+                Log.w(TAG, "Failed to create LoudnessEnhancer for session=$audioSessionId", it)
+            }
+            .getOrNull()
+        applyBoost()
+    }
+
+    private fun applyBoost() {
+        if (boostGainMb <= 0) {
+            runCatching { enhancer?.enabled = false }
+            return
+        }
+        ensureEnhancer()
+        val currentEnhancer = enhancer ?: return
+        runCatching {
+            currentEnhancer.setTargetGain(boostGainMb)
+            currentEnhancer.enabled = true
+        }.onFailure {
+            Log.w(TAG, "Failed to apply loudness boost=${boostGainMb}mB", it)
+            releaseEnhancer()
+        }
+    }
+
+    private fun releaseEnhancer() {
+        enhancer?.release()
+        enhancer = null
+    }
+
+    private companion object {
+        private const val TAG = "AppVolumeBoost"
+    }
+}

--- a/app/src/main/java/com/asmr/player/service/PlaybackService.kt
+++ b/app/src/main/java/com/asmr/player/service/PlaybackService.kt
@@ -41,6 +41,7 @@ import com.asmr.player.playback.ChannelModeAudioProcessor
 import com.asmr.player.playback.FadingPlayer
 import com.asmr.player.playback.GainAudioProcessor
 import com.asmr.player.playback.AppVolume
+import com.asmr.player.playback.AppVolumeBoostController
 import com.asmr.player.playback.GraphicEqualizerAudioProcessor
 import com.asmr.player.playback.PlaybackMediaCache
 import com.asmr.player.playback.RoutingPlaybackDataSource
@@ -79,6 +80,7 @@ class PlaybackService : MediaSessionService() {
     private lateinit var sessionPlayer: FadingPlayer
     private val graphicEqualizerAudioProcessor = GraphicEqualizerAudioProcessor()
     private val gainAudioProcessor = GainAudioProcessor()
+    private val appVolumeBoostController = AppVolumeBoostController()
     private val balanceAudioProcessor = BalanceAudioProcessor()
     private val stereoOrbitAudioProcessor = StereoOrbitAudioProcessor()
     private val channelModeAudioProcessor = ChannelModeAudioProcessor()
@@ -239,6 +241,7 @@ class PlaybackService : MediaSessionService() {
             switchFadeOutMs = 250L,
             switchFadeInMs = 250L
         )
+        appVolumeBoostController.setAudioSessionId(exoPlayer.audioSessionId)
         startEffectLoops()
         mediaSession = MediaSession.Builder(this, sessionPlayer)
             .setSessionActivity(createContentIntent())
@@ -355,6 +358,10 @@ class PlaybackService : MediaSessionService() {
                 currentTrackListenedMs = 0L
                 isCurrentTrackCounted = false
                 lastProgressPersistElapsedMs = 0L
+            }
+
+            override fun onAudioSessionIdChanged(audioSessionId: Int) {
+                appVolumeBoostController.setAudioSessionId(audioSessionId)
             }
         })
         StereoSpectrumBus.playbackActive = exoPlayer.isPlaying
@@ -642,7 +649,8 @@ class PlaybackService : MediaSessionService() {
                 graphicEqualizerAudioProcessor.setEnabled(settings.enabled)
                 graphicEqualizerAudioProcessor.setBandLevels(settings.bandLevels)
                 sessionPlayer.setBaseVolume(AppVolume.basePlayerVolume(appVolumePercent))
-                gainAudioProcessor.setGain(AppVolume.gainMultiplier(appVolumePercent))
+                gainAudioProcessor.setGain(1f)
+                appVolumeBoostController.setVolumePercent(appVolumePercent)
                 val stereoEnabled = settings.stereoEnabled
                 val panActive = stereoEnabled && (settings.orbitEnabled || settings.orbitAzimuthDeg != 0f)
                 balanceAudioProcessor.setBalance(if (stereoEnabled && !panActive) settings.balance else 0f)
@@ -680,6 +688,7 @@ class PlaybackService : MediaSessionService() {
         statsJob?.cancel()
         effectApplyJob?.cancel()
         sleepTimerJob?.cancel()
+        appVolumeBoostController.release()
         spectrumAnalyzer.stop()
         mediaSession?.run {
             player.release()

--- a/app/src/test/java/com/asmr/player/playback/AppVolumeTest.kt
+++ b/app/src/test/java/com/asmr/player/playback/AppVolumeTest.kt
@@ -1,0 +1,22 @@
+package com.asmr.player.playback
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class AppVolumeTest {
+
+    @Test
+    fun baseVolumeCapsAtOneHundredPercent() {
+        assertEquals(0.8f, AppVolume.basePlayerVolume(80), 0.0001f)
+        assertEquals(1.0f, AppVolume.basePlayerVolume(100), 0.0001f)
+        assertEquals(1.0f, AppVolume.basePlayerVolume(300), 0.0001f)
+    }
+
+    @Test
+    fun boostGainIsOnlyAppliedAboveOneHundredPercent() {
+        assertEquals(0, AppVolume.boostGainMb(0))
+        assertEquals(0, AppVolume.boostGainMb(100))
+        assertEquals(602, AppVolume.boostGainMb(200))
+        assertEquals(954, AppVolume.boostGainMb(300))
+    }
+}


### PR DESCRIPTION
## Summary
- replace PCM hard gain above 100% with session-based LoudnessEnhancer boost
- keep 0-100% app volume on player base volume and stop clipping decoded samples
- add app volume mapping tests for base volume and boost gain

## Verification
- ./gradlew compileDebugKotlin compileDebugUnitTestKotlin