### PR TITLE
fix: polish v1.0.2 playback settings and search chrome

### DIFF
--- a/app/src/main/java/com/asmr/player/MainActivity.kt
+++ b/app/src/main/java/com/asmr/player/MainActivity.kt
@@ -146,7 +146,10 @@ import com.asmr.player.ui.theme.dynamicPageContainerColor
 import com.asmr.player.ui.common.AppVolumeHearingWarningDialog
 import com.asmr.player.ui.common.AppVolumeWarningSessionState
 import com.asmr.player.ui.common.rememberAppVolumeWarningSessionState
+import com.asmr.player.ui.common.rememberCurrentAudioOutputRouteKind
 import com.asmr.player.ui.common.rememberProtectedAppVolumeChangeState
+import com.asmr.player.ui.common.volumeRouteIcon
+import com.asmr.player.service.AudioOutputRouteKind
 import javax.inject.Inject
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.withTimeoutOrNull
@@ -489,6 +492,7 @@ fun MainContainer(
     var lastNonZeroAppVolumePercent by rememberSaveable { mutableIntStateOf(AppVolume.DefaultPercent) }
     var hardwareVolumeOverlayBounds by remember { mutableStateOf<Rect?>(null) }
     val appVolumeWarningSessionState = rememberAppVolumeWarningSessionState()
+    val audioOutputRouteKind = rememberCurrentAudioOutputRouteKind()
     
     val configuration = LocalConfiguration.current
     val isLandscape = configuration.orientation == Configuration.ORIENTATION_LANDSCAPE
@@ -1271,6 +1275,7 @@ fun MainContainer(
                             coverBackgroundEnabled = coverBackgroundEnabled,
                             coverBackgroundClarity = coverBackgroundClarity,
                             coverPreviewMode = coverPreviewMode,
+                            audioOutputRouteKind = audioOutputRouteKind,
                             warningSessionState = appVolumeWarningSessionState
                         )
                     } else {
@@ -1298,6 +1303,7 @@ fun MainContainer(
                             coverBackgroundEnabled = coverBackgroundEnabled,
                             coverBackgroundClarity = coverBackgroundClarity,
                             coverPreviewMode = coverPreviewMode,
+                            audioOutputRouteKind = audioOutputRouteKind,
                             warningSessionState = appVolumeWarningSessionState
                         )
                     }
@@ -1545,6 +1551,7 @@ fun MainContainer(
                                 hardwareVolumeOverlayBounds = coordinates.boundsInRoot()
                             },
                             volumePercent = appVolumePercent,
+                            audioOutputRouteKind = audioOutputRouteKind,
                             onVolumeChange = {
                                 playerViewModel.setAppVolumePercent(it)
                                 hardwareVolumeOverlayHoldTick += 1L
@@ -1627,6 +1634,7 @@ fun MainContainer(
 @Composable
 private fun HardwareVolumeOverlay(
     volumePercent: Int,
+    audioOutputRouteKind: AudioOutputRouteKind,
     onVolumeChange: (Int) -> Unit,
     onToggleMute: () -> Unit,
     onInteractionActiveChanged: (Boolean) -> Unit,
@@ -1660,7 +1668,10 @@ private fun HardwareVolumeOverlay(
                 verticalArrangement = Arrangement.spacedBy(10.dp)
             ) {
                 Icon(
-                    imageVector = if (volumePercent == 0) Icons.Default.VolumeOff else Icons.Default.VolumeUp,
+                    imageVector = volumeRouteIcon(
+                        routeKind = audioOutputRouteKind,
+                        isMuted = volumePercent == 0
+                    ),
                     contentDescription = null,
                     tint = accentColor,
                     modifier = Modifier

--- a/app/src/main/java/com/asmr/player/data/settings/SettingsRepository.kt
+++ b/app/src/main/java/com/asmr/player/data/settings/SettingsRepository.kt
@@ -9,7 +9,18 @@ import javax.inject.Inject
 import javax.inject.Singleton
 import androidx.datastore.preferences.core.edit
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.withContext
+
+data class PlaybackRuntimeSettings(
+    val pauseOnOutputDisconnect: Boolean = true,
+    val resumeOnOutputConnect: Boolean = false,
+    val pauseOnOtherAudio: Boolean = true,
+    val playFadeInMs: Int = 500,
+    val pauseFadeOutMs: Int = 500,
+    val sfwHideSystemControls: Boolean = false,
+    val floatingLyricsEnabled: Boolean = false
+)
 
 @Singleton
 class SettingsRepository @Inject constructor(
@@ -147,6 +158,21 @@ class SettingsRepository @Inject constructor(
 
     val showMiniPlayerBar: Flow<Boolean> = context.settingsDataStore.data.map { prefs ->
         prefs[SettingsKeys.SHOW_MINI_PLAYER_BAR] ?: true
+    }
+
+    suspend fun loadPlaybackRuntimeSettings(): PlaybackRuntimeSettings {
+        return withContext(Dispatchers.IO) {
+            val prefs = context.settingsDataStore.data.first()
+            PlaybackRuntimeSettings(
+                pauseOnOutputDisconnect = prefs[SettingsKeys.PAUSE_ON_OUTPUT_DISCONNECT] ?: true,
+                resumeOnOutputConnect = prefs[SettingsKeys.RESUME_ON_OUTPUT_CONNECT] ?: false,
+                pauseOnOtherAudio = prefs[SettingsKeys.PAUSE_ON_OTHER_AUDIO] ?: true,
+                playFadeInMs = (prefs[SettingsKeys.PLAY_FADE_IN_MS] ?: 500).coerceIn(0, 3000),
+                pauseFadeOutMs = (prefs[SettingsKeys.PAUSE_FADE_OUT_MS] ?: 500).coerceIn(0, 3000),
+                sfwHideSystemControls = prefs[SettingsKeys.SFW_HIDE_SYSTEM_CONTROLS] ?: false,
+                floatingLyricsEnabled = prefs[SettingsKeys.FLOATING_LYRICS_ENABLED] ?: false
+            )
+        }
     }
 
     suspend fun setSleepTimerEndAtMs(endAtMs: Long) {

--- a/app/src/main/java/com/asmr/player/service/AudioOutputDevicePolicy.kt
+++ b/app/src/main/java/com/asmr/player/service/AudioOutputDevicePolicy.kt
@@ -1,6 +1,12 @@
 package com.asmr.player.service
 
 import android.media.AudioDeviceInfo
+import android.media.AudioManager
+
+enum class AudioOutputRouteKind {
+    Speaker,
+    Headphones
+}
 
 internal fun AudioDeviceInfo.isDisconnectSensitiveOutputDevice(): Boolean {
     return isDisconnectSensitiveOutputDeviceType(type)
@@ -8,6 +14,10 @@ internal fun AudioDeviceInfo.isDisconnectSensitiveOutputDevice(): Boolean {
 
 internal fun AudioDeviceInfo.isResumeEligibleOutputDevice(): Boolean {
     return isResumeEligibleOutputDeviceType(type)
+}
+
+internal fun AudioDeviceInfo.outputRouteKind(): AudioOutputRouteKind? {
+    return audioOutputRouteKindForDeviceType(type)
 }
 
 internal fun isDisconnectSensitiveOutputDeviceType(type: Int): Boolean {
@@ -53,4 +63,44 @@ internal fun isResumeEligibleOutputDeviceType(type: Int): Boolean {
 
         else -> false
     }
+}
+
+internal fun audioOutputRouteKindForDeviceType(type: Int): AudioOutputRouteKind? {
+    return when (type) {
+        AudioDeviceInfo.TYPE_WIRED_HEADSET,
+        AudioDeviceInfo.TYPE_WIRED_HEADPHONES,
+        AudioDeviceInfo.TYPE_BLUETOOTH_A2DP,
+        AudioDeviceInfo.TYPE_BLUETOOTH_SCO,
+        AudioDeviceInfo.TYPE_BLE_HEADSET,
+        AudioDeviceInfo.TYPE_USB_HEADSET,
+        AudioDeviceInfo.TYPE_BUILTIN_EARPIECE -> AudioOutputRouteKind.Headphones
+
+        AudioDeviceInfo.TYPE_BLE_SPEAKER,
+        AudioDeviceInfo.TYPE_BLE_BROADCAST,
+        AudioDeviceInfo.TYPE_BUILTIN_SPEAKER,
+        AudioDeviceInfo.TYPE_USB_DEVICE,
+        AudioDeviceInfo.TYPE_USB_ACCESSORY,
+        AudioDeviceInfo.TYPE_HDMI,
+        AudioDeviceInfo.TYPE_HDMI_ARC,
+        AudioDeviceInfo.TYPE_HDMI_EARC,
+        AudioDeviceInfo.TYPE_LINE_ANALOG,
+        AudioDeviceInfo.TYPE_LINE_DIGITAL -> AudioOutputRouteKind.Speaker
+
+        else -> null
+    }
+}
+
+internal fun resolveAudioOutputRouteKind(deviceTypes: Iterable<Int>): AudioOutputRouteKind {
+    val routeKinds = deviceTypes.mapNotNull(::audioOutputRouteKindForDeviceType)
+    return if (routeKinds.any { it == AudioOutputRouteKind.Headphones }) {
+        AudioOutputRouteKind.Headphones
+    } else {
+        routeKinds.firstOrNull() ?: AudioOutputRouteKind.Speaker
+    }
+}
+
+internal fun resolveCurrentAudioOutputRouteKind(audioManager: AudioManager): AudioOutputRouteKind {
+    return resolveAudioOutputRouteKind(
+        audioManager.getDevices(AudioManager.GET_DEVICES_OUTPUTS).map { it.type }
+    )
 }

--- a/app/src/main/java/com/asmr/player/service/PlaybackService.kt
+++ b/app/src/main/java/com/asmr/player/service/PlaybackService.kt
@@ -42,6 +42,7 @@ import com.asmr.player.data.lyrics.LyricsLoader
 import com.asmr.player.data.settings.SettingsRepository
 import com.asmr.player.data.settings.AudioEffectController
 import com.asmr.player.data.settings.EqualizerSettings
+import com.asmr.player.data.settings.PlaybackRuntimeSettings
 import com.asmr.player.data.repository.StatisticsRepository
 import com.asmr.player.playback.AsmrRenderersFactory
 import com.asmr.player.playback.BalanceAudioProcessor
@@ -210,9 +211,12 @@ class PlaybackService : MediaSessionService() {
         ensureNotificationChannel()
         appVolumeBoostController =
             AppVolumeBoostController(getSystemService(AUDIO_SERVICE) as AudioManager)
+        val runtimeSettings = runBlocking {
+            settingsRepository.loadPlaybackRuntimeSettings()
+        }
+        applyPlaybackRuntimeSettings(runtimeSettings)
         runBlocking {
             settingsRepository.setAppVolumePercent(appVolumeBoostController.currentVolumePercent())
-            sfwHideSystemControlsEnabled = settingsRepository.sfwHideSystemControls.first()
         }
         runCatching {
             val audioManager = getSystemService(AUDIO_SERVICE) as AudioManager
@@ -311,8 +315,8 @@ class PlaybackService : MediaSessionService() {
         sessionPlayer = FadingPlayer(
             delegate = exoPlayer,
             volumeFader = volumeFader,
-            playFadeMs = 500L,
-            pauseFadeMs = 500L,
+            playFadeMs = runtimeSettings.playFadeInMs.toLong(),
+            pauseFadeMs = runtimeSettings.pauseFadeOutMs.toLong(),
             switchFadeOutMs = 250L,
             switchFadeInMs = 250L,
             onPlayRequested = { requestPlaybackAudioFocus() }
@@ -337,6 +341,7 @@ class PlaybackService : MediaSessionService() {
                     abandonPlaybackAudioFocus()
                     serviceScope.launch { persistCurrentTrackProgressIfNeeded(force = true) }
                 }
+                refreshMediaNotification()
             }
 
             override fun onMediaItemTransition(mediaItem: androidx.media3.common.MediaItem?, reason: Int) {
@@ -352,6 +357,17 @@ class PlaybackService : MediaSessionService() {
                 currentTrackListenedMs = 0L
                 isCurrentTrackCounted = false
                 lastProgressPersistElapsedMs = 0L
+            }
+
+            override fun onEvents(player: Player, events: Player.Events) {
+                if (
+                    events.contains(Player.EVENT_AVAILABLE_COMMANDS_CHANGED) ||
+                    events.contains(Player.EVENT_TIMELINE_CHANGED) ||
+                    events.contains(Player.EVENT_MEDIA_ITEM_TRANSITION)
+                ) {
+                    syncMediaNotificationControllerState()
+                    refreshMediaNotification()
+                }
             }
         })
         StereoSpectrumBus.playbackActive = exoPlayer.isPlaying
@@ -428,8 +444,8 @@ class PlaybackService : MediaSessionService() {
                 val stateChanged = sfwHideSystemControlsEnabled != hide
                 sfwHideSystemControlsEnabled = hide
                 notificationProvider?.setHideSystemControls(hide)
-                if (stateChanged && exoPlayer.isPlaying) {
-                    recreateMediaSession()
+                if (stateChanged) {
+                    refreshMediaNotificationControllerRegistration()
                 }
                 syncMediaNotificationControllerState()
                 refreshMediaNotification()
@@ -698,12 +714,20 @@ class PlaybackService : MediaSessionService() {
             .any { it.isResumeEligibleOutputDevice() }
     }
 
+    private fun applyPlaybackRuntimeSettings(settings: PlaybackRuntimeSettings) {
+        floatingLyricsEnabled = settings.floatingLyricsEnabled
+        pauseOnOutputDisconnectEnabled = settings.pauseOnOutputDisconnect
+        resumeOnOutputConnectEnabled = settings.resumeOnOutputConnect
+        pauseOnOtherAudioEnabled = settings.pauseOnOtherAudio
+        sfwHideSystemControlsEnabled = settings.sfwHideSystemControls
+    }
+
     private fun refreshMediaNotification() {
         serviceScope.launch(Dispatchers.Main.immediate) {
             runCatching {
                 syncMediaNotificationControllerState()
-                notificationProvider?.refreshNotification()
                 mediaSession?.let { session ->
+                    notificationProvider?.refreshNotification()
                     onUpdateNotification(session, false)
                 }
             }.onFailure {
@@ -830,12 +854,20 @@ class PlaybackService : MediaSessionService() {
             .build()
     }
 
-    private fun recreateMediaSession() {
-        val oldSession = mediaSession
-        mediaSession = null
-        runCatching { oldSession?.release() }
-            .onFailure { Log.w("PlaybackService", "Failed to release old media session", it) }
-        mediaSession = buildMediaSession()
+    private fun refreshMediaNotificationControllerRegistration() {
+        val session = mediaSession ?: return
+        runCatching {
+            if (isSessionAdded(session)) {
+                removeSession(session)
+            }
+            addSession(session)
+        }.onFailure {
+            Log.w(
+                "PlaybackService",
+                "Failed to refresh media notification controller registration",
+                it
+            )
+        }
     }
 
     private fun syncMediaNotificationControllerState() {

--- a/app/src/main/java/com/asmr/player/ui/common/AudioOutputRouteUi.kt
+++ b/app/src/main/java/com/asmr/player/ui/common/AudioOutputRouteUi.kt
@@ -1,0 +1,59 @@
+package com.asmr.player.ui.common
+
+import android.content.Context
+import android.media.AudioDeviceCallback
+import android.media.AudioManager
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Headset
+import androidx.compose.material.icons.filled.VolumeOff
+import androidx.compose.material.icons.filled.VolumeUp
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.LocalContext
+import com.asmr.player.service.AudioOutputRouteKind
+import com.asmr.player.service.resolveCurrentAudioOutputRouteKind
+
+@Composable
+internal fun rememberCurrentAudioOutputRouteKind(): AudioOutputRouteKind {
+    val context = LocalContext.current
+    val audioManager = remember(context.applicationContext) {
+        context.applicationContext.getSystemService(Context.AUDIO_SERVICE) as AudioManager
+    }
+    var routeKind by remember(audioManager) {
+        mutableStateOf(resolveCurrentAudioOutputRouteKind(audioManager))
+    }
+
+    DisposableEffect(audioManager) {
+        val callback = object : AudioDeviceCallback() {
+            override fun onAudioDevicesAdded(addedDevices: Array<out android.media.AudioDeviceInfo>) {
+                routeKind = resolveCurrentAudioOutputRouteKind(audioManager)
+            }
+
+            override fun onAudioDevicesRemoved(removedDevices: Array<out android.media.AudioDeviceInfo>) {
+                routeKind = resolveCurrentAudioOutputRouteKind(audioManager)
+            }
+        }
+        routeKind = resolveCurrentAudioOutputRouteKind(audioManager)
+        audioManager.registerAudioDeviceCallback(callback, null)
+        onDispose {
+            runCatching { audioManager.unregisterAudioDeviceCallback(callback) }
+        }
+    }
+
+    return routeKind
+}
+
+internal fun volumeRouteIcon(routeKind: AudioOutputRouteKind, isMuted: Boolean): ImageVector {
+    return if (routeKind == AudioOutputRouteKind.Headphones) {
+        Icons.Default.Headset
+    } else if (isMuted) {
+        Icons.Default.VolumeOff
+    } else {
+        Icons.Default.VolumeUp
+    }
+}

--- a/app/src/main/java/com/asmr/player/ui/library/LibraryScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/LibraryScreen.kt
@@ -996,12 +996,13 @@ internal fun LibraryChrome(
                 {
                     IconButton(
                         onClick = onClearSearch,
-                        modifier = Modifier.size(24.dp)
+                        modifier = Modifier.size(20.dp)
                     ) {
                         Icon(
                             imageVector = Icons.Default.Close,
                             contentDescription = null,
-                            tint = colorScheme.onSurfaceVariant
+                            tint = colorScheme.onSurfaceVariant,
+                            modifier = Modifier.size(14.dp)
                         )
                     }
                 }

--- a/app/src/main/java/com/asmr/player/ui/player/MiniPlayer.kt
+++ b/app/src/main/java/com/asmr/player/ui/player/MiniPlayer.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.basicMarquee
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
@@ -89,7 +90,7 @@ fun MiniPlayer(
         0f
     }
 
-    Box(
+    BoxWithConstraints(
         modifier = Modifier
             .fillMaxWidth()
             .padding(top = 12.dp, bottom = 14.dp)
@@ -97,6 +98,11 @@ fun MiniPlayer(
             .clickable(onClick = onClick),
         contentAlignment = Alignment.Center
     ) {
+        val widthProgress = ((maxWidth.value - 360f) / 520f).coerceIn(0f, 1f)
+        val controlsEndPadding = (8f + 8f * widthProgress).dp
+        val controlsSpacing = (2f + 6f * widthProgress).dp
+        val controlsButtonSize = (36f + 8f * widthProgress).dp
+
         // 主卡片部分
         Box(
             modifier = Modifier
@@ -110,7 +116,7 @@ fun MiniPlayer(
                 Row(
                     modifier = Modifier
                         .weight(1f)
-                        .padding(start = 48.dp, end = 16.dp), // 增加左侧间距
+                        .padding(start = 48.dp, end = controlsEndPadding), // 增加左侧间距
                     verticalAlignment = Alignment.CenterVertically,
                     horizontalArrangement = Arrangement.spacedBy(8.dp)
                 ) {
@@ -132,8 +138,14 @@ fun MiniPlayer(
                         )
                     }
 
-                    Row(verticalAlignment = Alignment.CenterVertically) {
-                        IconButton(onClick = { viewModel.toggleFavorite() }) {
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(controlsSpacing)
+                    ) {
+                        IconButton(
+                            onClick = { viewModel.toggleFavorite() },
+                            modifier = Modifier.size(controlsButtonSize)
+                        ) {
                             Icon(
                                 imageVector = if (isFavorite) Icons.Default.Favorite else Icons.Default.FavoriteBorder,
                                 contentDescription = null,
@@ -141,10 +153,13 @@ fun MiniPlayer(
                                 modifier = Modifier.size(22.dp)
                             )
                         }
-                        IconButton(onClick = {
-                            optimisticIsPlaying = !(optimisticIsPlaying ?: playback.isPlaying)
-                            viewModel.togglePlayPause()
-                        }) {
+                        IconButton(
+                            onClick = {
+                                optimisticIsPlaying = !(optimisticIsPlaying ?: playback.isPlaying)
+                                viewModel.togglePlayPause()
+                            },
+                            modifier = Modifier.size(controlsButtonSize)
+                        ) {
                             Icon(
                                 imageVector = if (isPlayingEffective) Icons.Default.Pause else Icons.Default.PlayArrow,
                                 contentDescription = null,
@@ -152,7 +167,10 @@ fun MiniPlayer(
                                 modifier = Modifier.size(28.dp)
                             )
                         }
-                        IconButton(onClick = onOpenQueue) {
+                        IconButton(
+                            onClick = onOpenQueue,
+                            modifier = Modifier.size(controlsButtonSize)
+                        ) {
                             Icon(
                                 Icons.Default.PlaylistPlay,
                                 contentDescription = null,

--- a/app/src/main/java/com/asmr/player/ui/player/NowPlayingScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/player/NowPlayingScreen.kt
@@ -75,6 +75,7 @@ import com.asmr.player.ui.common.AsmrAsyncImage
 import com.asmr.player.ui.common.AppVolumeHearingWarningDialog
 import com.asmr.player.ui.common.AppVolumeSlider
 import com.asmr.player.ui.common.AppVolumeWarningSessionState
+import com.asmr.player.ui.common.volumeRouteIcon
 import com.asmr.player.playback.AppVolume
 import com.asmr.player.playback.PlaybackSnapshot
 import com.asmr.player.ui.common.EqualizerPanel
@@ -84,6 +85,7 @@ import com.asmr.player.ui.common.rememberComputedVideoFrameDominantColorCenterWe
 import com.asmr.player.ui.common.DiscPlaceholder
 import com.asmr.player.ui.common.smoothScrollToIndex
 import com.asmr.player.ui.library.TagAssignDialog
+import com.asmr.player.service.AudioOutputRouteKind
 import com.asmr.player.ui.theme.AsmrTheme
 import com.asmr.player.util.Formatting
 import com.asmr.player.util.SubtitleEntry
@@ -110,6 +112,7 @@ fun NowPlayingScreen(
     coverBackgroundEnabled: Boolean,
     coverBackgroundClarity: Float,
     coverPreviewMode: CoverPreviewMode,
+    audioOutputRouteKind: AudioOutputRouteKind,
     warningSessionState: AppVolumeWarningSessionState,
     lyricsViewModel: LyricsViewModel = hiltViewModel()
 ) {
@@ -880,6 +883,7 @@ fun NowPlayingScreen(
                         accentColor = accentColor,
                         viewModel = viewModel,
                         hardwareVolumeEventTick = hardwareVolumeEventTick,
+                        audioOutputRouteKind = audioOutputRouteKind,
                         warningSessionState = warningSessionState
                     )
                 }
@@ -1700,6 +1704,7 @@ private fun VolumeControl(
     accentColor: Color,
     viewModel: PlayerViewModel,
     hardwareVolumeEventTick: Long,
+    audioOutputRouteKind: AudioOutputRouteKind,
     warningSessionState: AppVolumeWarningSessionState
 ) {
     var expanded by remember { mutableStateOf(false) }
@@ -1758,7 +1763,10 @@ private fun VolumeControl(
 
     val colorScheme = AsmrTheme.colorScheme
     val isMuted = volume == 0
-    val icon = if (isMuted) Icons.Default.VolumeOff else Icons.Default.VolumeUp
+    val icon = volumeRouteIcon(
+        routeKind = audioOutputRouteKind,
+        isMuted = isMuted
+    )
 
     AnimatedContent(
         targetState = expanded,

--- a/app/src/main/java/com/asmr/player/ui/search/SearchScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/search/SearchScreen.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -33,6 +34,7 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.automirrored.filled.ArrowForward
+import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material.icons.filled.WifiOff
 import androidx.compose.material3.ButtonDefaults
@@ -96,6 +98,7 @@ import kotlin.math.absoluteValue
 internal const val SEARCH_INPUT_TAG = "search_input"
 internal const val SEARCH_SCOPE_BUTTON_TAG = "search_scope_button"
 internal const val SEARCH_LANGUAGE_BUTTON_TAG = "search_language_button"
+internal const val SEARCH_CLEAR_BUTTON_TAG = "search_clear_button"
 internal const val SEARCH_SUBMIT_BUTTON_TAG = "search_submit_button"
 internal const val SEARCH_SUBMIT_SPINNER_TAG = "search_submit_spinner"
 internal const val SEARCH_PREV_BUTTON_TAG = "search_prev_button"
@@ -630,7 +633,26 @@ internal fun SearchToolbar(
                 }
             },
             trailingIcon = {
-                Row(verticalAlignment = Alignment.CenterVertically) {
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(2.dp)
+                ) {
+                    if (keyword.isNotBlank()) {
+                        IconButton(
+                            onClick = { onKeywordChange("") },
+                            enabled = !searchSubmitLocked,
+                            modifier = Modifier
+                                .size(28.dp)
+                                .testTag(SEARCH_CLEAR_BUTTON_TAG)
+                        ) {
+                            Icon(
+                                imageVector = Icons.Default.Close,
+                                contentDescription = null,
+                                tint = colorScheme.primary,
+                                modifier = Modifier.size(16.dp)
+                            )
+                        }
+                    }
                     val languageLabel = when (selectedLocale.trim()) {
                         "zh_CN" -> "简中"
                         "zh_TW" -> "繁中"
@@ -641,9 +663,10 @@ internal fun SearchToolbar(
                             onClick = { languageMenuExpanded = true },
                             enabled = !filterControlsLocked,
                             modifier = Modifier
-                                .height(32.dp)
+                                .defaultMinSize(minWidth = 1.dp, minHeight = 30.dp)
+                                .height(30.dp)
                                 .testTag(SEARCH_LANGUAGE_BUTTON_TAG),
-                            contentPadding = PaddingValues(horizontal = 6.dp, vertical = 0.dp),
+                            contentPadding = PaddingValues(horizontal = 4.dp, vertical = 0.dp),
                             colors = ButtonDefaults.textButtonColors(
                                 contentColor = colorScheme.primary
                             )
@@ -681,13 +704,13 @@ internal fun SearchToolbar(
                         onClick = onSearchSubmit,
                         enabled = !searchSubmitLocked,
                         modifier = Modifier
-                            .size(32.dp)
+                            .size(28.dp)
                             .testTag(SEARCH_SUBMIT_BUTTON_TAG)
                     ) {
                         if (showSearchSpinner) {
                             CircularProgressIndicator(
                                 modifier = Modifier
-                                    .size(16.dp)
+                                    .size(14.dp)
                                     .testTag(SEARCH_SUBMIT_SPINNER_TAG),
                                 strokeWidth = 2.dp,
                                 color = colorScheme.primary
@@ -696,7 +719,8 @@ internal fun SearchToolbar(
                             Icon(
                                 imageVector = Icons.Default.Search,
                                 contentDescription = null,
-                                tint = colorScheme.primary
+                                tint = colorScheme.primary,
+                                modifier = Modifier.size(17.dp)
                             )
                         }
                     }

--- a/app/src/test/java/com/asmr/player/data/settings/SettingsRepositoryTest.kt
+++ b/app/src/test/java/com/asmr/player/data/settings/SettingsRepositoryTest.kt
@@ -1,0 +1,58 @@
+package com.asmr.player.data.settings
+
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import androidx.datastore.preferences.core.edit
+
+@RunWith(RobolectricTestRunner::class)
+class SettingsRepositoryTest {
+    private val context = RuntimeEnvironment.getApplication()
+    private val repository = SettingsRepository(context)
+
+    @Before
+    fun setUp() = runBlocking {
+        context.settingsDataStore.edit { it.clear() }
+    }
+
+    @After
+    fun tearDown() = runBlocking {
+        context.settingsDataStore.edit { it.clear() }
+    }
+
+    @Test
+    fun loadPlaybackRuntimeSettings_returnsDefaultsWhenUnset() = runBlocking {
+        assertEquals(PlaybackRuntimeSettings(), repository.loadPlaybackRuntimeSettings())
+    }
+
+    @Test
+    fun loadPlaybackRuntimeSettings_returnsStoredValues() = runBlocking {
+        context.settingsDataStore.edit { prefs ->
+            prefs[SettingsKeys.PAUSE_ON_OUTPUT_DISCONNECT] = false
+            prefs[SettingsKeys.RESUME_ON_OUTPUT_CONNECT] = true
+            prefs[SettingsKeys.PAUSE_ON_OTHER_AUDIO] = false
+            prefs[SettingsKeys.PLAY_FADE_IN_MS] = 1200
+            prefs[SettingsKeys.PAUSE_FADE_OUT_MS] = 900
+            prefs[SettingsKeys.SFW_HIDE_SYSTEM_CONTROLS] = true
+            prefs[SettingsKeys.FLOATING_LYRICS_ENABLED] = true
+        }
+
+        assertEquals(
+            PlaybackRuntimeSettings(
+                pauseOnOutputDisconnect = false,
+                resumeOnOutputConnect = true,
+                pauseOnOtherAudio = false,
+                playFadeInMs = 1200,
+                pauseFadeOutMs = 900,
+                sfwHideSystemControls = true,
+                floatingLyricsEnabled = true
+            ),
+            repository.loadPlaybackRuntimeSettings()
+        )
+    }
+}

--- a/app/src/test/java/com/asmr/player/service/AudioOutputDevicePolicyTest.kt
+++ b/app/src/test/java/com/asmr/player/service/AudioOutputDevicePolicyTest.kt
@@ -1,6 +1,7 @@
 package com.asmr.player.service
 
 import android.media.AudioDeviceInfo
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -26,5 +27,33 @@ class AudioOutputDevicePolicyTest {
     fun unknownDevicesDoNotTriggerPauseOrResume() {
         assertFalse(isDisconnectSensitiveOutputDeviceType(AudioDeviceInfo.TYPE_UNKNOWN))
         assertFalse(isResumeEligibleOutputDeviceType(AudioDeviceInfo.TYPE_UNKNOWN))
+    }
+
+    @Test
+    fun headphoneRoutesMapToHeadphonesIconState() {
+        assertEquals(AudioOutputRouteKind.Headphones, audioOutputRouteKindForDeviceType(AudioDeviceInfo.TYPE_WIRED_HEADPHONES))
+        assertEquals(AudioOutputRouteKind.Headphones, audioOutputRouteKindForDeviceType(AudioDeviceInfo.TYPE_BLUETOOTH_A2DP))
+        assertEquals(AudioOutputRouteKind.Headphones, audioOutputRouteKindForDeviceType(AudioDeviceInfo.TYPE_USB_HEADSET))
+    }
+
+    @Test
+    fun speakerRoutesMapToSpeakerIconState() {
+        assertEquals(AudioOutputRouteKind.Speaker, audioOutputRouteKindForDeviceType(AudioDeviceInfo.TYPE_BUILTIN_SPEAKER))
+        assertEquals(AudioOutputRouteKind.Speaker, audioOutputRouteKindForDeviceType(AudioDeviceInfo.TYPE_BLE_SPEAKER))
+        assertEquals(AudioOutputRouteKind.Speaker, audioOutputRouteKindForDeviceType(AudioDeviceInfo.TYPE_HDMI))
+        assertEquals(AudioOutputRouteKind.Speaker, audioOutputRouteKindForDeviceType(AudioDeviceInfo.TYPE_LINE_ANALOG))
+    }
+
+    @Test
+    fun routeResolutionPrefersHeadphonesWhenSpeakerIsAlsoPresent() {
+        assertEquals(
+            AudioOutputRouteKind.Headphones,
+            resolveAudioOutputRouteKind(
+                listOf(
+                    AudioDeviceInfo.TYPE_BUILTIN_SPEAKER,
+                    AudioDeviceInfo.TYPE_WIRED_HEADPHONES
+                )
+            )
+        )
     }
 }

--- a/app/src/test/java/com/asmr/player/ui/search/SearchScreenChromeTest.kt
+++ b/app/src/test/java/com/asmr/player/ui/search/SearchScreenChromeTest.kt
@@ -11,7 +11,9 @@ import androidx.compose.ui.semantics.SemanticsProperties
 import androidx.compose.ui.test.SemanticsMatcher
 import androidx.compose.ui.test.assert
 import androidx.compose.ui.test.assertIsNotEnabled
+import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performImeAction
@@ -99,6 +101,7 @@ class SearchScreenChromeTest {
         }
 
         composeRule.onNodeWithTag(SEARCH_SCOPE_BUTTON_TAG).assertIsNotEnabled()
+        composeRule.onNodeWithTag(SEARCH_CLEAR_BUTTON_TAG).assertIsNotEnabled()
         composeRule.onNodeWithTag(SEARCH_LANGUAGE_BUTTON_TAG).assertIsNotEnabled()
         composeRule.onNodeWithTag(SEARCH_SUBMIT_BUTTON_TAG).assertIsNotEnabled()
         composeRule.onNodeWithTag(SEARCH_SUBMIT_SPINNER_TAG).assert(
@@ -146,6 +149,41 @@ class SearchScreenChromeTest {
         composeRule.onNodeWithTag(SEARCH_PAGINATION_SPINNER_TAG).assert(
             SemanticsMatcher.expectValue(SemanticsProperties.TestTag, SEARCH_PAGINATION_SPINNER_TAG)
         )
+    }
+
+    @Test
+    fun clearButton_clearsKeywordWithoutSubmitting() {
+        var submitCount by mutableIntStateOf(0)
+        var latestKeyword = "RJ123456"
+
+        composeRule.setContent {
+            var keyword by remember { mutableStateOf("RJ123456") }
+            latestKeyword = keyword
+
+            AsmrPlayerTheme {
+                SearchToolbar(
+                    keyword = keyword,
+                    onKeywordChange = { keyword = it },
+                    selectedOrder = SearchSortOption.Trend,
+                    purchasedOnly = false,
+                    selectedLocale = "ja_JP",
+                    filterControlsLocked = false,
+                    searchSubmitLocked = false,
+                    showSearchSpinner = false,
+                    onSearchSubmit = { submitCount += 1 },
+                    onPurchasedOnlySelected = {},
+                    onOrderSelected = {},
+                    onLocaleSelected = {}
+                )
+            }
+        }
+
+        composeRule.onNodeWithTag(SEARCH_CLEAR_BUTTON_TAG).performClick()
+        composeRule.runOnIdle {
+            assertEquals("", latestKeyword)
+            assertEquals(0, submitCount)
+        }
+        composeRule.onAllNodesWithTag(SEARCH_CLEAR_BUTTON_TAG).assertCountEquals(0)
     }
 
     @Test


### PR DESCRIPTION
## Summary
- load and apply playback runtime settings in `PlaybackService`, and refresh media notification controller registration on SFW toggle without recreating the media session
- add audio output route UI/settings coverage, plus related repository and device policy tests
- tighten search and library search chrome controls, and make mini player action spacing responsive for phone vs tablet widths

## Verification
- `./gradlew.bat :app:compileDebugKotlin`
- `./gradlew.bat :app:testDebugUnitTest --tests "com.asmr.player.data.settings.SettingsRepositoryTest" --tests "com.asmr.player.service.AudioOutputDevicePolicyTest" --tests "com.asmr.player.ui.search.SearchScreenChromeTest"`
