### PR TITLE
fix: polish player ui interactions for v1.0.3

### DIFF
--- a/app/src/main/java/com/asmr/player/MainActivity.kt
+++ b/app/src/main/java/com/asmr/player/MainActivity.kt
@@ -162,7 +162,8 @@ import com.asmr.player.ui.common.AppVolumeWarningSessionState
 import com.asmr.player.ui.common.rememberAppVolumeWarningSessionState
 import com.asmr.player.ui.common.rememberCurrentAudioOutputRouteKind
 import com.asmr.player.ui.common.rememberProtectedAppVolumeChangeState
-import com.asmr.player.ui.common.volumeRouteIcon
+import com.asmr.player.ui.common.AudioOutputRouteIcon
+import com.asmr.player.ui.common.DismissOutsideBoundsOverlay
 import com.asmr.player.service.AudioOutputRouteKind
 import javax.inject.Inject
 import kotlinx.coroutines.delay
@@ -517,6 +518,8 @@ fun MainContainer(
     var nowPlayingVolumeEventTick by remember { mutableLongStateOf(0L) }
     var lastNonZeroAppVolumePercent by rememberSaveable { mutableIntStateOf(AppVolume.DefaultPercent) }
     var hardwareVolumeOverlayBounds by remember { mutableStateOf<Rect?>(null) }
+    var bottomChromeOverflowExpanded by remember { mutableStateOf(false) }
+    var bottomChromeOverflowBounds by remember { mutableStateOf<Rect?>(null) }
     val appVolumeWarningSessionState = rememberAppVolumeWarningSessionState()
     val audioOutputRouteKind = rememberCurrentAudioOutputRouteKind()
     
@@ -597,28 +600,12 @@ fun MainContainer(
         },
         label = "nowPlayingBackdropAlpha"
     )
-    val nowPlayingBottomScrimAlpha by animateFloatAsState(
-        targetValue = if (nowPlayingBackdropActive) 1f else 0f,
-        animationSpec = if (nowPlayingBackdropActive) {
-            tween(
-                durationMillis = 440,
-                easing = LinearOutSlowInEasing
-            )
-        } else {
-            keyframes {
-                durationMillis = nowPlayingBackdropExitDurationMs
-                1f at 0
-                1f at (nowPlayingBackdropExitDurationMs * 0.7f).toInt()
-                0f at nowPlayingBackdropExitDurationMs using FastOutLinearInEasing
-            }
-        },
-        label = "nowPlayingBottomScrimAlpha"
-    )
-
     LaunchedEffect(currentRoute) {
         showHardwareVolumeOverlay = false
         hardwareVolumeOverlayInteracting = false
         hardwareVolumeOverlayBounds = null
+        bottomChromeOverflowExpanded = false
+        bottomChromeOverflowBounds = null
         val last = lastRouteForTouchBlock
         val seq = ++touchBlockSeq
         if (last != null && currentRoute != null && last != currentRoute) {
@@ -659,6 +646,8 @@ fun MainContainer(
         showHardwareVolumeOverlay = false
         hardwareVolumeOverlayInteracting = false
         hardwareVolumeOverlayBounds = null
+        bottomChromeOverflowExpanded = false
+        bottomChromeOverflowBounds = null
         nowPlayingVolumeEventTick = 0L
     }
 
@@ -1611,21 +1600,18 @@ fun MainContainer(
 
             Box(
                 modifier = Modifier
-                    .fillMaxSize()
-                    .pointerInteropFilter { event ->
-                        if (!showHardwareVolumeOverlay || event.action != android.view.MotionEvent.ACTION_DOWN) {
-                            return@pointerInteropFilter false
-                        }
-                        val bounds = hardwareVolumeOverlayBounds
-                        if (bounds != null && bounds.contains(androidx.compose.ui.geometry.Offset(event.x, event.y))) {
-                            return@pointerInteropFilter false
-                        }
-                        showHardwareVolumeOverlay = false
-                        hardwareVolumeOverlayBounds = null
-                        false
-                    },
+                    .fillMaxSize(),
                 contentAlignment = Alignment.CenterEnd
             ) {
+                if (showHardwareVolumeOverlay) {
+                    DismissOutsideBoundsOverlay(
+                        targetBoundsInRoot = hardwareVolumeOverlayBounds,
+                        onDismiss = {
+                            showHardwareVolumeOverlay = false
+                            hardwareVolumeOverlayBounds = null
+                        }
+                    )
+                }
                 Box(
                     modifier = Modifier
                         .fillMaxSize()
@@ -1675,7 +1661,9 @@ fun MainContainer(
         }
 
         if (bottomChromeVisible) {
-            BoxWithConstraints(modifier = Modifier.fillMaxSize()) {
+            BoxWithConstraints(
+                modifier = Modifier.fillMaxSize()
+            ) {
                 val isCompactWidth = windowSizeClass.widthSizeClass == WindowWidthSizeClass.Compact
                 val canUseRightPanel = !isCompactWidth &&
                     !isPhone &&
@@ -1697,6 +1685,12 @@ fun MainContainer(
                     label = "miniPlayerReservedRight"
                 )
                 val chromeWidth = (maxWidth - reservedRight - 48.dp).coerceAtLeast(0.dp)
+                if (bottomChromeOverflowExpanded) {
+                    DismissOutsideBoundsOverlay(
+                        targetBoundsInRoot = bottomChromeOverflowBounds,
+                        onDismiss = { bottomChromeOverflowExpanded = false }
+                    )
+                }
                 Box(
                     modifier = Modifier
                         .align(Alignment.BottomStart)
@@ -1711,6 +1705,9 @@ fun MainContainer(
                         miniPlayerDisplayMode = miniPlayerDisplayMode,
                         largeLayout = useLargeBottomChrome,
                         navItems = bottomNavItems,
+                        overflowExpanded = bottomChromeOverflowExpanded,
+                        onOverflowExpandedChange = { bottomChromeOverflowExpanded = it },
+                        onOverflowBoundsChange = { bottomChromeOverflowBounds = it },
                         onMiniPlayerDisplayModeChange = { nextMode ->
                             miniPlayerDisplayMode = nextMode
                             scope.launch { settingsDataStore.setMiniPlayerDisplayMode(nextMode.name) }
@@ -1764,21 +1761,6 @@ fun MainContainer(
                         artworkAlignment = sharedPlayerBackdropAlignment
                     )
                 }
-                Box(
-                    modifier = Modifier
-                        .fillMaxSize()
-                        .graphicsLayer { alpha = nowPlayingBottomScrimAlpha }
-                        .background(
-                            Brush.verticalGradient(
-                                colorStops = arrayOf(
-                                    0f to Color.Transparent,
-                                    0.48f to Color.Transparent,
-                                    0.78f to colorScheme.background.copy(alpha = 0.24f),
-                                    1f to colorScheme.background.copy(alpha = if (colorScheme.isDark) 0.74f else 0.66f)
-                                )
-                            )
-                        )
-                )
                 NowPlayingScreen(
                     windowSizeClass = windowSizeClass,
                     hardwareVolumeEventTick = nowPlayingVolumeEventTick,
@@ -1858,12 +1840,9 @@ private fun HardwareVolumeOverlay(
                 horizontalAlignment = Alignment.CenterHorizontally,
                 verticalArrangement = Arrangement.spacedBy(10.dp)
             ) {
-                Icon(
-                    imageVector = volumeRouteIcon(
-                        routeKind = audioOutputRouteKind,
-                        isMuted = volumePercent == 0
-                    ),
-                    contentDescription = null,
+                AudioOutputRouteIcon(
+                    routeKind = audioOutputRouteKind,
+                    isMuted = volumePercent == 0,
                     tint = accentColor,
                     modifier = Modifier
                         .size(20.dp)

--- a/app/src/main/java/com/asmr/player/service/AudioOutputDevicePolicy.kt
+++ b/app/src/main/java/com/asmr/player/service/AudioOutputDevicePolicy.kt
@@ -72,9 +72,9 @@ internal fun audioOutputRouteKindForDeviceType(type: Int): AudioOutputRouteKind?
         AudioDeviceInfo.TYPE_BLUETOOTH_A2DP,
         AudioDeviceInfo.TYPE_BLUETOOTH_SCO,
         AudioDeviceInfo.TYPE_BLE_HEADSET,
-        AudioDeviceInfo.TYPE_USB_HEADSET,
-        AudioDeviceInfo.TYPE_BUILTIN_EARPIECE -> AudioOutputRouteKind.Headphones
+        AudioDeviceInfo.TYPE_USB_HEADSET -> AudioOutputRouteKind.Headphones
 
+        AudioDeviceInfo.TYPE_BUILTIN_EARPIECE,
         AudioDeviceInfo.TYPE_BLE_SPEAKER,
         AudioDeviceInfo.TYPE_BLE_BROADCAST,
         AudioDeviceInfo.TYPE_BUILTIN_SPEAKER,

--- a/app/src/main/java/com/asmr/player/ui/common/AsmrAsyncImage.kt
+++ b/app/src/main/java/com/asmr/player/ui/common/AsmrAsyncImage.kt
@@ -25,6 +25,7 @@ import com.asmr.player.cache.ImageCacheEntryPoint
 import dagger.hilt.android.EntryPointAccessors
 import androidx.compose.ui.platform.LocalContext
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.withTimeoutOrNull
 import java.io.File
 
@@ -45,8 +46,10 @@ fun AsmrAsyncImage(
     loading: @Composable (Modifier) -> Unit = { m ->
         AsmrShimmerPlaceholder(modifier = m, cornerRadius = placeholderCornerRadius)
     },
+    retainPainterDuringReload: Boolean = false,
+    loadWhenSizeStableForMillis: Long = 0L,
     fadeIn: Boolean = true,
-    fadeInMillis: Int = 1024,
+    fadeInMillis: Int = 500,
 ) {
     val normalizedModel = remember(model) { normalizeImageModel(model) }
     if (normalizedModel == null) {
@@ -62,23 +65,39 @@ fun AsmrAsyncImage(
     val painter: MutableState<Painter?> = remember(normalizedModel) { mutableStateOf(null) }
     val state: MutableState<AsmrAsyncImageState> =
         remember(normalizedModel) { mutableStateOf(AsmrAsyncImageState.Loading) }
+    val loadedSize: MutableState<IntSize?> = remember(normalizedModel) { mutableStateOf(null) }
     val crossfade = remember(normalizedModel) { Animatable(0f) }
     val sizedModifier = modifier.onSizeChanged { sz ->
         if (sz.width > 0 && sz.height > 0) measuredSize.value = IntSize(sz.width, sz.height)
     }
 
     LaunchedEffect(normalizedModel, measuredSize.value) {
-        val sz = measuredSize.value ?: return@LaunchedEffect
+        val initialSize = measuredSize.value ?: return@LaunchedEffect
+        if (loadWhenSizeStableForMillis > 0L) {
+            delay(loadWhenSizeStableForMillis)
+        }
+        val sz = measuredSize.value ?: initialSize
+        if (retainPainterDuringReload && loadedSize.value == sz && painter.value != null) {
+            return@LaunchedEffect
+        }
         try {
-            state.value = AsmrAsyncImageState.Loading
-            painter.value = null
-            crossfade.snapTo(0f)
+            val hasExistingPainter = painter.value != null
+            val shouldRetainPainter = retainPainterDuringReload && hasExistingPainter
+            if (!shouldRetainPainter) {
+                state.value = AsmrAsyncImageState.Loading
+                painter.value = null
+                crossfade.snapTo(0f)
+            } else {
+                state.value = AsmrAsyncImageState.Success
+                crossfade.snapTo(1f)
+            }
             val img = withTimeoutOrNull(15_000) {
                 manager.loadImage(model = normalizedModel, size = sz, cachePolicy = CachePolicy.DEFAULT)
             } ?: throw IllegalStateException("Image load timeout")
             painter.value = BitmapPainter(img)
+            loadedSize.value = sz
             state.value = AsmrAsyncImageState.Success
-            if (fadeIn) {
+            if (fadeIn && !shouldRetainPainter) {
                 crossfade.animateTo(1f, tween(durationMillis = fadeInMillis))
             } else {
                 crossfade.snapTo(1f)
@@ -86,8 +105,11 @@ fun AsmrAsyncImage(
         } catch (e: CancellationException) {
             throw e
         } catch (e: Throwable) {
-            state.value = AsmrAsyncImageState.Error
-            painter.value = null
+            if (painter.value == null) {
+                state.value = AsmrAsyncImageState.Error
+                painter.value = null
+                loadedSize.value = null
+            }
         }
     }
 

--- a/app/src/main/java/com/asmr/player/ui/common/AudioOutputRouteUi.kt
+++ b/app/src/main/java/com/asmr/player/ui/common/AudioOutputRouteUi.kt
@@ -3,16 +3,24 @@ package com.asmr.player.ui.common
 import android.content.Context
 import android.media.AudioDeviceCallback
 import android.media.AudioManager
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Headset
-import androidx.compose.material.icons.filled.VolumeOff
 import androidx.compose.material.icons.filled.VolumeUp
+import androidx.compose.material3.Icon
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalContext
 import com.asmr.player.service.AudioOutputRouteKind
@@ -48,12 +56,42 @@ internal fun rememberCurrentAudioOutputRouteKind(): AudioOutputRouteKind {
     return routeKind
 }
 
-internal fun volumeRouteIcon(routeKind: AudioOutputRouteKind, isMuted: Boolean): ImageVector {
+internal fun volumeRouteIcon(routeKind: AudioOutputRouteKind): ImageVector {
     return if (routeKind == AudioOutputRouteKind.Headphones) {
         Icons.Default.Headset
-    } else if (isMuted) {
-        Icons.Default.VolumeOff
     } else {
         Icons.Default.VolumeUp
+    }
+}
+
+@Composable
+internal fun AudioOutputRouteIcon(
+    routeKind: AudioOutputRouteKind,
+    isMuted: Boolean,
+    tint: Color,
+    modifier: Modifier = Modifier,
+    contentDescription: String? = null
+) {
+    Box(
+        modifier = modifier,
+        contentAlignment = Alignment.Center
+    ) {
+        Icon(
+            imageVector = volumeRouteIcon(routeKind),
+            contentDescription = contentDescription,
+            tint = tint
+        )
+        if (isMuted) {
+            Canvas(modifier = Modifier.fillMaxSize()) {
+                val strokeWidth = size.minDimension * 0.12f
+                drawLine(
+                    color = tint,
+                    start = Offset(size.width * 0.24f, size.height * 0.82f),
+                    end = Offset(size.width * 0.80f, size.height * 0.20f),
+                    strokeWidth = strokeWidth,
+                    cap = StrokeCap.Round
+                )
+            }
+        }
     }
 }

--- a/app/src/main/java/com/asmr/player/ui/common/DismissOutsideBoundsOverlay.kt
+++ b/app/src/main/java/com/asmr/player/ui/common/DismissOutsideBoundsOverlay.kt
@@ -1,0 +1,91 @@
+package com.asmr.player.ui.common
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.width
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.IntOffset
+import kotlin.math.roundToInt
+
+@Composable
+internal fun DismissOutsideBoundsOverlay(
+    targetBoundsInRoot: Rect?,
+    onDismiss: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val bounds = targetBoundsInRoot ?: return
+    if (!bounds.isSpecified()) return
+
+    BoxWithConstraints(modifier = modifier.fillMaxSize()) {
+        val density = LocalDensity.current
+        val maxWidthPx = with(density) { maxWidth.toPx() }
+        val maxHeightPx = with(density) { maxHeight.toPx() }
+        if (maxWidthPx <= 0f || maxHeightPx <= 0f) return@BoxWithConstraints
+
+        val leftPx = bounds.left.coerceIn(0f, maxWidthPx)
+        val topPx = bounds.top.coerceIn(0f, maxHeightPx)
+        val rightPx = bounds.right.coerceIn(leftPx, maxWidthPx)
+        val bottomPx = bounds.bottom.coerceIn(topPx, maxHeightPx)
+        val middleHeightPx = (bottomPx - topPx).coerceAtLeast(0f)
+        val interactionSource = remember { MutableInteractionSource() }
+
+        @Composable
+        fun DismissRegion(
+            xPx: Float,
+            yPx: Float,
+            widthPx: Float,
+            heightPx: Float
+        ) {
+            if (widthPx <= 0.5f || heightPx <= 0.5f) return
+            Box(
+                modifier = Modifier
+                    .offset { IntOffset(xPx.roundToInt(), yPx.roundToInt()) }
+                    .width(with(density) { widthPx.toDp() })
+                    .height(with(density) { heightPx.toDp() })
+                    .clickable(
+                        interactionSource = interactionSource,
+                        indication = null,
+                        onClick = onDismiss
+                    )
+            )
+        }
+
+        DismissRegion(
+            xPx = 0f,
+            yPx = 0f,
+            widthPx = maxWidthPx,
+            heightPx = topPx
+        )
+        DismissRegion(
+            xPx = 0f,
+            yPx = topPx,
+            widthPx = leftPx,
+            heightPx = middleHeightPx
+        )
+        DismissRegion(
+            xPx = rightPx,
+            yPx = topPx,
+            widthPx = maxWidthPx - rightPx,
+            heightPx = middleHeightPx
+        )
+        DismissRegion(
+            xPx = 0f,
+            yPx = bottomPx,
+            widthPx = maxWidthPx,
+            heightPx = maxHeightPx - bottomPx
+        )
+    }
+}
+
+private fun Rect.isSpecified(): Boolean {
+    return left.isFinite() && top.isFinite() && right.isFinite() && bottom.isFinite()
+}

--- a/app/src/main/java/com/asmr/player/ui/common/SearchBar.kt
+++ b/app/src/main/java/com/asmr/player/ui/common/SearchBar.kt
@@ -138,7 +138,7 @@ fun ActionButton(
                     )
                 } else Modifier
             )
-            .background(if (isDark) colorScheme.surface.copy(alpha = 0.3f) else Color.White, CircleShape)
+            .background(if (isDark) colorScheme.surface else Color.White, CircleShape)
             .clip(CircleShape)
             .clickable(onClick = onClick),
         contentAlignment = Alignment.Center

--- a/app/src/main/java/com/asmr/player/ui/nav/BottomChrome.kt
+++ b/app/src/main/java/com/asmr/player/ui/nav/BottomChrome.kt
@@ -6,7 +6,6 @@ import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.spring
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
@@ -56,6 +55,8 @@ import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.layout.boundsInParent
+import androidx.compose.ui.layout.boundsInRoot
+import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.layout.onPlaced
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.testTag
@@ -485,12 +486,14 @@ fun BottomChrome(
     onNavigate: (String) -> Unit,
     largeLayout: Boolean = false,
     modifier: Modifier = Modifier,
-    navItems: List<BottomChromeNavItem> = bottomChromeNavItems()
+    navItems: List<BottomChromeNavItem> = bottomChromeNavItems(),
+    overflowExpanded: Boolean = false,
+    onOverflowExpandedChange: (Boolean) -> Unit = {},
+    onOverflowBoundsChange: (Rect?) -> Unit = {}
 ) {
     BoxWithConstraints(modifier = modifier) {
         val metrics = remember(largeLayout) { bottomChromeMetrics(largeLayout) }
         val navExpanded = !miniPlayerVisible || miniPlayerDisplayMode == MiniPlayerDisplayMode.CoverOnly
-        var overflowExpanded by remember { mutableStateOf(false) }
         val miniCollapsedWidth = if (largeLayout) 76.dp else 64.dp
         val expandedNavWidthLimit = maxWidth.coerceAtMost(metrics.preferredExpandedWidth)
         val miniWidthTarget = when {
@@ -548,9 +551,10 @@ fun BottomChrome(
                 metrics = metrics,
                 maxVisibleItems = maxVisibleItems,
                 overflowExpanded = overflowExpanded,
-                onOverflowExpandedChange = { overflowExpanded = it },
+                onOverflowExpandedChange = onOverflowExpandedChange,
                 onExpandRequest = { onMiniPlayerDisplayModeChange(MiniPlayerDisplayMode.CoverOnly) },
                 onNavigate = onNavigate,
+                onOverflowBoundsChange = onOverflowBoundsChange,
                 modifier = Modifier.width(navWidth)
             )
 
@@ -582,6 +586,7 @@ private fun BottomNavigationPill(
     onOverflowExpandedChange: (Boolean) -> Unit = {},
     onExpandRequest: () -> Unit = {},
     onNavigate: (String) -> Unit,
+    onOverflowBoundsChange: (Rect?) -> Unit = {},
     modifier: Modifier = Modifier
 ) {
     LaunchedEffect(expanded) {
@@ -603,6 +608,7 @@ private fun BottomNavigationPill(
         onOverflowExpandedChange = onOverflowExpandedChange,
         onExpandRequest = onExpandRequest,
         onNavigate = onNavigate,
+        onOverflowBoundsChange = onOverflowBoundsChange,
         modifier = modifier
     )
 }
@@ -621,11 +627,11 @@ private fun BottomNavigationPillSurface(
     onOverflowExpandedChange: (Boolean) -> Unit = {},
     onExpandRequest: () -> Unit,
     onNavigate: (String) -> Unit,
+    onOverflowBoundsChange: (Rect?) -> Unit = {},
     modifier: Modifier = Modifier
 ) {
     val colorScheme = AsmrTheme.colorScheme
     val density = LocalDensity.current
-    val consumeClicksInteractionSource = remember { MutableInteractionSource() }
     val containerColor = colorScheme.primarySoft
         .copy(alpha = if (colorScheme.isDark) 0.10f else 0.14f)
         .compositeOver(colorScheme.surface)
@@ -686,11 +692,14 @@ private fun BottomNavigationPillSurface(
     } else {
         0.dp
     }
-    val overflowHeadroom = if (canShowOverflow && overflowExpanded) {
-        reservedOverflowHeadroom
-    } else {
-        0.dp
-    }
+    val overflowHeadroom by animateDpAsState(
+        targetValue = if (canShowOverflow && overflowExpanded) reservedOverflowHeadroom else 0.dp,
+        animationSpec = spring(
+            dampingRatio = Spring.DampingRatioNoBouncy,
+            stiffness = Spring.StiffnessMediumLow
+        ),
+        label = "bottomNavOverflowHeadroom"
+    )
     val overflowRevealProgress by animateFloatAsState(
         targetValue = if (canShowOverflow && overflowExpanded) 1f else 0f,
         animationSpec = spring(
@@ -723,20 +732,14 @@ private fun BottomNavigationPillSurface(
     Box(
         modifier = modifier
             .defaultMinSize(minHeight = metrics.barHeight)
-            .height(metrics.barHeight + reservedOverflowHeadroom)
+            .height(metrics.barHeight + overflowHeadroom)
+            .onGloballyPositioned { coordinates ->
+                onOverflowBoundsChange(coordinates.boundsInRoot())
+            }
             .testTag(BottomNavBarTag)
             .semantics {
                 stateDescription = if (expanded) "expanded" else "collapsed"
             }
-            .clickable(
-                interactionSource = consumeClicksInteractionSource,
-                indication = null,
-                onClick = {
-                    if (canShowOverflow && overflowExpanded) {
-                        onOverflowExpandedChange(false)
-                    }
-                }
-            )
             .graphicsLayer { clip = false }
             .drawBehind {
                 val outline = buildBottomNavContainerPath(

--- a/app/src/main/java/com/asmr/player/ui/player/NowPlayingScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/player/NowPlayingScreen.kt
@@ -30,6 +30,7 @@ import androidx.compose.material3.windowsizeclass.WindowSizeClass
 import androidx.compose.runtime.*
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
+import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.blur
@@ -38,6 +39,7 @@ import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.geometry.CornerRadius
 import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
@@ -50,6 +52,8 @@ import androidx.compose.ui.graphics.nativeCanvas
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.layout.boundsInRoot
+import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
@@ -73,11 +77,12 @@ import com.asmr.player.R
 import com.asmr.player.data.settings.CoverPreviewMode
 import com.asmr.player.data.settings.LyricsPageSettings
 import com.asmr.player.ui.common.AsmrAsyncImage
+import com.asmr.player.ui.common.AudioOutputRouteIcon
+import com.asmr.player.ui.common.DismissOutsideBoundsOverlay
 import com.asmr.player.ui.common.AppVolumeHearingWarningDialog
 import com.asmr.player.ui.common.AppVolumeSlider
 import com.asmr.player.ui.common.AppVolumeWarningSessionState
 import com.asmr.player.ui.common.StableWindowInsets
-import com.asmr.player.ui.common.volumeRouteIcon
 import com.asmr.player.playback.AppVolume
 import com.asmr.player.playback.PlaybackSnapshot
 import com.asmr.player.ui.common.EqualizerPanel
@@ -150,7 +155,7 @@ private fun AnimatedContentTransitionScope<NowPlayingSurfaceMode>.nowPlayingSurf
 
 @Composable
 @androidx.media3.common.util.UnstableApi
-@OptIn(ExperimentalFoundationApi::class, ExperimentalMaterial3Api::class)
+@OptIn(ExperimentalFoundationApi::class, ExperimentalMaterial3Api::class, ExperimentalComposeUiApi::class)
 internal fun NowPlayingScreen(
     windowSizeClass: WindowSizeClass,
     hardwareVolumeEventTick: Long,
@@ -181,6 +186,9 @@ internal fun NowPlayingScreen(
     val metadata = item?.mediaMetadata
     val colorScheme = AsmrTheme.colorScheme
     val uriText = item?.localConfiguration?.uri?.toString().orEmpty()
+    val artworkModel = remember(metadata?.artworkUri) {
+        sanitizeBackdropArtworkModel(metadata?.artworkUri)
+    }
     val videoUri = item?.localConfiguration?.uri
     val mimeType = item?.localConfiguration?.mimeType.orEmpty()
     val ext = uriText.substringBefore('#').substringBefore('?').substringAfterLast('.', "").lowercase()
@@ -195,10 +203,10 @@ internal fun NowPlayingScreen(
     val dominantColorResult by if (isVideo) {
         rememberComputedVideoFrameDominantColorCenterWeighted(videoUri = videoUri, defaultColor = colorScheme.background)
     } else {
-        rememberComputedDominantColorCenterWeighted(model = metadata?.artworkUri, defaultColor = colorScheme.background)
+        rememberComputedDominantColorCenterWeighted(model = artworkModel, defaultColor = colorScheme.background)
     }
     val targetAccentColor = if (coverBackgroundEnabled) {
-        dominantColorResult.color ?: colorScheme.primary
+        dominantColorResult.color ?: colorScheme.primarySoft
     } else {
         colorScheme.primary
     }
@@ -353,20 +361,15 @@ internal fun NowPlayingScreen(
         NowPlayingMotionSlot.HEADER
     )
     val sharedHeaderHorizontalPadding = if (isLandscape) 4.dp else 12.dp
+    var volumeControlExpanded by remember { mutableStateOf(false) }
+    var volumeControlBounds by remember { mutableStateOf<Rect?>(null) }
 
     Box(
         modifier = Modifier.fillMaxSize()
     ) {
         if (renderBackdrop && !isVideo) {
-            val backgroundArtwork = remember(metadata?.artworkUri) {
-                metadata?.artworkUri?.takeUnless { u ->
-                    val s = u.toString()
-                    u.scheme.equals("android.resource", ignoreCase = true) ||
-                        s.contains("ic_placeholder", ignoreCase = true)
-                }
-            }
             CoverArtworkBackground(
-                artworkModel = backgroundArtwork,
+                artworkModel = artworkModel,
                 enabled = coverBackgroundEnabled,
                 clarity = coverBackgroundClarity,
                 overlayBaseColor = colorScheme.background,
@@ -1101,12 +1104,17 @@ internal fun NowPlayingScreen(
                     VolumeControl(
                         modifier = Modifier
                             .fillMaxWidth()
-                            .then(volumeMotion),
+                            .then(volumeMotion)
+                            .onGloballyPositioned { coordinates ->
+                                volumeControlBounds = coordinates.boundsInRoot()
+                            },
                         accentColor = accentColor,
                         viewModel = viewModel,
                         hardwareVolumeEventTick = hardwareVolumeEventTick,
                         audioOutputRouteKind = audioOutputRouteKind,
-                        warningSessionState = warningSessionState
+                        warningSessionState = warningSessionState,
+                        expanded = volumeControlExpanded,
+                        onExpandedChange = { volumeControlExpanded = it }
                     )
                 }
             }
@@ -1327,10 +1335,18 @@ internal fun NowPlayingScreen(
                 }
             }
         }
+
+        if (volumeControlExpanded) {
+            DismissOutsideBoundsOverlay(
+                targetBoundsInRoot = volumeControlBounds,
+                onDismiss = { volumeControlExpanded = false }
+            )
+        }
     }
 }
 
 @Composable
+@OptIn(ExperimentalFoundationApi::class)
 private fun PlayerSurfaceHeader(
     title: String,
     isLandscape: Boolean,
@@ -1365,7 +1381,9 @@ private fun PlayerSurfaceHeader(
                 fontSize = if (isLandscape) 14.sp else 16.sp,
                 shadow = headerShadow
             ),
-            modifier = Modifier.weight(1f),
+            modifier = Modifier
+                .weight(1f)
+                .basicMarquee(),
             maxLines = 1,
             overflow = TextOverflow.Ellipsis,
             color = colorScheme.textPrimary
@@ -1498,6 +1516,8 @@ private fun ArtworkBox(
                         contentScale = ContentScale.Crop,
                         alignment = artworkAlignment,
                         placeholderCornerRadius = 28,
+                        retainPainterDuringReload = true,
+                        loadWhenSizeStableForMillis = 120L,
                         modifier = Modifier.fillMaxSize(),
                     )
                 }
@@ -2032,9 +2052,10 @@ private fun VolumeControl(
     viewModel: PlayerViewModel,
     hardwareVolumeEventTick: Long,
     audioOutputRouteKind: AudioOutputRouteKind,
-    warningSessionState: AppVolumeWarningSessionState
+    warningSessionState: AppVolumeWarningSessionState,
+    expanded: Boolean,
+    onExpandedChange: (Boolean) -> Unit
 ) {
-    var expanded by remember { mutableStateOf(false) }
     val volume by viewModel.appVolumePercent.collectAsState()
     var lastNonZeroVolume by remember { mutableIntStateOf(AppVolume.DefaultPercent) }
     var lastInteractionAt by remember { mutableLongStateOf(0L) }
@@ -2061,7 +2082,7 @@ private fun VolumeControl(
         if (hardwareVolumeEventTick <= 0L) return@LaunchedEffect
         if (hardwareVolumeEventTick == lastHandledHardwareVolumeEventTick) return@LaunchedEffect
         lastHandledHardwareVolumeEventTick = hardwareVolumeEventTick
-        expanded = true
+        onExpandedChange(true)
         lastInteractionAt = SystemClock.elapsedRealtime()
     }
 
@@ -2084,16 +2105,12 @@ private fun VolumeControl(
         val snapshot = lastInteractionAt
         delay(3_000)
         if (expanded && lastInteractionAt == snapshot) {
-            expanded = false
+            onExpandedChange(false)
         }
     }
 
     val colorScheme = AsmrTheme.colorScheme
     val isMuted = volume == 0
-    val icon = volumeRouteIcon(
-        routeKind = audioOutputRouteKind,
-        isMuted = isMuted
-    )
 
     AnimatedContent(
         targetState = expanded,
@@ -2116,16 +2133,16 @@ private fun VolumeControl(
                             }
                         },
                         onLongClick = {
-                            expanded = true
+                            onExpandedChange(true)
                             lastInteractionAt = SystemClock.elapsedRealtime()
                         }
                     ),
                 horizontalArrangement = Arrangement.Center,
                 verticalAlignment = Alignment.CenterVertically
             ) {
-                Icon(
-                    imageVector = icon,
-                    contentDescription = null,
+                AudioOutputRouteIcon(
+                    routeKind = audioOutputRouteKind,
+                    isMuted = isMuted,
                     tint = accentColor,
                     modifier = Modifier.size(22.dp)
                 )
@@ -2148,10 +2165,10 @@ private fun VolumeControl(
                     modifier = Modifier.fillMaxWidth(),
                     verticalAlignment = Alignment.CenterVertically
                 ) {
-                    Icon(
-                        imageVector = icon,
-                        contentDescription = null,
-                    tint = accentColor,
+                    AudioOutputRouteIcon(
+                        routeKind = audioOutputRouteKind,
+                        isMuted = isMuted,
+                        tint = accentColor,
                         modifier = Modifier
                             .size(20.dp)
                             .combinedClickable(

--- a/app/src/main/java/com/asmr/player/ui/player/PlayerSharedBackdrop.kt
+++ b/app/src/main/java/com/asmr/player/ui/player/PlayerSharedBackdrop.kt
@@ -1,5 +1,6 @@
 package com.asmr.player.ui.player
 
+import android.net.Uri
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
@@ -29,25 +30,29 @@ internal fun PlayerSharedBackdrop(
 
     if (isVideo) return
 
+    val artworkModel = remember(metadata?.artworkUri) {
+        sanitizeBackdropArtworkModel(metadata?.artworkUri)
+    }
     val dominantColorResult by rememberComputedDominantColorCenterWeighted(
-        model = metadata?.artworkUri,
+        model = artworkModel,
         defaultColor = colorScheme.background
     )
-    val backgroundArtwork = remember(metadata?.artworkUri) {
-        metadata?.artworkUri?.takeUnless { uri ->
-            val uriTextValue = uri.toString()
-            uri.scheme.equals("android.resource", ignoreCase = true) ||
-                uriTextValue.contains("ic_placeholder", ignoreCase = true)
-        }
-    }
 
     CoverArtworkBackground(
-        artworkModel = backgroundArtwork,
+        artworkModel = artworkModel,
         enabled = enabled,
         clarity = clarity,
         overlayBaseColor = colorScheme.background,
-        tintBaseColor = dominantColorResult.color ?: colorScheme.primary,
+        tintBaseColor = dominantColorResult.color ?: colorScheme.primarySoft,
         artworkAlignment = artworkAlignment,
         isDark = colorScheme.isDark
     )
+}
+
+internal fun sanitizeBackdropArtworkModel(artworkUri: Uri?): Uri? {
+    return artworkUri?.takeUnless { uri ->
+        val uriTextValue = uri.toString()
+        uri.scheme.equals("android.resource", ignoreCase = true) ||
+            uriTextValue.contains("ic_placeholder", ignoreCase = true)
+    }
 }

--- a/app/src/test/java/com/asmr/player/service/AudioOutputDevicePolicyTest.kt
+++ b/app/src/test/java/com/asmr/player/service/AudioOutputDevicePolicyTest.kt
@@ -39,6 +39,7 @@ class AudioOutputDevicePolicyTest {
     @Test
     fun speakerRoutesMapToSpeakerIconState() {
         assertEquals(AudioOutputRouteKind.Speaker, audioOutputRouteKindForDeviceType(AudioDeviceInfo.TYPE_BUILTIN_SPEAKER))
+        assertEquals(AudioOutputRouteKind.Speaker, audioOutputRouteKindForDeviceType(AudioDeviceInfo.TYPE_BUILTIN_EARPIECE))
         assertEquals(AudioOutputRouteKind.Speaker, audioOutputRouteKindForDeviceType(AudioDeviceInfo.TYPE_BLE_SPEAKER))
         assertEquals(AudioOutputRouteKind.Speaker, audioOutputRouteKindForDeviceType(AudioDeviceInfo.TYPE_HDMI))
         assertEquals(AudioOutputRouteKind.Speaker, audioOutputRouteKindForDeviceType(AudioDeviceInfo.TYPE_LINE_ANALOG))
@@ -52,6 +53,19 @@ class AudioOutputDevicePolicyTest {
                 listOf(
                     AudioDeviceInfo.TYPE_BUILTIN_SPEAKER,
                     AudioDeviceInfo.TYPE_WIRED_HEADPHONES
+                )
+            )
+        )
+    }
+
+    @Test
+    fun routeResolutionDoesNotTreatBuiltInEarpieceAsHeadphones() {
+        assertEquals(
+            AudioOutputRouteKind.Speaker,
+            resolveAudioOutputRouteKind(
+                listOf(
+                    AudioDeviceInfo.TYPE_BUILTIN_SPEAKER,
+                    AudioDeviceInfo.TYPE_BUILTIN_EARPIECE
                 )
             )
         )


### PR DESCRIPTION
## Summary
- fix bottom chrome overflow dismissal and irregular hit area behavior
- fix now playing volume route icon, title marquee, backdrop color fallback, and cover loading regressions
- align dark theme filter button background with the search bar and speed up image fade-in to 500ms

## Included fixes
- show speaker/headphone icons based on the actual output route and overlay a slash when muted
- prevent the now playing cover from flashing skeletons when the volume control expands or collapses
- add marquee scrolling for long titles on the now playing header
- fall back to the theme soft color when cover palette extraction is unavailable
- remove the extra black/white vertical scrim on the now playing page
- dismiss bottom chrome overflow and volume controls immediately when clicking outside
- stop the bottom chrome overflow shape from blocking taps in the lower third of the app
- unify the dark theme background of the library filter button with the search bar
- fix click-dispatch regressions introduced during the interaction cleanup
- reduce image fade-in from the skeleton state to 500ms

## Verification
- `./gradlew.bat :app:compileDebugKotlin :app:compileDebugUnitTestKotlin`
