### PR TITLE
feat: prioritize Chinese locales for cloud sync

### DIFF
--- a/app/src/main/java/com/asmr/player/data/remote/dlsite/DlsiteCloudSyncSupport.kt
+++ b/app/src/main/java/com/asmr/player/data/remote/dlsite/DlsiteCloudSyncSupport.kt
@@ -1,0 +1,178 @@
+package com.asmr.player.data.remote.dlsite
+
+import com.asmr.player.domain.model.Album
+
+internal const val CLOUD_SYNC_LOCALE_ZH_CN = "zh_CN"
+internal const val CLOUD_SYNC_LOCALE_ZH_TW = "zh_TW"
+internal const val CLOUD_SYNC_LOCALE_JA_JP = "ja_JP"
+
+private val CLOUD_SYNC_LANGUAGE_PRIORITY = listOf(
+    "CHI_HANS" to CLOUD_SYNC_LOCALE_ZH_CN,
+    "CHI_HANT" to CLOUD_SYNC_LOCALE_ZH_TW,
+    "JPN" to CLOUD_SYNC_LOCALE_JA_JP
+)
+
+internal data class DlsiteCloudSyncAttempt(
+    val workno: String,
+    val locale: String
+)
+
+internal data class DlsiteCloudSyncResolvedDetails(
+    val workno: String,
+    val locale: String,
+    val details: Album
+)
+
+internal sealed interface DlsiteCloudSyncSearchResult {
+    data class Unique(val workno: String, val locale: String) : DlsiteCloudSyncSearchResult
+    data class Ambiguous(val locale: String, val count: Int) : DlsiteCloudSyncSearchResult
+    data object NotFound : DlsiteCloudSyncSearchResult
+}
+
+internal sealed interface DlsiteCloudSyncResolveResult {
+    data class Success(
+        val workno: String,
+        val locale: String,
+        val details: Album
+    ) : DlsiteCloudSyncResolveResult
+
+    data object Ambiguous : DlsiteCloudSyncResolveResult
+    data object NotFound : DlsiteCloudSyncResolveResult
+}
+
+internal fun buildDlsiteCloudSyncAttempts(
+    baseWorkno: String,
+    editions: List<DlsiteLanguageEdition>?
+): List<DlsiteCloudSyncAttempt> {
+    val normalizedBase = baseWorkno.trim().uppercase()
+    if (normalizedBase.isBlank()) return emptyList()
+
+    val editionByLang = editions.orEmpty()
+        .asSequence()
+        .mapNotNull { edition ->
+            val lang = edition.lang.trim().uppercase()
+            val workno = edition.workno.trim().uppercase()
+            if (lang.isBlank() || workno.isBlank()) null else lang to workno
+        }
+        .toMap()
+
+    val attempts = CLOUD_SYNC_LANGUAGE_PRIORITY.mapNotNull { (lang, locale) ->
+        val workno = editionByLang[lang] ?: return@mapNotNull null
+        DlsiteCloudSyncAttempt(workno = workno, locale = locale)
+    }
+
+    if (attempts.isNotEmpty()) return attempts.distinct()
+
+    return CLOUD_SYNC_LANGUAGE_PRIORITY.map { (_, locale) ->
+        DlsiteCloudSyncAttempt(workno = normalizedBase, locale = locale)
+    }
+}
+
+internal suspend fun searchDlsiteWorknoWithLocaleFallback(
+    keyword: String,
+    search: suspend (keyword: String, locale: String) -> List<Album>
+): DlsiteCloudSyncSearchResult {
+    val normalizedKeyword = keyword.trim()
+    if (normalizedKeyword.isBlank()) return DlsiteCloudSyncSearchResult.NotFound
+
+    for ((_, locale) in CLOUD_SYNC_LANGUAGE_PRIORITY) {
+        val results = runCatching { search(normalizedKeyword, locale) }.getOrNull() ?: continue
+        when {
+            results.size > 1 -> return DlsiteCloudSyncSearchResult.Ambiguous(locale = locale, count = results.size)
+            results.size == 1 -> {
+                val workno = results.first().rjCode.trim().uppercase()
+                if (workno.isNotBlank()) {
+                    return DlsiteCloudSyncSearchResult.Unique(workno = workno, locale = locale)
+                }
+            }
+        }
+    }
+
+    return DlsiteCloudSyncSearchResult.NotFound
+}
+
+internal suspend fun fetchDlsiteDetailsWithLocaleFallback(
+    baseWorkno: String,
+    fetchLanguageEditions: suspend (productId: String) -> List<DlsiteLanguageEdition>,
+    fetchDetails: suspend (workno: String, locale: String) -> Album?
+): DlsiteCloudSyncResolvedDetails? {
+    val normalizedBase = baseWorkno.trim().uppercase()
+    if (normalizedBase.isBlank()) return null
+
+    val editions = runCatching { fetchLanguageEditions(normalizedBase) }.getOrNull()
+    val attempts = buildDlsiteCloudSyncAttempts(normalizedBase, editions)
+
+    for (attempt in attempts) {
+        val details = runCatching { fetchDetails(attempt.workno, attempt.locale) }.getOrNull() ?: continue
+        return DlsiteCloudSyncResolvedDetails(
+            workno = attempt.workno,
+            locale = attempt.locale,
+            details = details
+        )
+    }
+
+    return null
+}
+
+internal suspend fun resolveDlsiteCloudSync(
+    keyword: String,
+    baseWorkno: String,
+    search: suspend (keyword: String, locale: String) -> List<Album>,
+    fetchLanguageEditions: suspend (productId: String) -> List<DlsiteLanguageEdition>,
+    fetchDetails: suspend (workno: String, locale: String) -> Album?
+): DlsiteCloudSyncResolveResult {
+    val normalizedKeyword = keyword.trim()
+    var workno = baseWorkno.trim().uppercase()
+
+    if (workno.isBlank()) {
+        when (val searchResult = searchDlsiteWorknoWithLocaleFallback(normalizedKeyword, search)) {
+            is DlsiteCloudSyncSearchResult.Unique -> workno = searchResult.workno
+            is DlsiteCloudSyncSearchResult.Ambiguous -> return DlsiteCloudSyncResolveResult.Ambiguous
+            DlsiteCloudSyncSearchResult.NotFound -> return DlsiteCloudSyncResolveResult.NotFound
+        }
+    }
+
+    fetchDlsiteDetailsWithLocaleFallback(workno, fetchLanguageEditions, fetchDetails)?.let { resolved ->
+        return DlsiteCloudSyncResolveResult.Success(
+            workno = resolved.workno,
+            locale = resolved.locale,
+            details = resolved.details
+        )
+    }
+
+    if (normalizedKeyword.isBlank()) return DlsiteCloudSyncResolveResult.NotFound
+
+    return when (val searchResult = searchDlsiteWorknoWithLocaleFallback(normalizedKeyword, search)) {
+        is DlsiteCloudSyncSearchResult.Unique -> {
+            if (searchResult.workno.equals(workno, ignoreCase = true)) {
+                DlsiteCloudSyncResolveResult.NotFound
+            } else {
+                val resolved = fetchDlsiteDetailsWithLocaleFallback(searchResult.workno, fetchLanguageEditions, fetchDetails)
+                if (resolved != null) {
+                    DlsiteCloudSyncResolveResult.Success(
+                        workno = resolved.workno,
+                        locale = resolved.locale,
+                        details = resolved.details
+                    )
+                } else {
+                    DlsiteCloudSyncResolveResult.NotFound
+                }
+            }
+        }
+
+        is DlsiteCloudSyncSearchResult.Ambiguous -> DlsiteCloudSyncResolveResult.Ambiguous
+        DlsiteCloudSyncSearchResult.NotFound -> DlsiteCloudSyncResolveResult.NotFound
+    }
+}
+
+internal fun resolveCloudSyncWorkId(existingWorkId: String, resolvedWorkno: String): String {
+    val normalizedResolved = resolvedWorkno.trim().uppercase()
+    if (normalizedResolved.isBlank()) return existingWorkId
+
+    val trimmedExisting = existingWorkId.trim()
+    return when {
+        trimmedExisting.isBlank() -> normalizedResolved
+        Regex("""RJ\d+""", RegexOption.IGNORE_CASE).matches(trimmedExisting) -> normalizedResolved
+        else -> existingWorkId
+    }
+}

--- a/app/src/main/java/com/asmr/player/ui/library/AlbumDetailViewModel.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/AlbumDetailViewModel.kt
@@ -11,6 +11,7 @@ import com.asmr.player.data.local.db.dao.TagWithCount
 import com.asmr.player.data.local.db.dao.TrackDao
 import com.asmr.player.data.local.db.entities.AlbumEntity
 import com.asmr.player.data.local.db.entities.AlbumFtsEntity
+import com.asmr.player.data.local.db.entities.AlbumTagEntity
 import com.asmr.player.data.local.db.entities.RemoteSubtitleSourceEntity
 import com.asmr.player.data.local.db.entities.TrackEntity
 import com.asmr.player.data.local.db.entities.TagEntity
@@ -18,10 +19,13 @@ import com.asmr.player.data.local.db.entities.TagSource
 import com.asmr.player.data.local.db.entities.TrackTagEntity
 import com.asmr.player.data.remote.api.AsmrOneTrackNodeResponse
 import com.asmr.player.data.remote.crawler.AsmrOneCrawler
+import com.asmr.player.data.remote.dlsite.DlsiteCloudSyncResolveResult
 import com.asmr.player.data.remote.dlsite.DlsitePlayWorkClient
 import com.asmr.player.data.remote.dlsite.DlsitePlayTreeResult
 import com.asmr.player.data.remote.dlsite.DlsiteLanguageEdition
 import com.asmr.player.data.remote.dlsite.DlsiteProductInfoClient
+import com.asmr.player.data.remote.dlsite.resolveCloudSyncWorkId
+import com.asmr.player.data.remote.dlsite.resolveDlsiteCloudSync
 import com.asmr.player.data.remote.download.DownloadManager
 import com.asmr.player.data.remote.scraper.DLSiteScraper
 import com.asmr.player.data.remote.scraper.DlsiteRecommendedWork
@@ -374,49 +378,72 @@ class AlbumDetailViewModel @Inject constructor(
                     return@launch
                 }
 
-                val trimmedWorkId = entity.workId.trim()
-                val updatedWorkId = when {
-                    trimmedWorkId.isBlank() -> normalized
-                    Regex("""RJ\d+""", RegexOption.IGNORE_CASE).matches(trimmedWorkId) -> normalized
-                    else -> entity.workId
-                }
+                val updatedWorkId = resolveCloudSyncWorkId(entity.workId, normalized)
                 withContext(Dispatchers.IO) {
                     albumDao.updateAlbum(entity.copy(workId = updatedWorkId, rjCode = normalized))
                 }
 
-                val lang = current.model.dlsiteSelectedLang.trim().uppercase().ifBlank { "JPN" }
-                val locale = dlsiteLocaleForLang(lang)
-                val details = withContext(Dispatchers.IO) { dlsiteScraper.getDetails(normalized, locale = locale) }
-                if (details == null) {
-                    messageManager.showError("同步失败：未找到专辑信息")
-                    loadAlbum(local.id, normalized, force = true)
-                    return@launch
-                }
-
-                val oldTitle = entity.title.trim()
-                val newTitle = details.title.trim()
-                val finalTitle = when {
-                    oldTitle.isNotBlank() && newTitle.isBlank() -> oldTitle
-                    oldTitle.isNotBlank() && newTitle.isNotBlank() && oldTitle.contains(newTitle) && oldTitle.length > newTitle.length -> oldTitle
-                    else -> newTitle.ifBlank { oldTitle }
-                }
-
-                withContext(Dispatchers.IO) {
-                    albumDao.updateAlbum(
-                        entity.copy(
+                when (
+                    val result = withContext(Dispatchers.IO) {
+                        resolveDlsiteCloudSync(
+                            keyword = entity.title.trim(),
+                            baseWorkno = normalized,
+                            search = { searchKeyword, locale ->
+                                dlsiteScraper.search(searchKeyword, page = 1, order = "trend", locale = locale)
+                            },
+                            fetchLanguageEditions = { productId ->
+                                dlsiteProductInfoClient.fetchLanguageEditions(productId)
+                            },
+                            fetchDetails = { workno, locale ->
+                                dlsiteScraper.getDetails(workno, locale = locale)
+                            }
+                        )
+                    }
+                ) {
+                    is DlsiteCloudSyncResolveResult.Success -> {
+                        val resolvedWorkno = result.workno
+                        val details = result.details
+                        val oldTitle = entity.title.trim()
+                        val newTitle = details.title.trim()
+                        val finalTitle = when {
+                            oldTitle.isNotBlank() && newTitle.isBlank() -> oldTitle
+                            oldTitle.isNotBlank() && newTitle.isNotBlank() && oldTitle.contains(newTitle) && oldTitle.length > newTitle.length -> oldTitle
+                            else -> newTitle.ifBlank { oldTitle }
+                        }
+                        val updated = entity.copy(
                             title = finalTitle,
                             circle = details.circle.ifBlank { entity.circle },
                             cv = details.cv.ifBlank { entity.cv },
                             tags = if (details.tags.isNotEmpty()) details.tags.joinToString(",") else entity.tags,
                             coverUrl = details.coverUrl.ifBlank { entity.coverUrl },
                             description = details.description.ifBlank { entity.description },
-                            workId = updatedWorkId,
-                            rjCode = normalized
+                            workId = resolveCloudSyncWorkId(updatedWorkId, resolvedWorkno),
+                            rjCode = resolvedWorkno
                         )
-                    )
+                        withContext(Dispatchers.IO) {
+                            albumDao.updateAlbum(updated)
+                            upsertAlbumFtsIndex(updated.id, updated)
+                            upsertAlbumTagsFromCsv(updated.id, updated.tags, TagSource.AUTO)
+                            if (updated.coverPath.trim().isBlank() && updated.coverThumbPath.trim().isBlank()) {
+                                runCatching {
+                                    ensureAlbumCoverSaved(updated.id, updated.coverPath, updated.coverUrl)
+                                }
+                            }
+                        }
+                        messageManager.showSuccess("已绑定 $resolvedWorkno 并完成云同步")
+                        loadAlbum(local.id, resolvedWorkno, force = true)
+                    }
+
+                    DlsiteCloudSyncResolveResult.Ambiguous -> {
+                        messageManager.showError("同步失败：搜索结果不唯一")
+                        loadAlbum(local.id, normalized, force = true)
+                    }
+
+                    DlsiteCloudSyncResolveResult.NotFound -> {
+                        messageManager.showError("同步失败：未找到专辑信息")
+                        loadAlbum(local.id, normalized, force = true)
+                    }
                 }
-                messageManager.showSuccess("已绑定 $normalized 并完成云同步")
-                loadAlbum(local.id, normalized, force = true)
             } catch (e: Exception) {
                 messageManager.showError("同步失败，请稍后重试")
                 loadAlbum(local.id, normalized, force = true)
@@ -457,6 +484,70 @@ class AlbumDetailViewModel @Inject constructor(
             .build()
         WorkManager.getInstance(context)
             .enqueueUniqueWork("album_cover_thumb_$albumId", ExistingWorkPolicy.REPLACE, request)
+    }
+
+    private fun buildTagsToken(tagsCsv: String): String {
+        return tagsCsv.split(",")
+            .map { TagNormalizer.normalize(it) }
+            .filter { it.isNotBlank() }
+            .distinct()
+            .joinToString(" ")
+    }
+
+    private fun parseAlbumTags(tagsCsv: String): List<Pair<String, String>> {
+        return tagsCsv.split(",")
+            .map { it.trim() }
+            .filter { it.isNotBlank() }
+            .map { it to TagNormalizer.normalize(it) }
+            .filter { it.second.isNotBlank() }
+            .distinctBy { it.second }
+    }
+
+    private suspend fun upsertAlbumFtsIndex(albumId: Long, entity: AlbumEntity) {
+        val userTagsCsv = database.tagDao().getAlbumTagsCsvOnce(albumId, TagSource.USER).orEmpty()
+        val combinedTagsCsv = buildString {
+            append(entity.tags)
+            if (userTagsCsv.isNotBlank()) {
+                if (isNotEmpty() && last() != ',') append(',')
+                append(userTagsCsv)
+            }
+        }
+        val tagsToken = buildTagsToken(combinedTagsCsv)
+        database.albumFtsDao().upsert(
+            listOf(
+                AlbumFtsEntity(
+                    albumId = albumId,
+                    title = entity.title,
+                    circle = entity.circle,
+                    cv = entity.cv,
+                    rjCode = entity.rjCode,
+                    workId = entity.workId,
+                    tagsToken = tagsToken
+                )
+            )
+        )
+    }
+
+    private suspend fun upsertAlbumTagsFromCsv(albumId: Long, tagsCsv: String, source: Int) {
+        val tags = parseAlbumTags(tagsCsv)
+        if (tags.isEmpty()) return
+
+        val tagEntities = tags.map { (name, normalized) ->
+            TagEntity(name = name, nameNormalized = normalized)
+        }
+        val tagDao = database.tagDao()
+        tagDao.insertTags(tagEntities)
+
+        val normalizedList = tags.map { it.second }
+        val persisted = tagDao.getTagsByNormalized(normalizedList)
+        val idByNormalized = persisted.associateBy({ it.nameNormalized }, { it.id })
+
+        tagDao.deleteAlbumTagsByAlbumIdExceptSource(albumId, TagSource.USER)
+        val refs = normalizedList.mapNotNull { normalized ->
+            val tagId = idByNormalized[normalized] ?: return@mapNotNull null
+            AlbumTagEntity(albumId = albumId, tagId = tagId, source = source)
+        }
+        if (refs.isNotEmpty()) tagDao.insertAlbumTags(refs)
     }
 
     private fun defaultDlsiteEditions(rj: String): List<DlsiteLanguageEdition> {

--- a/app/src/main/java/com/asmr/player/ui/library/libraryviewmodel.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/libraryviewmodel.kt
@@ -37,8 +37,11 @@ import com.asmr.player.data.local.db.entities.TagSource
 import com.asmr.player.data.local.db.entities.TrackEntity
 import com.asmr.player.data.local.db.entities.TrackTagEntity
 import com.asmr.player.data.remote.api.AsmrOneApi
-import com.asmr.player.data.remote.scraper.DLSiteScraper
+import com.asmr.player.data.remote.dlsite.DlsiteCloudSyncResolveResult
 import com.asmr.player.data.remote.dlsite.DlsiteProductInfoClient
+import com.asmr.player.data.remote.dlsite.resolveCloudSyncWorkId
+import com.asmr.player.data.remote.dlsite.resolveDlsiteCloudSync
+import com.asmr.player.data.remote.scraper.DLSiteScraper
 import com.asmr.player.data.settings.SettingsRepository
 import com.asmr.player.domain.model.Album
 import com.asmr.player.domain.model.Track
@@ -73,7 +76,6 @@ import kotlinx.coroutines.withContext
 import java.io.File
 import java.io.FileOutputStream
 import java.util.concurrent.ConcurrentHashMap
-import java.util.Locale
 import javax.inject.Inject
 import javax.inject.Named
 import okhttp3.OkHttpClient
@@ -137,7 +139,6 @@ class LibraryViewModel @Inject constructor(
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), globalSyncState.value != null)
     private val scanMutex = Mutex()
     private val bulkStartMutex = Mutex()
-    private val dlsiteLocaleCache = ConcurrentHashMap<String, String>()
     private var bulkJob: Job? = null
     private val albumJobs = ConcurrentHashMap<Long, Job>()
     private var lastFileUpdateElapsedMs: Long = 0L
@@ -1074,66 +1075,57 @@ class LibraryViewModel @Inject constructor(
 
     private suspend fun syncAlbumMetadataInternal(entity: AlbumEntity, silent: Boolean = false) {
         val keyword = entity.title.trim()
-        var workno = entity.rjCode.ifBlank { entity.workId }.trim().uppercase()
-        if (workno.isBlank() && keyword.isNotBlank()) {
-            val results = runCatching { dlsiteScraper.search(keyword, page = 1, order = "trend") }.getOrDefault(emptyList())
-            if (results.size == 1) {
-                workno = results[0].rjCode.trim().uppercase()
-            } else {
-                if (!silent && results.isNotEmpty()) messageManager.showError("同步失败：搜索结果不唯一")
-                if (!silent && results.isEmpty()) messageManager.showError("同步失败：未找到专辑信息")
-                return
-            }
-        }
-        if (workno.isBlank()) return
+        val currentWorkno = entity.rjCode.ifBlank { entity.workId }.trim().uppercase()
+        if (currentWorkno.isBlank() && keyword.isBlank()) return
 
         _syncStatus.value += (entity.id to SyncStatus.Syncing)
         try {
-            val locale = resolveDlsiteLocaleForWork(workno)
-            val firstTry = runCatching { dlsiteScraper.getDetails(workno, locale = locale) }
-            var details = firstTry.getOrNull()
-            firstTry.exceptionOrNull()?.let { e ->
-                Log.e("LibraryViewModel", "getDetails failed: $workno ($locale)", e)
-                if (!silent) messageManager.showError("同步异常：${e.message}")
-            }
-            if (details == null && keyword.isNotBlank()) {
-                val results = runCatching { dlsiteScraper.search(keyword, page = 1, order = "trend") }.getOrDefault(emptyList())
-                if (results.size == 1) {
-                    val fallbackWorkno = results[0].rjCode.trim().uppercase()
-                    if (fallbackWorkno.isNotBlank() && fallbackWorkno != workno) {
-                        val fallbackLocale = resolveDlsiteLocaleForWork(fallbackWorkno)
-                        val fallbackTry = runCatching { dlsiteScraper.getDetails(fallbackWorkno, locale = fallbackLocale) }
-                        details = fallbackTry.getOrNull()
-                        fallbackTry.exceptionOrNull()?.let { e ->
-                            Log.e("LibraryViewModel", "getDetails fallback failed: $fallbackWorkno ($fallbackLocale)", e)
-                            if (!silent) messageManager.showError("同步异常：${e.message}")
-                        }
-                        if (details != null) workno = fallbackWorkno
-                    }
+            val result = resolveDlsiteCloudSync(
+                keyword = keyword,
+                baseWorkno = currentWorkno,
+                search = { searchKeyword, locale ->
+                    dlsiteScraper.search(searchKeyword, page = 1, order = "trend", locale = locale)
+                },
+                fetchLanguageEditions = { productId ->
+                    dlsiteProductInfoClient.fetchLanguageEditions(productId)
+                },
+                fetchDetails = { workno, locale ->
+                    dlsiteScraper.getDetails(workno, locale = locale)
                 }
-            }
+            )
             currentCoroutineContext().ensureActive()
-            if (details != null) {
-                val updated = entity.copy(
-                    title = details.title.ifBlank { entity.title },
-                    circle = details.circle.ifBlank { entity.circle },
-                    cv = details.cv.ifBlank { entity.cv },
-                    tags = if (details.tags.isNotEmpty()) details.tags.joinToString(",") else entity.tags,
-                    coverUrl = details.coverUrl.ifBlank { entity.coverUrl },
-                    description = details.description.ifBlank { entity.description },
-                    rjCode = workno
-                )
-                albumDao.updateAlbum(updated)
-                upsertAlbumFtsIndex(updated.id, updated)
-                upsertAlbumTagsFromCsv(updated.id, updated.tags, TagSource.AUTO)
-                if (updated.coverPath.trim().isBlank() && updated.coverThumbPath.trim().isBlank()) {
-                    runCatching {
-                        ensureAlbumCoverSaved(updated.id, updated.coverPath, updated.coverUrl)
+            when (result) {
+                is DlsiteCloudSyncResolveResult.Success -> {
+                    val resolvedWorkno = result.workno
+                    val details = result.details
+                    val updated = entity.copy(
+                        title = details.title.ifBlank { entity.title },
+                        circle = details.circle.ifBlank { entity.circle },
+                        cv = details.cv.ifBlank { entity.cv },
+                        tags = if (details.tags.isNotEmpty()) details.tags.joinToString(",") else entity.tags,
+                        coverUrl = details.coverUrl.ifBlank { entity.coverUrl },
+                        description = details.description.ifBlank { entity.description },
+                        workId = resolveCloudSyncWorkId(entity.workId, resolvedWorkno),
+                        rjCode = resolvedWorkno
+                    )
+                    albumDao.updateAlbum(updated)
+                    upsertAlbumFtsIndex(updated.id, updated)
+                    upsertAlbumTagsFromCsv(updated.id, updated.tags, TagSource.AUTO)
+                    if (updated.coverPath.trim().isBlank() && updated.coverThumbPath.trim().isBlank()) {
+                        runCatching {
+                            ensureAlbumCoverSaved(updated.id, updated.coverPath, updated.coverUrl)
+                        }
                     }
+                    if (!silent) messageManager.showSuccess("元数据同步成功：${details.title}")
                 }
-                if (!silent) messageManager.showSuccess("元数据同步成功：${details.title}")
-            } else if (!silent) {
-                messageManager.showError("同步失败：未找到专辑信息")
+
+                DlsiteCloudSyncResolveResult.Ambiguous -> {
+                    if (!silent) messageManager.showError("同步失败：搜索结果不唯一")
+                }
+
+                DlsiteCloudSyncResolveResult.NotFound -> {
+                    if (!silent) messageManager.showError("同步失败：未找到专辑信息")
+                }
             }
             _syncStatus.value -= entity.id
         } catch (e: CancellationException) {
@@ -1279,33 +1271,6 @@ class LibraryViewModel @Inject constructor(
             paint
         )
         return out
-    }
-
-    private suspend fun resolveDlsiteLocaleForWork(workno: String): String {
-        val normalized = workno.trim().uppercase()
-        if (normalized.isBlank()) return "ja_JP"
-        dlsiteLocaleCache[normalized]?.let { return it }
-
-        val preferred = preferredLocaleForSystem()
-        val editions = runCatching { dlsiteProductInfoClient.fetchLanguageEditions(normalized) }.getOrDefault(emptyList())
-        val out = when {
-            preferred == "zh_CN" && editions.any { it.lang == "CHI_HANS" } -> "zh_CN"
-            preferred == "zh_TW" && editions.any { it.lang == "CHI_HANT" } -> "zh_TW"
-            else -> "ja_JP"
-        }
-        dlsiteLocaleCache[normalized] = out
-        return out
-    }
-
-    private fun preferredLocaleForSystem(): String {
-        val locale = Locale.getDefault()
-        val language = locale.language.lowercase()
-        val country = locale.country.uppercase()
-        if (language != "zh") return "ja_JP"
-        return when (country) {
-            "TW", "HK", "MO" -> "zh_TW"
-            else -> "zh_CN"
-        }
     }
 
     fun rescanAlbum(album: Album) {

--- a/app/src/test/java/com/asmr/player/data/remote/dlsite/DlsiteCloudSyncSupportTest.kt
+++ b/app/src/test/java/com/asmr/player/data/remote/dlsite/DlsiteCloudSyncSupportTest.kt
@@ -1,0 +1,172 @@
+package com.asmr.player.data.remote.dlsite
+
+import com.asmr.player.domain.model.Album
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class DlsiteCloudSyncSupportTest {
+    @Test
+    fun buildDlsiteCloudSyncAttempts_prefersHansThenHantThenJpn() {
+        val attempts = buildDlsiteCloudSyncAttempts(
+            baseWorkno = "RJ000001",
+            editions = listOf(
+                DlsiteLanguageEdition(workno = "RJ000003", lang = "JPN", label = "日本語", displayOrder = 3),
+                DlsiteLanguageEdition(workno = "RJ000001", lang = "CHI_HANS", label = "简中", displayOrder = 1),
+                DlsiteLanguageEdition(workno = "RJ000002", lang = "CHI_HANT", label = "繁中", displayOrder = 2)
+            )
+        )
+
+        assertEquals(
+            listOf(
+                DlsiteCloudSyncAttempt("RJ000001", CLOUD_SYNC_LOCALE_ZH_CN),
+                DlsiteCloudSyncAttempt("RJ000002", CLOUD_SYNC_LOCALE_ZH_TW),
+                DlsiteCloudSyncAttempt("RJ000003", CLOUD_SYNC_LOCALE_JA_JP)
+            ),
+            attempts
+        )
+    }
+
+    @Test
+    fun buildDlsiteCloudSyncAttempts_skipsMissingLanguages() {
+        val attempts = buildDlsiteCloudSyncAttempts(
+            baseWorkno = "RJ000001",
+            editions = listOf(
+                DlsiteLanguageEdition(workno = "RJ000002", lang = "CHI_HANT", label = "繁中", displayOrder = 1),
+                DlsiteLanguageEdition(workno = "RJ000003", lang = "JPN", label = "日本語", displayOrder = 2)
+            )
+        )
+
+        assertEquals(
+            listOf(
+                DlsiteCloudSyncAttempt("RJ000002", CLOUD_SYNC_LOCALE_ZH_TW),
+                DlsiteCloudSyncAttempt("RJ000003", CLOUD_SYNC_LOCALE_JA_JP)
+            ),
+            attempts
+        )
+    }
+
+    @Test
+    fun buildDlsiteCloudSyncAttempts_fallsBackToBaseWorknoWhenEditionsEmpty() {
+        val attempts = buildDlsiteCloudSyncAttempts(baseWorkno = "RJ000001", editions = emptyList())
+
+        assertEquals(
+            listOf(
+                DlsiteCloudSyncAttempt("RJ000001", CLOUD_SYNC_LOCALE_ZH_CN),
+                DlsiteCloudSyncAttempt("RJ000001", CLOUD_SYNC_LOCALE_ZH_TW),
+                DlsiteCloudSyncAttempt("RJ000001", CLOUD_SYNC_LOCALE_JA_JP)
+            ),
+            attempts
+        )
+    }
+
+    @Test
+    fun searchDlsiteWorknoWithLocaleFallback_returnsTraditionalWhenSimplifiedEmpty() = runBlocking {
+        val result = searchDlsiteWorknoWithLocaleFallback("test") { _, locale ->
+            when (locale) {
+                CLOUD_SYNC_LOCALE_ZH_CN -> emptyList()
+                CLOUD_SYNC_LOCALE_ZH_TW -> listOf(albumOf("RJ000222"))
+                else -> emptyList()
+            }
+        }
+
+        assertEquals(
+            DlsiteCloudSyncSearchResult.Unique(workno = "RJ000222", locale = CLOUD_SYNC_LOCALE_ZH_TW),
+            result
+        )
+    }
+
+    @Test
+    fun searchDlsiteWorknoWithLocaleFallback_returnsJapaneseWhenFirstTwoMiss() = runBlocking {
+        val result = searchDlsiteWorknoWithLocaleFallback("test") { _, locale ->
+            when (locale) {
+                CLOUD_SYNC_LOCALE_ZH_CN -> error("network")
+                CLOUD_SYNC_LOCALE_ZH_TW -> emptyList()
+                else -> listOf(albumOf("RJ000333"))
+            }
+        }
+
+        assertEquals(
+            DlsiteCloudSyncSearchResult.Unique(workno = "RJ000333", locale = CLOUD_SYNC_LOCALE_JA_JP),
+            result
+        )
+    }
+
+    @Test
+    fun searchDlsiteWorknoWithLocaleFallback_returnsAmbiguousWhenPreferredLocaleHasMultipleResults() = runBlocking {
+        val result = searchDlsiteWorknoWithLocaleFallback("test") { _, locale ->
+            when (locale) {
+                CLOUD_SYNC_LOCALE_ZH_CN -> listOf(albumOf("RJ000111"), albumOf("RJ000112"))
+                else -> emptyList()
+            }
+        }
+
+        assertEquals(
+            DlsiteCloudSyncSearchResult.Ambiguous(locale = CLOUD_SYNC_LOCALE_ZH_CN, count = 2),
+            result
+        )
+    }
+
+    @Test
+    fun fetchDlsiteDetailsWithLocaleFallback_fallsBackToBaseWorknoWhenLanguageEditionsFail() = runBlocking {
+        val attempts = mutableListOf<DlsiteCloudSyncAttempt>()
+
+        val result = fetchDlsiteDetailsWithLocaleFallback(
+            baseWorkno = "RJ000777",
+            fetchLanguageEditions = { error("boom") },
+            fetchDetails = { workno, locale ->
+                attempts += DlsiteCloudSyncAttempt(workno, locale)
+                if (workno == "RJ000777" && locale == CLOUD_SYNC_LOCALE_ZH_TW) albumOf(workno, "繁中详情") else null
+            }
+        )
+
+        assertEquals(
+            listOf(
+                DlsiteCloudSyncAttempt("RJ000777", CLOUD_SYNC_LOCALE_ZH_CN),
+                DlsiteCloudSyncAttempt("RJ000777", CLOUD_SYNC_LOCALE_ZH_TW)
+            ),
+            attempts
+        )
+        assertEquals("RJ000777", result?.workno)
+        assertEquals(CLOUD_SYNC_LOCALE_ZH_TW, result?.locale)
+        assertEquals("繁中详情", result?.details?.title)
+    }
+
+    @Test
+    fun resolveDlsiteCloudSync_fallsBackToKeywordSearchWhenKnownWorknoFails() = runBlocking {
+        val detailAttempts = mutableListOf<DlsiteCloudSyncAttempt>()
+
+        val result = resolveDlsiteCloudSync(
+            keyword = "album title",
+            baseWorkno = "RJ000100",
+            search = { _, locale ->
+                when (locale) {
+                    CLOUD_SYNC_LOCALE_ZH_CN -> listOf(albumOf("RJ000200"))
+                    else -> emptyList()
+                }
+            },
+            fetchLanguageEditions = { emptyList() },
+            fetchDetails = { workno, locale ->
+                detailAttempts += DlsiteCloudSyncAttempt(workno, locale)
+                if (workno == "RJ000200" && locale == CLOUD_SYNC_LOCALE_ZH_CN) albumOf(workno, "简中命中") else null
+            }
+        )
+
+        assertTrue(result is DlsiteCloudSyncResolveResult.Success)
+        result as DlsiteCloudSyncResolveResult.Success
+        assertEquals("RJ000200", result.workno)
+        assertEquals(CLOUD_SYNC_LOCALE_ZH_CN, result.locale)
+        assertEquals("简中命中", result.details.title)
+        assertTrue(detailAttempts.take(3).all { it.workno == "RJ000100" })
+    }
+
+    private fun albumOf(rjCode: String, title: String = rjCode): Album {
+        return Album(
+            title = title,
+            path = "",
+            workId = rjCode,
+            rjCode = rjCode
+        )
+    }
+}


### PR DESCRIPTION
﻿## Summary
- add a shared DLsite cloud-sync locale fallback helper with zh_CN -> zh_TW -> ja_JP
- apply the shared resolver to library cloud sync and manual RJ binding sync
- persist the resolved locale-specific RJ/workno and keep FTS, auto tags, and cover persistence in sync
- add JVM tests for locale attempt ordering and search/detail fallback behavior

## Testing
- ./gradlew compileDebugKotlin compileDebugUnitTestKotlin
- ./gradlew testDebugUnitTest --tests "com.asmr.player.data.remote.dlsite.DlsiteCloudSyncSupportTest" --tests "com.asmr.player.data.remote.dlsite.DlsiteProductInfoClientTest"
