### PR TITLE
fix: polish headers and mini player on v1.0.3

### DIFF
--- a/app/src/main/java/com/asmr/player/MainActivity.kt
+++ b/app/src/main/java/com/asmr/player/MainActivity.kt
@@ -935,6 +935,10 @@ fun MainContainer(
             else -> false
         }
         val showBackButton = !currentScreenIsPrimary
+        val showPrimaryBrand = currentScreenIsPrimary
+        val topBarDividerColor = colorScheme.onSurface.copy(
+            alpha = if (colorScheme.isDark) 0.16f else 0.10f
+        )
         val useLargeBottomChrome = windowSizeClass.widthSizeClass != WindowWidthSizeClass.Compact && !isPhone
         CompositionLocalProvider(
             LocalBottomOverlayPadding provides (if (bottomChromeVisible) bottomChromeOverlayHeight(useLargeBottomChrome) else 0.dp),
@@ -1029,6 +1033,11 @@ fun MainContainer(
                                                 IconButton(onClick = { navController.popBackStack() }) {
                                                     Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = null)
                                                 }
+                                            } else if (showPrimaryBrand) {
+                                                PrimaryTopBarBrand(
+                                                    appName = stringResource(R.string.app_name),
+                                                    tint = topBarContentColor
+                                                )
                                             }
                                         },
                                         actions = {
@@ -1156,6 +1165,11 @@ fun MainContainer(
                                                 }
                                             }
                                         }
+                                    )
+                                    HorizontalDivider(
+                                        modifier = Modifier.fillMaxWidth(),
+                                        thickness = 0.5.dp,
+                                        color = topBarDividerColor
                                     )
 
                                     val p = bulkProgress
@@ -2286,6 +2300,36 @@ private fun NavHostController.navigateSingleTop(route: String, popUpToRoute: Str
                 saveState = true
             }
         }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun PrimaryTopBarBrand(
+    appName: String,
+    tint: Color,
+    modifier: Modifier = Modifier
+) {
+    Row(
+        modifier = modifier
+            .fillMaxHeight()
+            .padding(start = 10.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(2.dp)
+    ) {
+        Icon(
+            painter = painterResource(R.drawable.ic_launcher_foreground),
+            contentDescription = null,
+            tint = tint,
+            modifier = Modifier.size(42.dp)
+        )
+        Text(
+            text = appName,
+            style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.Bold),
+            color = tint,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis
+        )
     }
 }
 

--- a/app/src/main/java/com/asmr/player/ui/player/MiniPlayer.kt
+++ b/app/src/main/java/com/asmr/player/ui/player/MiniPlayer.kt
@@ -315,7 +315,7 @@ private fun MiniPlayerCoverOnly(
             )
             MiniPlayerActivityBars(
                 isPlaying = isPlaying,
-                modifier = Modifier.align(Alignment.BottomCenter),
+                modifier = Modifier.align(Alignment.Center),
                 tint = Color.White
             )
         }
@@ -331,8 +331,8 @@ private fun MiniPlayerActivityBars(
     val transition = rememberInfiniteTransition(label = "miniPlayerBars")
     val heights = listOf(0, 60, 120, 180, 240, 300).map { delayMs ->
         transition.animateFloat(
-            initialValue = 0.14f,
-            targetValue = 0.92f,
+            initialValue = 0.18f,
+            targetValue = 1f,
             animationSpec = infiniteRepeatable(
                 animation = tween(
                     durationMillis = 520,
@@ -346,18 +346,17 @@ private fun MiniPlayerActivityBars(
     }
 
     Row(
-        modifier = modifier
-            .padding(bottom = 6.dp),
-        horizontalArrangement = Arrangement.spacedBy(1.5.dp),
-        verticalAlignment = Alignment.Bottom
+        modifier = modifier,
+        horizontalArrangement = Arrangement.spacedBy(1.8.dp),
+        verticalAlignment = Alignment.CenterVertically
     ) {
         heights.forEachIndexed { index, height ->
-            val maxHeight = 4.2f + (index % 3) * 0.9f + index * 0.15f
+            val maxHeight = 8.2f + (index % 3) * 1.8f + index * 0.35f
             Box(
                 modifier = Modifier
                     .size(
-                        width = 1.8.dp,
-                        height = (if (isPlaying) 3f + height.value * maxHeight else 3f).dp
+                        width = 2.6.dp,
+                        height = (if (isPlaying) 4f + height.value * maxHeight else 4f).dp
                     )
                     .clip(RoundedCornerShape(99.dp))
                     .background(tint)

--- a/app/src/main/java/com/asmr/player/ui/player/NowPlayingScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/player/NowPlayingScreen.kt
@@ -1362,11 +1362,15 @@ private fun PlayerSurfaceHeader(
     } else {
         Shadow(color = Color.Black.copy(alpha = 0.15f), offset = Offset(0f, 1f), blurRadius = 2f)
     }
+    val dividerColor = colorScheme.onSurface.copy(
+        alpha = if (colorScheme.isDark) 0.16f else 0.10f
+    )
 
-    Row(
-        modifier = modifier,
-        verticalAlignment = Alignment.CenterVertically
-    ) {
+    Column(modifier = modifier) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
         IconButton(onClick = onNavigateUp, enabled = navigationEnabled) {
             Icon(
                 Icons.Default.KeyboardArrowDown,
@@ -1406,6 +1410,14 @@ private fun PlayerSurfaceHeader(
                 )
             }
         }
+        }
+        HorizontalDivider(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(top = 4.dp),
+            thickness = 0.5.dp,
+            color = dividerColor
+        )
     }
 }
 


### PR DESCRIPTION
## Summary
- add a divider under shared page headers and show the app logo/name on primary pages without a back button
- add a divider under the now playing header and refine the primary header brand sizing/spacing
- update the collapsed mini player cover bars to animate from the center with larger motion and thicker bars

## Testing
- .\\gradlew.bat :app:compileDebugKotlin