### PR TITLE
fix: handle ambiguous DLsite cloud sync matches with manual selection

### DIFF
--- a/app/src/main/java/com/asmr/player/MainActivity.kt
+++ b/app/src/main/java/com/asmr/player/MainActivity.kt
@@ -55,6 +55,7 @@ import androidx.navigation.navArgument
 import com.asmr.player.ui.library.AlbumDetailScreen
 import com.asmr.player.ui.library.AlbumDetailUiState
 import com.asmr.player.ui.library.AlbumDetailViewModel
+import com.asmr.player.ui.library.CloudSyncSelectionDialog
 import com.asmr.player.ui.library.LibraryFilterScreen
 import com.asmr.player.ui.library.LibraryScreen
 import com.asmr.player.ui.library.LibraryViewModel
@@ -476,6 +477,7 @@ fun MainContainer(
     val drawerStatusViewModel: DrawerStatusViewModel = hiltViewModel()
     val statisticsViewModel: StatisticsViewModel = hiltViewModel()
     val bulkProgress by libraryViewModel.bulkProgress.collectAsState()
+    val cloudSyncSelectionDialogState by libraryViewModel.cloudSyncSelectionDialogState.collectAsState()
     val appVolumePercent by playerViewModel.appVolumePercent.collectAsState()
     var showManualRjDialog by remember { mutableStateOf(false) }
     var manualRjInput by remember { mutableStateOf("") }
@@ -1493,6 +1495,20 @@ fun MainContainer(
                     dismissButton = {
                         TextButton(onClick = { showManualRjDialog = false }) { Text("取消") }
                     }
+                )
+            }
+
+            cloudSyncSelectionDialogState?.let { dialogState ->
+                val ignoreAllHandler = if (bulkProgress != null) {
+                    { libraryViewModel.ignoreAllCloudSyncSelections() }
+                } else {
+                    null
+                }
+                CloudSyncSelectionDialog(
+                    state = dialogState,
+                    onSelect = libraryViewModel::confirmCloudSyncSelection,
+                    onCancel = libraryViewModel::cancelCloudSyncSelection,
+                    onIgnoreAll = ignoreAllHandler
                 )
             }
 

--- a/app/src/main/java/com/asmr/player/data/remote/dlsite/DlsiteCloudSyncSupport.kt
+++ b/app/src/main/java/com/asmr/player/data/remote/dlsite/DlsiteCloudSyncSupport.kt
@@ -24,9 +24,19 @@ internal data class DlsiteCloudSyncResolvedDetails(
     val details: Album
 )
 
+internal data class DlsiteCloudSyncCandidate(
+    val workno: String,
+    val title: String,
+    val cv: String,
+    val coverUrl: String
+)
+
 internal sealed interface DlsiteCloudSyncSearchResult {
     data class Unique(val workno: String, val locale: String) : DlsiteCloudSyncSearchResult
-    data class Ambiguous(val locale: String, val count: Int) : DlsiteCloudSyncSearchResult
+    data class Ambiguous(
+        val locale: String,
+        val candidates: List<DlsiteCloudSyncCandidate>
+    ) : DlsiteCloudSyncSearchResult
     data object NotFound : DlsiteCloudSyncSearchResult
 }
 
@@ -37,7 +47,10 @@ internal sealed interface DlsiteCloudSyncResolveResult {
         val details: Album
     ) : DlsiteCloudSyncResolveResult
 
-    data object Ambiguous : DlsiteCloudSyncResolveResult
+    data class Ambiguous(
+        val locale: String,
+        val candidates: List<DlsiteCloudSyncCandidate>
+    ) : DlsiteCloudSyncResolveResult
     data object NotFound : DlsiteCloudSyncResolveResult
 }
 
@@ -85,18 +98,41 @@ internal suspend fun searchDlsiteWorknoWithLocaleFallback(
 
     for ((_, locale) in CLOUD_SYNC_LANGUAGE_PRIORITY) {
         val results = runCatching { search(normalizedKeyword, locale) }.getOrNull() ?: continue
+        val candidates = results.toDlsiteCloudSyncCandidates()
         when {
-            results.size > 1 -> return DlsiteCloudSyncSearchResult.Ambiguous(locale = locale, count = results.size)
-            results.size == 1 -> {
-                val workno = results.first().rjCode.trim().uppercase()
-                if (workno.isNotBlank()) {
-                    return DlsiteCloudSyncSearchResult.Unique(workno = workno, locale = locale)
-                }
+            candidates.size > 1 -> {
+                return DlsiteCloudSyncSearchResult.Ambiguous(locale = locale, candidates = candidates)
+            }
+
+            candidates.size == 1 -> {
+                return DlsiteCloudSyncSearchResult.Unique(
+                    workno = candidates.first().workno,
+                    locale = locale
+                )
             }
         }
     }
 
     return DlsiteCloudSyncSearchResult.NotFound
+}
+
+private fun List<Album>.toDlsiteCloudSyncCandidates(): List<DlsiteCloudSyncCandidate> {
+    return asSequence()
+        .mapNotNull { album ->
+            val workno = album.rjCode
+                .trim()
+                .uppercase()
+                .ifBlank { album.workId.trim().uppercase() }
+            if (workno.isBlank()) return@mapNotNull null
+            DlsiteCloudSyncCandidate(
+                workno = workno,
+                title = album.title.trim().ifBlank { workno },
+                cv = album.cv.trim(),
+                coverUrl = album.coverUrl.trim()
+            )
+        }
+        .distinctBy { it.workno }
+        .toList()
 }
 
 internal suspend fun fetchDlsiteDetailsWithLocaleFallback(
@@ -135,17 +171,18 @@ internal suspend fun resolveDlsiteCloudSync(
     if (workno.isBlank()) {
         when (val searchResult = searchDlsiteWorknoWithLocaleFallback(normalizedKeyword, search)) {
             is DlsiteCloudSyncSearchResult.Unique -> workno = searchResult.workno
-            is DlsiteCloudSyncSearchResult.Ambiguous -> return DlsiteCloudSyncResolveResult.Ambiguous
+            is DlsiteCloudSyncSearchResult.Ambiguous -> {
+                return DlsiteCloudSyncResolveResult.Ambiguous(
+                    locale = searchResult.locale,
+                    candidates = searchResult.candidates
+                )
+            }
             DlsiteCloudSyncSearchResult.NotFound -> return DlsiteCloudSyncResolveResult.NotFound
         }
     }
 
-    fetchDlsiteDetailsWithLocaleFallback(workno, fetchLanguageEditions, fetchDetails)?.let { resolved ->
-        return DlsiteCloudSyncResolveResult.Success(
-            workno = resolved.workno,
-            locale = resolved.locale,
-            details = resolved.details
-        )
+    resolveSelectedDlsiteCloudSync(workno, fetchLanguageEditions, fetchDetails).let { resolved ->
+        if (resolved is DlsiteCloudSyncResolveResult.Success) return resolved
     }
 
     if (normalizedKeyword.isBlank()) return DlsiteCloudSyncResolveResult.NotFound
@@ -168,9 +205,27 @@ internal suspend fun resolveDlsiteCloudSync(
             }
         }
 
-        is DlsiteCloudSyncSearchResult.Ambiguous -> DlsiteCloudSyncResolveResult.Ambiguous
+        is DlsiteCloudSyncSearchResult.Ambiguous -> DlsiteCloudSyncResolveResult.Ambiguous(
+            locale = searchResult.locale,
+            candidates = searchResult.candidates
+        )
         DlsiteCloudSyncSearchResult.NotFound -> DlsiteCloudSyncResolveResult.NotFound
     }
+}
+
+internal suspend fun resolveSelectedDlsiteCloudSync(
+    workno: String,
+    fetchLanguageEditions: suspend (productId: String) -> List<DlsiteLanguageEdition>,
+    fetchDetails: suspend (workno: String, locale: String) -> Album?
+): DlsiteCloudSyncResolveResult {
+    fetchDlsiteDetailsWithLocaleFallback(workno, fetchLanguageEditions, fetchDetails)?.let { resolved ->
+        return DlsiteCloudSyncResolveResult.Success(
+            workno = resolved.workno,
+            locale = resolved.locale,
+            details = resolved.details
+        )
+    }
+    return DlsiteCloudSyncResolveResult.NotFound
 }
 
 internal fun resolveCloudSyncWorkId(existingWorkId: String, resolvedWorkno: String): String {

--- a/app/src/main/java/com/asmr/player/data/remote/dlsite/DlsiteCloudSyncSupport.kt
+++ b/app/src/main/java/com/asmr/player/data/remote/dlsite/DlsiteCloudSyncSupport.kt
@@ -11,6 +11,7 @@ private val CLOUD_SYNC_LANGUAGE_PRIORITY = listOf(
     "CHI_HANT" to CLOUD_SYNC_LOCALE_ZH_TW,
     "JPN" to CLOUD_SYNC_LOCALE_JA_JP
 )
+private val CLOUD_SYNC_TITLE_BLOCK_REGEX = Regex("\u3010[^\u3010\u3011]*\u3011")
 
 internal data class DlsiteCloudSyncAttempt(
     val workno: String,
@@ -38,6 +39,13 @@ internal sealed interface DlsiteCloudSyncResolveResult {
 
     data object Ambiguous : DlsiteCloudSyncResolveResult
     data object NotFound : DlsiteCloudSyncResolveResult
+}
+
+internal fun sanitizeDlsiteCloudSyncKeyword(raw: String): String {
+    return CLOUD_SYNC_TITLE_BLOCK_REGEX
+        .replace(raw, " ")
+        .replace(Regex("""\s+"""), " ")
+        .trim()
 }
 
 internal fun buildDlsiteCloudSyncAttempts(
@@ -72,7 +80,7 @@ internal suspend fun searchDlsiteWorknoWithLocaleFallback(
     keyword: String,
     search: suspend (keyword: String, locale: String) -> List<Album>
 ): DlsiteCloudSyncSearchResult {
-    val normalizedKeyword = keyword.trim()
+    val normalizedKeyword = sanitizeDlsiteCloudSyncKeyword(keyword)
     if (normalizedKeyword.isBlank()) return DlsiteCloudSyncSearchResult.NotFound
 
     for ((_, locale) in CLOUD_SYNC_LANGUAGE_PRIORITY) {

--- a/app/src/main/java/com/asmr/player/ui/library/AlbumDetailScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/AlbumDetailScreen.kt
@@ -158,6 +158,7 @@ fun AlbumDetailScreen(
     viewModel: AlbumDetailViewModel = hiltViewModel()
 ) {
     val uiState by viewModel.uiState.collectAsState()
+    val cloudSyncSelectionDialogState by viewModel.cloudSyncSelectionDialogState.collectAsState()
     val colorScheme = AsmrTheme.colorScheme
     val screenKey = remember(albumId, rjCode) {
         val idPart = albumId?.takeIf { it > 0 }?.toString().orEmpty()
@@ -612,6 +613,14 @@ fun AlbumDetailScreen(
                     }
                 }
             }
+        }
+
+        cloudSyncSelectionDialogState?.let { dialogState ->
+            CloudSyncSelectionDialog(
+                state = dialogState,
+                onSelect = viewModel::confirmCloudSyncSelection,
+                onCancel = viewModel::cancelCloudSyncSelection
+            )
         }
     }
 }
@@ -1316,7 +1325,7 @@ private fun dlsiteCoverUrlForRj(rj: String): String {
     val clean = sanitizeRj(rj)
     val digits = clean.removePrefix("RJ")
     val num = digits.toLongOrNull() ?: return ""
-    val group = (num / 1000L) * 1000L
+    val group = ((num + 999L) / 1000L) * 1000L
     val padded = group.toString().padStart(digits.length, '0')
     val folder = "RJ$padded"
     return "https://img.dlsite.jp/modpub/images2/work/doujin/$folder/${clean}_img_main.jpg"

--- a/app/src/main/java/com/asmr/player/ui/library/AlbumDetailViewModel.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/AlbumDetailViewModel.kt
@@ -19,6 +19,7 @@ import com.asmr.player.data.local.db.entities.TagSource
 import com.asmr.player.data.local.db.entities.TrackTagEntity
 import com.asmr.player.data.remote.api.AsmrOneTrackNodeResponse
 import com.asmr.player.data.remote.crawler.AsmrOneCrawler
+import com.asmr.player.data.remote.dlsite.DlsiteCloudSyncCandidate
 import com.asmr.player.data.remote.dlsite.DlsiteCloudSyncResolveResult
 import com.asmr.player.data.remote.dlsite.DlsitePlayWorkClient
 import com.asmr.player.data.remote.dlsite.DlsitePlayTreeResult
@@ -26,6 +27,7 @@ import com.asmr.player.data.remote.dlsite.DlsiteLanguageEdition
 import com.asmr.player.data.remote.dlsite.DlsiteProductInfoClient
 import com.asmr.player.data.remote.dlsite.resolveCloudSyncWorkId
 import com.asmr.player.data.remote.dlsite.resolveDlsiteCloudSync
+import com.asmr.player.data.remote.dlsite.resolveSelectedDlsiteCloudSync
 import com.asmr.player.data.remote.download.DownloadManager
 import com.asmr.player.data.remote.scraper.DLSiteScraper
 import com.asmr.player.data.remote.scraper.DlsiteRecommendedWork
@@ -41,6 +43,7 @@ import com.asmr.player.util.DlsiteWorkNo
 import com.asmr.player.data.remote.crawler.asmrOneWorkMatchesRj
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
@@ -97,6 +100,9 @@ class AlbumDetailViewModel @Inject constructor(
 
     private val _uiState = MutableStateFlow<AlbumDetailUiState>(AlbumDetailUiState.Loading)
     val uiState = _uiState.asStateFlow()
+    private val _cloudSyncSelectionDialogState = MutableStateFlow<CloudSyncSelectionDialogState?>(null)
+    internal val cloudSyncSelectionDialogState: StateFlow<CloudSyncSelectionDialogState?> = _cloudSyncSelectionDialogState.asStateFlow()
+    private var pendingCloudSyncSelection: CompletableDeferred<String?>? = null
 
     val availableTags: StateFlow<List<TagWithCount>> = database.tagDao()
         .getTagsWithCounts(TagSource.USER)
@@ -226,6 +232,119 @@ class AlbumDetailViewModel @Inject constructor(
     fun persistListScrollPosition(stateKey: String, index: Int, offset: Int) {
         if (stateKey.isBlank()) return
         listScrollByKey[stateKey] = (index.coerceAtLeast(0) to offset.coerceAtLeast(0))
+    }
+
+    fun confirmCloudSyncSelection(workno: String) {
+        val deferred = pendingCloudSyncSelection ?: return
+        if (deferred.isActive) {
+            deferred.complete(workno.trim().uppercase().ifBlank { null })
+        }
+        if (pendingCloudSyncSelection === deferred) {
+            pendingCloudSyncSelection = null
+            _cloudSyncSelectionDialogState.value = null
+        }
+    }
+
+    fun cancelCloudSyncSelection() {
+        val deferred = pendingCloudSyncSelection ?: return
+        if (deferred.isActive) {
+            deferred.complete(null)
+        }
+        if (pendingCloudSyncSelection === deferred) {
+            pendingCloudSyncSelection = null
+            _cloudSyncSelectionDialogState.value = null
+        }
+    }
+
+    private suspend fun awaitCloudSyncSelection(
+        albumTitle: String,
+        candidates: List<DlsiteCloudSyncCandidate>
+    ): String? {
+        cancelCloudSyncSelection()
+        val normalizedCandidates = candidates.distinctBy { it.workno }.filter { it.workno.isNotBlank() }
+        if (normalizedCandidates.isEmpty()) return null
+        val deferred = CompletableDeferred<String?>()
+        pendingCloudSyncSelection = deferred
+        _cloudSyncSelectionDialogState.value = CloudSyncSelectionDialogState(
+            albumTitle = albumTitle,
+            candidates = normalizedCandidates
+        )
+        return try {
+            deferred.await()
+        } finally {
+            if (pendingCloudSyncSelection === deferred) {
+                pendingCloudSyncSelection = null
+                _cloudSyncSelectionDialogState.value = null
+            }
+        }
+    }
+
+    private suspend fun resolveManualCloudSync(
+        entity: AlbumEntity,
+        baseWorkno: String
+    ): DlsiteCloudSyncResolveResult {
+        return resolveDlsiteCloudSync(
+            keyword = entity.title.trim(),
+            baseWorkno = baseWorkno,
+            search = { searchKeyword, locale ->
+                dlsiteScraper.search(searchKeyword, page = 1, order = "trend", locale = locale)
+            },
+            fetchLanguageEditions = { productId ->
+                dlsiteProductInfoClient.fetchLanguageEditions(productId)
+            },
+            fetchDetails = { workno, locale ->
+                dlsiteScraper.getDetails(workno, locale = locale)
+            }
+        )
+    }
+
+    private suspend fun resolveSelectedManualCloudSync(workno: String): DlsiteCloudSyncResolveResult {
+        return resolveSelectedDlsiteCloudSync(
+            workno = workno,
+            fetchLanguageEditions = { productId ->
+                dlsiteProductInfoClient.fetchLanguageEditions(productId)
+            },
+            fetchDetails = { selectedWorkno, locale ->
+                dlsiteScraper.getDetails(selectedWorkno, locale = locale)
+            }
+        )
+    }
+
+    private suspend fun applyManualCloudSyncSuccess(
+        entity: AlbumEntity,
+        updatedWorkId: String,
+        result: DlsiteCloudSyncResolveResult.Success
+    ): String {
+        val resolvedWorkno = result.workno
+        val details = result.details
+        val oldTitle = entity.title.trim()
+        val newTitle = details.title.trim()
+        val finalTitle = when {
+            oldTitle.isNotBlank() && newTitle.isBlank() -> oldTitle
+            oldTitle.isNotBlank() && newTitle.isNotBlank() && oldTitle.contains(newTitle) && oldTitle.length > newTitle.length -> oldTitle
+            else -> newTitle.ifBlank { oldTitle }
+        }
+        val updated = entity.copy(
+            title = finalTitle,
+            circle = details.circle.ifBlank { entity.circle },
+            cv = details.cv.ifBlank { entity.cv },
+            tags = if (details.tags.isNotEmpty()) details.tags.joinToString(",") else entity.tags,
+            coverUrl = details.coverUrl.ifBlank { entity.coverUrl },
+            description = details.description.ifBlank { entity.description },
+            workId = resolveCloudSyncWorkId(updatedWorkId, resolvedWorkno),
+            rjCode = resolvedWorkno
+        )
+        withContext(Dispatchers.IO) {
+            albumDao.updateAlbum(updated)
+            upsertAlbumFtsIndex(updated.id, updated)
+            upsertAlbumTagsFromCsv(updated.id, updated.tags, TagSource.AUTO)
+            if (updated.coverPath.trim().isBlank() && updated.coverThumbPath.trim().isBlank()) {
+                runCatching {
+                    ensureAlbumCoverSaved(updated.id, updated.coverPath, updated.coverUrl)
+                }
+            }
+        }
+        return resolvedWorkno
     }
 
     fun loadAlbum(albumId: Long?, rjCode: String?, force: Boolean = false) {
@@ -385,56 +504,50 @@ class AlbumDetailViewModel @Inject constructor(
 
                 when (
                     val result = withContext(Dispatchers.IO) {
-                        resolveDlsiteCloudSync(
-                            keyword = entity.title.trim(),
-                            baseWorkno = normalized,
-                            search = { searchKeyword, locale ->
-                                dlsiteScraper.search(searchKeyword, page = 1, order = "trend", locale = locale)
-                            },
-                            fetchLanguageEditions = { productId ->
-                                dlsiteProductInfoClient.fetchLanguageEditions(productId)
-                            },
-                            fetchDetails = { workno, locale ->
-                                dlsiteScraper.getDetails(workno, locale = locale)
-                            }
-                        )
+                        resolveManualCloudSync(entity, normalized)
                     }
                 ) {
                     is DlsiteCloudSyncResolveResult.Success -> {
-                        val resolvedWorkno = result.workno
-                        val details = result.details
-                        val oldTitle = entity.title.trim()
-                        val newTitle = details.title.trim()
-                        val finalTitle = when {
-                            oldTitle.isNotBlank() && newTitle.isBlank() -> oldTitle
-                            oldTitle.isNotBlank() && newTitle.isNotBlank() && oldTitle.contains(newTitle) && oldTitle.length > newTitle.length -> oldTitle
-                            else -> newTitle.ifBlank { oldTitle }
-                        }
-                        val updated = entity.copy(
-                            title = finalTitle,
-                            circle = details.circle.ifBlank { entity.circle },
-                            cv = details.cv.ifBlank { entity.cv },
-                            tags = if (details.tags.isNotEmpty()) details.tags.joinToString(",") else entity.tags,
-                            coverUrl = details.coverUrl.ifBlank { entity.coverUrl },
-                            description = details.description.ifBlank { entity.description },
-                            workId = resolveCloudSyncWorkId(updatedWorkId, resolvedWorkno),
-                            rjCode = resolvedWorkno
-                        )
-                        withContext(Dispatchers.IO) {
-                            albumDao.updateAlbum(updated)
-                            upsertAlbumFtsIndex(updated.id, updated)
-                            upsertAlbumTagsFromCsv(updated.id, updated.tags, TagSource.AUTO)
-                            if (updated.coverPath.trim().isBlank() && updated.coverThumbPath.trim().isBlank()) {
-                                runCatching {
-                                    ensureAlbumCoverSaved(updated.id, updated.coverPath, updated.coverUrl)
-                                }
-                            }
+                        val resolvedWorkno = withContext(Dispatchers.IO) {
+                            applyManualCloudSyncSuccess(entity, updatedWorkId, result)
                         }
                         messageManager.showSuccess("已绑定 $resolvedWorkno 并完成云同步")
                         loadAlbum(local.id, resolvedWorkno, force = true)
                     }
 
-                    DlsiteCloudSyncResolveResult.Ambiguous -> {
+                    is DlsiteCloudSyncResolveResult.Ambiguous -> {
+                        val selectedWorkno = awaitCloudSyncSelection(
+                            albumTitle = local.title,
+                            candidates = result.candidates
+                        )
+                        if (selectedWorkno == null) {
+                            loadAlbum(local.id, normalized, force = true)
+                            return@launch
+                        }
+                        when (val selectedResult = withContext(Dispatchers.IO) {
+                            resolveSelectedManualCloudSync(selectedWorkno)
+                        }) {
+                            is DlsiteCloudSyncResolveResult.Success -> {
+                                val resolvedWorkno = withContext(Dispatchers.IO) {
+                                    applyManualCloudSyncSuccess(entity, updatedWorkId, selectedResult)
+                                }
+                                messageManager.showSuccess("已绑定 $resolvedWorkno 并完成云同步")
+                                loadAlbum(local.id, resolvedWorkno, force = true)
+                                return@launch
+                            }
+
+                            is DlsiteCloudSyncResolveResult.Ambiguous -> {
+                                messageManager.showError("同步失败：搜索结果不唯一")
+                                loadAlbum(local.id, normalized, force = true)
+                                return@launch
+                            }
+
+                            DlsiteCloudSyncResolveResult.NotFound -> {
+                                messageManager.showError("同步失败：未找到专辑信息")
+                                loadAlbum(local.id, normalized, force = true)
+                                return@launch
+                            }
+                        }
                         messageManager.showError("同步失败：搜索结果不唯一")
                         loadAlbum(local.id, normalized, force = true)
                     }
@@ -2095,6 +2208,11 @@ class AlbumDetailViewModel @Inject constructor(
 
     private fun safeFileName(input: String): String {
         return input.trim().ifEmpty { "track" }.replace(Regex("""[\\/:*?"<>|]"""), "_")
+    }
+
+    override fun onCleared() {
+        cancelCloudSyncSelection()
+        super.onCleared()
     }
 }
 

--- a/app/src/main/java/com/asmr/player/ui/library/CloudSyncSelectionDialog.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/CloudSyncSelectionDialog.kt
@@ -1,0 +1,475 @@
+package com.asmr.player.ui.library
+
+import android.util.Log
+import android.webkit.CookieManager
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.FilledTonalButton
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.painter.BitmapPainter
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.layout.onSizeChanged
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
+import com.asmr.player.cache.CacheImageModel
+import com.asmr.player.cache.ImageCacheEntryPoint
+import com.asmr.player.data.remote.NetworkHeaders
+import com.asmr.player.data.remote.dlsite.DlsiteCloudSyncCandidate
+import com.asmr.player.ui.common.AsmrShimmerPlaceholder
+import com.asmr.player.ui.common.CvChipsSingleLine
+import com.asmr.player.ui.common.DiscPlaceholder
+import com.asmr.player.ui.theme.AsmrTheme
+import com.asmr.player.util.DlsiteAntiHotlink
+import dagger.hilt.android.EntryPointAccessors
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.withTimeoutOrNull
+import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
+
+internal const val CLOUD_SYNC_SELECTION_DIALOG_TAG = "cloud_sync_selection_dialog"
+internal const val CLOUD_SYNC_SELECTION_PROGRESS_TAG = "cloud_sync_selection_progress"
+internal const val CLOUD_SYNC_SELECTION_LIST_TAG = "cloud_sync_selection_list"
+internal val CLOUD_SYNC_SELECTION_SECTION_SPACING = 8.dp
+internal val CLOUD_SYNC_SELECTION_ROW_SPACING = 8.dp
+internal val CLOUD_SYNC_SELECTION_ROW_HEIGHT = 86.dp
+internal val CLOUD_SYNC_SELECTION_LIST_HEIGHT =
+    (CLOUD_SYNC_SELECTION_ROW_HEIGHT * 3) + (CLOUD_SYNC_SELECTION_ROW_SPACING * 2)
+
+internal data class CloudSyncSelectionDialogState(
+    val albumTitle: String,
+    val candidates: List<DlsiteCloudSyncCandidate>,
+    val currentPosition: Int? = null,
+    val totalCount: Int? = null
+) {
+    val progressLabel: String?
+        get() = if ((currentPosition ?: 0) > 0 && (totalCount ?: 0) > 0) {
+            "待确认 ${currentPosition} / ${totalCount}"
+        } else {
+            null
+        }
+}
+
+internal data class CloudSyncCandidateCoverSource(
+    val label: String,
+    val url: String
+)
+
+private data class CloudSyncCandidateCoverRequest(
+    val label: String,
+    val url: String,
+    val model: Any
+)
+
+private enum class CloudSyncCandidateCoverLoadState {
+    Loading,
+    Success,
+    Error
+}
+
+@Composable
+internal fun CloudSyncSelectionDialog(
+    state: CloudSyncSelectionDialogState,
+    onSelect: (String) -> Unit,
+    onCancel: () -> Unit,
+    onIgnoreAll: (() -> Unit)? = null
+) {
+    val colorScheme = AsmrTheme.colorScheme
+    Dialog(
+        onDismissRequest = onCancel,
+        properties = DialogProperties(usePlatformDefaultWidth = false)
+    ) {
+        Card(
+            modifier = Modifier
+                .fillMaxWidth(0.92f)
+                .widthIn(max = 540.dp)
+                .testTag(CLOUD_SYNC_SELECTION_DIALOG_TAG),
+            shape = RoundedCornerShape(28.dp),
+            colors = CardDefaults.cardColors(
+                containerColor = MaterialTheme.colorScheme.surface
+            ),
+            border = BorderStroke(
+                width = 1.dp,
+                color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = if (colorScheme.isDark) 0.28f else 0.42f)
+            )
+        ) {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .background(colorScheme.surface.copy(alpha = if (colorScheme.isDark) 0.97f else 0.985f))
+                    .padding(horizontal = 16.dp, vertical = 14.dp)
+            ) {
+                Surface(
+                    modifier = Modifier.fillMaxWidth(),
+                    shape = RoundedCornerShape(20.dp),
+                    color = colorScheme.primarySoft.copy(alpha = if (colorScheme.isDark) 0.16f else 0.88f),
+                    border = BorderStroke(
+                        1.dp,
+                        colorScheme.primary.copy(alpha = if (colorScheme.isDark) 0.2f else 0.14f)
+                    )
+                ) {
+                    Column(
+                        modifier = Modifier.padding(horizontal = 16.dp, vertical = 12.dp),
+                        verticalArrangement = Arrangement.spacedBy(4.dp)
+                    ) {
+                        Text(
+                            text = "云同步候选：${state.candidates.size} 个疑似结果(点击对应作品以确认同步)",
+                            style = MaterialTheme.typography.labelSmall.copy(
+                                fontWeight = FontWeight.SemiBold,
+                                lineHeight = 16.sp
+                            ),
+                            color = colorScheme.primary,
+                            maxLines = 2,
+                            overflow = TextOverflow.Ellipsis
+                        )
+                        Text(
+                            text = state.albumTitle.ifBlank { "当前专辑" },
+                            style = MaterialTheme.typography.titleSmall.copy(
+                                fontWeight = FontWeight.SemiBold,
+                                lineHeight = 20.sp
+                            ),
+                            color = colorScheme.textPrimary,
+                            maxLines = 2,
+                            overflow = TextOverflow.Ellipsis
+                        )
+                    }
+                }
+
+                Spacer(modifier = Modifier.height(12.dp))
+                HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.34f))
+                Spacer(modifier = Modifier.height(CLOUD_SYNC_SELECTION_SECTION_SPACING))
+                LazyColumn(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(CLOUD_SYNC_SELECTION_LIST_HEIGHT)
+                        .testTag(CLOUD_SYNC_SELECTION_LIST_TAG),
+                    verticalArrangement = Arrangement.spacedBy(CLOUD_SYNC_SELECTION_ROW_SPACING)
+                ) {
+                    items(state.candidates, key = { it.workno }) { candidate ->
+                        CloudSyncSelectionCandidateRow(
+                            candidate = candidate,
+                            onClick = { onSelect(candidate.workno) }
+                        )
+                    }
+                }
+                Spacer(modifier = Modifier.height(CLOUD_SYNC_SELECTION_SECTION_SPACING))
+                HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.34f))
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(top = 12.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Box(
+                        modifier = Modifier.weight(1f),
+                        contentAlignment = Alignment.CenterStart
+                    ) {
+                        if (onIgnoreAll != null) {
+                            OutlinedButton(
+                                onClick = onIgnoreAll,
+                                border = BorderStroke(
+                                    1.dp,
+                                    color = colorScheme.textSecondary.copy(alpha = 0.28f)
+                                ),
+                                colors = ButtonDefaults.outlinedButtonColors(
+                                    contentColor = colorScheme.textSecondary
+                                )
+                            ) {
+                                Text("忽略全部")
+                            }
+                        }
+                    }
+                    Box(
+                        modifier = Modifier.weight(1f),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        state.progressLabel?.let { progress ->
+                            Text(
+                                text = progress,
+                                modifier = Modifier.testTag(CLOUD_SYNC_SELECTION_PROGRESS_TAG),
+                                style = MaterialTheme.typography.labelMedium.copy(fontWeight = FontWeight.SemiBold),
+                                color = colorScheme.textSecondary
+                            )
+                        }
+                    }
+                    Box(
+                        modifier = Modifier.weight(1f),
+                        contentAlignment = Alignment.CenterEnd
+                    ) {
+                        FilledTonalButton(
+                            onClick = onCancel,
+                            colors = ButtonDefaults.filledTonalButtonColors(
+                                containerColor = colorScheme.primarySoft.copy(alpha = if (colorScheme.isDark) 0.24f else 1f),
+                                contentColor = colorScheme.primary
+                            )
+                        ) {
+                            Text(if (onIgnoreAll != null) "取消当前" else "取消")
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun CloudSyncSelectionCandidateRow(
+    candidate: DlsiteCloudSyncCandidate,
+    onClick: () -> Unit
+) {
+    val colorScheme = AsmrTheme.colorScheme
+    val coverShape = RoundedCornerShape(topStart = 16.dp, bottomStart = 16.dp, topEnd = 0.dp, bottomEnd = 0.dp)
+    Surface(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(CLOUD_SYNC_SELECTION_ROW_HEIGHT)
+            .clickable(onClick = onClick),
+        shape = RoundedCornerShape(16.dp),
+        color = colorScheme.surface.copy(alpha = if (colorScheme.isDark) 0.62f else 0.5f),
+        border = BorderStroke(
+            1.dp,
+            color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = if (colorScheme.isDark) 0.16f else 0.28f)
+        )
+    ) {
+        Row(
+            modifier = Modifier.fillMaxSize(),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Surface(
+                modifier = Modifier
+                    .fillMaxHeight()
+                    .width(84.dp),
+                shape = coverShape,
+                color = colorScheme.surface.copy(alpha = 0.72f)
+            ) {
+                CloudSyncSelectionCandidateCover(
+                    candidate = candidate,
+                    modifier = Modifier.fillMaxSize()
+                )
+            }
+            Column(
+                modifier = Modifier
+                    .weight(1f)
+                    .padding(start = 14.dp, end = 14.dp, top = 8.dp, bottom = 8.dp),
+                verticalArrangement = Arrangement.spacedBy(4.dp)
+            ) {
+                Text(
+                    text = candidate.title,
+                    style = MaterialTheme.typography.bodyMedium.copy(
+                        fontWeight = FontWeight.SemiBold,
+                        lineHeight = 19.sp
+                    ),
+                    color = colorScheme.textPrimary,
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis
+                )
+                if (candidate.cv.isNotBlank()) {
+                    CvChipsSingleLine(
+                        cvText = candidate.cv,
+                        modifier = Modifier.fillMaxWidth(),
+                        showLabel = true
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun CloudSyncSelectionCandidateCover(
+    candidate: DlsiteCloudSyncCandidate,
+    modifier: Modifier = Modifier
+) {
+    val context = LocalContext.current.applicationContext
+    val manager = remember(context) {
+        EntryPointAccessors.fromApplication(context, ImageCacheEntryPoint::class.java).imageCacheManager()
+    }
+    val requests = remember(candidate.coverUrl, candidate.workno) {
+        buildCloudSyncCandidateCoverRequests(candidate)
+    }
+    var measuredSize by remember { mutableStateOf<IntSize?>(null) }
+    var attemptIndex by remember(requests) { mutableIntStateOf(0) }
+    var image by remember(requests) { mutableStateOf<ImageBitmap?>(null) }
+    var loadState by remember(requests) {
+        mutableStateOf(
+            if (requests.isEmpty()) CloudSyncCandidateCoverLoadState.Error else CloudSyncCandidateCoverLoadState.Loading
+        )
+    }
+    var failureLogged by remember(requests) { mutableStateOf(false) }
+
+    LaunchedEffect(requests, measuredSize, attemptIndex) {
+        val size = measuredSize ?: return@LaunchedEffect
+        val request = requests.getOrNull(attemptIndex) ?: return@LaunchedEffect
+        try {
+            loadState = CloudSyncCandidateCoverLoadState.Loading
+            image = null
+            val loaded = withTimeoutOrNull(15_000) {
+                manager.loadImage(model = request.model, size = size)
+            } ?: throw IllegalStateException("cover load timeout")
+            image = loaded
+            loadState = CloudSyncCandidateCoverLoadState.Success
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Throwable) {
+            val nextIndex = attemptIndex + 1
+            if (nextIndex < requests.size) {
+                attemptIndex = nextIndex
+            } else {
+                loadState = CloudSyncCandidateCoverLoadState.Error
+                if (!failureLogged) {
+                    failureLogged = true
+                    Log.w(
+                        "CloudSyncSelectionDialog",
+                        "cover load failed workno=${candidate.workno} sources=${
+                            requests.joinToString(" | ") { summarizeCloudSyncCandidateCoverSource(it.label, it.url) }
+                        }",
+                        e
+                    )
+                }
+            }
+        }
+    }
+
+    Box(
+        modifier = modifier.onSizeChanged { size ->
+            if (size.width > 0 && size.height > 0) {
+                measuredSize = IntSize(size.width, size.height)
+            }
+        }
+    ) {
+        when {
+            image != null -> {
+                androidx.compose.foundation.Image(
+                    painter = BitmapPainter(image!!),
+                    contentDescription = null,
+                    modifier = Modifier.fillMaxSize(),
+                    contentScale = ContentScale.Crop,
+                    alignment = Alignment.Center
+                )
+            }
+
+            loadState == CloudSyncCandidateCoverLoadState.Loading -> {
+                AsmrShimmerPlaceholder(
+                    modifier = Modifier.fillMaxSize(),
+                    cornerRadius = 0
+                )
+            }
+
+            else -> {
+                DiscPlaceholder(
+                    modifier = Modifier.fillMaxSize(),
+                    cornerRadius = 0
+                )
+            }
+        }
+    }
+}
+
+internal fun resolveCloudSyncCandidateCoverSources(candidate: DlsiteCloudSyncCandidate): List<CloudSyncCandidateCoverSource> {
+    val canonical = dlsiteCoverUrlForWorkno(candidate.workno)
+        .trim()
+        .takeIf { it.isNotBlank() }
+        ?.let { CloudSyncCandidateCoverSource(label = "canonical", url = it) }
+    val raw = normalizeCloudSyncCandidateRawCoverUrl(candidate.coverUrl)
+        .takeIf { it.isNotBlank() }
+        ?.let { CloudSyncCandidateCoverSource(label = "search", url = it) }
+    return listOfNotNull(canonical, raw).distinctBy { it.url }
+}
+
+private fun buildCloudSyncCandidateCoverRequests(candidate: DlsiteCloudSyncCandidate): List<CloudSyncCandidateCoverRequest> {
+    val cookieManager = runCatching { CookieManager.getInstance() }.getOrNull()
+    return resolveCloudSyncCandidateCoverSources(candidate).map { source ->
+        val baseHeaders = if (source.url.startsWith("http", ignoreCase = true)) {
+            DlsiteAntiHotlink.headersForImageUrl(source.url)
+        } else {
+            emptyMap()
+        }
+        val cookie = cookieManager?.getCookie(source.url).orEmpty()
+            .ifBlank { cookieManager?.getCookie(NetworkHeaders.REFERER_DLSITE).orEmpty() }
+        val headers = buildMap {
+            putAll(baseHeaders)
+            if (cookie.isNotBlank()) put("Cookie", cookie)
+        }
+        val model = if (headers.isEmpty()) {
+            source.url
+        } else {
+            CacheImageModel(data = source.url, headers = headers, keyTag = "dlsite")
+        }
+        CloudSyncCandidateCoverRequest(
+            label = source.label,
+            url = source.url,
+            model = model
+        )
+    }
+}
+
+internal fun normalizeCloudSyncCandidateRawCoverUrl(raw: String): String {
+    val trimmed = raw.trim()
+    return when {
+        trimmed.isBlank() -> ""
+        trimmed.startsWith("http://", ignoreCase = true) || trimmed.startsWith("https://", ignoreCase = true) -> trimmed
+        trimmed.startsWith("//") -> "https:$trimmed"
+        trimmed.startsWith("/modpub/") || trimmed.startsWith("/images2/") -> "https://img.dlsite.jp$trimmed"
+        trimmed.startsWith("/") -> "https://www.dlsite.com$trimmed"
+        else -> trimmed
+    }
+}
+
+private fun summarizeCloudSyncCandidateCoverSource(label: String, url: String): String {
+    val parsed = url.toHttpUrlOrNull()
+    val summary = if (parsed != null) {
+        "${parsed.host}${parsed.encodedPath}"
+    } else {
+        url.take(160)
+    }
+    return "$label:$summary"
+}
+
+private fun dlsiteCoverUrlForWorkno(raw: String): String {
+    val clean = Regex("""RJ\d+""", RegexOption.IGNORE_CASE).find(raw)?.value?.uppercase().orEmpty()
+    val digits = clean.removePrefix("RJ")
+    val num = digits.toLongOrNull() ?: return ""
+    val group = ((num + 999L) / 1000L) * 1000L
+    val folder = "RJ${group.toString().padStart(digits.length, '0')}"
+    return "https://img.dlsite.jp/modpub/images2/work/doujin/$folder/${clean}_img_main.jpg"
+}

--- a/app/src/main/java/com/asmr/player/ui/library/CloudSyncSelectionRequestQueue.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/CloudSyncSelectionRequestQueue.kt
@@ -1,0 +1,177 @@
+package com.asmr.player.ui.library
+
+import com.asmr.player.data.remote.dlsite.DlsiteCloudSyncCandidate
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+internal class CloudSyncSelectionRequestQueue {
+    private data class PendingRequest(
+        val requestId: Long,
+        val albumId: Long?,
+        val albumTitle: String,
+        val candidates: List<DlsiteCloudSyncCandidate>,
+        val deferred: CompletableDeferred<String?>
+    )
+
+    private val lock = Any()
+    private val queued = ArrayDeque<PendingRequest>()
+    private var current: PendingRequest? = null
+    private var nextRequestId: Long = 1L
+    private var processedInSession: Int = 0
+    private var batchSessionActive = false
+    private var ignoreRemainingInBatchSession = false
+    private val _dialogState = MutableStateFlow<CloudSyncSelectionDialogState?>(null)
+    val dialogState: StateFlow<CloudSyncSelectionDialogState?> = _dialogState.asStateFlow()
+
+    fun beginBatchSession() {
+        synchronized(lock) {
+            batchSessionActive = true
+            ignoreRemainingInBatchSession = false
+            if (current == null && queued.isEmpty()) {
+                processedInSession = 0
+            }
+        }
+    }
+
+    fun endBatchSession() {
+        synchronized(lock) {
+            batchSessionActive = false
+            ignoreRemainingInBatchSession = false
+            if (current == null && queued.isEmpty()) {
+                processedInSession = 0
+            }
+        }
+    }
+
+    fun enqueue(
+        albumId: Long?,
+        albumTitle: String,
+        candidates: List<DlsiteCloudSyncCandidate>
+    ): CompletableDeferred<String?> {
+        val normalizedCandidates = candidates.distinctBy { it.workno }.filter { it.workno.isNotBlank() }
+        val deferred = CompletableDeferred<String?>()
+        if (normalizedCandidates.isEmpty()) {
+            deferred.complete(null)
+            return deferred
+        }
+
+        synchronized(lock) {
+            if (batchSessionActive && ignoreRemainingInBatchSession) {
+                deferred.complete(null)
+                return deferred
+            }
+            if (current == null && queued.isEmpty()) {
+                processedInSession = 0
+            }
+            val request = PendingRequest(
+                requestId = nextRequestId++,
+                albumId = albumId,
+                albumTitle = albumTitle.trim(),
+                candidates = normalizedCandidates,
+                deferred = deferred
+            )
+            if (current == null) {
+                current = request
+            } else {
+                queued.addLast(request)
+            }
+            publishLocked()
+        }
+        return deferred
+    }
+
+    fun resolveCurrent(workno: String?) {
+        val deferred = synchronized(lock) {
+            val request = current ?: return
+            processedInSession += 1
+            advanceLocked()
+            publishLocked()
+            request.deferred
+        }
+        deferred.complete(workno?.trim()?.uppercase()?.ifBlank { null })
+    }
+
+    fun ignoreAllRemainingInBatch() {
+        val deferreds = synchronized(lock) {
+            if (!batchSessionActive) return
+            ignoreRemainingInBatchSession = true
+            val removed = mutableListOf<CompletableDeferred<String?>>()
+            current?.deferred?.let(removed::add)
+            queued.forEach { removed += it.deferred }
+            current = null
+            queued.clear()
+            processedInSession = 0
+            publishLocked()
+            removed
+        }
+        deferreds.forEach { it.complete(null) }
+    }
+
+    fun cancelForAlbum(albumId: Long) {
+        if (albumId <= 0L) return
+        val deferreds = synchronized(lock) {
+            val removed = mutableListOf<CompletableDeferred<String?>>()
+            if (current?.albumId == albumId) {
+                current?.deferred?.let(removed::add)
+                processedInSession += 1
+                advanceLocked()
+            }
+            val iter = queued.iterator()
+            while (iter.hasNext()) {
+                val request = iter.next()
+                if (request.albumId == albumId) {
+                    removed += request.deferred
+                    iter.remove()
+                }
+            }
+            publishLocked()
+            removed
+        }
+        deferreds.forEach { it.complete(null) }
+    }
+
+    fun cancelAll() {
+        val deferreds = synchronized(lock) {
+            val removed = mutableListOf<CompletableDeferred<String?>>()
+            current?.deferred?.let(removed::add)
+            queued.forEach { removed += it.deferred }
+            current = null
+            queued.clear()
+            processedInSession = 0
+            batchSessionActive = false
+            ignoreRemainingInBatchSession = false
+            publishLocked()
+            removed
+        }
+        deferreds.forEach { it.complete(null) }
+    }
+
+    fun pendingCount(): Int = synchronized(lock) { unresolvedCountLocked() }
+
+    private fun advanceLocked() {
+        current = queued.removeFirstOrNull()
+        if (current == null) {
+            processedInSession = 0
+        }
+    }
+
+    private fun unresolvedCountLocked(): Int {
+        return (if (current != null) 1 else 0) + queued.size
+    }
+
+    private fun publishLocked() {
+        val active = current
+        _dialogState.value = if (active == null) {
+            null
+        } else {
+            CloudSyncSelectionDialogState(
+                albumTitle = active.albumTitle,
+                candidates = active.candidates,
+                currentPosition = processedInSession + 1,
+                totalCount = processedInSession + unresolvedCountLocked()
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/asmr/player/ui/library/libraryviewmodel.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/libraryviewmodel.kt
@@ -37,10 +37,12 @@ import com.asmr.player.data.local.db.entities.TagSource
 import com.asmr.player.data.local.db.entities.TrackEntity
 import com.asmr.player.data.local.db.entities.TrackTagEntity
 import com.asmr.player.data.remote.api.AsmrOneApi
+import com.asmr.player.data.remote.dlsite.DlsiteCloudSyncCandidate
 import com.asmr.player.data.remote.dlsite.DlsiteCloudSyncResolveResult
 import com.asmr.player.data.remote.dlsite.DlsiteProductInfoClient
 import com.asmr.player.data.remote.dlsite.resolveCloudSyncWorkId
 import com.asmr.player.data.remote.dlsite.resolveDlsiteCloudSync
+import com.asmr.player.data.remote.dlsite.resolveSelectedDlsiteCloudSync
 import com.asmr.player.data.remote.scraper.DLSiteScraper
 import com.asmr.player.data.settings.SettingsRepository
 import com.asmr.player.domain.model.Album
@@ -61,9 +63,13 @@ import com.google.gson.Gson
 import com.asmr.player.BuildConfig
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.ensureActive
@@ -132,7 +138,9 @@ class LibraryViewModel @Inject constructor(
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyList())
     private val _syncStatus = MutableStateFlow<Map<Long, SyncStatus>>(emptyMap())
     private val _bulkProgress = MutableStateFlow<BulkProgress?>(null)
+    private val cloudSyncSelectionQueue = CloudSyncSelectionRequestQueue()
     val bulkProgress: StateFlow<BulkProgress?> = _bulkProgress.asStateFlow()
+    internal val cloudSyncSelectionDialogState: StateFlow<CloudSyncSelectionDialogState?> = cloudSyncSelectionQueue.dialogState
     val globalSyncState: StateFlow<GlobalSyncState?> = syncCoordinator.state
     val isGlobalSyncRunning: StateFlow<Boolean> = globalSyncState
         .map { it != null }
@@ -518,6 +526,7 @@ class LibraryViewModel @Inject constructor(
         val job = bulkJob
         job?.cancel()
         bulkJob = null
+        cloudSyncSelectionQueue.cancelAll()
         _bulkProgress.value = null
     }
 
@@ -568,8 +577,22 @@ class LibraryViewModel @Inject constructor(
             return
         }
         job.cancel()
+        cloudSyncSelectionQueue.cancelForAlbum(albumId)
         _syncStatus.value -= albumId
         messageManager.showInfo("已取消任务")
+    }
+
+    fun confirmCloudSyncSelection(workno: String) {
+        cloudSyncSelectionQueue.resolveCurrent(workno)
+    }
+
+    fun cancelCloudSyncSelection() {
+        cloudSyncSelectionQueue.resolveCurrent(null)
+    }
+
+    fun ignoreAllCloudSyncSelections() {
+        cloudSyncSelectionQueue.ignoreAllRemainingInBatch()
+        messageManager.showInfo("已忽略本轮剩余待确认项")
     }
 
     private fun startBulkProgress(phase: BulkPhase, total: Int, current: Int = 0, currentAlbumTitle: String = "") {
@@ -976,16 +999,7 @@ class LibraryViewModel @Inject constructor(
                     bulkJob = currentCoroutineContext()[Job]
                     try {
                         val albums = withContext(Dispatchers.IO) { albumDao.getAllAlbumsOnce() }
-                        startBulkProgress(phase = BulkPhase.SyncingCloud, total = albums.size)
-                        var current = 0
-                        albums.forEach { entity ->
-                            currentCoroutineContext().ensureActive()
-                            current += 1
-                            updateBulkAlbumProgress(current = current, currentAlbumTitle = entity.title)
-                            withContext(Dispatchers.IO) {
-                                syncAlbumMetadataInternal(entity, silent = true)
-                            }
-                        }
+                        runBatchCloudSync(albums)
                         messageManager.showSuccess("全量同步完成")
                     } catch (e: CancellationException) {
                         messageManager.showInfo("已取消云同步")
@@ -1022,16 +1036,7 @@ class LibraryViewModel @Inject constructor(
                                     entity.path.startsWith(uriString) || (entity.localPath?.startsWith(uriString) == true)
                                 }
                         }
-                        startBulkProgress(phase = BulkPhase.SyncingCloud, total = albums.size)
-                        var current = 0
-                        albums.forEach { entity ->
-                            currentCoroutineContext().ensureActive()
-                            current += 1
-                            updateBulkAlbumProgress(current = current, currentAlbumTitle = entity.title)
-                            withContext(Dispatchers.IO) {
-                                syncAlbumMetadataInternal(entity, silent = true)
-                            }
-                        }
+                        runBatchCloudSync(albums)
                         messageManager.showSuccess("云同步完成")
                     } catch (e: CancellationException) {
                         messageManager.showInfo("已取消云同步")
@@ -1073,53 +1078,179 @@ class LibraryViewModel @Inject constructor(
         albumJobs[album.id] = job
     }
 
-    private suspend fun syncAlbumMetadataInternal(entity: AlbumEntity, silent: Boolean = false) {
+    private suspend fun runBatchCloudSync(albums: List<AlbumEntity>) = coroutineScope {
+        startBulkProgress(phase = BulkPhase.SyncingCloud, total = albums.size)
+        cloudSyncSelectionQueue.beginBatchSession()
+        try {
+        val pendingSelections = mutableListOf<Deferred<Unit>>()
+        var current = 0
+        albums.forEach { entity ->
+            currentCoroutineContext().ensureActive()
+            current += 1
+            updateBulkAlbumProgress(current = current, currentAlbumTitle = entity.title)
+            withContext(Dispatchers.IO) {
+                syncAlbumMetadataInternal(
+                    entity = entity,
+                    silent = true,
+                    onAmbiguous = { pendingEntity, result ->
+                        pendingSelections += this@coroutineScope.async(Dispatchers.IO) {
+                            continueSyncAlbumMetadataAfterSelection(
+                                entity = pendingEntity,
+                                candidates = result.candidates,
+                                silent = true
+                            )
+                        }
+                    }
+                )
+            }
+        }
+        val pendingCount = cloudSyncSelectionQueue.pendingCount()
+        if (pendingCount > 0) {
+            messageManager.showInfo("主流程已完成，剩余${pendingCount}项待确认")
+        }
+        pendingSelections.awaitAll()
+        } finally {
+            cloudSyncSelectionQueue.endBatchSession()
+        }
+    }
+
+    private suspend fun resolveAlbumCloudSync(entity: AlbumEntity): DlsiteCloudSyncResolveResult {
+        return resolveDlsiteCloudSync(
+            keyword = entity.title.trim(),
+            baseWorkno = entity.rjCode.ifBlank { entity.workId }.trim().uppercase(),
+            search = { searchKeyword, locale ->
+                dlsiteScraper.search(searchKeyword, page = 1, order = "trend", locale = locale)
+            },
+            fetchLanguageEditions = { productId ->
+                dlsiteProductInfoClient.fetchLanguageEditions(productId)
+            },
+            fetchDetails = { workno, locale ->
+                dlsiteScraper.getDetails(workno, locale = locale)
+            }
+        )
+    }
+
+    private suspend fun resolveSelectedAlbumCloudSync(workno: String): DlsiteCloudSyncResolveResult {
+        return resolveSelectedDlsiteCloudSync(
+            workno = workno,
+            fetchLanguageEditions = { productId ->
+                dlsiteProductInfoClient.fetchLanguageEditions(productId)
+            },
+            fetchDetails = { selectedWorkno, locale ->
+                dlsiteScraper.getDetails(selectedWorkno, locale = locale)
+            }
+        )
+    }
+
+    private suspend fun applyResolvedCloudSync(
+        entity: AlbumEntity,
+        result: DlsiteCloudSyncResolveResult.Success
+    ) {
+        val resolvedWorkno = result.workno
+        val details = result.details
+        val updated = entity.copy(
+            title = details.title.ifBlank { entity.title },
+            circle = details.circle.ifBlank { entity.circle },
+            cv = details.cv.ifBlank { entity.cv },
+            tags = if (details.tags.isNotEmpty()) details.tags.joinToString(",") else entity.tags,
+            coverUrl = details.coverUrl.ifBlank { entity.coverUrl },
+            description = details.description.ifBlank { entity.description },
+            workId = resolveCloudSyncWorkId(entity.workId, resolvedWorkno),
+            rjCode = resolvedWorkno
+        )
+        albumDao.updateAlbum(updated)
+        upsertAlbumFtsIndex(updated.id, updated)
+        upsertAlbumTagsFromCsv(updated.id, updated.tags, TagSource.AUTO)
+        if (updated.coverPath.trim().isBlank() && updated.coverThumbPath.trim().isBlank()) {
+            runCatching {
+                ensureAlbumCoverSaved(updated.id, updated.coverPath, updated.coverUrl)
+            }
+        }
+    }
+
+    private suspend fun continueSyncAlbumMetadataAfterSelection(
+        entity: AlbumEntity,
+        candidates: List<DlsiteCloudSyncCandidate>,
+        silent: Boolean
+    ) {
+        try {
+            val selectedWorkno = cloudSyncSelectionQueue.enqueue(
+                albumId = entity.id.takeIf { it > 0L },
+                albumTitle = entity.title,
+                candidates = candidates
+            ).await()
+            currentCoroutineContext().ensureActive()
+            if (selectedWorkno != null) {
+                when (val selectedResult = resolveSelectedAlbumCloudSync(selectedWorkno)) {
+                    is DlsiteCloudSyncResolveResult.Success -> {
+                        applyResolvedCloudSync(entity, selectedResult)
+                        if (!silent) {
+                            messageManager.showSuccess("元数据同步成功：${selectedResult.details.title}")
+                        }
+                    }
+
+                    is DlsiteCloudSyncResolveResult.Ambiguous -> {
+                        if (!silent) {
+                            messageManager.showError("同步失败：搜索结果不唯一")
+                        }
+                    }
+
+                    DlsiteCloudSyncResolveResult.NotFound -> {
+                        if (!silent) {
+                            messageManager.showError("同步失败：未找到专辑信息")
+                        }
+                    }
+                }
+            }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            reportSyncAlbumMetadataFailure(entity.id, e, silent)
+            return
+        } finally {
+            _syncStatus.value -= entity.id
+        }
+    }
+
+    private suspend fun reportSyncAlbumMetadataFailure(entityId: Long, error: Exception, silent: Boolean) {
+        Log.e("LibraryViewModel", "syncAlbumMetadataInternal failed: $entityId", error)
+        _syncStatus.value += (entityId to SyncStatus.Error(error.message ?: "同步失败"))
+        if (!silent) {
+            messageManager.showError("同步异常：${error.message}")
+            delay(3000)
+        }
+        _syncStatus.value -= entityId
+    }
+
+    private suspend fun syncAlbumMetadataInternal(
+        entity: AlbumEntity,
+        silent: Boolean = false,
+        onAmbiguous: (suspend (AlbumEntity, DlsiteCloudSyncResolveResult.Ambiguous) -> Unit)? = null
+    ) {
         val keyword = entity.title.trim()
         val currentWorkno = entity.rjCode.ifBlank { entity.workId }.trim().uppercase()
         if (currentWorkno.isBlank() && keyword.isBlank()) return
 
         _syncStatus.value += (entity.id to SyncStatus.Syncing)
+        var clearSyncStatus = true
         try {
-            val result = resolveDlsiteCloudSync(
-                keyword = keyword,
-                baseWorkno = currentWorkno,
-                search = { searchKeyword, locale ->
-                    dlsiteScraper.search(searchKeyword, page = 1, order = "trend", locale = locale)
-                },
-                fetchLanguageEditions = { productId ->
-                    dlsiteProductInfoClient.fetchLanguageEditions(productId)
-                },
-                fetchDetails = { workno, locale ->
-                    dlsiteScraper.getDetails(workno, locale = locale)
-                }
-            )
+            val result = resolveAlbumCloudSync(entity)
             currentCoroutineContext().ensureActive()
             when (result) {
                 is DlsiteCloudSyncResolveResult.Success -> {
-                    val resolvedWorkno = result.workno
                     val details = result.details
-                    val updated = entity.copy(
-                        title = details.title.ifBlank { entity.title },
-                        circle = details.circle.ifBlank { entity.circle },
-                        cv = details.cv.ifBlank { entity.cv },
-                        tags = if (details.tags.isNotEmpty()) details.tags.joinToString(",") else entity.tags,
-                        coverUrl = details.coverUrl.ifBlank { entity.coverUrl },
-                        description = details.description.ifBlank { entity.description },
-                        workId = resolveCloudSyncWorkId(entity.workId, resolvedWorkno),
-                        rjCode = resolvedWorkno
-                    )
-                    albumDao.updateAlbum(updated)
-                    upsertAlbumFtsIndex(updated.id, updated)
-                    upsertAlbumTagsFromCsv(updated.id, updated.tags, TagSource.AUTO)
-                    if (updated.coverPath.trim().isBlank() && updated.coverThumbPath.trim().isBlank()) {
-                        runCatching {
-                            ensureAlbumCoverSaved(updated.id, updated.coverPath, updated.coverUrl)
-                        }
-                    }
+                    applyResolvedCloudSync(entity, result)
                     if (!silent) messageManager.showSuccess("元数据同步成功：${details.title}")
                 }
 
-                DlsiteCloudSyncResolveResult.Ambiguous -> {
+                is DlsiteCloudSyncResolveResult.Ambiguous -> {
+                    clearSyncStatus = false
+                    if (onAmbiguous != null) {
+                        onAmbiguous(entity, result)
+                    } else {
+                        continueSyncAlbumMetadataAfterSelection(entity, result.candidates, silent)
+                    }
+                    return
                     if (!silent) messageManager.showError("同步失败：搜索结果不唯一")
                 }
 
@@ -1127,9 +1258,13 @@ class LibraryViewModel @Inject constructor(
                     if (!silent) messageManager.showError("同步失败：未找到专辑信息")
                 }
             }
-            _syncStatus.value -= entity.id
+            if (clearSyncStatus) {
+                _syncStatus.value -= entity.id
+            }
         } catch (e: CancellationException) {
-            _syncStatus.value -= entity.id
+            if (clearSyncStatus) {
+                _syncStatus.value -= entity.id
+            }
             throw e
         } catch (e: Exception) {
             Log.e("LibraryViewModel", "syncAlbumMetadataInternal failed: ${entity.id}", e)
@@ -2523,5 +2658,10 @@ class LibraryViewModel @Inject constructor(
                 .thenBy { it.fileName.lowercase() }
         )
         return sorted.first().entries
+    }
+
+    override fun onCleared() {
+        cloudSyncSelectionQueue.cancelAll()
+        super.onCleared()
     }
 }

--- a/app/src/test/java/com/asmr/player/data/remote/dlsite/DlsiteCloudSyncSupportTest.kt
+++ b/app/src/test/java/com/asmr/player/data/remote/dlsite/DlsiteCloudSyncSupportTest.kt
@@ -23,7 +23,9 @@ class DlsiteCloudSyncSupportTest {
     fun sanitizeDlsiteCloudSyncKeyword_removesMultipleBlocksAndCollapsesWhitespace() {
         assertEquals(
             "alpha beta gamma",
-            sanitizeDlsiteCloudSyncKeyword(" alpha ${leftBracket}first${rightBracket} beta  ${leftBracket}second${rightBracket}   gamma ")
+            sanitizeDlsiteCloudSyncKeyword(
+                " alpha ${leftBracket}first${rightBracket} beta  ${leftBracket}second${rightBracket}   gamma "
+            )
         )
     }
 
@@ -40,9 +42,9 @@ class DlsiteCloudSyncSupportTest {
         val attempts = buildDlsiteCloudSyncAttempts(
             baseWorkno = "RJ000001",
             editions = listOf(
-                DlsiteLanguageEdition(workno = "RJ000003", lang = "JPN", label = "日本語", displayOrder = 3),
-                DlsiteLanguageEdition(workno = "RJ000001", lang = "CHI_HANS", label = "简中", displayOrder = 1),
-                DlsiteLanguageEdition(workno = "RJ000002", lang = "CHI_HANT", label = "繁中", displayOrder = 2)
+                DlsiteLanguageEdition(workno = "RJ000003", lang = "JPN", label = "jp", displayOrder = 3),
+                DlsiteLanguageEdition(workno = "RJ000001", lang = "CHI_HANS", label = "zh-cn", displayOrder = 1),
+                DlsiteLanguageEdition(workno = "RJ000002", lang = "CHI_HANT", label = "zh-tw", displayOrder = 2)
             )
         )
 
@@ -61,8 +63,8 @@ class DlsiteCloudSyncSupportTest {
         val attempts = buildDlsiteCloudSyncAttempts(
             baseWorkno = "RJ000001",
             editions = listOf(
-                DlsiteLanguageEdition(workno = "RJ000002", lang = "CHI_HANT", label = "繁中", displayOrder = 1),
-                DlsiteLanguageEdition(workno = "RJ000003", lang = "JPN", label = "日本語", displayOrder = 2)
+                DlsiteLanguageEdition(workno = "RJ000002", lang = "CHI_HANT", label = "zh-tw", displayOrder = 1),
+                DlsiteLanguageEdition(workno = "RJ000003", lang = "JPN", label = "jp", displayOrder = 2)
             )
         )
 
@@ -126,16 +128,35 @@ class DlsiteCloudSyncSupportTest {
     }
 
     @Test
-    fun searchDlsiteWorknoWithLocaleFallback_returnsAmbiguousWhenPreferredLocaleHasMultipleResults() = runBlocking {
+    fun searchDlsiteWorknoWithLocaleFallback_returnsAmbiguousCandidatesWhenPreferredLocaleHasMultipleResults() = runBlocking {
         val result = searchDlsiteWorknoWithLocaleFallback("test") { _, locale ->
             when (locale) {
-                CLOUD_SYNC_LOCALE_ZH_CN -> listOf(albumOf("RJ000111"), albumOf("RJ000112"))
+                CLOUD_SYNC_LOCALE_ZH_CN -> listOf(
+                    albumOf("RJ000111", title = "Candidate One", cv = "CV A", coverUrl = "https://example.com/1.jpg"),
+                    albumOf("RJ000112", title = "Candidate Two", cv = "CV B", coverUrl = "https://example.com/2.jpg")
+                )
                 else -> emptyList()
             }
         }
 
         assertEquals(
-            DlsiteCloudSyncSearchResult.Ambiguous(locale = CLOUD_SYNC_LOCALE_ZH_CN, count = 2),
+            DlsiteCloudSyncSearchResult.Ambiguous(
+                locale = CLOUD_SYNC_LOCALE_ZH_CN,
+                candidates = listOf(
+                    DlsiteCloudSyncCandidate(
+                        workno = "RJ000111",
+                        title = "Candidate One",
+                        cv = "CV A",
+                        coverUrl = "https://example.com/1.jpg"
+                    ),
+                    DlsiteCloudSyncCandidate(
+                        workno = "RJ000112",
+                        title = "Candidate Two",
+                        cv = "CV B",
+                        coverUrl = "https://example.com/2.jpg"
+                    )
+                )
+            ),
             result
         )
     }
@@ -165,7 +186,9 @@ class DlsiteCloudSyncSupportTest {
     fun searchDlsiteWorknoWithLocaleFallback_returnsNotFoundWithoutCallingSearchWhenSanitizedKeywordBlank() = runBlocking {
         var called = false
 
-        val result = searchDlsiteWorknoWithLocaleFallback("${leftBracket}tag1${rightBracket} ${leftBracket}tag2${rightBracket}") { _, _ ->
+        val result = searchDlsiteWorknoWithLocaleFallback(
+            "${leftBracket}tag1${rightBracket} ${leftBracket}tag2${rightBracket}"
+        ) { _, _ ->
             called = true
             emptyList()
         }
@@ -183,7 +206,7 @@ class DlsiteCloudSyncSupportTest {
             fetchLanguageEditions = { error("boom") },
             fetchDetails = { workno, locale ->
                 attempts += DlsiteCloudSyncAttempt(workno, locale)
-                if (workno == "RJ000777" && locale == CLOUD_SYNC_LOCALE_ZH_TW) albumOf(workno, "繁中详情") else null
+                if (workno == "RJ000777" && locale == CLOUD_SYNC_LOCALE_ZH_TW) albumOf(workno, "Traditional") else null
             }
         )
 
@@ -196,7 +219,7 @@ class DlsiteCloudSyncSupportTest {
         )
         assertEquals("RJ000777", result?.workno)
         assertEquals(CLOUD_SYNC_LOCALE_ZH_TW, result?.locale)
-        assertEquals("繁中详情", result?.details?.title)
+        assertEquals("Traditional", result?.details?.title)
     }
 
     @Test
@@ -215,7 +238,7 @@ class DlsiteCloudSyncSupportTest {
             fetchLanguageEditions = { emptyList() },
             fetchDetails = { workno, locale ->
                 detailAttempts += DlsiteCloudSyncAttempt(workno, locale)
-                if (workno == "RJ000200" && locale == CLOUD_SYNC_LOCALE_ZH_CN) albumOf(workno, "简中命中") else null
+                if (workno == "RJ000200" && locale == CLOUD_SYNC_LOCALE_ZH_CN) albumOf(workno, "Resolved") else null
             }
         )
 
@@ -223,14 +246,52 @@ class DlsiteCloudSyncSupportTest {
         result as DlsiteCloudSyncResolveResult.Success
         assertEquals("RJ000200", result.workno)
         assertEquals(CLOUD_SYNC_LOCALE_ZH_CN, result.locale)
-        assertEquals("简中命中", result.details.title)
+        assertEquals("Resolved", result.details.title)
         assertTrue(detailAttempts.take(3).all { it.workno == "RJ000100" })
     }
 
-    private fun albumOf(rjCode: String, title: String = rjCode): Album {
+    @Test
+    fun resolveSelectedDlsiteCloudSync_usesLocaleFallbackForChosenCandidate() = runBlocking {
+        val detailAttempts = mutableListOf<DlsiteCloudSyncAttempt>()
+
+        val result = resolveSelectedDlsiteCloudSync(
+            workno = "RJ000555",
+            fetchLanguageEditions = { emptyList() },
+            fetchDetails = { workno, locale ->
+                detailAttempts += DlsiteCloudSyncAttempt(workno, locale)
+                if (workno == "RJ000555" && locale == CLOUD_SYNC_LOCALE_ZH_TW) {
+                    albumOf(workno, title = "Chosen")
+                } else {
+                    null
+                }
+            }
+        )
+
+        assertTrue(result is DlsiteCloudSyncResolveResult.Success)
+        result as DlsiteCloudSyncResolveResult.Success
+        assertEquals("RJ000555", result.workno)
+        assertEquals(CLOUD_SYNC_LOCALE_ZH_TW, result.locale)
+        assertEquals("Chosen", result.details.title)
+        assertEquals(
+            listOf(
+                DlsiteCloudSyncAttempt("RJ000555", CLOUD_SYNC_LOCALE_ZH_CN),
+                DlsiteCloudSyncAttempt("RJ000555", CLOUD_SYNC_LOCALE_ZH_TW)
+            ),
+            detailAttempts
+        )
+    }
+
+    private fun albumOf(
+        rjCode: String,
+        title: String = rjCode,
+        cv: String = "",
+        coverUrl: String = ""
+    ): Album {
         return Album(
             title = title,
             path = "",
+            cv = cv,
+            coverUrl = coverUrl,
             workId = rjCode,
             rjCode = rjCode
         )

--- a/app/src/test/java/com/asmr/player/data/remote/dlsite/DlsiteCloudSyncSupportTest.kt
+++ b/app/src/test/java/com/asmr/player/data/remote/dlsite/DlsiteCloudSyncSupportTest.kt
@@ -3,10 +3,38 @@ package com.asmr.player.data.remote.dlsite
 import com.asmr.player.domain.model.Album
 import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class DlsiteCloudSyncSupportTest {
+    private val leftBracket = "\u3010"
+    private val rightBracket = "\u3011"
+
+    @Test
+    fun sanitizeDlsiteCloudSyncKeyword_removesSingleBracketBlock() {
+        assertEquals(
+            "title rest",
+            sanitizeDlsiteCloudSyncKeyword("title ${leftBracket}tag${rightBracket} rest")
+        )
+    }
+
+    @Test
+    fun sanitizeDlsiteCloudSyncKeyword_removesMultipleBlocksAndCollapsesWhitespace() {
+        assertEquals(
+            "alpha beta gamma",
+            sanitizeDlsiteCloudSyncKeyword(" alpha ${leftBracket}first${rightBracket} beta  ${leftBracket}second${rightBracket}   gamma ")
+        )
+    }
+
+    @Test
+    fun sanitizeDlsiteCloudSyncKeyword_keepsOriginalWhenNoBracketBlock() {
+        assertEquals(
+            "plain title",
+            sanitizeDlsiteCloudSyncKeyword(" plain title ")
+        )
+    }
+
     @Test
     fun buildDlsiteCloudSyncAttempts_prefersHansThenHantThenJpn() {
         val attempts = buildDlsiteCloudSyncAttempts(
@@ -63,7 +91,10 @@ class DlsiteCloudSyncSupportTest {
 
     @Test
     fun searchDlsiteWorknoWithLocaleFallback_returnsTraditionalWhenSimplifiedEmpty() = runBlocking {
-        val result = searchDlsiteWorknoWithLocaleFallback("test") { _, locale ->
+        val keywords = mutableListOf<String>()
+
+        val result = searchDlsiteWorknoWithLocaleFallback("test") { keyword, locale ->
+            keywords += keyword
             when (locale) {
                 CLOUD_SYNC_LOCALE_ZH_CN -> emptyList()
                 CLOUD_SYNC_LOCALE_ZH_TW -> listOf(albumOf("RJ000222"))
@@ -75,6 +106,7 @@ class DlsiteCloudSyncSupportTest {
             DlsiteCloudSyncSearchResult.Unique(workno = "RJ000222", locale = CLOUD_SYNC_LOCALE_ZH_TW),
             result
         )
+        assertEquals(listOf("test", "test"), keywords)
     }
 
     @Test
@@ -106,6 +138,40 @@ class DlsiteCloudSyncSupportTest {
             DlsiteCloudSyncSearchResult.Ambiguous(locale = CLOUD_SYNC_LOCALE_ZH_CN, count = 2),
             result
         )
+    }
+
+    @Test
+    fun searchDlsiteWorknoWithLocaleFallback_removesMultipleBracketBlocksBeforeSearch() = runBlocking {
+        val keywords = mutableListOf<String>()
+
+        val result = searchDlsiteWorknoWithLocaleFallback(
+            "alpha ${leftBracket}first${rightBracket} beta ${leftBracket}second${rightBracket} gamma"
+        ) { keyword, locale ->
+            keywords += "$locale:$keyword"
+            when (locale) {
+                CLOUD_SYNC_LOCALE_ZH_CN -> listOf(albumOf("RJ000210"))
+                else -> emptyList()
+            }
+        }
+
+        assertEquals(
+            DlsiteCloudSyncSearchResult.Unique(workno = "RJ000210", locale = CLOUD_SYNC_LOCALE_ZH_CN),
+            result
+        )
+        assertEquals(listOf("$CLOUD_SYNC_LOCALE_ZH_CN:alpha beta gamma"), keywords)
+    }
+
+    @Test
+    fun searchDlsiteWorknoWithLocaleFallback_returnsNotFoundWithoutCallingSearchWhenSanitizedKeywordBlank() = runBlocking {
+        var called = false
+
+        val result = searchDlsiteWorknoWithLocaleFallback("${leftBracket}tag1${rightBracket} ${leftBracket}tag2${rightBracket}") { _, _ ->
+            called = true
+            emptyList()
+        }
+
+        assertEquals(DlsiteCloudSyncSearchResult.NotFound, result)
+        assertFalse(called)
     }
 
     @Test

--- a/app/src/test/java/com/asmr/player/ui/library/CloudSyncSelectionCoverSupportTest.kt
+++ b/app/src/test/java/com/asmr/player/ui/library/CloudSyncSelectionCoverSupportTest.kt
@@ -1,0 +1,114 @@
+package com.asmr.player.ui.library
+
+import com.asmr.player.data.remote.dlsite.DlsiteCloudSyncCandidate
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class CloudSyncSelectionCoverSupportTest {
+    @Test
+    fun resolveCoverSources_usesCanonicalWhenCoverUrlBlank() {
+        val candidate = candidate(workno = "RJ123456", coverUrl = "")
+
+        val result = resolveCloudSyncCandidateCoverSources(candidate)
+
+        assertEquals(
+            listOf(
+                CloudSyncCandidateCoverSource(
+                    label = "canonical",
+                    url = "https://img.dlsite.jp/modpub/images2/work/doujin/RJ124000/RJ123456_img_main.jpg"
+                )
+            ),
+            result
+        )
+    }
+
+    @Test
+    fun resolveCoverSources_normalizesProtocolRelativeAndKeepsCanonicalFirst() {
+        val candidate = candidate(
+            workno = "RJ123456",
+            coverUrl = "//img.dlsite.jp/modpub/images2/work/doujin/RJ124000/RJ123456_img_sam.jpg"
+        )
+
+        val result = resolveCloudSyncCandidateCoverSources(candidate)
+
+        assertEquals(
+            listOf(
+                CloudSyncCandidateCoverSource(
+                    label = "canonical",
+                    url = "https://img.dlsite.jp/modpub/images2/work/doujin/RJ124000/RJ123456_img_main.jpg"
+                ),
+                CloudSyncCandidateCoverSource(
+                    label = "search",
+                    url = "https://img.dlsite.jp/modpub/images2/work/doujin/RJ124000/RJ123456_img_sam.jpg"
+                )
+            ),
+            result
+        )
+    }
+
+    @Test
+    fun resolveCoverSources_deduplicatesWhenRawMatchesCanonical() {
+        val candidate = candidate(
+            workno = "RJ123456",
+            coverUrl = "https://img.dlsite.jp/modpub/images2/work/doujin/RJ124000/RJ123456_img_main.jpg"
+        )
+
+        val result = resolveCloudSyncCandidateCoverSources(candidate)
+
+        assertEquals(
+            listOf(
+                CloudSyncCandidateCoverSource(
+                    label = "canonical",
+                    url = "https://img.dlsite.jp/modpub/images2/work/doujin/RJ124000/RJ123456_img_main.jpg"
+                )
+            ),
+            result
+        )
+    }
+
+    @Test
+    fun resolveCoverSources_fallsBackToNormalizedRawWhenCanonicalUnavailable() {
+        val candidate = candidate(
+            workno = "INVALID",
+            coverUrl = "/images2/work/pro/fallback/sample.jpg"
+        )
+
+        val result = resolveCloudSyncCandidateCoverSources(candidate)
+
+        assertEquals(
+            listOf(
+                CloudSyncCandidateCoverSource(
+                    label = "search",
+                    url = "https://img.dlsite.jp/images2/work/pro/fallback/sample.jpg"
+                )
+            ),
+            result
+        )
+    }
+
+    @Test
+    fun resolveCoverSources_roundsCanonicalFolderUpToNextThousand() {
+        val candidate = candidate(workno = "RJ01524112", coverUrl = "")
+
+        val result = resolveCloudSyncCandidateCoverSources(candidate)
+
+        assertEquals(
+            listOf(
+                CloudSyncCandidateCoverSource(
+                    label = "canonical",
+                    url = "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01525000/RJ01524112_img_main.jpg"
+                )
+            ),
+            result
+        )
+    }
+
+    private fun candidate(workno: String, coverUrl: String): DlsiteCloudSyncCandidate {
+        return DlsiteCloudSyncCandidate(
+            workno = workno,
+            title = "Title",
+            cv = "CV",
+            coverUrl = coverUrl
+        )
+    }
+}

--- a/app/src/test/java/com/asmr/player/ui/library/CloudSyncSelectionDialogTest.kt
+++ b/app/src/test/java/com/asmr/player/ui/library/CloudSyncSelectionDialogTest.kt
@@ -1,0 +1,169 @@
+package com.asmr.player.ui.library
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.test.SemanticsMatcher
+import androidx.compose.ui.test.assert
+import androidx.compose.ui.test.assertHeightIsEqualTo
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onAllNodesWithTag
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.asmr.player.data.remote.dlsite.DlsiteCloudSyncCandidate
+import com.asmr.player.ui.theme.AsmrPlayerTheme
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class CloudSyncSelectionDialogTest {
+    private val existsMatcher = SemanticsMatcher("exists") { true }
+
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    @Test
+    fun dialog_rendersCompactHeaderAndFooterProgress() {
+        composeRule.setContent {
+            AsmrPlayerTheme {
+                CloudSyncSelectionDialog(
+                    state = CloudSyncSelectionDialogState(
+                        albumTitle = "Album A",
+                        candidates = listOf(
+                            candidate("RJ000111", "Candidate One", "CV A"),
+                            candidate("RJ000112", "Candidate Two", "CV B"),
+                            candidate("RJ000113", "Candidate Three", "CV C"),
+                            candidate("RJ000114", "Candidate Four", "CV D")
+                        ),
+                        currentPosition = 2,
+                        totalCount = 5
+                    ),
+                    onSelect = {},
+                    onCancel = {},
+                    onIgnoreAll = {}
+                )
+            }
+        }
+
+        composeRule.onNodeWithTag(CLOUD_SYNC_SELECTION_DIALOG_TAG).assert(
+            SemanticsMatcher.expectValue(SemanticsProperties.TestTag, CLOUD_SYNC_SELECTION_DIALOG_TAG)
+        )
+        composeRule.onNodeWithText("云同步候选：4 个疑似结果(点击对应作品以确认同步)").assert(existsMatcher)
+        composeRule.onNodeWithText("Album A").assert(existsMatcher)
+        composeRule.onNodeWithTag(CLOUD_SYNC_SELECTION_PROGRESS_TAG).assert(
+            SemanticsMatcher.expectValue(SemanticsProperties.TestTag, CLOUD_SYNC_SELECTION_PROGRESS_TAG)
+        )
+        composeRule.onNodeWithText("待确认 2 / 5").assert(existsMatcher)
+        composeRule.onNodeWithText("Candidate One").assert(existsMatcher)
+        composeRule.onNodeWithText("CV A").assert(existsMatcher)
+        composeRule.onNodeWithText("忽略全部").assert(existsMatcher)
+        composeRule.onNodeWithText("取消当前").assert(existsMatcher)
+        assertTrue(composeRule.onAllNodesWithText("RJ000111").fetchSemanticsNodes().isEmpty())
+        composeRule.onNodeWithTag(CLOUD_SYNC_SELECTION_LIST_TAG)
+            .assertHeightIsEqualTo(CLOUD_SYNC_SELECTION_LIST_HEIGHT)
+    }
+
+    @Test
+    fun dialog_rendersLongTitleCandidateWithoutCroppingListHeightContract() {
+        composeRule.setContent {
+            AsmrPlayerTheme {
+                CloudSyncSelectionDialog(
+                    state = CloudSyncSelectionDialogState(
+                        albumTitle = "Album A",
+                        candidates = listOf(
+                            candidate(
+                                "RJ000111",
+                                "A very long candidate title that should still fit within two lines of text in the dialog row",
+                                "CV A, CV B, CV C"
+                            )
+                        ),
+                        currentPosition = 1,
+                        totalCount = 1
+                    ),
+                    onSelect = {},
+                    onCancel = {}
+                )
+            }
+        }
+
+        composeRule.onNodeWithText("A very long candidate title that should still fit within two lines of text in the dialog row")
+            .assert(existsMatcher)
+        composeRule.onNodeWithText("CV A").assert(existsMatcher)
+        composeRule.onNodeWithTag(CLOUD_SYNC_SELECTION_LIST_TAG)
+            .assertHeightIsEqualTo(CLOUD_SYNC_SELECTION_LIST_HEIGHT)
+    }
+
+    @Test
+    fun dialog_hidesIgnoreAllOutsideBatchQueueMode() {
+        composeRule.setContent {
+            AsmrPlayerTheme {
+                CloudSyncSelectionDialog(
+                    state = CloudSyncSelectionDialogState(
+                        albumTitle = "Album A",
+                        candidates = listOf(candidate("RJ000111", "Candidate One", "CV A"))
+                    ),
+                    onSelect = {},
+                    onCancel = {}
+                )
+            }
+        }
+
+        assertTrue(composeRule.onAllNodesWithText("忽略全部").fetchSemanticsNodes().isEmpty())
+        composeRule.onNodeWithText("取消").assert(existsMatcher)
+    }
+
+    @Test
+    fun dialog_allowsSwitchingToNextRequestAfterSelection() {
+        composeRule.setContent {
+            var state by mutableStateOf<CloudSyncSelectionDialogState?>(
+                CloudSyncSelectionDialogState(
+                    albumTitle = "Album A",
+                    candidates = listOf(candidate("RJ000111", "Candidate One", "CV A")),
+                    currentPosition = 1,
+                    totalCount = 2
+                )
+            )
+
+            AsmrPlayerTheme {
+                state?.let {
+                    CloudSyncSelectionDialog(
+                        state = it,
+                        onSelect = {
+                            state = CloudSyncSelectionDialogState(
+                                albumTitle = "Album B",
+                                candidates = listOf(candidate("RJ000222", "Candidate Two", "CV B")),
+                                currentPosition = 2,
+                                totalCount = 2
+                            )
+                        },
+                        onCancel = { state = null },
+                        onIgnoreAll = {}
+                    )
+                }
+            }
+        }
+
+        composeRule.onNodeWithText("Candidate One").performClick()
+        composeRule.onNodeWithText("Album B").assert(existsMatcher)
+        composeRule.onNodeWithText("Candidate Two").assert(existsMatcher)
+        composeRule.onNodeWithText("待确认 2 / 2").assert(existsMatcher)
+
+        composeRule.onNodeWithText("取消当前").performClick()
+        assertTrue(composeRule.onAllNodesWithTag(CLOUD_SYNC_SELECTION_DIALOG_TAG).fetchSemanticsNodes().isEmpty())
+    }
+
+    private fun candidate(workno: String, title: String, cv: String): DlsiteCloudSyncCandidate {
+        return DlsiteCloudSyncCandidate(
+            workno = workno,
+            title = title,
+            cv = cv,
+            coverUrl = ""
+        )
+    }
+}

--- a/app/src/test/java/com/asmr/player/ui/library/CloudSyncSelectionRequestQueueTest.kt
+++ b/app/src/test/java/com/asmr/player/ui/library/CloudSyncSelectionRequestQueueTest.kt
@@ -1,0 +1,103 @@
+package com.asmr.player.ui.library
+
+import com.asmr.player.data.remote.dlsite.DlsiteCloudSyncCandidate
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class CloudSyncSelectionRequestQueueTest {
+    @Test
+    fun enqueueAndResolve_keepsFifoOrder() = runBlocking {
+        val queue = CloudSyncSelectionRequestQueue()
+
+        val first = queue.enqueue(albumId = 1L, albumTitle = "Album A", candidates = listOf(candidate("RJ000001", "First")))
+        val second = queue.enqueue(albumId = 2L, albumTitle = "Album B", candidates = listOf(candidate("RJ000002", "Second")))
+
+        assertEquals("Album A", queue.dialogState.value?.albumTitle)
+        assertEquals(1, queue.dialogState.value?.currentPosition)
+        assertEquals(2, queue.dialogState.value?.totalCount)
+
+        queue.resolveCurrent("RJ000001")
+
+        assertEquals("RJ000001", first.await())
+        assertEquals("Album B", queue.dialogState.value?.albumTitle)
+        assertEquals(2, queue.dialogState.value?.currentPosition)
+        assertEquals(2, queue.dialogState.value?.totalCount)
+
+        queue.resolveCurrent(null)
+
+        assertNull(second.await())
+        assertNull(queue.dialogState.value)
+    }
+
+    @Test
+    fun enqueueWhileCurrentIsVisible_doesNotInterruptCurrentRequest() {
+        val queue = CloudSyncSelectionRequestQueue()
+
+        queue.enqueue(albumId = 1L, albumTitle = "Album A", candidates = listOf(candidate("RJ000001", "First")))
+        queue.enqueue(albumId = 2L, albumTitle = "Album B", candidates = listOf(candidate("RJ000002", "Second")))
+        queue.enqueue(albumId = 3L, albumTitle = "Album C", candidates = listOf(candidate("RJ000003", "Third")))
+
+        assertEquals("Album A", queue.dialogState.value?.albumTitle)
+        assertEquals(1, queue.dialogState.value?.currentPosition)
+        assertEquals(3, queue.dialogState.value?.totalCount)
+    }
+
+    @Test
+    fun cancelCurrentAndQueuedRequests_releasesDeferredsAndAdvancesQueue() = runBlocking {
+        val queue = CloudSyncSelectionRequestQueue()
+
+        val first = queue.enqueue(albumId = 1L, albumTitle = "Album A", candidates = listOf(candidate("RJ000001", "First")))
+        val second = queue.enqueue(albumId = 2L, albumTitle = "Album B", candidates = listOf(candidate("RJ000002", "Second")))
+        val third = queue.enqueue(albumId = 3L, albumTitle = "Album C", candidates = listOf(candidate("RJ000003", "Third")))
+
+        queue.cancelForAlbum(1L)
+
+        assertNull(first.await())
+        assertEquals("Album B", queue.dialogState.value?.albumTitle)
+        assertEquals(2, queue.dialogState.value?.currentPosition)
+        assertEquals(3, queue.dialogState.value?.totalCount)
+
+        queue.cancelAll()
+
+        assertNull(second.await())
+        assertNull(third.await())
+        assertEquals(0, queue.pendingCount())
+        assertNull(queue.dialogState.value)
+    }
+
+    @Test
+    fun ignoreAllRemainingInBatch_releasesCurrentQueuedAndFutureRequests() = runBlocking {
+        val queue = CloudSyncSelectionRequestQueue()
+        queue.beginBatchSession()
+
+        val first = queue.enqueue(albumId = 1L, albumTitle = "Album A", candidates = listOf(candidate("RJ000001", "First")))
+        val second = queue.enqueue(albumId = 2L, albumTitle = "Album B", candidates = listOf(candidate("RJ000002", "Second")))
+
+        queue.ignoreAllRemainingInBatch()
+
+        assertNull(first.await())
+        assertNull(second.await())
+        assertNull(queue.dialogState.value)
+        assertEquals(0, queue.pendingCount())
+
+        val future = queue.enqueue(albumId = 3L, albumTitle = "Album C", candidates = listOf(candidate("RJ000003", "Third")))
+        assertNull(future.await())
+        assertNull(queue.dialogState.value)
+
+        queue.endBatchSession()
+
+        queue.enqueue(albumId = 4L, albumTitle = "Album D", candidates = listOf(candidate("RJ000004", "Fourth")))
+        assertEquals("Album D", queue.dialogState.value?.albumTitle)
+    }
+
+    private fun candidate(workno: String, title: String): DlsiteCloudSyncCandidate {
+        return DlsiteCloudSyncCandidate(
+            workno = workno,
+            title = title,
+            cv = "CV",
+            coverUrl = ""
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- replace the DLsite cloud sync "ambiguous result" hard error with a manual candidate selection flow
- cover single-album sync, album-detail "bind RJ and sync", and batch/directory sync with a queued confirmation dialog
- add compact candidate rows with thumbnail, title, and CV only, including ignore-current / ignore-all handling in batch mode
- fix DLsite candidate cover loading in the selection dialog by using the correct canonical image folder and fallback cover sources
- add tests for cloud sync ambiguity propagation, selection queue behavior, cover source resolution, and dialog rendering

## Validation
- `./gradlew :app:compileDebugKotlin :app:compileDebugUnitTestKotlin`
