### PR TITLE
feat: add playback settings controls

### DIFF
--- a/app/src/main/java/com/asmr/player/MainActivity.kt
+++ b/app/src/main/java/com/asmr/player/MainActivity.kt
@@ -208,6 +208,7 @@ class MainActivity : ComponentActivity() {
             val coverBackgroundClarity by settingsDataStore.coverBackgroundClarity.collectAsState(initial = 0.35f)
             val coverPreviewMode by settingsDataStore.coverPreviewMode.collectAsState(initial = CoverPreviewMode.Disabled)
             val lyricsPageSettings by settingsDataStore.lyricsPageSettings.collectAsState(initial = LyricsPageSettings())
+            val showMiniPlayerBar by settingsRepository.showMiniPlayerBar.collectAsState(initial = true)
             val neutral = remember(mode) { neutralPaletteForMode(mode) }
             val cacheManager = remember(context.applicationContext) {
                 dagger.hilt.android.EntryPointAccessors.fromApplication(
@@ -337,6 +338,7 @@ class MainActivity : ComponentActivity() {
                         onContentReady = { contentReady = true },
                         visibleMessages = visibleMessagesSnapshot,
                         mode = mode,
+                        showMiniPlayerBar = showMiniPlayerBar,
                         globalDynamicHueEnabled = globalDynamicHueEnabled,
                         coverBackgroundEnabled = coverBackgroundEnabled,
                         coverBackgroundClarity = coverBackgroundClarity,
@@ -432,6 +434,7 @@ fun MainContainer(
     onContentReady: () -> Unit,
     visibleMessages: List<VisibleAppMessage>,
     mode: ThemeMode,
+    showMiniPlayerBar: Boolean,
     globalDynamicHueEnabled: Boolean,
     coverBackgroundEnabled: Boolean,
     coverBackgroundClarity: Float,
@@ -745,7 +748,7 @@ fun MainContainer(
             }
         }
     ) {
-        val miniPlayerVisible = hasCurrentMediaItem && currentRoute != "now_playing" && currentRoute != "lyrics"
+        val miniPlayerVisible = showMiniPlayerBar && hasCurrentMediaItem && currentRoute != "now_playing" && currentRoute != "lyrics"
         val rightPanelExpandedFromStore by settingsDataStore.recentAlbumsPanelExpanded.collectAsState(initial = recentAlbumsPanelExpandedInitial)
         val rightPanelExpandedState = remember(settingsDataStore, scope, recentAlbumsPanelExpandedInitial) {
             PersistedBooleanState(initial = recentAlbumsPanelExpandedInitial) { expanded ->

--- a/app/src/main/java/com/asmr/player/data/settings/SettingsDataStore.kt
+++ b/app/src/main/java/com/asmr/player/data/settings/SettingsDataStore.kt
@@ -67,4 +67,12 @@ object SettingsKeys {
 
     val SLEEP_TIMER_END_AT_MS = longPreferencesKey("sleep_timer_end_at_ms")
     val SLEEP_TIMER_LAST_DURATION_MIN = intPreferencesKey("sleep_timer_last_duration_min")
+
+    val PAUSE_ON_OUTPUT_DISCONNECT = booleanPreferencesKey("pause_on_output_disconnect")
+    val RESUME_ON_OUTPUT_CONNECT = booleanPreferencesKey("resume_on_output_connect")
+    val PAUSE_ON_OTHER_AUDIO = booleanPreferencesKey("pause_on_other_audio")
+    val PLAY_FADE_IN_MS = intPreferencesKey("play_fade_in_ms")
+    val PAUSE_FADE_OUT_MS = intPreferencesKey("pause_fade_out_ms")
+    val SFW_HIDE_SYSTEM_CONTROLS = booleanPreferencesKey("sfw_hide_system_controls")
+    val SHOW_MINI_PLAYER_BAR = booleanPreferencesKey("show_mini_player_bar")
 }

--- a/app/src/main/java/com/asmr/player/data/settings/SettingsRepository.kt
+++ b/app/src/main/java/com/asmr/player/data/settings/SettingsRepository.kt
@@ -121,6 +121,34 @@ class SettingsRepository @Inject constructor(
         prefs[SettingsKeys.SLEEP_TIMER_LAST_DURATION_MIN] ?: 30
     }
 
+    val pauseOnOutputDisconnect: Flow<Boolean> = context.settingsDataStore.data.map { prefs ->
+        prefs[SettingsKeys.PAUSE_ON_OUTPUT_DISCONNECT] ?: true
+    }
+
+    val resumeOnOutputConnect: Flow<Boolean> = context.settingsDataStore.data.map { prefs ->
+        prefs[SettingsKeys.RESUME_ON_OUTPUT_CONNECT] ?: false
+    }
+
+    val pauseOnOtherAudio: Flow<Boolean> = context.settingsDataStore.data.map { prefs ->
+        prefs[SettingsKeys.PAUSE_ON_OTHER_AUDIO] ?: true
+    }
+
+    val playFadeInMs: Flow<Int> = context.settingsDataStore.data.map { prefs ->
+        (prefs[SettingsKeys.PLAY_FADE_IN_MS] ?: 500).coerceIn(0, 3000)
+    }
+
+    val pauseFadeOutMs: Flow<Int> = context.settingsDataStore.data.map { prefs ->
+        (prefs[SettingsKeys.PAUSE_FADE_OUT_MS] ?: 500).coerceIn(0, 3000)
+    }
+
+    val sfwHideSystemControls: Flow<Boolean> = context.settingsDataStore.data.map { prefs ->
+        prefs[SettingsKeys.SFW_HIDE_SYSTEM_CONTROLS] ?: false
+    }
+
+    val showMiniPlayerBar: Flow<Boolean> = context.settingsDataStore.data.map { prefs ->
+        prefs[SettingsKeys.SHOW_MINI_PLAYER_BAR] ?: true
+    }
+
     suspend fun setSleepTimerEndAtMs(endAtMs: Long) {
         withContext(Dispatchers.IO) {
             context.settingsDataStore.edit { it[SettingsKeys.SLEEP_TIMER_END_AT_MS] = endAtMs }
@@ -134,6 +162,48 @@ class SettingsRepository @Inject constructor(
     suspend fun setSleepTimerLastDurationMin(minutes: Int) {
         withContext(Dispatchers.IO) {
             context.settingsDataStore.edit { it[SettingsKeys.SLEEP_TIMER_LAST_DURATION_MIN] = minutes }
+        }
+    }
+
+    suspend fun setPauseOnOutputDisconnect(enabled: Boolean) {
+        withContext(Dispatchers.IO) {
+            context.settingsDataStore.edit { it[SettingsKeys.PAUSE_ON_OUTPUT_DISCONNECT] = enabled }
+        }
+    }
+
+    suspend fun setResumeOnOutputConnect(enabled: Boolean) {
+        withContext(Dispatchers.IO) {
+            context.settingsDataStore.edit { it[SettingsKeys.RESUME_ON_OUTPUT_CONNECT] = enabled }
+        }
+    }
+
+    suspend fun setPauseOnOtherAudio(enabled: Boolean) {
+        withContext(Dispatchers.IO) {
+            context.settingsDataStore.edit { it[SettingsKeys.PAUSE_ON_OTHER_AUDIO] = enabled }
+        }
+    }
+
+    suspend fun setPlayFadeInMs(durationMs: Int) {
+        withContext(Dispatchers.IO) {
+            context.settingsDataStore.edit { it[SettingsKeys.PLAY_FADE_IN_MS] = durationMs.coerceIn(0, 3000) }
+        }
+    }
+
+    suspend fun setPauseFadeOutMs(durationMs: Int) {
+        withContext(Dispatchers.IO) {
+            context.settingsDataStore.edit { it[SettingsKeys.PAUSE_FADE_OUT_MS] = durationMs.coerceIn(0, 3000) }
+        }
+    }
+
+    suspend fun setSfwHideSystemControls(enabled: Boolean) {
+        withContext(Dispatchers.IO) {
+            context.settingsDataStore.edit { it[SettingsKeys.SFW_HIDE_SYSTEM_CONTROLS] = enabled }
+        }
+    }
+
+    suspend fun setShowMiniPlayerBar(enabled: Boolean) {
+        withContext(Dispatchers.IO) {
+            context.settingsDataStore.edit { it[SettingsKeys.SHOW_MINI_PLAYER_BAR] = enabled }
         }
     }
 

--- a/app/src/main/java/com/asmr/player/playback/FadingPlayer.kt
+++ b/app/src/main/java/com/asmr/player/playback/FadingPlayer.kt
@@ -9,15 +9,18 @@ import androidx.media3.common.util.UnstableApi
 class FadingPlayer(
     private val delegate: Player,
     private val volumeFader: VolumeFader,
-    private val playFadeMs: Long,
-    private val pauseFadeMs: Long,
+    playFadeMs: Long,
+    pauseFadeMs: Long,
     private val switchFadeOutMs: Long,
-    private val switchFadeInMs: Long
+    private val switchFadeInMs: Long,
+    private val onPlayRequested: (() -> Boolean)? = null
 ) : ForwardingPlayer(delegate) {
 
     private var pendingSwitchFadeIn: Boolean = false
     private var baseVolume: Float = 1f
     private var fadeVolume: Float = 1f
+    @Volatile private var playFadeDurationMs: Long = playFadeMs.coerceAtLeast(0L)
+    @Volatile private var pauseFadeDurationMs: Long = pauseFadeMs.coerceAtLeast(0L)
 
     private val transitionListener = object : Player.Listener {
         override fun onMediaItemTransition(mediaItem: MediaItem?, reason: Int) {
@@ -37,12 +40,18 @@ class FadingPlayer(
         syncOutputVolume()
     }
 
+    fun setFadeDurations(playFadeMs: Long, pauseFadeMs: Long) {
+        playFadeDurationMs = playFadeMs.coerceAtLeast(0L)
+        pauseFadeDurationMs = pauseFadeMs.coerceAtLeast(0L)
+    }
+
     override fun play() {
+        if (onPlayRequested?.invoke() == false) return
         pendingSwitchFadeIn = false
         volumeFader.cancel()
         volume = 0f
         delegate.play()
-        volumeFader.fadeTo(this, 1f, playFadeMs)
+        volumeFader.fadeTo(this, 1f, playFadeDurationMs)
     }
 
     override fun pause() {
@@ -51,7 +60,7 @@ class FadingPlayer(
             delegate.pause()
             return
         }
-        volumeFader.fadeTo(this, 0f, pauseFadeMs) {
+        volumeFader.fadeTo(this, 0f, pauseFadeDurationMs) {
             delegate.pause()
         }
     }

--- a/app/src/main/java/com/asmr/player/service/LyricMediaNotificationProvider.kt
+++ b/app/src/main/java/com/asmr/player/service/LyricMediaNotificationProvider.kt
@@ -17,6 +17,7 @@ import androidx.compose.ui.graphics.asAndroidBitmap
 import androidx.compose.ui.unit.IntSize
 import com.asmr.player.cache.CachePolicy
 import com.asmr.player.cache.ImageCacheEntryPoint
+import com.asmr.player.data.settings.SettingsRepository
 import com.asmr.player.R
 import com.google.common.collect.ImmutableList
 import dagger.hilt.android.EntryPointAccessors
@@ -30,7 +31,8 @@ import java.io.File
 
 @UnstableApi
 class LyricMediaNotificationProvider(
-    private val context: Context
+    private val context: Context,
+    private val settingsRepository: SettingsRepository
 ) : MediaNotification.Provider {
     private val appContext = context.applicationContext
     private val CHANNEL_ID = "playback"
@@ -42,6 +44,7 @@ class LyricMediaNotificationProvider(
     @Volatile private var lastRequest: LastRequest? = null
     @Volatile private var lastArtworkKeyRequested: String? = null
     @Volatile private var artworkJob: Job? = null
+    @Volatile private var hideSystemControls: Boolean = false
 
     private data class LastRequest(
         val mediaSession: MediaSession,
@@ -72,37 +75,8 @@ class LyricMediaNotificationProvider(
             }
         }
 
-        val prevAction = actionFactory.createMediaAction(
-            mediaSession,
-            IconCompat.createWithResource(appContext, R.drawable.ic_notif_prev),
-            "上一首",
-            Player.COMMAND_SEEK_TO_PREVIOUS_MEDIA_ITEM
-        )
-        val playPauseAction = actionFactory.createMediaAction(
-            mediaSession,
-            IconCompat.createWithResource(
-                appContext,
-                if (player.isPlaying) R.drawable.ic_notif_pause else R.drawable.ic_notif_play
-            ),
-            if (player.isPlaying) "暂停" else "播放",
-            Player.COMMAND_PLAY_PAUSE
-        )
-        val nextAction = actionFactory.createMediaAction(
-            mediaSession,
-            IconCompat.createWithResource(appContext, R.drawable.ic_notif_next),
-            "下一首",
-            Player.COMMAND_SEEK_TO_NEXT_MEDIA_ITEM
-        )
-
-        val mediaStyle = MediaStyleNotificationHelper.MediaStyle(mediaSession)
-            .setShowActionsInCompactView(0, 1, 2)
-
         val builder = NotificationCompat.Builder(appContext, CHANNEL_ID)
             .setSmallIcon(R.drawable.ic_stat_playback)
-            .addAction(prevAction)
-            .addAction(playPauseAction)
-            .addAction(nextAction)
-            .setStyle(mediaStyle)
             .setContentTitle(contentTitle)
             .setContentText(contentText)
             .setSubText("")
@@ -110,14 +84,54 @@ class LyricMediaNotificationProvider(
             .setOngoing(player.isPlaying)
             .setOnlyAlertOnce(true)
             .setSilent(true)
-            .setVisibility(NotificationCompat.VISIBILITY_PUBLIC)
+            .setVisibility(
+                if (hideSystemControls) NotificationCompat.VISIBILITY_SECRET
+                else NotificationCompat.VISIBILITY_PUBLIC
+            )
             .setContentIntent(mediaSession.sessionActivity)
             .setDeleteIntent(actionFactory.createMediaActionPendingIntent(mediaSession, Player.COMMAND_STOP.toLong()))
             .apply {
                 if (artworkBitmap != null) setLargeIcon(artworkBitmap)
             }
 
+        if (!hideSystemControls) {
+            val prevAction = actionFactory.createMediaAction(
+                mediaSession,
+                IconCompat.createWithResource(appContext, R.drawable.ic_notif_prev),
+                "上一首",
+                Player.COMMAND_SEEK_TO_PREVIOUS_MEDIA_ITEM
+            )
+            val playPauseAction = actionFactory.createMediaAction(
+                mediaSession,
+                IconCompat.createWithResource(
+                    appContext,
+                    if (player.isPlaying) R.drawable.ic_notif_pause else R.drawable.ic_notif_play
+                ),
+                if (player.isPlaying) "暂停" else "播放",
+                Player.COMMAND_PLAY_PAUSE
+            )
+            val nextAction = actionFactory.createMediaAction(
+                mediaSession,
+                IconCompat.createWithResource(appContext, R.drawable.ic_notif_next),
+                "下一首",
+                Player.COMMAND_SEEK_TO_NEXT_MEDIA_ITEM
+            )
+            val mediaStyle = MediaStyleNotificationHelper.MediaStyle(mediaSession)
+                .setShowActionsInCompactView(0, 1, 2)
+            builder
+                .addAction(prevAction)
+                .addAction(playPauseAction)
+                .addAction(nextAction)
+                .setStyle(mediaStyle)
+        }
+
         return MediaNotification(1001, builder.build())
+    }
+
+    fun setHideSystemControls(hide: Boolean) {
+        if (hideSystemControls == hide) return
+        hideSystemControls = hide
+        refreshNotification()
     }
 
     private fun getCachedArtworkBitmap(uri: Uri?): android.graphics.Bitmap? {
@@ -185,5 +199,28 @@ class LyricMediaNotificationProvider(
 
     override fun handleCustomCommand(session: MediaSession, action: String, extras: Bundle): Boolean {
         return false
+    }
+
+    init {
+        scope.launch {
+            settingsRepository.sfwHideSystemControls.collect { hide ->
+                hideSystemControls = hide
+                withContext(Dispatchers.Main) {
+                    refreshNotification()
+                }
+            }
+        }
+    }
+
+    private fun refreshNotification() {
+        val latest = lastRequest ?: return
+        latest.callback.onNotificationChanged(
+            createNotification(
+                latest.mediaSession,
+                latest.customLayout,
+                latest.actionFactory,
+                latest.callback
+            )
+        )
     }
 }

--- a/app/src/main/java/com/asmr/player/service/PlaybackService.kt
+++ b/app/src/main/java/com/asmr/player/service/PlaybackService.kt
@@ -1,9 +1,16 @@
 package com.asmr.player.service
 
 import android.app.PendingIntent
+import android.bluetooth.BluetoothAdapter
+import android.content.BroadcastReceiver
+import android.content.Context
 import android.content.Intent
+import android.content.IntentFilter
 import android.app.NotificationChannel
 import android.app.NotificationManager
+import android.media.AudioDeviceCallback
+import android.media.AudioDeviceInfo
+import android.media.AudioFocusRequest
 import android.media.AudioManager
 import android.net.Uri
 import android.os.Build
@@ -66,6 +73,7 @@ import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
@@ -111,6 +119,70 @@ class PlaybackService : MediaSessionService() {
     private var lastLyricIndex: Int = Int.MIN_VALUE
     private var floatingLyricsEnabled: Boolean = false
     private var overlay: FloatingLyricsOverlay? = null
+    private var pauseOnOutputDisconnectEnabled: Boolean = true
+    private var resumeOnOutputConnectEnabled: Boolean = false
+    private var pauseOnOtherAudioEnabled: Boolean = true
+    private var autoPausedByDisconnect: Boolean = false
+    private var autoPausedByAudioFocusLoss: Boolean = false
+    private var lastOutputEventAtMs: Long = 0L
+    private var audioFocusRequest: AudioFocusRequest? = null
+    private var hasAudioFocus: Boolean = false
+    private var notificationProvider: LyricMediaNotificationProvider? = null
+
+    private val audioFocusChangeListener = AudioManager.OnAudioFocusChangeListener { focusChange ->
+        when (focusChange) {
+            AudioManager.AUDIOFOCUS_GAIN -> hasAudioFocus = true
+            AudioManager.AUDIOFOCUS_LOSS,
+            AudioManager.AUDIOFOCUS_LOSS_TRANSIENT -> {
+                hasAudioFocus = false
+                if (pauseOnOtherAudioEnabled && exoPlayer.isPlaying) {
+                    autoPausedByAudioFocusLoss = true
+                    serviceScope.launch(Dispatchers.Main.immediate) {
+                        sessionPlayer.pause()
+                    }
+                }
+            }
+            AudioManager.AUDIOFOCUS_LOSS_TRANSIENT_CAN_DUCK -> Unit
+        }
+    }
+
+    private val outputBroadcastReceiver = object : BroadcastReceiver() {
+        override fun onReceive(context: Context?, intent: Intent?) {
+            when (intent?.action) {
+                AudioManager.ACTION_AUDIO_BECOMING_NOISY -> handlePotentialOutputDisconnect("becoming_noisy")
+                Intent.ACTION_HEADSET_PLUG -> {
+                    val state = intent.getIntExtra("state", -1)
+                    if (state == 0) {
+                        handlePotentialOutputDisconnect("headset_unplugged")
+                    } else if (state == 1) {
+                        handlePotentialOutputConnect("headset_plugged")
+                    }
+                }
+                BluetoothAdapter.ACTION_STATE_CHANGED -> {
+                    val state = intent.getIntExtra(BluetoothAdapter.EXTRA_STATE, BluetoothAdapter.ERROR)
+                    if (state == BluetoothAdapter.STATE_OFF || state == BluetoothAdapter.STATE_TURNING_OFF) {
+                        handlePotentialOutputDisconnect("bluetooth_off")
+                    } else if (state == BluetoothAdapter.STATE_ON) {
+                        handlePotentialOutputConnect("bluetooth_on")
+                    }
+                }
+            }
+        }
+    }
+
+    private val audioDeviceCallback = object : AudioDeviceCallback() {
+        override fun onAudioDevicesAdded(addedDevices: Array<out AudioDeviceInfo>) {
+            if (addedDevices.any { it.isRelevantOutputDevice() }) {
+                handlePotentialOutputConnect("device_added")
+            }
+        }
+
+        override fun onAudioDevicesRemoved(removedDevices: Array<out AudioDeviceInfo>) {
+            if (removedDevices.any { it.isRelevantOutputDevice() }) {
+                handlePotentialOutputDisconnect("device_removed")
+            }
+        }
+    }
 
     @Inject
     lateinit var audioEffectController: AudioEffectController
@@ -232,7 +304,7 @@ class PlaybackService : MediaSessionService() {
                     .setContentType(C.AUDIO_CONTENT_TYPE_MUSIC)
                     .setUsage(C.USAGE_MEDIA)
                     .build(),
-                true
+                false
             )
             .setHandleAudioBecomingNoisy(true)
             .build()
@@ -242,11 +314,13 @@ class PlaybackService : MediaSessionService() {
         sessionPlayer = FadingPlayer(
             delegate = exoPlayer,
             volumeFader = volumeFader,
-            playFadeMs = 1000L,
+            playFadeMs = 500L,
             pauseFadeMs = 500L,
             switchFadeOutMs = 250L,
-            switchFadeInMs = 250L
+            switchFadeInMs = 250L,
+            onPlayRequested = { requestPlaybackAudioFocus() }
         )
+        registerPlaybackRouteListeners()
         startEffectLoops()
         mediaSession = MediaSession.Builder(this, sessionPlayer)
             .setSessionActivity(createContentIntent())
@@ -337,7 +411,8 @@ class PlaybackService : MediaSessionService() {
             })
             .build()
 
-        setMediaNotificationProvider(LyricMediaNotificationProvider(this))
+        notificationProvider = LyricMediaNotificationProvider(this, settingsRepository)
+        setMediaNotificationProvider(notificationProvider!!)
         overlay = FloatingLyricsOverlay(this)
         
         exoPlayer.addListener(object : androidx.media3.common.Player.Listener {
@@ -346,6 +421,7 @@ class PlaybackService : MediaSessionService() {
                 if (isPlaying) {
                     markCurrentAlbumPlayed()
                 } else {
+                    abandonPlaybackAudioFocus()
                     serviceScope.launch { persistCurrentTrackProgressIfNeeded(force = true) }
                 }
             }
@@ -397,6 +473,41 @@ class PlaybackService : MediaSessionService() {
         serviceScope.launch {
             settingsRepository.floatingLyricsSettings.collect { settings ->
                 overlay?.applySettings(settings)
+            }
+        }
+        serviceScope.launch {
+            settingsRepository.pauseOnOutputDisconnect.collectLatest { enabled ->
+                pauseOnOutputDisconnectEnabled = enabled
+                if (!enabled) autoPausedByDisconnect = false
+            }
+        }
+        serviceScope.launch {
+            settingsRepository.resumeOnOutputConnect.collectLatest { enabled ->
+                resumeOnOutputConnectEnabled = enabled
+            }
+        }
+        serviceScope.launch {
+            settingsRepository.pauseOnOtherAudio.collectLatest { enabled ->
+                pauseOnOtherAudioEnabled = enabled
+                if (!enabled) autoPausedByAudioFocusLoss = false
+            }
+        }
+        serviceScope.launch {
+            combine(
+                settingsRepository.playFadeInMs,
+                settingsRepository.pauseFadeOutMs
+            ) { fadeInMs, fadeOutMs ->
+                fadeInMs to fadeOutMs
+            }.collectLatest { (fadeInMs, fadeOutMs) ->
+                sessionPlayer.setFadeDurations(
+                    playFadeMs = fadeInMs.toLong(),
+                    pauseFadeMs = fadeOutMs.toLong()
+                )
+            }
+        }
+        serviceScope.launch {
+            settingsRepository.sfwHideSystemControls.collectLatest { hide ->
+                notificationProvider?.setHideSystemControls(hide)
             }
         }
         serviceScope.launch {
@@ -556,6 +667,100 @@ class PlaybackService : MediaSessionService() {
         }
     }
 
+    private fun requestPlaybackAudioFocus(): Boolean {
+        val audioManager = getSystemService(AUDIO_SERVICE) as AudioManager
+        val result = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val request = (audioFocusRequest ?: AudioFocusRequest.Builder(AudioManager.AUDIOFOCUS_GAIN)
+                .setAudioAttributes(
+                    android.media.AudioAttributes.Builder()
+                        .setUsage(android.media.AudioAttributes.USAGE_MEDIA)
+                        .setContentType(android.media.AudioAttributes.CONTENT_TYPE_MUSIC)
+                        .build()
+                )
+                .setAcceptsDelayedFocusGain(false)
+                .setOnAudioFocusChangeListener(audioFocusChangeListener)
+                .build()
+                .also { audioFocusRequest = it })
+            audioManager.requestAudioFocus(request)
+        } else {
+            @Suppress("DEPRECATION")
+            audioManager.requestAudioFocus(
+                audioFocusChangeListener,
+                AudioManager.STREAM_MUSIC,
+                AudioManager.AUDIOFOCUS_GAIN
+            )
+        }
+        hasAudioFocus = result == AudioManager.AUDIOFOCUS_REQUEST_GRANTED
+        return hasAudioFocus
+    }
+
+    private fun abandonPlaybackAudioFocus() {
+        val audioManager = getSystemService(AUDIO_SERVICE) as AudioManager
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            audioFocusRequest?.let { audioManager.abandonAudioFocusRequest(it) }
+        } else {
+            @Suppress("DEPRECATION")
+            audioManager.abandonAudioFocus(audioFocusChangeListener)
+        }
+        hasAudioFocus = false
+    }
+
+    private fun registerPlaybackRouteListeners() {
+        val intentFilter = IntentFilter().apply {
+            addAction(AudioManager.ACTION_AUDIO_BECOMING_NOISY)
+            addAction(Intent.ACTION_HEADSET_PLUG)
+            addAction(BluetoothAdapter.ACTION_STATE_CHANGED)
+        }
+        registerReceiver(outputBroadcastReceiver, intentFilter)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            val audioManager = getSystemService(AUDIO_SERVICE) as AudioManager
+            audioManager.registerAudioDeviceCallback(audioDeviceCallback, null)
+        }
+    }
+
+    private fun unregisterPlaybackRouteListeners() {
+        runCatching { unregisterReceiver(outputBroadcastReceiver) }
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            val audioManager = getSystemService(AUDIO_SERVICE) as AudioManager
+            runCatching { audioManager.unregisterAudioDeviceCallback(audioDeviceCallback) }
+        }
+    }
+
+    private fun handlePotentialOutputDisconnect(reason: String) {
+        val now = SystemClock.elapsedRealtime()
+        if (now - lastOutputEventAtMs < OUTPUT_EVENT_DEBOUNCE_MS) return
+        lastOutputEventAtMs = now
+        if (!pauseOnOutputDisconnectEnabled) return
+        if (!exoPlayer.isPlaying) return
+        autoPausedByDisconnect = true
+        Log.d("PlaybackService", "Auto pause due to output disconnect: $reason")
+        serviceScope.launch(Dispatchers.Main.immediate) {
+            sessionPlayer.pause()
+        }
+    }
+
+    private fun handlePotentialOutputConnect(reason: String) {
+        val now = SystemClock.elapsedRealtime()
+        if (now - lastOutputEventAtMs < OUTPUT_EVENT_DEBOUNCE_MS) return
+        lastOutputEventAtMs = now
+        if (!resumeOnOutputConnectEnabled) return
+        if (!hasRelevantOutputDevice()) return
+        if (exoPlayer.isPlaying) return
+        Log.d("PlaybackService", "Auto resume due to output connect: $reason")
+        serviceScope.launch(Dispatchers.Main.immediate) {
+            runCatching { sessionPlayer.play() }
+            autoPausedByDisconnect = false
+            autoPausedByAudioFocusLoss = false
+        }
+    }
+
+    private fun hasRelevantOutputDevice(): Boolean {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) return true
+        val audioManager = getSystemService(AUDIO_SERVICE) as AudioManager
+        return audioManager.getDevices(AudioManager.GET_DEVICES_OUTPUTS)
+            .any { it.isRelevantOutputDevice() }
+    }
+
     private fun ensureNotificationChannel() {
         if (Build.VERSION.SDK_INT < 26) return
         val manager = getSystemService(NotificationManager::class.java) ?: return
@@ -688,6 +893,8 @@ class PlaybackService : MediaSessionService() {
         statsJob?.cancel()
         effectApplyJob?.cancel()
         sleepTimerJob?.cancel()
+        unregisterPlaybackRouteListeners()
+        abandonPlaybackAudioFocus()
         appVolumeBoostController.release()
         spectrumAnalyzer.stop()
         mediaSession?.run {
@@ -695,6 +902,7 @@ class PlaybackService : MediaSessionService() {
             release()
             mediaSession = null
         }
+        notificationProvider = null
         runCatching { PlaybackMediaCache.release() }
         super.onDestroy()
     }
@@ -710,5 +918,28 @@ class PlaybackService : MediaSessionService() {
         private const val DLSITE_UA =
             "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
         private const val LYRICS_CHANNEL_ID = "playback"
+        private const val OUTPUT_EVENT_DEBOUNCE_MS = 1200L
+    }
+}
+
+private fun AudioDeviceInfo.isRelevantOutputDevice(): Boolean {
+    return when (type) {
+        AudioDeviceInfo.TYPE_WIRED_HEADSET,
+        AudioDeviceInfo.TYPE_WIRED_HEADPHONES,
+        AudioDeviceInfo.TYPE_BLUETOOTH_A2DP,
+        AudioDeviceInfo.TYPE_BLUETOOTH_SCO,
+        AudioDeviceInfo.TYPE_BLE_HEADSET,
+        AudioDeviceInfo.TYPE_BLE_SPEAKER,
+        AudioDeviceInfo.TYPE_BLE_BROADCAST,
+        AudioDeviceInfo.TYPE_BUILTIN_SPEAKER,
+        AudioDeviceInfo.TYPE_USB_HEADSET,
+        AudioDeviceInfo.TYPE_USB_DEVICE,
+        AudioDeviceInfo.TYPE_USB_ACCESSORY,
+        AudioDeviceInfo.TYPE_HDMI,
+        AudioDeviceInfo.TYPE_HDMI_ARC,
+        AudioDeviceInfo.TYPE_HDMI_EARC,
+        AudioDeviceInfo.TYPE_LINE_ANALOG,
+        AudioDeviceInfo.TYPE_LINE_DIGITAL -> true
+        else -> false
     }
 }

--- a/app/src/main/java/com/asmr/player/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/settings/SettingsScreen.kt
@@ -83,6 +83,13 @@ fun SettingsScreen(
     val coverBackgroundEnabled by viewModel.coverBackgroundEnabled.collectAsState()
     val coverBackgroundClarity by viewModel.coverBackgroundClarity.collectAsState()
     val coverPreviewMode by viewModel.coverPreviewMode.collectAsState()
+    val pauseOnOutputDisconnect by viewModel.pauseOnOutputDisconnect.collectAsState()
+    val resumeOnOutputConnect by viewModel.resumeOnOutputConnect.collectAsState()
+    val pauseOnOtherAudio by viewModel.pauseOnOtherAudio.collectAsState()
+    val playFadeInMs by viewModel.playFadeInMs.collectAsState()
+    val pauseFadeOutMs by viewModel.pauseFadeOutMs.collectAsState()
+    val sfwHideSystemControls by viewModel.sfwHideSystemControls.collectAsState()
+    val showMiniPlayerBar by viewModel.showMiniPlayerBar.collectAsState()
     val updateState by viewModel.updateState.collectAsState()
     val scanRoots by libraryViewModel.scanRoots.collectAsState()
     val bulkProgress by libraryViewModel.bulkProgress.collectAsState()
@@ -409,6 +416,7 @@ fun SettingsScreen(
                         DeferredCommitSettingsSliderRow(
                             committedValue = coverBackgroundClarity,
                             range = 0f..1f,
+                            stepSize = 0.05f,
                             textForValue = { value ->
                                 "封面背景清晰度：${(value.coerceIn(0f, 1f) * 100).toInt()}%"
                             },
@@ -418,6 +426,85 @@ fun SettingsScreen(
                 }
             }
 
+                }
+
+                item(key = "group:playback") {
+                    SettingsGroup(title = "播放设置") {
+                        SettingsToggleRow(
+                            text = "断开扬声器、有线/蓝牙耳机或蓝牙关闭时立刻暂停播放",
+                            checked = pauseOnOutputDisconnect,
+                            onCheckedChange = viewModel::setPauseOnOutputDisconnect,
+                            infoKey = "pause_on_output_disconnect",
+                            infoTitle = "输出断开自动暂停",
+                            infoText = "播放中如果外放、耳机或蓝牙输出被移除，会立刻暂停，避免声音突然外放。",
+                            activeTipKey = activeTipKey,
+                            onToggleTip = { key -> activeTipKey = if (activeTipKey == key) null else key }
+                        )
+                        SettingsToggleRow(
+                            text = "打开蓝牙、有线/蓝牙耳机、扬声器时继续播放",
+                            checked = resumeOnOutputConnect,
+                            onCheckedChange = viewModel::setResumeOnOutputConnect,
+                            infoKey = "resume_on_output_connect",
+                            infoTitle = "输出接入自动恢复",
+                            infoText = "检测到新的可用输出设备时，如果播放器当前处于暂停，会自动尝试恢复播放。",
+                            activeTipKey = activeTipKey,
+                            onToggleTip = { key -> activeTipKey = if (activeTipKey == key) null else key }
+                        )
+                        SettingsToggleRow(
+                            text = "其他应用播放音/视频时暂停",
+                            checked = pauseOnOtherAudio,
+                            onCheckedChange = viewModel::setPauseOnOtherAudio,
+                            infoKey = "pause_on_other_audio",
+                            infoTitle = "音频焦点暂停",
+                            infoText = "当其他音乐或视频应用抢占音频焦点时暂停播放；普通通知提示音不会触发。",
+                            activeTipKey = activeTipKey,
+                            onToggleTip = { key -> activeTipKey = if (activeTipKey == key) null else key }
+                        )
+                        DeferredCommitSettingsSliderRow(
+                            committedValue = playFadeInMs.toFloat(),
+                            range = 0f..3000f,
+                            stepSize = 100f,
+                            textForValue = { value -> "播放时逐渐增强音量: ${value.toInt()}ms" },
+                            onValueCommitted = { viewModel.setPlayFadeInMs(it.toInt()) },
+                            infoKey = "play_fade_in",
+                            infoTitle = "播放淡入",
+                            infoText = "点击播放时，音量会在设定时长内从低到高平滑升到正常值。",
+                            activeTipKey = activeTipKey,
+                            onToggleTip = { key -> activeTipKey = if (activeTipKey == key) null else key }
+                        )
+                        DeferredCommitSettingsSliderRow(
+                            committedValue = pauseFadeOutMs.toFloat(),
+                            range = 0f..3000f,
+                            stepSize = 100f,
+                            textForValue = { value -> "暂停时逐渐降低音量: ${value.toInt()}ms" },
+                            onValueCommitted = { viewModel.setPauseFadeOutMs(it.toInt()) },
+                            infoKey = "pause_fade_out",
+                            infoTitle = "暂停淡出",
+                            infoText = "点击暂停时，音量会在设定时长内逐渐降到 0，然后再真正暂停。",
+                            activeTipKey = activeTipKey,
+                            onToggleTip = { key -> activeTipKey = if (activeTipKey == key) null else key }
+                        )
+                        SettingsToggleRow(
+                            text = "SFW开关",
+                            checked = sfwHideSystemControls,
+                            onCheckedChange = viewModel::setSfwHideSystemControls,
+                            infoKey = "sfw_hide_system_controls",
+                            infoTitle = "SFW",
+                            infoText = "开启后会尽量隐藏系统锁屏和通知栏里的媒体控制按钮，但仍保留后台播放所需的前台通知。",
+                            activeTipKey = activeTipKey,
+                            onToggleTip = { key -> activeTipKey = if (activeTipKey == key) null else key }
+                        )
+                        SettingsToggleRow(
+                            text = "迷你播放栏开关",
+                            checked = showMiniPlayerBar,
+                            onCheckedChange = viewModel::setShowMiniPlayerBar,
+                            infoKey = "show_mini_player_bar",
+                            infoTitle = "迷你播放栏",
+                            infoText = "关闭后，应用底部的迷你播放栏会隐藏，同时页面底部不会再为它预留空白。",
+                            activeTipKey = activeTipKey,
+                            onToggleTip = { key -> activeTipKey = if (activeTipKey == key) null else key }
+                        )
+                    }
                 }
 
                 // 悬浮歌词
@@ -726,18 +813,21 @@ private fun LyricsPageSettingsSection(
         text = "字体大小: ${settings.fontSizeSp.toInt()}sp",
         value = settings.fontSizeSp,
         range = 18f..36f,
+        stepSize = 1f,
         onValueChange = { onSettingsChange(settings.copy(fontSizeSp = it)) }
     )
     SettingsSliderRow(
         text = "字体阴影: ${"%.1f".format(settings.strokeWidthSp)}sp",
         value = settings.strokeWidthSp,
         range = 0f..3f,
+        stepSize = 0.1f,
         onValueChange = { onSettingsChange(settings.copy(strokeWidthSp = it)) }
     )
     SettingsSliderRow(
         text = "行间距: ${"%.2f".format(settings.lineHeightMultiplier)}x",
         value = settings.lineHeightMultiplier,
         range = 0.1f..3.0f,
+        stepSize = 0.1f,
         onValueChange = { onSettingsChange(settings.copy(lineHeightMultiplier = it)) }
     )
     Row(
@@ -852,10 +942,27 @@ private fun SettingsGroup(title: String, content: @Composable ColumnScope.() -> 
 }
 
 @Composable
-private fun SettingsToggleRow(text: String, checked: Boolean, onCheckedChange: (Boolean) -> Unit) {
+private fun SettingsToggleRow(
+    text: String,
+    checked: Boolean,
+    onCheckedChange: (Boolean) -> Unit,
+    infoKey: String? = null,
+    infoTitle: String = text,
+    infoText: String? = null,
+    activeTipKey: String? = null,
+    onToggleTip: ((String) -> Unit)? = null
+) {
     Row(modifier = Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
-        Text(text, style = MaterialTheme.typography.bodyMedium)
-        Spacer(modifier = Modifier.weight(1f))
+        SettingsRowLabel(
+            text = text,
+            infoKey = infoKey,
+            infoTitle = infoTitle,
+            infoText = infoText,
+            activeTipKey = activeTipKey,
+            onToggleTip = onToggleTip,
+            modifier = Modifier.weight(1f)
+        )
+        Spacer(modifier = Modifier.width(12.dp))
         Switch(checked = checked, onCheckedChange = onCheckedChange)
     }
 }
@@ -865,17 +972,36 @@ private fun SettingsSliderRow(
     text: String,
     value: Float,
     range: ClosedFloatingPointRange<Float>,
+    stepSize: Float? = null,
+    infoKey: String? = null,
+    infoTitle: String = text,
+    infoText: String? = null,
+    activeTipKey: String? = null,
+    onToggleTip: ((String) -> Unit)? = null,
     onValueChange: (Float) -> Unit,
     onValueChangeFinished: (() -> Unit)? = null,
     interactionSource: MutableInteractionSource? = null
 ) {
     val sliderInteractionSource = interactionSource ?: remember { MutableInteractionSource() }
+    val steps = stepSize
+        ?.takeIf { it > 0f }
+        ?.let { ((range.endInclusive - range.start) / it).toInt() - 1 }
+        ?.coerceAtLeast(0)
+        ?: 0
     Column(modifier = Modifier.fillMaxWidth()) {
-        Text(text, style = MaterialTheme.typography.bodyMedium)
+        SettingsRowLabel(
+            text = text,
+            infoKey = infoKey,
+            infoTitle = infoTitle,
+            infoText = infoText,
+            activeTipKey = activeTipKey,
+            onToggleTip = onToggleTip
+        )
         Slider(
             value = value,
             onValueChange = onValueChange,
             valueRange = range,
+            steps = steps,
             onValueChangeFinished = onValueChangeFinished,
             interactionSource = sliderInteractionSource,
             modifier = Modifier.fillMaxWidth()
@@ -887,12 +1013,30 @@ private fun SettingsSliderRow(
 private fun DeferredCommitSettingsSliderRow(
     committedValue: Float,
     range: ClosedFloatingPointRange<Float>,
+    stepSize: Float? = null,
     textForValue: (Float) -> String,
-    onValueCommitted: (Float) -> Unit
+    onValueCommitted: (Float) -> Unit,
+    infoKey: String? = null,
+    infoTitle: String = "",
+    infoText: String? = null,
+    activeTipKey: String? = null,
+    onToggleTip: ((String) -> Unit)? = null
 ) {
     val coercedCommittedValue = committedValue.coerceIn(range.start, range.endInclusive)
-    var draftValue by rememberSaveable(range.start, range.endInclusive) {
-        mutableStateOf(coercedCommittedValue)
+    val snap: (Float) -> Float = remember(range.start, range.endInclusive, stepSize) {
+        { raw ->
+            val bounded = raw.coerceIn(range.start, range.endInclusive)
+            val step = stepSize
+            if (step == null || step <= 0f) {
+                bounded
+            } else {
+                val snapped = ((bounded - range.start) / step).toInt().toFloat() * step + range.start
+                snapped.coerceIn(range.start, range.endInclusive)
+            }
+        }
+    }
+    var draftValue by rememberSaveable(range.start, range.endInclusive, stepSize) {
+        mutableStateOf(snap(coercedCommittedValue))
     }
     var pendingCommit by rememberSaveable { mutableStateOf<Float?>(null) }
     val interactionSource = remember { MutableInteractionSource() }
@@ -908,7 +1052,7 @@ private fun DeferredCommitSettingsSliderRow(
                 }
             }
             abs(draftValue - coercedCommittedValue) > 0.001f -> {
-                draftValue = coercedCommittedValue
+                draftValue = snap(coercedCommittedValue)
             }
         }
     }
@@ -917,16 +1061,116 @@ private fun DeferredCommitSettingsSliderRow(
         text = textForValue(draftValue),
         value = draftValue,
         range = range,
+        stepSize = stepSize,
+        infoKey = infoKey,
+        infoTitle = infoTitle.ifBlank { textForValue(draftValue) },
+        infoText = infoText,
+        activeTipKey = activeTipKey,
+        onToggleTip = onToggleTip,
         onValueChange = { newValue ->
-            draftValue = newValue.coerceIn(range.start, range.endInclusive)
+            draftValue = snap(newValue)
         },
         onValueChangeFinished = {
-            val valueToCommit = draftValue.coerceIn(range.start, range.endInclusive)
+            val valueToCommit = snap(draftValue)
             pendingCommit = valueToCommit
             onValueCommitted(valueToCommit)
         },
         interactionSource = interactionSource
     )
+}
+
+@Composable
+private fun SettingsRowLabel(
+    text: String,
+    infoKey: String? = null,
+    infoTitle: String = text,
+    infoText: String? = null,
+    activeTipKey: String? = null,
+    onToggleTip: ((String) -> Unit)? = null,
+    modifier: Modifier = Modifier
+) {
+    Row(
+        modifier = modifier,
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(6.dp)
+    ) {
+        Text(
+            text,
+            style = MaterialTheme.typography.bodyMedium,
+            modifier = Modifier.weight(1f, fill = false)
+        )
+        if (infoKey != null && !infoText.isNullOrBlank() && onToggleTip != null) {
+            SettingsInfoTip(
+                active = activeTipKey == infoKey,
+                title = infoTitle,
+                text = infoText,
+                onToggle = { onToggleTip(infoKey) }
+            )
+        }
+    }
+}
+
+@Composable
+private fun SettingsInfoTip(active: Boolean, title: String, text: String, onToggle: () -> Unit) {
+    val density = LocalDensity.current
+    val offset = with(density) { IntOffset(0, 26.dp.roundToPx()) }
+
+    Surface(
+        shape = CircleShape,
+        color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.7f)
+    ) {
+        Box {
+            IconButton(
+                onClick = onToggle,
+                modifier = Modifier.size(22.dp)
+            ) {
+                Icon(
+                    imageVector = Icons.Default.Info,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.size(14.dp)
+                )
+            }
+            if (active) {
+                Popup(
+                    alignment = Alignment.TopStart,
+                    offset = offset,
+                    onDismissRequest = onToggle,
+                    properties = PopupProperties(
+                        focusable = true,
+                        dismissOnBackPress = true,
+                        dismissOnClickOutside = true
+                    )
+                ) {
+                    Surface(
+                        shape = RoundedCornerShape(10.dp),
+                        tonalElevation = 6.dp,
+                        shadowElevation = 10.dp,
+                        color = MaterialTheme.colorScheme.surface.copy(alpha = 0.96f),
+                        border = androidx.compose.foundation.BorderStroke(
+                            width = 1.dp,
+                            color = MaterialTheme.colorScheme.outline.copy(alpha = 0.2f)
+                        )
+                    ) {
+                        Column(
+                            modifier = Modifier.widthIn(max = 260.dp).padding(12.dp),
+                            verticalArrangement = Arrangement.spacedBy(6.dp)
+                        ) {
+                            Text(
+                                text = title,
+                                style = MaterialTheme.typography.titleSmall,
+                                fontWeight = FontWeight.SemiBold
+                            )
+                            Text(
+                                text = text,
+                                style = MaterialTheme.typography.bodySmall
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
 }
 
 @Composable

--- a/app/src/main/java/com/asmr/player/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/asmr/player/ui/settings/SettingsViewModel.kt
@@ -80,6 +80,27 @@ class SettingsViewModel @Inject constructor(
     val coverPreviewMode: StateFlow<CoverPreviewMode> = settingsDataStore.coverPreviewMode
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), CoverPreviewMode.Disabled)
 
+    val pauseOnOutputDisconnect: StateFlow<Boolean> = settingsRepository.pauseOnOutputDisconnect
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), true)
+
+    val resumeOnOutputConnect: StateFlow<Boolean> = settingsRepository.resumeOnOutputConnect
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), false)
+
+    val pauseOnOtherAudio: StateFlow<Boolean> = settingsRepository.pauseOnOtherAudio
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), true)
+
+    val playFadeInMs: StateFlow<Int> = settingsRepository.playFadeInMs
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), 500)
+
+    val pauseFadeOutMs: StateFlow<Int> = settingsRepository.pauseFadeOutMs
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), 500)
+
+    val sfwHideSystemControls: StateFlow<Boolean> = settingsRepository.sfwHideSystemControls
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), false)
+
+    val showMiniPlayerBar: StateFlow<Boolean> = settingsRepository.showMiniPlayerBar
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), true)
+
     private val updateClient = GitHubUpdateClient(okHttpClient)
     private val _updateState = MutableStateFlow<AppUpdateState>(AppUpdateState.Idle)
     val updateState = _updateState.asStateFlow()
@@ -119,6 +140,34 @@ class SettingsViewModel @Inject constructor(
 
     fun setCoverPreviewMode(mode: CoverPreviewMode) {
         viewModelScope.launch { settingsDataStore.setCoverPreviewMode(mode) }
+    }
+
+    fun setPauseOnOutputDisconnect(enabled: Boolean) {
+        viewModelScope.launch { settingsRepository.setPauseOnOutputDisconnect(enabled) }
+    }
+
+    fun setResumeOnOutputConnect(enabled: Boolean) {
+        viewModelScope.launch { settingsRepository.setResumeOnOutputConnect(enabled) }
+    }
+
+    fun setPauseOnOtherAudio(enabled: Boolean) {
+        viewModelScope.launch { settingsRepository.setPauseOnOtherAudio(enabled) }
+    }
+
+    fun setPlayFadeInMs(durationMs: Int) {
+        viewModelScope.launch { settingsRepository.setPlayFadeInMs(durationMs) }
+    }
+
+    fun setPauseFadeOutMs(durationMs: Int) {
+        viewModelScope.launch { settingsRepository.setPauseFadeOutMs(durationMs) }
+    }
+
+    fun setSfwHideSystemControls(enabled: Boolean) {
+        viewModelScope.launch { settingsRepository.setSfwHideSystemControls(enabled) }
+    }
+
+    fun setShowMiniPlayerBar(enabled: Boolean) {
+        viewModelScope.launch { settingsRepository.setShowMiniPlayerBar(enabled) }
     }
 
     fun checkUpdate() {


### PR DESCRIPTION
## Summary
- add a new playback settings group in Settings
- wire new playback preferences into DataStore, ViewModel, playback service and notification behavior
- add inline info tips and discrete slider steps for playback and lyrics related controls

## Changes
- add toggles for output disconnect pause, output connect resume, audio focus pause, SFW mode and mini player visibility
- add configurable fade in/fade out durations with discrete 100ms steps
- apply discrete steps to cover background clarity, lyrics line height, font size and font shadow sliders
- update playback service to react to audio route changes, audio focus and SFW notification mode
- gate app mini player visibility from settings

## Verification
- ran `./gradlew :app:compileDebugKotlin`