### PR TITLE
fix: prevent lyrics jump crash on duplicate timestamps

### DIFF
--- a/app/src/main/java/com/asmr/player/ui/player/AppleLyricsView.kt
+++ b/app/src/main/java/com/asmr/player/ui/player/AppleLyricsView.kt
@@ -350,7 +350,7 @@ internal fun AppleLyricsView(
             ) {
                 itemsIndexed(
                     items = lyrics,
-                    key = { _, entry -> entry.startMs },
+                    key = { index, entry -> lyricItemKey(index, entry) },
                     contentType = { _, _ -> "appleLyricLine" }
                 ) { index, entry ->
                     val isActive = index == activeIndex

--- a/app/src/main/java/com/asmr/player/ui/player/LyricItemKey.kt
+++ b/app/src/main/java/com/asmr/player/ui/player/LyricItemKey.kt
@@ -1,0 +1,7 @@
+package com.asmr.player.ui.player
+
+import com.asmr.player.util.SubtitleEntry
+
+internal fun lyricItemKey(index: Int, entry: SubtitleEntry): String {
+    return "${entry.startMs}:${entry.endMs}:$index"
+}

--- a/app/src/main/java/com/asmr/player/ui/player/LyricsScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/player/LyricsScreen.kt
@@ -58,7 +58,7 @@ fun LyricsScreen(
             ) {
                 itemsIndexed(
                     items = lyrics,
-                    key = { _, entry -> entry.startMs },
+                    key = { index, entry -> lyricItemKey(index, entry) },
                     contentType = { _, _ -> "lyricLine" }
                 ) { index, entry ->
                     val isActive = index == activeIndex

--- a/app/src/test/java/com/asmr/player/ui/player/LyricItemKeyTest.kt
+++ b/app/src/test/java/com/asmr/player/ui/player/LyricItemKeyTest.kt
@@ -1,0 +1,23 @@
+package com.asmr.player.ui.player
+
+import com.asmr.player.util.SubtitleEntry
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Test
+
+class LyricItemKeyTest {
+    @Test
+    fun duplicateStartTimesStillProduceUniqueKeys() {
+        val first = SubtitleEntry(startMs = 727760L, endMs = 729000L, text = "line one")
+        val second = SubtitleEntry(startMs = 727760L, endMs = 730100L, text = "line two")
+
+        assertNotEquals(lyricItemKey(0, first), lyricItemKey(1, second))
+    }
+
+    @Test
+    fun sameEntryAndIndexProduceStableKey() {
+        val entry = SubtitleEntry(startMs = 566780L, endMs = 568120L, text = "same line")
+
+        assertEquals(lyricItemKey(3, entry), lyricItemKey(3, entry))
+    }
+}


### PR DESCRIPTION
## Summary
- fix lyrics list item keys to stay unique even when multiple lyric lines share the same timestamp
- reuse the same stable key strategy in both lyrics page list implementations
- add a regression test for duplicate-timestamp lyric entries

## Root Cause
Some works contain multiple lyric lines with the same `startMs`. The lyrics `LazyColumn` used `startMs` directly as the Compose item key, so jumping in the lyrics page could trigger `IllegalArgumentException: Key was already used` and crash the app.

## Verification
- `./gradlew.bat :app:assembleDebug`
- `./gradlew.bat :app:testDebugUnitTest`