### PR TITLE
feat: 手动排序支持我的收藏/我的列表/我的分组

### DIFF
--- a/app/src/main/java/com/asmr/player/data/local/db/dao/AlbumGroupItemDao.kt
+++ b/app/src/main/java/com/asmr/player/data/local/db/dao/AlbumGroupItemDao.kt
@@ -41,6 +41,29 @@ interface AlbumGroupItemDao {
     )
     fun observeGroupTracks(groupId: Long): Flow<List<AlbumGroupTrackRow>>
 
+    @Query(
+        """
+        SELECT i.*
+        FROM album_group_items i
+        INNER JOIN tracks t ON t.path = i.mediaId
+        WHERE i.groupId = :groupId
+          AND t.albumId = :albumId
+        ORDER BY i.itemOrder ASC, i.rowid ASC
+        """
+    )
+    suspend fun getAlbumItemsOnce(groupId: Long, albumId: Long): List<AlbumGroupItemEntity>
+
+    @Query(
+        """
+        SELECT COALESCE(MAX(i.itemOrder), -1)
+        FROM album_group_items i
+        INNER JOIN tracks t ON t.path = i.mediaId
+        WHERE i.groupId = :groupId
+          AND t.albumId = :albumId
+        """
+    )
+    suspend fun getMaxItemOrderInAlbum(groupId: Long, albumId: Long): Int
+
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun upsertItems(items: List<AlbumGroupItemEntity>)
 

--- a/app/src/main/java/com/asmr/player/data/local/db/dao/PlaylistItemDao.kt
+++ b/app/src/main/java/com/asmr/player/data/local/db/dao/PlaylistItemDao.kt
@@ -14,6 +14,9 @@ interface PlaylistItemDao {
     @Query("SELECT * FROM playlist_items WHERE playlistId = :playlistId ORDER BY itemOrder ASC, rowid ASC")
     fun observeItems(playlistId: Long): Flow<List<PlaylistItemEntity>>
 
+    @Query("SELECT * FROM playlist_items WHERE playlistId = :playlistId ORDER BY itemOrder ASC, rowid ASC")
+    suspend fun getItemsOnce(playlistId: Long): List<PlaylistItemEntity>
+
     @Query(
         """
         SELECT
@@ -62,6 +65,9 @@ interface PlaylistItemDao {
 
     @Query("DELETE FROM playlist_items WHERE playlistId = :playlistId")
     suspend fun clearPlaylist(playlistId: Long)
+
+    @Query("SELECT COALESCE(MAX(itemOrder), -1) FROM playlist_items WHERE playlistId = :playlistId")
+    suspend fun getMaxItemOrder(playlistId: Long): Int
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun upsertItems(items: List<PlaylistItemEntity>)

--- a/app/src/main/java/com/asmr/player/data/repository/AlbumGroupRepository.kt
+++ b/app/src/main/java/com/asmr/player/data/repository/AlbumGroupRepository.kt
@@ -7,6 +7,7 @@ import com.asmr.player.data.local.db.dao.AlbumGroupTrackRow
 import com.asmr.player.data.local.db.dao.TrackDao
 import com.asmr.player.data.local.db.entities.AlbumGroupEntity
 import com.asmr.player.data.local.db.entities.AlbumGroupItemEntity
+import com.asmr.player.util.ManualItemOrder
 import kotlinx.coroutines.flow.Flow
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -52,16 +53,49 @@ class AlbumGroupRepository @Inject constructor(
         if (groupId <= 0L || albumId <= 0L) return
         val tracks = trackDao.getTracksForAlbumOnce(albumId).filter { it.path.isNotBlank() }
         if (tracks.isEmpty()) return
+        val existingItems = groupItemDao.getAlbumItemsOnce(groupId, albumId)
+        val existingMediaIds = existingItems.mapTo(linkedSetOf()) { it.mediaId }
+        val nextOrder = groupItemDao.getMaxItemOrderInAlbum(groupId, albumId) + 1
         val items = tracks
             .sortedBy { it.path }
+            .filterNot { it.path in existingMediaIds }
             .mapIndexed { index, t ->
                 AlbumGroupItemEntity(
                     groupId = groupId,
                     mediaId = t.path,
-                    itemOrder = index
+                    itemOrder = nextOrder + index
                 )
             }
+        if (items.isEmpty()) return
         groupItemDao.upsertItems(items)
+    }
+
+    suspend fun reorderAlbumTracks(
+        groupId: Long,
+        albumId: Long,
+        orderedMediaIds: List<String>
+    ): Boolean {
+        if (groupId <= 0L || albumId <= 0L) return false
+        val current = groupItemDao.getAlbumItemsOnce(groupId, albumId)
+        if (current.size < 2) return false
+        val reordered = ManualItemOrder.reorderByKeys(current, orderedMediaIds) { it.mediaId }
+        return persistAlbumItems(current = current, ordered = reordered)
+    }
+
+    suspend fun moveTrackToTop(groupId: Long, albumId: Long, mediaId: String): Boolean {
+        if (groupId <= 0L || albumId <= 0L || mediaId.isBlank()) return false
+        val current = groupItemDao.getAlbumItemsOnce(groupId, albumId)
+        if (current.size < 2) return false
+        val reordered = ManualItemOrder.moveKeyToStart(current, mediaId) { it.mediaId }
+        return persistAlbumItems(current = current, ordered = reordered)
+    }
+
+    suspend fun moveTrackToBottom(groupId: Long, albumId: Long, mediaId: String): Boolean {
+        if (groupId <= 0L || albumId <= 0L || mediaId.isBlank()) return false
+        val current = groupItemDao.getAlbumItemsOnce(groupId, albumId)
+        if (current.size < 2) return false
+        val reordered = ManualItemOrder.moveKeyToEnd(current, mediaId) { it.mediaId }
+        return persistAlbumItems(current = current, ordered = reordered)
     }
 
     suspend fun removeTrackFromGroup(groupId: Long, mediaId: String) {
@@ -72,6 +106,18 @@ class AlbumGroupRepository @Inject constructor(
     suspend fun removeAlbumFromGroup(groupId: Long, albumId: Long) {
         if (groupId <= 0L || albumId <= 0L) return
         groupItemDao.deleteAlbumFromGroup(groupId, albumId)
+    }
+
+    private suspend fun persistAlbumItems(
+        current: List<AlbumGroupItemEntity>,
+        ordered: List<AlbumGroupItemEntity>
+    ): Boolean {
+        val updated = ManualItemOrder.reindex(ordered) { item, index ->
+            item.copy(itemOrder = index)
+        }
+        if (current == updated) return false
+        groupItemDao.upsertItems(updated)
+        return true
     }
 }
 

--- a/app/src/main/java/com/asmr/player/data/repository/PlaylistRepository.kt
+++ b/app/src/main/java/com/asmr/player/data/repository/PlaylistRepository.kt
@@ -11,9 +11,10 @@ import com.asmr.player.data.local.db.entities.AlbumEntity
 import com.asmr.player.data.local.db.entities.PlaylistEntity
 import com.asmr.player.data.local.db.entities.PlaylistItemEntity
 import com.asmr.player.data.local.db.entities.PlaylistItemWithSubtitles
+import com.asmr.player.util.ManualItemOrder
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.map
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -96,6 +97,7 @@ class PlaylistRepository @Inject constructor(
         if (mediaId.isNotBlank() && playlistItemDao.isItemInPlaylist(playlistId, mediaId)) {
             return false
         }
+        val nextOrder = playlistItemDao.getMaxItemOrder(playlistId) + 1
         val entity = PlaylistItemEntity(
             playlistId = playlistId,
             mediaId = mediaId,
@@ -103,10 +105,34 @@ class PlaylistRepository @Inject constructor(
             artist = item.mediaMetadata.artist?.toString().orEmpty(),
             uri = item.localConfiguration?.uri.toString(),
             artworkUri = resolvePlaylistItemArtwork(item),
-            itemOrder = Int.MAX_VALUE
+            itemOrder = nextOrder
         )
         playlistItemDao.upsertItems(listOf(entity))
         return true
+    }
+
+    suspend fun reorderPlaylistItems(playlistId: Long, orderedMediaIds: List<String>): Boolean {
+        if (playlistId <= 0L) return false
+        val current = playlistItemDao.getItemsOnce(playlistId)
+        if (current.size < 2) return false
+        val reordered = ManualItemOrder.reorderByKeys(current, orderedMediaIds) { it.mediaId }
+        return persistPlaylistOrder(current = current, ordered = reordered)
+    }
+
+    suspend fun movePlaylistItemToTop(playlistId: Long, mediaId: String): Boolean {
+        if (playlistId <= 0L || mediaId.isBlank()) return false
+        val current = playlistItemDao.getItemsOnce(playlistId)
+        if (current.size < 2) return false
+        val reordered = ManualItemOrder.moveKeyToStart(current, mediaId) { it.mediaId }
+        return persistPlaylistOrder(current = current, ordered = reordered)
+    }
+
+    suspend fun movePlaylistItemToBottom(playlistId: Long, mediaId: String): Boolean {
+        if (playlistId <= 0L || mediaId.isBlank()) return false
+        val current = playlistItemDao.getItemsOnce(playlistId)
+        if (current.size < 2) return false
+        val reordered = ManualItemOrder.moveKeyToEnd(current, mediaId) { it.mediaId }
+        return persistPlaylistOrder(current = current, ordered = reordered)
     }
 
     suspend fun removeItemFromPlaylist(playlistId: Long, mediaId: String) {
@@ -184,6 +210,18 @@ class PlaylistRepository @Inject constructor(
         if (local.isNotBlank()) return local
         val url = album.coverUrl.trim()
         return url.takeIf { it.isNotBlank() }
+    }
+
+    private suspend fun persistPlaylistOrder(
+        current: List<PlaylistItemEntity>,
+        ordered: List<PlaylistItemEntity>
+    ): Boolean {
+        val updated = ManualItemOrder.reindex(ordered) { item, index ->
+            item.copy(itemOrder = index)
+        }
+        if (current == updated) return false
+        playlistItemDao.upsertItems(updated)
+        return true
     }
 }
 

--- a/app/src/main/java/com/asmr/player/ui/common/ManualReorderDialog.kt
+++ b/app/src/main/java/com/asmr/player/ui/common/ManualReorderDialog.kt
@@ -1,0 +1,288 @@
+package com.asmr.player.ui.common
+
+import androidx.compose.animation.animateColorAsState
+import androidx.compose.animation.core.animateDpAsState
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxScope
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshots.SnapshotStateList
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
+import com.asmr.player.ui.common.reorderable.ItemPosition
+import com.asmr.player.ui.common.reorderable.ReorderableItem
+import com.asmr.player.ui.common.reorderable.detectReorderAfterLongPress
+import com.asmr.player.ui.common.reorderable.rememberReorderableLazyListState
+import com.asmr.player.ui.common.reorderable.reorderable
+import com.asmr.player.ui.theme.AsmrTheme
+import kotlinx.coroutines.delay
+
+internal data class ManualReorderListItem(
+    val key: String,
+    val title: String,
+    val subtitle: String = "",
+    val artworkModel: Any? = null,
+    val supportingText: String = ""
+)
+
+private const val MANUAL_REORDER_TOP_SENTINEL_KEY = "__manual_reorder_top_sentinel__"
+
+@Composable
+internal fun ManualReorderDialog(
+    title: String,
+    items: List<ManualReorderListItem>,
+    initialKey: String,
+    dialogTag: String,
+    rowTagPrefix: String,
+    onDismiss: () -> Unit,
+    onOrderCommitted: (List<String>) -> Unit
+) {
+    val colorScheme = AsmrTheme.colorScheme
+    val listState = rememberLazyListState()
+    val localItems = remember { mutableStateListOf<ManualReorderListItem>() }
+    var highlightKey by remember(initialKey) { mutableStateOf<String?>(initialKey) }
+
+    val reorderState = rememberReorderableLazyListState(
+        listState = listState,
+        maxScrollPerFrame = 28.dp,
+        scrollTriggerPadding = 112.dp,
+        onMove = { from, to ->
+            localItems.move(from, to)
+        },
+        canDragOver = { draggedOver, _ ->
+            localItems.any { item -> item.key == draggedOver.key }
+        },
+        onDragEnd = { _, _ ->
+            onOrderCommitted(localItems.map { it.key })
+        }
+    )
+
+    LaunchedEffect(items) {
+        if (reorderState.draggingItemIndex == null) {
+            localItems.clear()
+            localItems.addAll(items)
+        }
+    }
+
+    LaunchedEffect(initialKey, items) {
+        val targetIndex = items.indexOfFirst { it.key == initialKey }
+        if (targetIndex >= 0) {
+            listState.scrollToItem((targetIndex - 1).coerceAtLeast(0))
+            delay(1200)
+        }
+        highlightKey = null
+    }
+
+    Dialog(
+        onDismissRequest = onDismiss,
+        properties = DialogProperties(usePlatformDefaultWidth = false)
+    ) {
+        Surface(
+            modifier = Modifier
+                .fillMaxSize()
+                .testTag(dialogTag),
+            color = colorScheme.background,
+            contentColor = colorScheme.onBackground
+        ) {
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .statusBarsPadding()
+                    .navigationBarsPadding()
+            ) {
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 8.dp, vertical = 4.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    IconButton(onClick = onDismiss) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = null
+                        )
+                    }
+                    Column(modifier = Modifier.weight(1f)) {
+                        Text(
+                            text = title,
+                            style = MaterialTheme.typography.titleLarge.copy(fontWeight = FontWeight.SemiBold),
+                            color = colorScheme.textPrimary,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis
+                        )
+                        Text(
+                            text = "长按后拖动，放手立即保存",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = colorScheme.textSecondary
+                        )
+                    }
+                }
+
+                HorizontalDivider(
+                    thickness = 0.5.dp,
+                    color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.3f)
+                )
+
+                LazyColumn(
+                    state = listState,
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .reorderable(reorderState)
+                        .detectReorderAfterLongPress(reorderState),
+                    contentPadding = PaddingValues(
+                        start = 16.dp,
+                        top = 12.dp,
+                        end = 16.dp,
+                        bottom = 28.dp
+                    ),
+                    verticalArrangement = Arrangement.spacedBy(10.dp)
+                ) {
+                    item(key = MANUAL_REORDER_TOP_SENTINEL_KEY) {
+                        Spacer(modifier = Modifier.height(1.dp))
+                    }
+                    items(localItems, key = { item -> item.key }) { item ->
+                        ReorderableItem(
+                            reorderableState = reorderState,
+                            key = item.key
+                        ) { isDragging ->
+                            ManualReorderRow(
+                                item = item,
+                                highlighted = highlightKey == item.key,
+                                isDragging = isDragging,
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .testTag("$rowTagPrefix:${item.key}")
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun BoxScope.ManualReorderRow(
+    item: ManualReorderListItem,
+    highlighted: Boolean,
+    isDragging: Boolean,
+    modifier: Modifier = Modifier
+) {
+    val colorScheme = AsmrTheme.colorScheme
+    val backgroundColor by animateColorAsState(
+        targetValue = when {
+            highlighted -> colorScheme.primary.copy(alpha = 0.14f)
+            else -> colorScheme.surface.copy(alpha = 0.78f)
+        },
+        label = "manualReorderRowColor"
+    )
+    val elevation by animateDpAsState(
+        targetValue = if (isDragging) 18.dp else 0.dp,
+        label = "manualReorderRowElevation"
+    )
+
+    Row(
+        modifier = modifier
+            .align(Alignment.TopStart)
+            .shadow(elevation, RoundedCornerShape(18.dp))
+            .clip(RoundedCornerShape(18.dp))
+            .background(backgroundColor)
+            .padding(horizontal = 14.dp, vertical = 12.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        AsmrAsyncImage(
+            model = item.artworkModel?.toString().orEmpty(),
+            contentDescription = null,
+            contentScale = ContentScale.Crop,
+            placeholderCornerRadius = 10,
+            modifier = Modifier
+                .size(48.dp)
+                .clip(RoundedCornerShape(10.dp))
+        )
+        Spacer(modifier = Modifier.width(12.dp))
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = item.title,
+                style = MaterialTheme.typography.bodyLarge.copy(fontWeight = FontWeight.Medium),
+                color = colorScheme.textPrimary,
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis
+            )
+            if (item.subtitle.isNotBlank()) {
+                Text(
+                    text = item.subtitle,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = colorScheme.textSecondary,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    modifier = Modifier.padding(top = 4.dp)
+                )
+            }
+            if (item.supportingText.isNotBlank()) {
+                Text(
+                    text = item.supportingText,
+                    style = MaterialTheme.typography.labelSmall,
+                    color = colorScheme.textTertiary,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    modifier = Modifier.padding(top = 4.dp)
+                )
+            }
+        }
+        Text(
+            text = "拖动",
+            style = MaterialTheme.typography.labelMedium,
+            color = colorScheme.textTertiary,
+            modifier = Modifier.padding(start = 12.dp)
+        )
+    }
+
+}
+
+private fun SnapshotStateList<ManualReorderListItem>.move(from: ItemPosition, to: ItemPosition) {
+    if (isEmpty()) return
+    val fromIndex = from.index - 1
+    val toIndex = to.index - 1
+    if (fromIndex !in indices || toIndex !in indices || fromIndex == toIndex) return
+    add(toIndex, removeAt(fromIndex))
+}

--- a/app/src/main/java/com/asmr/player/ui/common/reorderable/DetectReorder.kt
+++ b/app/src/main/java/com/asmr/player/ui/common/reorderable/DetectReorder.kt
@@ -1,0 +1,44 @@
+package com.asmr.player.ui.common.reorderable
+
+import androidx.compose.foundation.gestures.awaitFirstDown
+import androidx.compose.foundation.gestures.forEachGesture
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.input.pointer.PointerInputChange
+import androidx.compose.ui.input.pointer.pointerInput
+
+fun Modifier.detectReorder(state: ReorderableState<*>) =
+    this.then(
+        Modifier.pointerInput(Unit) {
+            forEachGesture {
+                awaitPointerEventScope {
+                    val down = awaitFirstDown(requireUnconsumed = false)
+                    var drag: PointerInputChange?
+                    var overSlop = Offset.Zero
+                    do {
+                        drag = awaitPointerSlopOrCancellation(down.id, down.type) { change, over ->
+                            change.consume()
+                            overSlop = over
+                        }
+                    } while (drag != null && !drag.isConsumed)
+                    if (drag != null) {
+                        state.interactions.trySend(StartDrag(down.id, overSlop))
+                    }
+                }
+            }
+        }
+    )
+
+fun Modifier.detectReorderAfterLongPress(state: ReorderableState<*>) =
+    this.then(
+        Modifier.pointerInput(Unit) {
+            forEachGesture {
+                val down = awaitPointerEventScope {
+                    awaitFirstDown(requireUnconsumed = false)
+                }
+                awaitLongPressOrCancellation(down)?.also {
+                    state.interactions.trySend(StartDrag(down.id))
+                }
+            }
+        }
+    )

--- a/app/src/main/java/com/asmr/player/ui/common/reorderable/DragCancelledAnimation.kt
+++ b/app/src/main/java/com/asmr/player/ui/common/reorderable/DragCancelledAnimation.kt
@@ -1,0 +1,54 @@
+package com.asmr.player.ui.common.reorderable
+
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.AnimationVector2D
+import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.TwoWayConverter
+import androidx.compose.animation.core.VisibilityThreshold
+import androidx.compose.animation.core.spring
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.geometry.Offset
+
+interface DragCancelledAnimation {
+    suspend fun dragCancelled(position: ItemPosition, offset: Offset)
+    val position: ItemPosition?
+    val offset: Offset
+}
+
+class NoDragCancelledAnimation : DragCancelledAnimation {
+    override suspend fun dragCancelled(position: ItemPosition, offset: Offset) = Unit
+    override val position: ItemPosition? = null
+    override val offset: Offset = Offset.Zero
+}
+
+class SpringDragCancelledAnimation(
+    private val stiffness: Float = Spring.StiffnessMediumLow
+) : DragCancelledAnimation {
+    private val animatable = Animatable(Offset.Zero, OffsetVectorConverter)
+
+    override val offset: Offset
+        get() = animatable.value
+
+    override var position by mutableStateOf<ItemPosition?>(null)
+        private set
+
+    override suspend fun dragCancelled(position: ItemPosition, offset: Offset) {
+        this.position = position
+        animatable.snapTo(offset)
+        animatable.animateTo(
+            targetValue = Offset.Zero,
+            animationSpec = spring(
+                stiffness = stiffness,
+                visibilityThreshold = Offset(1f, 1f)
+            )
+        )
+        this.position = null
+    }
+}
+
+private val OffsetVectorConverter = TwoWayConverter<Offset, AnimationVector2D>(
+    convertToVector = { offset -> AnimationVector2D(offset.x, offset.y) },
+    convertFromVector = { vector -> Offset(vector.v1, vector.v2) }
+)

--- a/app/src/main/java/com/asmr/player/ui/common/reorderable/DragGesture.kt
+++ b/app/src/main/java/com/asmr/player/ui/common/reorderable/DragGesture.kt
@@ -1,0 +1,122 @@
+package com.asmr.player.ui.common.reorderable
+
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.input.pointer.AwaitPointerEventScope
+import androidx.compose.ui.input.pointer.PointerEvent
+import androidx.compose.ui.input.pointer.PointerEventPass
+import androidx.compose.ui.input.pointer.PointerId
+import androidx.compose.ui.input.pointer.PointerInputChange
+import androidx.compose.ui.input.pointer.PointerInputScope
+import androidx.compose.ui.input.pointer.PointerType
+import androidx.compose.ui.input.pointer.changedToUpIgnoreConsumed
+import androidx.compose.ui.input.pointer.isOutOfBounds
+import androidx.compose.ui.input.pointer.positionChange
+import androidx.compose.ui.platform.ViewConfiguration
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.util.fastAll
+import androidx.compose.ui.util.fastAny
+import androidx.compose.ui.util.fastFirstOrNull
+import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.withTimeout
+
+internal suspend fun AwaitPointerEventScope.awaitPointerSlopOrCancellation(
+    pointerId: PointerId,
+    pointerType: PointerType,
+    onPointerSlopReached: (change: PointerInputChange, overSlop: Offset) -> Unit
+): PointerInputChange? {
+    if (currentEvent.isPointerUp(pointerId)) return null
+    var offset = Offset.Zero
+    val touchSlop = viewConfiguration.pointerSlop(pointerType)
+    var pointer = pointerId
+
+    while (true) {
+        val event = awaitPointerEvent()
+        val dragEvent = event.changes.fastFirstOrNull { it.id == pointer } ?: return null
+        if (dragEvent.isConsumed) {
+            return null
+        } else if (dragEvent.changedToUpIgnoreConsumed()) {
+            val otherDown = event.changes.fastFirstOrNull { it.pressed }
+            if (otherDown == null) {
+                return null
+            } else {
+                pointer = otherDown.id
+            }
+        } else {
+            offset += dragEvent.positionChange()
+            val distance = offset.getDistance()
+            var acceptedDrag = false
+            if (distance >= touchSlop) {
+                val touchSlopOffset = offset / distance * touchSlop
+                onPointerSlopReached(dragEvent, offset - touchSlopOffset)
+                if (dragEvent.isConsumed) {
+                    acceptedDrag = true
+                } else {
+                    offset = Offset.Zero
+                }
+            }
+
+            if (acceptedDrag) {
+                return dragEvent
+            } else {
+                awaitPointerEvent(PointerEventPass.Final)
+                if (dragEvent.isConsumed) return null
+            }
+        }
+    }
+}
+
+internal suspend fun PointerInputScope.awaitLongPressOrCancellation(
+    initialDown: PointerInputChange
+): PointerInputChange? {
+    var longPress: PointerInputChange? = null
+    var currentDown = initialDown
+    val longPressTimeout = viewConfiguration.longPressTimeoutMillis
+    return try {
+        withTimeout(longPressTimeout) {
+            awaitPointerEventScope {
+                var finished = false
+                while (!finished) {
+                    val event = awaitPointerEvent(PointerEventPass.Main)
+                    if (event.changes.fastAll { it.changedToUpIgnoreConsumed() }) {
+                        finished = true
+                    }
+                    if (event.changes.fastAny { it.isConsumed || it.isOutOfBounds(size, extendedTouchPadding) }) {
+                        finished = true
+                    }
+                    val consumeCheck = awaitPointerEvent(PointerEventPass.Final)
+                    if (consumeCheck.changes.fastAny { it.isConsumed }) {
+                        finished = true
+                    }
+                    if (!event.isPointerUp(currentDown.id)) {
+                        longPress = event.changes.fastFirstOrNull { it.id == currentDown.id }
+                    } else {
+                        val newPressed = event.changes.fastFirstOrNull { it.pressed }
+                        if (newPressed != null) {
+                            currentDown = newPressed
+                            longPress = currentDown
+                        } else {
+                            finished = true
+                        }
+                    }
+                }
+            }
+        }
+        null
+    } catch (_: TimeoutCancellationException) {
+        longPress ?: initialDown
+    }
+}
+
+private fun PointerEvent.isPointerUp(pointerId: PointerId): Boolean =
+    changes.fastFirstOrNull { it.id == pointerId }?.pressed != true
+
+private val mouseSlop = 0.125.dp
+private val defaultTouchSlop = 18.dp
+private val mouseToTouchSlopRatio = mouseSlop / defaultTouchSlop
+
+private fun ViewConfiguration.pointerSlop(pointerType: PointerType): Float {
+    return when (pointerType) {
+        PointerType.Mouse -> touchSlop * mouseToTouchSlopRatio
+        else -> touchSlop
+    }
+}

--- a/app/src/main/java/com/asmr/player/ui/common/reorderable/ItemPosition.kt
+++ b/app/src/main/java/com/asmr/player/ui/common/reorderable/ItemPosition.kt
@@ -1,0 +1,3 @@
+package com.asmr.player.ui.common.reorderable
+
+data class ItemPosition(val index: Int, val key: Any?)

--- a/app/src/main/java/com/asmr/player/ui/common/reorderable/Reorderable.kt
+++ b/app/src/main/java/com/asmr/player/ui/common/reorderable/Reorderable.kt
@@ -1,0 +1,63 @@
+package com.asmr.player.ui.common.reorderable
+
+import androidx.compose.foundation.gestures.drag
+import androidx.compose.foundation.gestures.forEachGesture
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.input.pointer.PointerId
+import androidx.compose.ui.input.pointer.PointerInputChange
+import androidx.compose.ui.input.pointer.PointerInputScope
+import androidx.compose.ui.input.pointer.changedToUp
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.input.pointer.positionChange
+import androidx.compose.ui.util.fastFirstOrNull
+
+fun Modifier.reorderable(state: ReorderableState<*>) = then(
+    Modifier.pointerInput(Unit) {
+        forEachGesture {
+            val dragStart = state.interactions.receive()
+            val down = awaitPointerEventScope {
+                currentEvent.changes.fastFirstOrNull { it.id == dragStart.id }
+            }
+            if (down != null && state.onDragStart(down.position.x.toInt(), down.position.y.toInt())) {
+                dragStart.offset?.apply {
+                    state.onDrag(x.toInt(), y.toInt())
+                }
+                detectDrag(
+                    down = down.id,
+                    onDragEnd = { state.onDragCanceled() },
+                    onDragCancel = { state.onDragCanceled() },
+                    onDrag = { change, dragAmount ->
+                        change.consume()
+                        state.onDrag(dragAmount.x.toInt(), dragAmount.y.toInt())
+                    }
+                )
+            }
+        }
+    }
+)
+
+internal suspend fun PointerInputScope.detectDrag(
+    down: PointerId,
+    onDragEnd: () -> Unit = { },
+    onDragCancel: () -> Unit = { },
+    onDrag: (change: PointerInputChange, dragAmount: Offset) -> Unit
+) {
+    awaitPointerEventScope {
+        if (
+            drag(down) {
+                onDrag(it, it.positionChange())
+                it.consume()
+            }
+        ) {
+            currentEvent.changes.forEach {
+                if (it.changedToUp()) it.consume()
+            }
+            onDragEnd()
+        } else {
+            onDragCancel()
+        }
+    }
+}
+
+internal data class StartDrag(val id: PointerId, val offset: Offset? = null)

--- a/app/src/main/java/com/asmr/player/ui/common/reorderable/ReorderableItem.kt
+++ b/app/src/main/java/com/asmr/player/ui/common/reorderable/ReorderableItem.kt
@@ -1,0 +1,73 @@
+package com.asmr.player.ui.common.reorderable
+
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxScope
+import androidx.compose.foundation.lazy.LazyItemScope
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.zIndex
+
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+fun LazyItemScope.ReorderableItem(
+    reorderableState: ReorderableState<*>,
+    key: Any?,
+    modifier: Modifier = Modifier,
+    index: Int? = null,
+    orientationLocked: Boolean = true,
+    content: @Composable BoxScope.(isDragging: Boolean) -> Unit
+) = ReorderableItem(
+    state = reorderableState,
+    key = key,
+    modifier = modifier,
+    defaultDraggingModifier = Modifier.animateItemPlacement(),
+    orientationLocked = orientationLocked,
+    index = index,
+    content = content
+)
+
+@Composable
+fun ReorderableItem(
+    state: ReorderableState<*>,
+    key: Any?,
+    modifier: Modifier = Modifier,
+    defaultDraggingModifier: Modifier = Modifier,
+    orientationLocked: Boolean = true,
+    index: Int? = null,
+    content: @Composable BoxScope.(isDragging: Boolean) -> Unit
+) {
+    val isDragging = if (index != null) {
+        index == state.draggingItemIndex
+    } else {
+        key == state.draggingItemKey
+    }
+    val draggingModifier = if (isDragging) {
+        Modifier
+            .zIndex(1f)
+            .graphicsLayer {
+                translationX = if (!orientationLocked || !state.isVerticalScroll) state.draggingItemLeft else 0f
+                translationY = if (!orientationLocked || state.isVerticalScroll) state.draggingItemTop else 0f
+            }
+    } else {
+        val cancel = if (index != null) {
+            index == state.dragCancelledAnimation.position?.index
+        } else {
+            key == state.dragCancelledAnimation.position?.key
+        }
+        if (cancel) {
+            Modifier
+                .zIndex(1f)
+                .graphicsLayer {
+                    translationX = if (!orientationLocked || !state.isVerticalScroll) state.dragCancelledAnimation.offset.x else 0f
+                    translationY = if (!orientationLocked || state.isVerticalScroll) state.dragCancelledAnimation.offset.y else 0f
+                }
+        } else {
+            defaultDraggingModifier
+        }
+    }
+    Box(modifier = modifier.then(draggingModifier)) {
+        content(isDragging)
+    }
+}

--- a/app/src/main/java/com/asmr/player/ui/common/reorderable/ReorderableLazyListState.kt
+++ b/app/src/main/java/com/asmr/player/ui/common/reorderable/ReorderableLazyListState.kt
@@ -1,0 +1,175 @@
+package com.asmr.player.ui.common.reorderable
+
+import androidx.compose.foundation.gestures.Orientation
+import androidx.compose.foundation.gestures.scrollBy
+import androidx.compose.foundation.lazy.LazyListItemInfo
+import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalLayoutDirection
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.LayoutDirection
+import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.CoroutineScope
+
+@Composable
+fun rememberReorderableLazyListState(
+    onMove: (ItemPosition, ItemPosition) -> Unit,
+    listState: LazyListState = rememberLazyListState(),
+    canDragOver: ((draggedOver: ItemPosition, dragging: ItemPosition) -> Boolean)? = null,
+    onDragEnd: ((startIndex: Int, endIndex: Int) -> Unit)? = null,
+    maxScrollPerFrame: Dp = 28.dp,
+    scrollTriggerPadding: Dp = 56.dp,
+    dragCancelledAnimation: DragCancelledAnimation = SpringDragCancelledAnimation()
+): ReorderableLazyListState {
+    val maxScroll = with(LocalDensity.current) { maxScrollPerFrame.toPx() }
+    val triggerPadding = with(LocalDensity.current) { scrollTriggerPadding.toPx() }
+    val scope = rememberCoroutineScope()
+    val state = remember(listState) {
+        ReorderableLazyListState(
+            listState = listState,
+            scope = scope,
+            maxScrollPerFrame = maxScroll,
+            scrollTriggerPadding = triggerPadding,
+            onMove = onMove,
+            canDragOver = canDragOver,
+            onDragEnd = onDragEnd,
+            dragCancelledAnimation = dragCancelledAnimation
+        )
+    }
+    val isRtl = LocalLayoutDirection.current == LayoutDirection.Rtl
+
+    LaunchedEffect(state) {
+        state.visibleItemsChanged().collect {
+            state.onDrag(0, 0)
+        }
+    }
+
+    LaunchedEffect(state) {
+        var reverseDirection = !listState.layoutInfo.reverseLayout
+        if (isRtl && listState.layoutInfo.orientation != Orientation.Vertical) {
+            reverseDirection = !reverseDirection
+        }
+        val direction = if (reverseDirection) 1f else -1f
+        while (true) {
+            val diff = state.scrollChannel.receive()
+            listState.scrollBy(diff * direction)
+        }
+    }
+
+    return state
+}
+
+class ReorderableLazyListState(
+    val listState: LazyListState,
+    scope: CoroutineScope,
+    maxScrollPerFrame: Float,
+    scrollTriggerPadding: Float,
+    onMove: (fromIndex: ItemPosition, toIndex: ItemPosition) -> Unit,
+    canDragOver: ((draggedOver: ItemPosition, dragging: ItemPosition) -> Boolean)? = null,
+    onDragEnd: ((startIndex: Int, endIndex: Int) -> Unit)? = null,
+    dragCancelledAnimation: DragCancelledAnimation = SpringDragCancelledAnimation()
+) : ReorderableState<LazyListItemInfo>(
+    scope = scope,
+    maxScrollPerFrame = maxScrollPerFrame,
+    scrollTriggerPadding = scrollTriggerPadding,
+    onMove = onMove,
+    canDragOver = canDragOver,
+    onDragEnd = onDragEnd,
+    dragCancelledAnimation = dragCancelledAnimation
+) {
+    override val isVerticalScroll: Boolean
+        get() = listState.layoutInfo.orientation == Orientation.Vertical
+
+    override val LazyListItemInfo.left: Int
+        get() = when {
+            isVerticalScroll -> 0
+            listState.layoutInfo.reverseLayout -> listState.layoutInfo.viewportSize.width - offset - size
+            else -> offset
+        }
+
+    override val LazyListItemInfo.top: Int
+        get() = when {
+            !isVerticalScroll -> 0
+            listState.layoutInfo.reverseLayout -> listState.layoutInfo.viewportSize.height - offset - size
+            else -> offset
+        }
+
+    override val LazyListItemInfo.right: Int
+        get() = when {
+            isVerticalScroll -> 0
+            listState.layoutInfo.reverseLayout -> listState.layoutInfo.viewportSize.width - offset
+            else -> offset + size
+        }
+
+    override val LazyListItemInfo.bottom: Int
+        get() = when {
+            !isVerticalScroll -> 0
+            listState.layoutInfo.reverseLayout -> listState.layoutInfo.viewportSize.height - offset
+            else -> offset + size
+        }
+
+    override val LazyListItemInfo.width: Int
+        get() = if (isVerticalScroll) 0 else size
+
+    override val LazyListItemInfo.height: Int
+        get() = if (isVerticalScroll) size else 0
+
+    override val LazyListItemInfo.itemIndex: Int
+        get() = index
+
+    override val LazyListItemInfo.itemKey: Any
+        get() = key
+
+    override val visibleItemsInfo: List<LazyListItemInfo>
+        get() = listState.layoutInfo.visibleItemsInfo
+
+    override val viewportStartOffset: Int
+        get() = listState.layoutInfo.viewportStartOffset
+
+    override val viewportEndOffset: Int
+        get() = listState.layoutInfo.viewportEndOffset
+
+    override val firstVisibleItemIndex: Int
+        get() = listState.firstVisibleItemIndex
+
+    override val firstVisibleItemScrollOffset: Int
+        get() = listState.firstVisibleItemScrollOffset
+
+    override suspend fun scrollToItem(index: Int, offset: Int) {
+        listState.scrollToItem(index, offset)
+    }
+
+    override fun onDragStart(offsetX: Int, offsetY: Int): Boolean {
+        return if (isVerticalScroll) {
+            super.onDragStart(0, offsetY)
+        } else {
+            super.onDragStart(offsetX, 0)
+        }
+    }
+
+    override fun findTargets(x: Int, y: Int, selected: LazyListItemInfo): List<LazyListItemInfo> {
+        return if (isVerticalScroll) {
+            super.findTargets(0, y, selected)
+        } else {
+            super.findTargets(x, 0, selected)
+        }
+    }
+
+    override fun chooseDropItem(
+        draggedItemInfo: LazyListItemInfo?,
+        items: List<LazyListItemInfo>,
+        curX: Int,
+        curY: Int
+    ): LazyListItemInfo? {
+        return if (isVerticalScroll) {
+            super.chooseDropItem(draggedItemInfo, items, 0, curY)
+        } else {
+            super.chooseDropItem(draggedItemInfo, items, curX, 0)
+        }
+    }
+}

--- a/app/src/main/java/com/asmr/player/ui/common/reorderable/ReorderableState.kt
+++ b/app/src/main/java/com/asmr/player/ui/common/reorderable/ReorderableState.kt
@@ -1,0 +1,351 @@
+package com.asmr.player.ui.common.reorderable
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
+import androidx.compose.runtime.withFrameMillis
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.util.fastForEach
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.launch
+import kotlin.math.absoluteValue
+import kotlin.math.min
+import kotlin.math.sign
+
+abstract class ReorderableState<T>(
+    private val scope: CoroutineScope,
+    private val maxScrollPerFrame: Float,
+    private val scrollTriggerPadding: Float,
+    private val onMove: (fromIndex: ItemPosition, toIndex: ItemPosition) -> Unit,
+    private val canDragOver: ((draggedOver: ItemPosition, dragging: ItemPosition) -> Boolean)?,
+    private val onDragEnd: ((startIndex: Int, endIndex: Int) -> Unit)?,
+    val dragCancelledAnimation: DragCancelledAnimation
+) {
+    var draggingItemIndex by mutableStateOf<Int?>(null)
+        private set
+
+    val draggingItemKey: Any?
+        get() = selected?.itemKey
+
+    protected abstract val T.left: Int
+    protected abstract val T.top: Int
+    protected abstract val T.right: Int
+    protected abstract val T.bottom: Int
+    protected abstract val T.width: Int
+    protected abstract val T.height: Int
+    protected abstract val T.itemIndex: Int
+    protected abstract val T.itemKey: Any
+    protected abstract val visibleItemsInfo: List<T>
+    protected abstract val firstVisibleItemIndex: Int
+    protected abstract val firstVisibleItemScrollOffset: Int
+    protected abstract val viewportStartOffset: Int
+    protected abstract val viewportEndOffset: Int
+
+    internal val interactions = Channel<StartDrag>()
+    internal val scrollChannel = Channel<Float>()
+
+    val draggingItemLeft: Float
+        get() = draggingLayoutInfo?.let { item ->
+            (selected?.left ?: 0) + draggingDelta.x - item.left
+        } ?: 0f
+
+    val draggingItemTop: Float
+        get() = draggingLayoutInfo?.let { item ->
+            (selected?.top ?: 0) + draggingDelta.y - item.top
+        } ?: 0f
+
+    abstract val isVerticalScroll: Boolean
+
+    private val draggingLayoutInfo: T?
+        get() = visibleItemsInfo.firstOrNull { it.itemIndex == draggingItemIndex }
+
+    private var draggingDelta by mutableStateOf(Offset.Zero)
+    private var selected by mutableStateOf<T?>(null)
+    private var autoscroller: Job? = null
+    private val targets = mutableListOf<T>()
+    private val distances = mutableListOf<Int>()
+
+    protected abstract suspend fun scrollToItem(index: Int, offset: Int)
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    internal fun visibleItemsChanged() =
+        snapshotFlow { draggingItemIndex != null }
+            .flatMapLatest { isDragging ->
+                if (isDragging) snapshotFlow { visibleItemsInfo } else flowOf(null)
+            }
+            .filterNotNull()
+            .distinctUntilChanged { old, new ->
+                old.firstOrNull()?.itemIndex == new.firstOrNull()?.itemIndex && old.count() == new.count()
+            }
+
+    internal open fun onDragStart(offsetX: Int, offsetY: Int): Boolean {
+        val x: Int
+        val y: Int
+        if (isVerticalScroll) {
+            x = offsetX
+            y = offsetY + viewportStartOffset
+        } else {
+            x = offsetX + viewportStartOffset
+            y = offsetY
+        }
+        return visibleItemsInfo
+            .firstOrNull { x in it.left..it.right && y in it.top..it.bottom }
+            ?.also {
+                selected = it
+                draggingItemIndex = it.itemIndex
+            } != null
+    }
+
+    internal fun onDragCanceled() {
+        val dragIdx = draggingItemIndex
+        if (dragIdx != null) {
+            val position = ItemPosition(dragIdx, selected?.itemKey)
+            val offset = Offset(draggingItemLeft, draggingItemTop)
+            scope.launch {
+                dragCancelledAnimation.dragCancelled(position, offset)
+            }
+        }
+        val startIndex = selected?.itemIndex
+        val endIndex = draggingItemIndex
+        selected = null
+        draggingDelta = Offset.Zero
+        draggingItemIndex = null
+        cancelAutoScroll()
+        onDragEnd?.let { callback ->
+            if (startIndex != null && endIndex != null) {
+                callback(startIndex, endIndex)
+            }
+        }
+    }
+
+    internal fun onDrag(offsetX: Int, offsetY: Int) {
+        val selected = selected ?: return
+        draggingDelta = Offset(draggingDelta.x + offsetX, draggingDelta.y + offsetY)
+        val draggingItem = draggingLayoutInfo ?: return
+        val startOffset = draggingItem.top + draggingItemTop
+        val startOffsetX = draggingItem.left + draggingItemLeft
+        chooseDropItem(
+            draggedItemInfo = draggingItem,
+            items = findTargets(draggingDelta.x.toInt(), draggingDelta.y.toInt(), selected),
+            curX = startOffsetX.toInt(),
+            curY = startOffset.toInt()
+        )?.also { targetItem ->
+            if (targetItem.itemIndex == firstVisibleItemIndex || draggingItem.itemIndex == firstVisibleItemIndex) {
+                scope.launch {
+                    onMove(
+                        ItemPosition(draggingItem.itemIndex, draggingItem.itemKey),
+                        ItemPosition(targetItem.itemIndex, targetItem.itemKey)
+                    )
+                    scrollToItem(firstVisibleItemIndex, firstVisibleItemScrollOffset)
+                }
+            } else {
+                onMove(
+                    ItemPosition(draggingItem.itemIndex, draggingItem.itemKey),
+                    ItemPosition(targetItem.itemIndex, targetItem.itemKey)
+                )
+            }
+            draggingItemIndex = targetItem.itemIndex
+        }
+
+        val scrollOffset = calcAutoScrollOffset(0, maxScrollPerFrame)
+        if (scrollOffset != 0f) {
+            autoscroll(scrollOffset)
+        } else {
+            cancelAutoScroll()
+        }
+    }
+
+    private fun autoscroll(scrollOffset: Float) {
+        if (autoscroller?.isActive == true) return
+        autoscroller = scope.launch {
+            var scroll = scrollOffset
+            var start = 0L
+            while (scroll != 0f && autoscroller?.isActive == true) {
+                withFrameMillis {
+                    if (start == 0L) {
+                        start = it
+                    } else {
+                        scroll = calcAutoScrollOffset(it - start, maxScrollPerFrame)
+                    }
+                }
+                if (scroll != 0f) {
+                    scrollChannel.trySend(scroll)
+                }
+            }
+        }
+    }
+
+    private fun cancelAutoScroll() {
+        autoscroller?.cancel()
+        autoscroller = null
+    }
+
+    protected open fun findTargets(x: Int, y: Int, selected: T): List<T> {
+        targets.clear()
+        distances.clear()
+        val left = x + selected.left
+        val right = x + selected.right
+        val top = y + selected.top
+        val bottom = y + selected.bottom
+        val centerX = (left + right) / 2
+        val centerY = (top + bottom) / 2
+        visibleItemsInfo.fastForEach { item ->
+            if (
+                item.itemIndex == draggingItemIndex ||
+                item.bottom < top ||
+                item.top > bottom ||
+                item.right < left ||
+                item.left > right
+            ) {
+                return@fastForEach
+            }
+            if (
+                canDragOver?.invoke(
+                    ItemPosition(item.itemIndex, item.itemKey),
+                    ItemPosition(selected.itemIndex, selected.itemKey)
+                ) != false
+            ) {
+                val dx = (centerX - (item.left + item.right) / 2).absoluteValue
+                val dy = (centerY - (item.top + item.bottom) / 2).absoluteValue
+                val dist = dx * dx + dy * dy
+                var pos = 0
+                for (j in targets.indices) {
+                    if (dist > distances[j]) {
+                        pos++
+                    } else {
+                        break
+                    }
+                }
+                targets.add(pos, item)
+                distances.add(pos, dist)
+            }
+        }
+        return targets
+    }
+
+    protected open fun chooseDropItem(
+        draggedItemInfo: T?,
+        items: List<T>,
+        curX: Int,
+        curY: Int
+    ): T? {
+        if (draggedItemInfo == null) {
+            return if (draggingItemIndex != null) items.lastOrNull() else null
+        }
+        var target: T? = null
+        var highScore = -1
+        val right = curX + draggedItemInfo.width
+        val bottom = curY + draggedItemInfo.height
+        val dx = curX - draggedItemInfo.left
+        val dy = curY - draggedItemInfo.top
+
+        items.fastForEach { item ->
+            if (dx > 0) {
+                val diff = item.right - right
+                if (diff < 0 && item.right > draggedItemInfo.right) {
+                    val score = diff.absoluteValue
+                    if (score > highScore) {
+                        highScore = score
+                        target = item
+                    }
+                }
+            }
+            if (dx < 0) {
+                val diff = item.left - curX
+                if (diff > 0 && item.left < draggedItemInfo.left) {
+                    val score = diff.absoluteValue
+                    if (score > highScore) {
+                        highScore = score
+                        target = item
+                    }
+                }
+            }
+            if (dy < 0) {
+                val diff = item.top - curY
+                if (diff > 0 && item.top < draggedItemInfo.top) {
+                    val score = diff.absoluteValue
+                    if (score > highScore) {
+                        highScore = score
+                        target = item
+                    }
+                }
+            }
+            if (dy > 0) {
+                val diff = item.bottom - bottom
+                if (diff < 0 && item.bottom > draggedItemInfo.bottom) {
+                    val score = diff.absoluteValue
+                    if (score > highScore) {
+                        highScore = score
+                        target = item
+                    }
+                }
+            }
+        }
+        return target
+    }
+
+    private fun calcAutoScrollOffset(time: Long, maxScroll: Float): Float {
+        val draggingItem = draggingLayoutInfo ?: return 0f
+        val startOffset: Float
+        val endOffset: Float
+        val delta: Float
+        if (isVerticalScroll) {
+            startOffset = draggingItem.top + draggingItemTop
+            endOffset = startOffset + draggingItem.height
+            delta = draggingDelta.y
+        } else {
+            startOffset = draggingItem.left + draggingItemLeft
+            endOffset = startOffset + draggingItem.width
+            delta = draggingDelta.x
+        }
+        val outOfBounds = when {
+            delta > 0 -> (endOffset - (viewportEndOffset - scrollTriggerPadding)).coerceAtLeast(0f)
+            delta < 0 -> (startOffset - (viewportStartOffset + scrollTriggerPadding)).coerceAtMost(0f)
+            else -> 0f
+        }
+        return interpolateOutOfBoundsScroll(
+            viewSize = (endOffset - startOffset).toInt(),
+            viewSizeOutOfBounds = outOfBounds,
+            time = time,
+            maxScroll = maxScroll
+        )
+    }
+
+    companion object {
+        private const val ACCELERATION_LIMIT_TIME_MS: Long = 1500
+        private val EaseOutQuadInterpolator: (Float) -> Float = {
+            val t = 1 - it
+            1 - t * t * t * t
+        }
+        private val EaseInQuintInterpolator: (Float) -> Float = {
+            it * it * it * it * it
+        }
+
+        private fun interpolateOutOfBoundsScroll(
+            viewSize: Int,
+            viewSizeOutOfBounds: Float,
+            time: Long,
+            maxScroll: Float
+        ): Float {
+            if (viewSizeOutOfBounds == 0f) return 0f
+            val outOfBoundsRatio = min(1f, viewSizeOutOfBounds.absoluteValue / viewSize.coerceAtLeast(1))
+            val cappedScroll = sign(viewSizeOutOfBounds) * maxScroll * EaseOutQuadInterpolator(outOfBoundsRatio)
+            val timeRatio = if (time > ACCELERATION_LIMIT_TIME_MS) 1f else time.toFloat() / ACCELERATION_LIMIT_TIME_MS
+            return (cappedScroll * EaseInQuintInterpolator(timeRatio)).let {
+                if (it == 0f) {
+                    if (viewSizeOutOfBounds > 0f) 1f else -1f
+                } else {
+                    it
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/asmr/player/ui/groups/AlbumGroupDetailScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/groups/AlbumGroupDetailScreen.kt
@@ -2,22 +2,23 @@ package com.asmr.player.ui.groups
 
 import android.net.Uri
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
+import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.WindowInsetsSides
-import androidx.compose.foundation.layout.only
-import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -47,7 +48,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.core.net.toUri
@@ -57,11 +58,29 @@ import androidx.media3.common.MediaMetadata
 import com.asmr.player.data.local.db.dao.AlbumGroupTrackRow
 import com.asmr.player.ui.common.AsmrAsyncImage
 import com.asmr.player.ui.common.LocalBottomOverlayPadding
+import com.asmr.player.ui.common.ManualReorderDialog
+import com.asmr.player.ui.common.ManualReorderListItem
 import com.asmr.player.ui.common.StableWindowInsets
 import com.asmr.player.ui.theme.AsmrTheme
 import com.asmr.player.ui.theme.dynamicPageContainerColor
 import com.asmr.player.util.Formatting
 import kotlin.math.roundToLong
+
+internal const val GROUP_DETAIL_SECTION_HEADER_TAG_PREFIX = "groupDetailSectionHeader"
+internal const val GROUP_DETAIL_TRACK_TAG_PREFIX = "groupDetailTrack"
+internal const val GROUP_DETAIL_TRACK_MENU_BUTTON_TAG_PREFIX = "groupDetailTrackMenu"
+internal const val GROUP_DETAIL_MOVE_TOP_MENU_ITEM_TAG = "groupDetailMoveTopMenuItem"
+internal const val GROUP_DETAIL_MOVE_BOTTOM_MENU_ITEM_TAG = "groupDetailMoveBottomMenuItem"
+internal const val GROUP_DETAIL_REORDER_DIALOG_TAG = "groupDetailReorderDialog"
+internal const val GROUP_DETAIL_REORDER_ROW_TAG_PREFIX = "groupDetailReorderRow"
+
+private data class GroupReorderSession(
+    val albumId: Long,
+    val albumTitle: String,
+    val coverModel: String,
+    val initialMediaId: String,
+    val items: List<AlbumGroupTrackRow>
+)
 
 @Composable
 fun AlbumGroupDetailScreen(
@@ -75,16 +94,39 @@ fun AlbumGroupDetailScreen(
         viewModel.setGroupId(groupId)
     }
     val tracks by viewModel.tracks.collectAsState()
+    AlbumGroupDetailContent(
+        windowSizeClass = windowSizeClass,
+        title = title,
+        tracks = tracks,
+        onPlayMediaItems = onPlayMediaItems,
+        onRemoveTrack = viewModel::removeTrack,
+        onRemoveAlbum = viewModel::removeAlbum,
+        onMoveTrackToTop = viewModel::moveTrackToTop,
+        onMoveTrackToBottom = viewModel::moveTrackToBottom,
+        onSaveAlbumTrackOrder = viewModel::saveAlbumTrackOrder
+    )
+}
+
+@Composable
+internal fun AlbumGroupDetailContent(
+    windowSizeClass: WindowSizeClass,
+    title: String,
+    tracks: List<AlbumGroupTrackRow>,
+    onPlayMediaItems: (List<MediaItem>, Int) -> Unit,
+    onRemoveTrack: (String) -> Unit,
+    onRemoveAlbum: (Long) -> Unit,
+    onMoveTrackToTop: (Long, String) -> Unit,
+    onMoveTrackToBottom: (Long, String) -> Unit,
+    onSaveAlbumTrackOrder: (Long, List<String>) -> Unit
+) {
     val colorScheme = AsmrTheme.colorScheme
     val isCompact = windowSizeClass.widthSizeClass == WindowWidthSizeClass.Compact
-    val expandedAlbumIds = rememberSaveable(groupId) { mutableStateOf(setOf<Long>()) }
-
+    val expandedAlbumIds = rememberSaveable { mutableStateOf(setOf<Long>()) }
     var pendingRemoveTrack by remember { mutableStateOf<AlbumGroupTrackRow?>(null) }
     var pendingRemoveAlbum by remember { mutableStateOf<Pair<Long, String>?>(null) }
+    var reorderSession by remember { mutableStateOf<GroupReorderSession?>(null) }
 
-    val sections = remember(tracks) {
-        tracks.groupBy { it.albumId }
-    }
+    val sections = remember(tracks) { tracks.groupBy { it.albumId } }
 
     Box(
         modifier = Modifier
@@ -109,7 +151,7 @@ fun AlbumGroupDetailScreen(
                 verticalAlignment = Alignment.CenterVertically
             ) {
                 Text(
-                    title,
+                    text = title,
                     style = MaterialTheme.typography.titleLarge,
                     maxLines = 1,
                     overflow = TextOverflow.Ellipsis,
@@ -131,11 +173,11 @@ fun AlbumGroupDetailScreen(
                         .ifBlank { first?.albumCoverPath.orEmpty() }
                         .ifBlank { first?.albumCoverUrl.orEmpty() }
                         .trim()
-                        .ifBlank { "" }
-
                     val expanded = expandedAlbumIds.value.contains(albumId)
+
                     item(key = "header:$albumId") {
                         AlbumSectionHeader(
+                            albumId = albumId,
                             albumTitle = sectionTitle,
                             rjCode = rj,
                             coverModel = coverModel,
@@ -147,25 +189,37 @@ fun AlbumGroupDetailScreen(
                                     expandedAlbumIds.value + albumId
                                 }
                             },
-                            onRemoveAlbum = {
-                                pendingRemoveAlbum = albumId to sectionTitle
-                            }
+                            onRemoveAlbum = { pendingRemoveAlbum = albumId to sectionTitle }
                         )
                     }
 
                     if (expanded) {
-                        itemsIndexed(list, key = { idx, item -> "${item.mediaId}#$idx" }) { index, item ->
+                        itemsIndexed(list, key = { _, item -> item.mediaId }) { index, item ->
                             GroupTrackRow(
                                 item = item,
                                 coverModel = coverModel,
                                 onPlay = {
-                                    val mediaItems = list.map { it.toMediaItem() }
-                                    val startIndex = list.indexOfFirst { it.mediaId == item.mediaId }.coerceAtLeast(0)
+                                    val mediaItems = list.map { track -> track.toMediaItem() }
+                                    val startIndex = list.indexOfFirst { track -> track.mediaId == item.mediaId }
+                                        .coerceAtLeast(0)
                                     onPlayMediaItems(mediaItems, startIndex)
                                 },
+                                onLongPress = {
+                                    if (list.size > 1) {
+                                        reorderSession = GroupReorderSession(
+                                            albumId = albumId,
+                                            albumTitle = sectionTitle,
+                                            coverModel = coverModel,
+                                            initialMediaId = item.mediaId,
+                                            items = list
+                                        )
+                                    }
+                                },
+                                onMoveToTop = { onMoveTrackToTop(albumId, item.mediaId) },
+                                onMoveToBottom = { onMoveTrackToBottom(albumId, item.mediaId) },
                                 onRemove = { pendingRemoveTrack = item }
                             )
-                            if (index < list.size - 1) {
+                            if (index < list.lastIndex) {
                                 HorizontalDivider(
                                     modifier = Modifier.padding(horizontal = 16.dp),
                                     thickness = 0.5.dp,
@@ -179,8 +233,7 @@ fun AlbumGroupDetailScreen(
         }
     }
 
-    val track = pendingRemoveTrack
-    if (track != null) {
+    pendingRemoveTrack?.let { track ->
         AlertDialog(
             onDismissRequest = { pendingRemoveTrack = null },
             title = { Text("确认移除") },
@@ -189,7 +242,7 @@ fun AlbumGroupDetailScreen(
                 TextButton(
                     onClick = {
                         pendingRemoveTrack = null
-                        viewModel.removeTrack(track.mediaId)
+                        onRemoveTrack(track.mediaId)
                     }
                 ) { Text("移除") }
             },
@@ -199,8 +252,7 @@ fun AlbumGroupDetailScreen(
         )
     }
 
-    val album = pendingRemoveAlbum
-    if (album != null) {
+    pendingRemoveAlbum?.let { album ->
         AlertDialog(
             onDismissRequest = { pendingRemoveAlbum = null },
             title = { Text("确认移除") },
@@ -209,7 +261,7 @@ fun AlbumGroupDetailScreen(
                 TextButton(
                     onClick = {
                         pendingRemoveAlbum = null
-                        viewModel.removeAlbum(album.first)
+                        onRemoveAlbum(album.first)
                     }
                 ) { Text("移除") }
             },
@@ -218,10 +270,35 @@ fun AlbumGroupDetailScreen(
             }
         )
     }
+
+    reorderSession?.let { session ->
+        ManualReorderDialog(
+            title = "手动排序",
+            items = session.items.map { track ->
+                val durationMs = (track.trackDuration * 1000.0).roundToLong().coerceAtLeast(0L)
+                ManualReorderListItem(
+                    key = track.mediaId,
+                    title = track.trackTitle.ifBlank { "未命名" },
+                    subtitle = Formatting.formatTrackTime(durationMs),
+                    artworkModel = session.coverModel,
+                    supportingText = session.albumTitle
+                )
+            },
+            initialKey = session.initialMediaId,
+            dialogTag = GROUP_DETAIL_REORDER_DIALOG_TAG,
+            rowTagPrefix = GROUP_DETAIL_REORDER_ROW_TAG_PREFIX,
+            onDismiss = { reorderSession = null },
+            onOrderCommitted = { orderedMediaIds ->
+                onSaveAlbumTrackOrder(session.albumId, orderedMediaIds)
+            }
+        )
+    }
 }
 
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
 private fun AlbumSectionHeader(
+    albumId: Long,
     albumTitle: String,
     rjCode: String,
     coverModel: Any?,
@@ -233,8 +310,9 @@ private fun AlbumSectionHeader(
     Row(
         modifier = Modifier
             .fillMaxWidth()
+            .testTag("$GROUP_DETAIL_SECTION_HEADER_TAG_PREFIX:$albumId")
             .background(colorScheme.surface)
-            .clickable { onToggle() }
+            .combinedClickable(onClick = onToggle, onLongClick = onToggle)
             .padding(horizontal = 16.dp, vertical = 10.dp),
         verticalAlignment = Alignment.CenterVertically
     ) {
@@ -248,25 +326,27 @@ private fun AlbumSectionHeader(
                 .clip(RoundedCornerShape(8.dp))
         )
         Spacer(modifier = Modifier.width(10.dp))
-        Text(
-            text = albumTitle.ifBlank { rjCode.ifBlank { "专辑" } },
-            style = MaterialTheme.typography.titleMedium,
-            color = colorScheme.textPrimary,
-            maxLines = 2,
-            overflow = TextOverflow.Ellipsis,
-            modifier = Modifier.weight(1f)
-        )
-        if (rjCode.isNotBlank()) {
+        Column(modifier = Modifier.weight(1f)) {
             Text(
-                text = rjCode,
-                style = MaterialTheme.typography.labelSmall,
-                color = colorScheme.textTertiary,
-                modifier = Modifier.padding(start = 6.dp)
+                text = albumTitle.ifBlank { rjCode.ifBlank { "专辑" } },
+                style = MaterialTheme.typography.titleMedium,
+                color = colorScheme.textPrimary,
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis
             )
+            if (rjCode.isNotBlank()) {
+                Text(
+                    text = if (expanded) "$rjCode · 已展开" else "$rjCode · 已折叠",
+                    style = MaterialTheme.typography.labelSmall,
+                    color = colorScheme.textTertiary,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
+            }
         }
         IconButton(onClick = onRemoveAlbum) {
             Icon(
-                Icons.Default.Delete,
+                imageVector = Icons.Default.Delete,
                 contentDescription = null,
                 tint = colorScheme.danger.copy(alpha = 0.7f)
             )
@@ -274,11 +354,15 @@ private fun AlbumSectionHeader(
     }
 }
 
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
 private fun GroupTrackRow(
     item: AlbumGroupTrackRow,
     coverModel: Any?,
     onPlay: () -> Unit,
+    onLongPress: () -> Unit,
+    onMoveToTop: () -> Unit,
+    onMoveToBottom: () -> Unit,
     onRemove: () -> Unit
 ) {
     val colorScheme = AsmrTheme.colorScheme
@@ -291,7 +375,11 @@ private fun GroupTrackRow(
     Row(
         modifier = Modifier
             .fillMaxWidth()
-            .clickable { onPlay() }
+            .testTag("$GROUP_DETAIL_TRACK_TAG_PREFIX:${item.mediaId}")
+            .combinedClickable(
+                onClick = onPlay,
+                onLongClick = onLongPress
+            )
             .padding(horizontal = 16.dp, vertical = 10.dp),
         verticalAlignment = Alignment.CenterVertically
     ) {
@@ -320,7 +408,10 @@ private fun GroupTrackRow(
             )
         }
         Box {
-            IconButton(onClick = { expanded = true }) {
+            IconButton(
+                onClick = { expanded = true },
+                modifier = Modifier.testTag("$GROUP_DETAIL_TRACK_MENU_BUTTON_TAG_PREFIX:${item.mediaId}")
+            ) {
                 Icon(imageVector = Icons.Default.MoreVert, contentDescription = null)
             }
             MaterialTheme(
@@ -339,6 +430,22 @@ private fun GroupTrackRow(
                         onClick = {
                             expanded = false
                             onPlay()
+                        }
+                    )
+                    DropdownMenuItem(
+                        text = { Text("移至顶部") },
+                        modifier = Modifier.testTag(GROUP_DETAIL_MOVE_TOP_MENU_ITEM_TAG),
+                        onClick = {
+                            expanded = false
+                            onMoveToTop()
+                        }
+                    )
+                    DropdownMenuItem(
+                        text = { Text("移至末尾") },
+                        modifier = Modifier.testTag(GROUP_DETAIL_MOVE_BOTTOM_MENU_ITEM_TAG),
+                        onClick = {
+                            expanded = false
+                            onMoveToBottom()
                         }
                     )
                     HorizontalDivider(
@@ -393,13 +500,14 @@ private fun toPlayableUri(path: String): Uri {
 private fun String.toArtworkUriOrNull(): Uri? {
     val trimmed = trim()
     if (trimmed.isBlank()) return null
-    return if (trimmed.startsWith("http", ignoreCase = true) ||
+    return if (
+        trimmed.startsWith("http", ignoreCase = true) ||
         trimmed.startsWith("content://", ignoreCase = true) ||
         trimmed.startsWith("file://", ignoreCase = true)
     ) {
         trimmed.toUri()
     } else {
-        val f = java.io.File(trimmed)
-        if (f.exists()) Uri.fromFile(f) else null
+        val file = java.io.File(trimmed)
+        if (file.exists()) Uri.fromFile(file) else null
     }
 }

--- a/app/src/main/java/com/asmr/player/ui/groups/AlbumGroupDetailScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/groups/AlbumGroupDetailScreen.kt
@@ -1,9 +1,10 @@
 package com.asmr.player.ui.groups
 
 import android.net.Uri
-import androidx.compose.foundation.background
-import androidx.compose.foundation.combinedClickable
+import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
@@ -13,6 +14,7 @@ import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -21,6 +23,7 @@ import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Delete
@@ -40,13 +43,16 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshots.SnapshotStateList
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.style.TextOverflow
@@ -58,9 +64,12 @@ import androidx.media3.common.MediaMetadata
 import com.asmr.player.data.local.db.dao.AlbumGroupTrackRow
 import com.asmr.player.ui.common.AsmrAsyncImage
 import com.asmr.player.ui.common.LocalBottomOverlayPadding
-import com.asmr.player.ui.common.ManualReorderDialog
-import com.asmr.player.ui.common.ManualReorderListItem
 import com.asmr.player.ui.common.StableWindowInsets
+import com.asmr.player.ui.common.reorderable.ItemPosition
+import com.asmr.player.ui.common.reorderable.ReorderableItem
+import com.asmr.player.ui.common.reorderable.detectReorderAfterLongPress
+import com.asmr.player.ui.common.reorderable.rememberReorderableLazyListState
+import com.asmr.player.ui.common.reorderable.reorderable
 import com.asmr.player.ui.theme.AsmrTheme
 import com.asmr.player.ui.theme.dynamicPageContainerColor
 import com.asmr.player.util.Formatting
@@ -74,13 +83,29 @@ internal const val GROUP_DETAIL_MOVE_BOTTOM_MENU_ITEM_TAG = "groupDetailMoveBott
 internal const val GROUP_DETAIL_REORDER_DIALOG_TAG = "groupDetailReorderDialog"
 internal const val GROUP_DETAIL_REORDER_ROW_TAG_PREFIX = "groupDetailReorderRow"
 
-private data class GroupReorderSession(
+private const val GROUP_DETAIL_REORDER_SENTINEL_KEY = "__group_detail_reorder_sentinel__"
+
+private sealed interface GroupDetailListRow {
+    val key: String
+}
+
+private data class GroupDetailHeaderRow(
     val albumId: Long,
     val albumTitle: String,
+    val rjCode: String,
     val coverModel: String,
-    val initialMediaId: String,
-    val items: List<AlbumGroupTrackRow>
-)
+    val expanded: Boolean
+) : GroupDetailListRow {
+    override val key: String = "header:$albumId"
+}
+
+private data class GroupDetailTrackRow(
+    val albumId: Long,
+    val coverModel: String,
+    val track: AlbumGroupTrackRow
+) : GroupDetailListRow {
+    override val key: String = track.mediaId
+}
 
 @Composable
 fun AlbumGroupDetailScreen(
@@ -121,12 +146,35 @@ internal fun AlbumGroupDetailContent(
 ) {
     val colorScheme = AsmrTheme.colorScheme
     val isCompact = windowSizeClass.widthSizeClass == WindowWidthSizeClass.Compact
+    val listState = rememberLazyListState()
     val expandedAlbumIds = rememberSaveable { mutableStateOf(setOf<Long>()) }
+    val localRows = remember { mutableStateListOf<GroupDetailListRow>() }
     var pendingRemoveTrack by remember { mutableStateOf<AlbumGroupTrackRow?>(null) }
     var pendingRemoveAlbum by remember { mutableStateOf<Pair<Long, String>?>(null) }
-    var reorderSession by remember { mutableStateOf<GroupReorderSession?>(null) }
 
-    val sections = remember(tracks) { tracks.groupBy { it.albumId } }
+    val reorderState = rememberReorderableLazyListState(
+        listState = listState,
+        maxScrollPerFrame = 28.dp,
+        scrollTriggerPadding = 112.dp,
+        onMove = { from, to ->
+            localRows.moveTrackRows(from, to)
+        },
+        canDragOver = { draggedOver, dragging ->
+            val target = localRows.findTrackRowByKey(draggedOver.key)
+            val dragged = localRows.findTrackRowByKey(dragging.key)
+            target != null && dragged != null && target.albumId == dragged.albumId
+        },
+        onDragEnd = { startIndex, endIndex ->
+            val albumId = localRows.resolveDraggedAlbumId(startIndex, endIndex) ?: return@rememberReorderableLazyListState
+            onSaveAlbumTrackOrder(albumId, localRows.mediaIdsForAlbum(albumId))
+        }
+    )
+
+    LaunchedEffect(tracks, expandedAlbumIds.value) {
+        if (reorderState.draggingItemIndex == null) {
+            localRows.sync(buildGroupDetailRows(tracks, expandedAlbumIds.value))
+        }
+    }
 
     Box(
         modifier = Modifier
@@ -160,70 +208,69 @@ internal fun AlbumGroupDetailContent(
             }
 
             LazyColumn(
-                modifier = Modifier.fillMaxSize(),
+                state = listState,
+                modifier = Modifier
+                    .fillMaxSize()
+                    .reorderable(reorderState),
                 contentPadding = PaddingValues(bottom = LocalBottomOverlayPadding.current)
             ) {
-                sections.forEach { (albumId, list) ->
-                    val first = list.firstOrNull()
-                    val sectionTitle = (first?.albumTitle ?: "").ifBlank {
-                        (first?.albumRjCode ?: "").ifBlank { "专辑" }
-                    }
-                    val rj = first?.albumRjCode.orEmpty()
-                    val coverModel = first?.albumCoverThumbPath.orEmpty()
-                        .ifBlank { first?.albumCoverPath.orEmpty() }
-                        .ifBlank { first?.albumCoverUrl.orEmpty() }
-                        .trim()
-                    val expanded = expandedAlbumIds.value.contains(albumId)
-
-                    item(key = "header:$albumId") {
-                        AlbumSectionHeader(
-                            albumId = albumId,
-                            albumTitle = sectionTitle,
-                            rjCode = rj,
-                            coverModel = coverModel,
-                            expanded = expanded,
-                            onToggle = {
-                                expandedAlbumIds.value = if (expanded) {
-                                    expandedAlbumIds.value - albumId
-                                } else {
-                                    expandedAlbumIds.value + albumId
-                                }
-                            },
-                            onRemoveAlbum = { pendingRemoveAlbum = albumId to sectionTitle }
-                        )
-                    }
-
-                    if (expanded) {
-                        itemsIndexed(list, key = { _, item -> item.mediaId }) { index, item ->
-                            GroupTrackRow(
-                                item = item,
-                                coverModel = coverModel,
-                                onPlay = {
-                                    val mediaItems = list.map { track -> track.toMediaItem() }
-                                    val startIndex = list.indexOfFirst { track -> track.mediaId == item.mediaId }
-                                        .coerceAtLeast(0)
-                                    onPlayMediaItems(mediaItems, startIndex)
-                                },
-                                onLongPress = {
-                                    if (list.size > 1) {
-                                        reorderSession = GroupReorderSession(
-                                            albumId = albumId,
-                                            albumTitle = sectionTitle,
-                                            coverModel = coverModel,
-                                            initialMediaId = item.mediaId,
-                                            items = list
-                                        )
+                item(key = GROUP_DETAIL_REORDER_SENTINEL_KEY) {
+                    Spacer(modifier = Modifier.height(1.dp))
+                }
+                itemsIndexed(localRows, key = { _, row -> row.key }) { index, row ->
+                    when (row) {
+                        is GroupDetailHeaderRow -> {
+                            AlbumSectionHeader(
+                                albumId = row.albumId,
+                                albumTitle = row.albumTitle,
+                                rjCode = row.rjCode,
+                                coverModel = row.coverModel,
+                                expanded = row.expanded,
+                                onToggle = {
+                                    expandedAlbumIds.value = if (row.expanded) {
+                                        expandedAlbumIds.value - row.albumId
+                                    } else {
+                                        expandedAlbumIds.value + row.albumId
                                     }
                                 },
-                                onMoveToTop = { onMoveTrackToTop(albumId, item.mediaId) },
-                                onMoveToBottom = { onMoveTrackToBottom(albumId, item.mediaId) },
-                                onRemove = { pendingRemoveTrack = item }
+                                onRemoveAlbum = {
+                                    pendingRemoveAlbum = row.albumId to row.albumTitle
+                                }
                             )
-                            if (index < list.lastIndex) {
-                                HorizontalDivider(
-                                    modifier = Modifier.padding(horizontal = 16.dp),
-                                    thickness = 0.5.dp,
-                                    color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.2f)
+                        }
+
+                        is GroupDetailTrackRow -> {
+                            ReorderableItem(
+                                reorderableState = reorderState,
+                                key = row.track.mediaId
+                            ) { isDragging ->
+                                val albumTracks = localRows.tracksForAlbum(row.albumId)
+                                val startIndex = albumTracks.indexOfFirst { it.mediaId == row.track.mediaId }
+                                    .coerceAtLeast(0)
+                                GroupTrackRow(
+                                    item = row.track,
+                                    coverModel = row.coverModel,
+                                    showTopDivider = index > 0 && localRows[index - 1] is GroupDetailTrackRow,
+                                    isDragging = isDragging,
+                                    modifier = Modifier
+                                        .fillMaxWidth()
+                                        .testTag("$GROUP_DETAIL_TRACK_TAG_PREFIX:${row.track.mediaId}")
+                                        .detectReorderAfterLongPress(reorderState)
+                                        .clickable {
+                                            onPlayMediaItems(
+                                                albumTracks.map { it.toMediaItem() },
+                                                startIndex
+                                            )
+                                        },
+                                    onPlay = {
+                                        onPlayMediaItems(
+                                            albumTracks.map { it.toMediaItem() },
+                                            startIndex
+                                        )
+                                    },
+                                    onMoveToTop = { onMoveTrackToTop(row.albumId, row.track.mediaId) },
+                                    onMoveToBottom = { onMoveTrackToBottom(row.albumId, row.track.mediaId) },
+                                    onRemove = { pendingRemoveTrack = row.track }
                                 )
                             }
                         }
@@ -270,29 +317,6 @@ internal fun AlbumGroupDetailContent(
             }
         )
     }
-
-    reorderSession?.let { session ->
-        ManualReorderDialog(
-            title = "手动排序",
-            items = session.items.map { track ->
-                val durationMs = (track.trackDuration * 1000.0).roundToLong().coerceAtLeast(0L)
-                ManualReorderListItem(
-                    key = track.mediaId,
-                    title = track.trackTitle.ifBlank { "未命名" },
-                    subtitle = Formatting.formatTrackTime(durationMs),
-                    artworkModel = session.coverModel,
-                    supportingText = session.albumTitle
-                )
-            },
-            initialKey = session.initialMediaId,
-            dialogTag = GROUP_DETAIL_REORDER_DIALOG_TAG,
-            rowTagPrefix = GROUP_DETAIL_REORDER_ROW_TAG_PREFIX,
-            onDismiss = { reorderSession = null },
-            onOrderCommitted = { orderedMediaIds ->
-                onSaveAlbumTrackOrder(session.albumId, orderedMediaIds)
-            }
-        )
-    }
 }
 
 @OptIn(ExperimentalFoundationApi::class)
@@ -312,7 +336,7 @@ private fun AlbumSectionHeader(
             .fillMaxWidth()
             .testTag("$GROUP_DETAIL_SECTION_HEADER_TAG_PREFIX:$albumId")
             .background(colorScheme.surface)
-            .combinedClickable(onClick = onToggle, onLongClick = onToggle)
+            .clickable { onToggle() }
             .padding(horizontal = 16.dp, vertical = 10.dp),
         verticalAlignment = Alignment.CenterVertically
     ) {
@@ -354,13 +378,14 @@ private fun AlbumSectionHeader(
     }
 }
 
-@OptIn(ExperimentalFoundationApi::class)
 @Composable
 private fun GroupTrackRow(
     item: AlbumGroupTrackRow,
     coverModel: Any?,
+    showTopDivider: Boolean,
+    isDragging: Boolean,
+    modifier: Modifier = Modifier,
     onPlay: () -> Unit,
-    onLongPress: () -> Unit,
     onMoveToTop: () -> Unit,
     onMoveToBottom: () -> Unit,
     onRemove: () -> Unit
@@ -371,99 +396,189 @@ private fun GroupTrackRow(
     var expanded by remember { mutableStateOf(false) }
     val durationMs = remember(item.trackDuration) { (item.trackDuration * 1000.0).roundToLong().coerceAtLeast(0L) }
     val subtitle = remember(durationMs) { Formatting.formatTrackTime(durationMs) }
+    val elevation by animateDpAsState(
+        targetValue = if (isDragging) 18.dp else 0.dp,
+        label = "groupTrackElevation"
+    )
 
-    Row(
-        modifier = Modifier
-            .fillMaxWidth()
-            .testTag("$GROUP_DETAIL_TRACK_TAG_PREFIX:${item.mediaId}")
-            .combinedClickable(
-                onClick = onPlay,
-                onLongClick = onLongPress
-            )
-            .padding(horizontal = 16.dp, vertical = 10.dp),
-        verticalAlignment = Alignment.CenterVertically
+    Box(
+        modifier = modifier.shadow(elevation, RoundedCornerShape(18.dp))
     ) {
-        AsmrAsyncImage(
-            model = coverModel?.toString().orEmpty(),
-            contentDescription = null,
-            contentScale = ContentScale.Crop,
-            placeholderCornerRadius = 6,
-            modifier = Modifier
-                .size(40.dp)
-                .clip(RoundedCornerShape(6.dp))
-        )
-        Spacer(modifier = Modifier.width(12.dp))
-        Column(modifier = Modifier.weight(1f)) {
-            Text(
-                text = item.trackTitle.ifBlank { "未命名" },
-                maxLines = 2,
-                overflow = TextOverflow.Ellipsis,
-                style = MaterialTheme.typography.bodyMedium,
-                color = colorScheme.textPrimary
-            )
-            Text(
-                text = subtitle,
-                style = MaterialTheme.typography.bodySmall,
-                color = colorScheme.textTertiary
+        if (showTopDivider) {
+            HorizontalDivider(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp)
+                    .align(Alignment.TopCenter),
+                thickness = 0.5.dp,
+                color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.2f)
             )
         }
-        Box {
-            IconButton(
-                onClick = { expanded = true },
-                modifier = Modifier.testTag("$GROUP_DETAIL_TRACK_MENU_BUTTON_TAG_PREFIX:${item.mediaId}")
-            ) {
-                Icon(imageVector = Icons.Default.MoreVert, contentDescription = null)
-            }
-            MaterialTheme(
-                colorScheme = materialColorScheme.copy(
-                    surface = dynamicContainerColor,
-                    surfaceContainer = dynamicContainerColor
+        Row(
+            modifier = Modifier.padding(horizontal = 16.dp, vertical = 10.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            AsmrAsyncImage(
+                model = coverModel?.toString().orEmpty(),
+                contentDescription = null,
+                contentScale = ContentScale.Crop,
+                placeholderCornerRadius = 6,
+                modifier = Modifier
+                    .size(40.dp)
+                    .clip(RoundedCornerShape(6.dp))
+            )
+            Spacer(modifier = Modifier.width(12.dp))
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = item.trackTitle.ifBlank { "未命名" },
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = colorScheme.textPrimary
                 )
-            ) {
-                DropdownMenu(
-                    expanded = expanded,
-                    onDismissRequest = { expanded = false },
-                    modifier = Modifier.background(dynamicContainerColor)
+                Text(
+                    text = subtitle,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = colorScheme.textTertiary
+                )
+            }
+            Box {
+                IconButton(
+                    onClick = { expanded = true },
+                    modifier = Modifier.testTag("$GROUP_DETAIL_TRACK_MENU_BUTTON_TAG_PREFIX:${item.mediaId}")
                 ) {
-                    DropdownMenuItem(
-                        text = { Text("播放") },
-                        onClick = {
-                            expanded = false
-                            onPlay()
-                        }
+                    Icon(imageVector = Icons.Default.MoreVert, contentDescription = null)
+                }
+                MaterialTheme(
+                    colorScheme = materialColorScheme.copy(
+                        surface = dynamicContainerColor,
+                        surfaceContainer = dynamicContainerColor
                     )
-                    DropdownMenuItem(
-                        text = { Text("移至顶部") },
-                        modifier = Modifier.testTag(GROUP_DETAIL_MOVE_TOP_MENU_ITEM_TAG),
-                        onClick = {
-                            expanded = false
-                            onMoveToTop()
-                        }
-                    )
-                    DropdownMenuItem(
-                        text = { Text("移至末尾") },
-                        modifier = Modifier.testTag(GROUP_DETAIL_MOVE_BOTTOM_MENU_ITEM_TAG),
-                        onClick = {
-                            expanded = false
-                            onMoveToBottom()
-                        }
-                    )
-                    HorizontalDivider(
-                        modifier = Modifier.padding(horizontal = 8.dp),
-                        thickness = 0.5.dp,
-                        color = materialColorScheme.outlineVariant.copy(alpha = 0.3f)
-                    )
-                    DropdownMenuItem(
-                        text = { Text("从分组移除") },
-                        onClick = {
-                            expanded = false
-                            onRemove()
-                        }
-                    )
+                ) {
+                    DropdownMenu(
+                        expanded = expanded,
+                        onDismissRequest = { expanded = false },
+                        modifier = Modifier.background(dynamicContainerColor)
+                    ) {
+                        DropdownMenuItem(
+                            text = { Text("播放") },
+                            onClick = {
+                                expanded = false
+                                onPlay()
+                            }
+                        )
+                        DropdownMenuItem(
+                            text = { Text("移至顶部") },
+                            modifier = Modifier.testTag(GROUP_DETAIL_MOVE_TOP_MENU_ITEM_TAG),
+                            onClick = {
+                                expanded = false
+                                onMoveToTop()
+                            }
+                        )
+                        DropdownMenuItem(
+                            text = { Text("移至末尾") },
+                            modifier = Modifier.testTag(GROUP_DETAIL_MOVE_BOTTOM_MENU_ITEM_TAG),
+                            onClick = {
+                                expanded = false
+                                onMoveToBottom()
+                            }
+                        )
+                        HorizontalDivider(
+                            modifier = Modifier.padding(horizontal = 8.dp),
+                            thickness = 0.5.dp,
+                            color = materialColorScheme.outlineVariant.copy(alpha = 0.3f)
+                        )
+                        DropdownMenuItem(
+                            text = { Text("从分组移除") },
+                            onClick = {
+                                expanded = false
+                                onRemove()
+                            }
+                        )
+                    }
                 }
             }
         }
     }
+}
+
+private fun buildGroupDetailRows(
+    tracks: List<AlbumGroupTrackRow>,
+    expandedAlbumIds: Set<Long>
+): List<GroupDetailListRow> {
+    val sections = tracks.groupBy { it.albumId }
+    val rows = mutableListOf<GroupDetailListRow>()
+    sections.forEach { (albumId, list) ->
+        val first = list.firstOrNull() ?: return@forEach
+        val sectionTitle = first.albumTitle.orEmpty().ifBlank {
+            first.albumRjCode.orEmpty().ifBlank { "专辑" }
+        }
+        val coverModel = first.albumCoverThumbPath.orEmpty()
+            .ifBlank { first.albumCoverPath.orEmpty() }
+            .ifBlank { first.albumCoverUrl.orEmpty() }
+            .trim()
+        val expanded = expandedAlbumIds.contains(albumId)
+        rows += GroupDetailHeaderRow(
+            albumId = albumId,
+            albumTitle = sectionTitle,
+            rjCode = first.albumRjCode.orEmpty(),
+            coverModel = coverModel,
+            expanded = expanded
+        )
+        if (expanded) {
+            rows += list.map { track ->
+                GroupDetailTrackRow(
+                    albumId = albumId,
+                    coverModel = coverModel,
+                    track = track
+                )
+            }
+        }
+    }
+    return rows
+}
+
+private fun SnapshotStateList<GroupDetailListRow>.sync(rows: List<GroupDetailListRow>) {
+    clear()
+    addAll(rows)
+}
+
+private fun SnapshotStateList<GroupDetailListRow>.findTrackRowByKey(key: Any?): GroupDetailTrackRow? {
+    return firstOrNull { row -> row is GroupDetailTrackRow && row.track.mediaId == key } as? GroupDetailTrackRow
+}
+
+private fun SnapshotStateList<GroupDetailListRow>.tracksForAlbum(albumId: Long): List<AlbumGroupTrackRow> {
+    return filterIsInstance<GroupDetailTrackRow>()
+        .filter { row -> row.albumId == albumId }
+        .map { row -> row.track }
+}
+
+private fun SnapshotStateList<GroupDetailListRow>.mediaIdsForAlbum(albumId: Long): List<String> {
+    return tracksForAlbum(albumId).map { track -> track.mediaId }
+}
+
+private fun SnapshotStateList<GroupDetailListRow>.resolveDraggedAlbumId(
+    startIndex: Int,
+    endIndex: Int
+): Long? {
+    val endRow = getOrNull(endIndex - 1) as? GroupDetailTrackRow
+    if (endRow != null) return endRow.albumId
+    val startRow = getOrNull(startIndex - 1) as? GroupDetailTrackRow
+    return startRow?.albumId
+}
+
+private fun SnapshotStateList<GroupDetailListRow>.moveTrackRows(
+    from: ItemPosition,
+    to: ItemPosition
+) {
+    if (isEmpty()) return
+    val fromIndex = from.index - 1
+    val toIndex = to.index - 1
+    if (fromIndex !in indices || toIndex !in indices || fromIndex == toIndex) return
+    val fromRow = getOrNull(fromIndex) as? GroupDetailTrackRow ?: return
+    val toRow = getOrNull(toIndex) as? GroupDetailTrackRow ?: return
+    if (fromRow.albumId != toRow.albumId) return
+    add(toIndex, removeAt(fromIndex))
 }
 
 private fun AlbumGroupTrackRow.toMediaItem(): MediaItem {

--- a/app/src/main/java/com/asmr/player/ui/groups/AlbumGroupDetailViewModel.kt
+++ b/app/src/main/java/com/asmr/player/ui/groups/AlbumGroupDetailViewModel.kt
@@ -45,7 +45,7 @@ class AlbumGroupDetailViewModel @Inject constructor(
         if (id <= 0L || mediaId.isBlank()) return
         viewModelScope.launch {
             groupRepository.removeTrackFromGroup(id, mediaId)
-            messageManager.showInfo("已从分组移除")
+            messageManager.showInfo("\u5DF2\u4ECE\u5206\u7EC4\u79FB\u9664")
         }
     }
 
@@ -54,7 +54,35 @@ class AlbumGroupDetailViewModel @Inject constructor(
         if (id <= 0L || albumId <= 0L) return
         viewModelScope.launch {
             groupRepository.removeAlbumFromGroup(id, albumId)
-            messageManager.showInfo("已从分组移除")
+            messageManager.showInfo("\u5DF2\u4ECE\u5206\u7EC4\u79FB\u9664")
+        }
+    }
+
+    fun moveTrackToTop(albumId: Long, mediaId: String) {
+        val id = groupIdFlow.value
+        if (id <= 0L || albumId <= 0L || mediaId.isBlank()) return
+        viewModelScope.launch {
+            if (groupRepository.moveTrackToTop(id, albumId, mediaId)) {
+                messageManager.showInfo("\u5DF2\u79FB\u81F3\u9876\u90E8")
+            }
+        }
+    }
+
+    fun moveTrackToBottom(albumId: Long, mediaId: String) {
+        val id = groupIdFlow.value
+        if (id <= 0L || albumId <= 0L || mediaId.isBlank()) return
+        viewModelScope.launch {
+            if (groupRepository.moveTrackToBottom(id, albumId, mediaId)) {
+                messageManager.showInfo("\u5DF2\u79FB\u81F3\u672B\u5C3E")
+            }
+        }
+    }
+
+    fun saveAlbumTrackOrder(albumId: Long, orderedMediaIds: List<String>) {
+        val id = groupIdFlow.value
+        if (id <= 0L || albumId <= 0L || orderedMediaIds.isEmpty()) return
+        viewModelScope.launch {
+            groupRepository.reorderAlbumTracks(id, albumId, orderedMediaIds)
         }
     }
 }

--- a/app/src/main/java/com/asmr/player/ui/playlists/PlaylistDetailScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/playlists/PlaylistDetailScreen.kt
@@ -1,24 +1,25 @@
 package com.asmr.player.ui.playlists
 
-import androidx.compose.foundation.background
-import androidx.compose.foundation.combinedClickable
+import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.navigationBars
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.MoreVert
@@ -38,12 +39,15 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshots.SnapshotStateList
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.testTag
@@ -54,10 +58,13 @@ import com.asmr.player.data.local.db.entities.PlaylistItemEntity
 import com.asmr.player.data.local.db.entities.PlaylistItemWithSubtitles
 import com.asmr.player.ui.common.AsmrAsyncImage
 import com.asmr.player.ui.common.LocalBottomOverlayPadding
-import com.asmr.player.ui.common.ManualReorderDialog
-import com.asmr.player.ui.common.ManualReorderListItem
 import com.asmr.player.ui.common.StableWindowInsets
 import com.asmr.player.ui.common.SubtitleStamp
+import com.asmr.player.ui.common.reorderable.ItemPosition
+import com.asmr.player.ui.common.reorderable.ReorderableItem
+import com.asmr.player.ui.common.reorderable.detectReorderAfterLongPress
+import com.asmr.player.ui.common.reorderable.rememberReorderableLazyListState
+import com.asmr.player.ui.common.reorderable.reorderable
 import com.asmr.player.ui.theme.AsmrTheme
 import com.asmr.player.ui.theme.dynamicPageContainerColor
 
@@ -68,10 +75,7 @@ internal const val PLAYLIST_DETAIL_MOVE_BOTTOM_MENU_ITEM_TAG = "playlistDetailMo
 internal const val PLAYLIST_DETAIL_REORDER_DIALOG_TAG = "playlistDetailReorderDialog"
 internal const val PLAYLIST_DETAIL_REORDER_ROW_TAG_PREFIX = "playlistDetailReorderRow"
 
-private data class PlaylistReorderSession(
-    val initialMediaId: String,
-    val items: List<PlaylistItemWithSubtitles>
-)
+private const val PLAYLIST_DETAIL_REORDER_SENTINEL_KEY = "__playlist_detail_reorder_sentinel__"
 
 @Composable
 fun PlaylistDetailScreen(
@@ -108,24 +112,35 @@ internal fun PlaylistDetailContent(
     onMoveItemToBottom: (String) -> Unit,
     onSaveManualOrder: (List<String>) -> Unit
 ) {
-    val playItems = remember(items) {
-        items.map {
-            PlaylistItemEntity(
-                playlistId = it.playlistId,
-                mediaId = it.mediaId,
-                title = it.title,
-                artist = it.artist,
-                uri = it.uri,
-                artworkUri = it.playbackArtworkUri.ifBlank { it.artworkUri },
-                itemOrder = it.itemOrder
-            )
+    val listState = rememberLazyListState()
+    val localItems = remember { mutableStateListOf<PlaylistItemWithSubtitles>() }
+    var pendingRemoveItem by remember { mutableStateOf<PlaylistItemWithSubtitles?>(null) }
+
+    val reorderState = rememberReorderableLazyListState(
+        listState = listState,
+        maxScrollPerFrame = 28.dp,
+        scrollTriggerPadding = 112.dp,
+        onMove = { from, to ->
+            localItems.movePlaylistItems(from, to)
+        },
+        canDragOver = { draggedOver, _ ->
+            localItems.any { item -> item.mediaId == draggedOver.key }
+        },
+        onDragEnd = { _, _ ->
+            onSaveManualOrder(localItems.map { it.mediaId })
+        }
+    )
+
+    LaunchedEffect(items) {
+        if (reorderState.draggingItemIndex == null) {
+            localItems.sync(items)
         }
     }
-    var pendingRemoveItem by remember { mutableStateOf<PlaylistItemWithSubtitles?>(null) }
-    var reorderSession by remember { mutableStateOf<PlaylistReorderSession?>(null) }
 
+    val playItems = localItems.map { item -> item.toPlaybackEntity() }
     val isCompact = windowSizeClass.widthSizeClass == WindowWidthSizeClass.Compact
     val colorScheme = AsmrTheme.colorScheme
+
     Scaffold(
         contentWindowInsets = StableWindowInsets.navigationBars,
         containerColor = Color.Transparent,
@@ -146,40 +161,32 @@ internal fun PlaylistDetailContent(
                     .fillMaxWidth()
             }
             LazyColumn(
-                modifier = contentModifier,
+                state = listState,
+                modifier = contentModifier.reorderable(reorderState),
                 contentPadding = PaddingValues(top = 6.dp, bottom = LocalBottomOverlayPadding.current)
             ) {
-                itemsIndexed(items, key = { _, item -> item.mediaId }) { index, item ->
-                    val startItem = PlaylistItemEntity(
-                        playlistId = item.playlistId,
-                        mediaId = item.mediaId,
-                        title = item.title,
-                        artist = item.artist,
-                        uri = item.uri,
-                        artworkUri = item.playbackArtworkUri.ifBlank { item.artworkUri },
-                        itemOrder = item.itemOrder
-                    )
-                    PlaylistItemRow(
-                        item = item,
-                        showSubtitleStamp = item.hasSubtitles,
-                        onPlay = { onPlayAll(playItems, startItem) },
-                        onLongPress = {
-                            if (items.size > 1) {
-                                reorderSession = PlaylistReorderSession(
-                                    initialMediaId = item.mediaId,
-                                    items = items
-                                )
-                            }
-                        },
-                        onMoveToTop = { onMoveItemToTop(item.mediaId) },
-                        onMoveToBottom = { onMoveItemToBottom(item.mediaId) },
-                        onRemove = { pendingRemoveItem = item }
-                    )
-                    if (index < items.lastIndex) {
-                        HorizontalDivider(
-                            modifier = Modifier.padding(horizontal = 16.dp),
-                            thickness = 0.5.dp,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.2f)
+                item(key = PLAYLIST_DETAIL_REORDER_SENTINEL_KEY) {
+                    Spacer(modifier = Modifier.height(1.dp))
+                }
+                itemsIndexed(localItems, key = { _, item -> item.mediaId }) { index, item ->
+                    ReorderableItem(
+                        reorderableState = reorderState,
+                        key = item.mediaId
+                    ) { isDragging ->
+                        PlaylistItemRow(
+                            item = item,
+                            showSubtitleStamp = item.hasSubtitles,
+                            showTopDivider = index > 0,
+                            isDragging = isDragging,
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .testTag("$PLAYLIST_DETAIL_ITEM_TAG_PREFIX:${item.mediaId}")
+                                .detectReorderAfterLongPress(reorderState)
+                                .clickable { onPlayAll(playItems, item.toPlaybackEntity()) },
+                            onPlay = { onPlayAll(playItems, item.toPlaybackEntity()) },
+                            onMoveToTop = { onMoveItemToTop(item.mediaId) },
+                            onMoveToBottom = { onMoveItemToBottom(item.mediaId) },
+                            onRemove = { pendingRemoveItem = item }
                         )
                     }
                 }
@@ -214,26 +221,6 @@ internal fun PlaylistDetailContent(
             }
         )
     }
-
-    reorderSession?.let { session ->
-        ManualReorderDialog(
-            title = "手动排序",
-            items = session.items.map { item ->
-                ManualReorderListItem(
-                    key = item.mediaId,
-                    title = item.title.ifBlank { "未命名" },
-                    subtitle = item.artist,
-                    artworkModel = item.playbackArtworkUri.ifBlank { item.artworkUri },
-                    supportingText = if (item.hasSubtitles) "含字幕" else ""
-                )
-            },
-            initialKey = session.initialMediaId,
-            dialogTag = PLAYLIST_DETAIL_REORDER_DIALOG_TAG,
-            rowTagPrefix = PLAYLIST_DETAIL_REORDER_ROW_TAG_PREFIX,
-            onDismiss = { reorderSession = null },
-            onOrderCommitted = onSaveManualOrder
-        )
-    }
 }
 
 @OptIn(ExperimentalFoundationApi::class)
@@ -241,8 +228,10 @@ internal fun PlaylistDetailContent(
 private fun PlaylistItemRow(
     item: PlaylistItemWithSubtitles,
     showSubtitleStamp: Boolean,
+    showTopDivider: Boolean,
+    isDragging: Boolean,
+    modifier: Modifier = Modifier,
     onPlay: () -> Unit,
-    onLongPress: () -> Unit,
     onMoveToTop: () -> Unit,
     onMoveToBottom: () -> Unit,
     onRemove: () -> Unit
@@ -251,106 +240,147 @@ private fun PlaylistItemRow(
     val materialColorScheme = MaterialTheme.colorScheme
     val dynamicContainerColor = dynamicPageContainerColor(colorScheme)
     var expanded by remember { mutableStateOf(false) }
+    val elevation by animateDpAsState(
+        targetValue = if (isDragging) 18.dp else 0.dp,
+        label = "playlistItemElevation"
+    )
 
-    Row(
-        modifier = Modifier
-            .fillMaxWidth()
-            .testTag("$PLAYLIST_DETAIL_ITEM_TAG_PREFIX:${item.mediaId}")
-            .combinedClickable(
-                onClick = onPlay,
-                onLongClick = onLongPress
-            )
-            .padding(horizontal = 16.dp, vertical = 10.dp),
-        verticalAlignment = Alignment.CenterVertically
+    Box(
+        modifier = modifier.shadow(elevation, RoundedCornerShape(18.dp))
     ) {
-        AsmrAsyncImage(
-            model = item.artworkUri,
-            contentDescription = null,
-            contentScale = ContentScale.Crop,
-            placeholderCornerRadius = 6,
-            modifier = Modifier
-                .size(40.dp)
-                .clip(RoundedCornerShape(6.dp))
-        )
-        Spacer(modifier = Modifier.width(12.dp))
-        Column(modifier = Modifier.weight(1f)) {
-            Text(
-                text = item.title.ifBlank { "未命名" },
-                maxLines = 2,
-                overflow = TextOverflow.Ellipsis,
-                style = MaterialTheme.typography.bodyMedium,
-                color = colorScheme.textPrimary
+        if (showTopDivider) {
+            HorizontalDivider(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp)
+                    .align(Alignment.TopCenter),
+                thickness = 0.5.dp,
+                color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.2f)
             )
-            if (item.artist.isNotBlank()) {
+        }
+        Row(
+            modifier = Modifier.padding(horizontal = 16.dp, vertical = 10.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            AsmrAsyncImage(
+                model = item.artworkUri,
+                contentDescription = null,
+                contentScale = ContentScale.Crop,
+                placeholderCornerRadius = 6,
+                modifier = Modifier
+                    .size(40.dp)
+                    .clip(RoundedCornerShape(6.dp))
+            )
+            Spacer(modifier = Modifier.width(12.dp))
+            Column(modifier = Modifier.weight(1f)) {
                 Text(
-                    text = item.artist,
-                    maxLines = 1,
+                    text = item.title.ifBlank { "未命名" },
+                    maxLines = 2,
                     overflow = TextOverflow.Ellipsis,
-                    style = MaterialTheme.typography.bodySmall,
-                    color = colorScheme.textTertiary,
-                    modifier = Modifier.padding(top = 2.dp)
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = colorScheme.textPrimary
                 )
+                if (item.artist.isNotBlank()) {
+                    Text(
+                        text = item.artist,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = colorScheme.textTertiary,
+                        modifier = Modifier.padding(top = 2.dp)
+                    )
+                }
             }
-        }
-        Spacer(modifier = Modifier.width(8.dp))
-        if (showSubtitleStamp) {
-            SubtitleStamp(modifier = Modifier.padding(end = 8.dp))
-        }
-        Box {
-            IconButton(
-                onClick = { expanded = true },
-                modifier = Modifier.testTag("$PLAYLIST_DETAIL_ITEM_MENU_BUTTON_TAG_PREFIX:${item.mediaId}")
-            ) {
-                Icon(imageVector = Icons.Default.MoreVert, contentDescription = null)
+            Spacer(modifier = Modifier.width(8.dp))
+            if (showSubtitleStamp) {
+                SubtitleStamp(modifier = Modifier.padding(end = 8.dp))
             }
-            MaterialTheme(
-                colorScheme = materialColorScheme.copy(
-                    surface = dynamicContainerColor,
-                    surfaceContainer = dynamicContainerColor
-                )
-            ) {
-                DropdownMenu(
-                    expanded = expanded,
-                    onDismissRequest = { expanded = false },
-                    modifier = Modifier.background(dynamicContainerColor)
+            Box {
+                IconButton(
+                    onClick = { expanded = true },
+                    modifier = Modifier.testTag("$PLAYLIST_DETAIL_ITEM_MENU_BUTTON_TAG_PREFIX:${item.mediaId}")
                 ) {
-                    DropdownMenuItem(
-                        text = { Text("播放") },
-                        onClick = {
-                            expanded = false
-                            onPlay()
-                        }
+                    Icon(imageVector = Icons.Default.MoreVert, contentDescription = null)
+                }
+                MaterialTheme(
+                    colorScheme = materialColorScheme.copy(
+                        surface = dynamicContainerColor,
+                        surfaceContainer = dynamicContainerColor
                     )
-                    DropdownMenuItem(
-                        text = { Text("移至顶部") },
-                        modifier = Modifier.testTag(PLAYLIST_DETAIL_MOVE_TOP_MENU_ITEM_TAG),
-                        onClick = {
-                            expanded = false
-                            onMoveToTop()
-                        }
-                    )
-                    DropdownMenuItem(
-                        text = { Text("移至末尾") },
-                        modifier = Modifier.testTag(PLAYLIST_DETAIL_MOVE_BOTTOM_MENU_ITEM_TAG),
-                        onClick = {
-                            expanded = false
-                            onMoveToBottom()
-                        }
-                    )
-                    HorizontalDivider(
-                        modifier = Modifier.padding(horizontal = 8.dp),
-                        thickness = 0.5.dp,
-                        color = materialColorScheme.outlineVariant.copy(alpha = 0.3f)
-                    )
-                    DropdownMenuItem(
-                        text = { Text("移除") },
-                        onClick = {
-                            expanded = false
-                            onRemove()
-                        }
-                    )
+                ) {
+                    DropdownMenu(
+                        expanded = expanded,
+                        onDismissRequest = { expanded = false },
+                        modifier = Modifier.background(dynamicContainerColor)
+                    ) {
+                        DropdownMenuItem(
+                            text = { Text("播放") },
+                            onClick = {
+                                expanded = false
+                                onPlay()
+                            }
+                        )
+                        DropdownMenuItem(
+                            text = { Text("移至顶部") },
+                            modifier = Modifier.testTag(PLAYLIST_DETAIL_MOVE_TOP_MENU_ITEM_TAG),
+                            onClick = {
+                                expanded = false
+                                onMoveToTop()
+                            }
+                        )
+                        DropdownMenuItem(
+                            text = { Text("移至末尾") },
+                            modifier = Modifier.testTag(PLAYLIST_DETAIL_MOVE_BOTTOM_MENU_ITEM_TAG),
+                            onClick = {
+                                expanded = false
+                                onMoveToBottom()
+                            }
+                        )
+                        HorizontalDivider(
+                            modifier = Modifier.padding(horizontal = 8.dp),
+                            thickness = 0.5.dp,
+                            color = materialColorScheme.outlineVariant.copy(alpha = 0.3f)
+                        )
+                        DropdownMenuItem(
+                            text = { Text("移除") },
+                            onClick = {
+                                expanded = false
+                                onRemove()
+                            }
+                        )
+                    }
                 }
             }
         }
     }
+}
+
+private fun PlaylistItemWithSubtitles.toPlaybackEntity(): PlaylistItemEntity {
+    return PlaylistItemEntity(
+        playlistId = playlistId,
+        mediaId = mediaId,
+        title = title,
+        artist = artist,
+        uri = uri,
+        artworkUri = playbackArtworkUri.ifBlank { artworkUri },
+        itemOrder = itemOrder
+    )
+}
+
+private fun SnapshotStateList<PlaylistItemWithSubtitles>.sync(
+    items: List<PlaylistItemWithSubtitles>
+) {
+    clear()
+    addAll(items)
+}
+
+private fun SnapshotStateList<PlaylistItemWithSubtitles>.movePlaylistItems(
+    from: ItemPosition,
+    to: ItemPosition
+) {
+    if (isEmpty()) return
+    val fromIndex = from.index - 1
+    val toIndex = to.index - 1
+    if (fromIndex !in indices || toIndex !in indices || fromIndex == toIndex) return
+    add(toIndex, removeAt(fromIndex))
 }

--- a/app/src/main/java/com/asmr/player/ui/playlists/PlaylistDetailScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/playlists/PlaylistDetailScreen.kt
@@ -1,33 +1,43 @@
 package com.asmr.player.ui.playlists
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.MoreVert
-import androidx.compose.material3.*
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.material3.windowsizeclass.WindowSizeClass
 import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
@@ -36,18 +46,32 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.asmr.player.data.local.db.entities.PlaylistItemEntity
 import com.asmr.player.data.local.db.entities.PlaylistItemWithSubtitles
 import com.asmr.player.ui.common.AsmrAsyncImage
-import com.asmr.player.ui.common.SubtitleStamp
-
-import androidx.compose.foundation.lazy.itemsIndexed
 import com.asmr.player.ui.common.LocalBottomOverlayPadding
+import com.asmr.player.ui.common.ManualReorderDialog
+import com.asmr.player.ui.common.ManualReorderListItem
 import com.asmr.player.ui.common.StableWindowInsets
+import com.asmr.player.ui.common.SubtitleStamp
+import com.asmr.player.ui.theme.AsmrTheme
 import com.asmr.player.ui.theme.dynamicPageContainerColor
+
+internal const val PLAYLIST_DETAIL_ITEM_TAG_PREFIX = "playlistDetailItem"
+internal const val PLAYLIST_DETAIL_ITEM_MENU_BUTTON_TAG_PREFIX = "playlistDetailItemMenu"
+internal const val PLAYLIST_DETAIL_MOVE_TOP_MENU_ITEM_TAG = "playlistDetailMoveTopMenuItem"
+internal const val PLAYLIST_DETAIL_MOVE_BOTTOM_MENU_ITEM_TAG = "playlistDetailMoveBottomMenuItem"
+internal const val PLAYLIST_DETAIL_REORDER_DIALOG_TAG = "playlistDetailReorderDialog"
+internal const val PLAYLIST_DETAIL_REORDER_ROW_TAG_PREFIX = "playlistDetailReorderRow"
+
+private data class PlaylistReorderSession(
+    val initialMediaId: String,
+    val items: List<PlaylistItemWithSubtitles>
+)
 
 @Composable
 fun PlaylistDetailScreen(
@@ -61,6 +85,29 @@ fun PlaylistDetailScreen(
         viewModel.setPlaylistId(playlistId)
     }
     val items by viewModel.items.collectAsState()
+    PlaylistDetailContent(
+        windowSizeClass = windowSizeClass,
+        title = title,
+        items = items,
+        onPlayAll = onPlayAll,
+        onRemoveItem = viewModel::removeItem,
+        onMoveItemToTop = viewModel::moveItemToTop,
+        onMoveItemToBottom = viewModel::moveItemToBottom,
+        onSaveManualOrder = viewModel::saveManualOrder
+    )
+}
+
+@Composable
+internal fun PlaylistDetailContent(
+    windowSizeClass: WindowSizeClass,
+    title: String,
+    items: List<PlaylistItemWithSubtitles>,
+    onPlayAll: (List<PlaylistItemEntity>, PlaylistItemEntity) -> Unit,
+    onRemoveItem: (String) -> Unit,
+    onMoveItemToTop: (String) -> Unit,
+    onMoveItemToBottom: (String) -> Unit,
+    onSaveManualOrder: (List<String>) -> Unit
+) {
     val playItems = remember(items) {
         items.map {
             PlaylistItemEntity(
@@ -75,11 +122,10 @@ fun PlaylistDetailScreen(
         }
     }
     var pendingRemoveItem by remember { mutableStateOf<PlaylistItemWithSubtitles?>(null) }
+    var reorderSession by remember { mutableStateOf<PlaylistReorderSession?>(null) }
 
-    // 屏幕尺寸判断
     val isCompact = windowSizeClass.widthSizeClass == WindowWidthSizeClass.Compact
-
-    val colorScheme = com.asmr.player.ui.theme.AsmrTheme.colorScheme
+    val colorScheme = AsmrTheme.colorScheme
     Scaffold(
         contentWindowInsets = StableWindowInsets.navigationBars,
         containerColor = Color.Transparent,
@@ -103,7 +149,7 @@ fun PlaylistDetailScreen(
                 modifier = contentModifier,
                 contentPadding = PaddingValues(top = 6.dp, bottom = LocalBottomOverlayPadding.current)
             ) {
-                itemsIndexed(items, key = { idx, item -> "${item.mediaId}#$idx" }) { index, item ->
+                itemsIndexed(items, key = { _, item -> item.mediaId }) { index, item ->
                     val startItem = PlaylistItemEntity(
                         playlistId = item.playlistId,
                         mediaId = item.mediaId,
@@ -117,11 +163,19 @@ fun PlaylistDetailScreen(
                         item = item,
                         showSubtitleStamp = item.hasSubtitles,
                         onPlay = { onPlayAll(playItems, startItem) },
-                        onRemove = {
-                            pendingRemoveItem = item
-                        }
+                        onLongPress = {
+                            if (items.size > 1) {
+                                reorderSession = PlaylistReorderSession(
+                                    initialMediaId = item.mediaId,
+                                    items = items
+                                )
+                            }
+                        },
+                        onMoveToTop = { onMoveItemToTop(item.mediaId) },
+                        onMoveToBottom = { onMoveItemToBottom(item.mediaId) },
+                        onRemove = { pendingRemoveItem = item }
                     )
-                    if (index < items.size - 1) {
+                    if (index < items.lastIndex) {
                         HorizontalDivider(
                             modifier = Modifier.padding(horizontal = 16.dp),
                             thickness = 0.5.dp,
@@ -133,8 +187,7 @@ fun PlaylistDetailScreen(
         }
     }
 
-    val item = pendingRemoveItem
-    if (item != null) {
+    pendingRemoveItem?.let { item ->
         AlertDialog(
             onDismissRequest = { pendingRemoveItem = null },
             title = { Text("确认移除") },
@@ -148,7 +201,7 @@ fun PlaylistDetailScreen(
                 TextButton(
                     onClick = {
                         pendingRemoveItem = null
-                        viewModel.removeItem(item.mediaId)
+                        onRemoveItem(item.mediaId)
                     }
                 ) {
                     Text("移除")
@@ -161,23 +214,52 @@ fun PlaylistDetailScreen(
             }
         )
     }
+
+    reorderSession?.let { session ->
+        ManualReorderDialog(
+            title = "手动排序",
+            items = session.items.map { item ->
+                ManualReorderListItem(
+                    key = item.mediaId,
+                    title = item.title.ifBlank { "未命名" },
+                    subtitle = item.artist,
+                    artworkModel = item.playbackArtworkUri.ifBlank { item.artworkUri },
+                    supportingText = if (item.hasSubtitles) "含字幕" else ""
+                )
+            },
+            initialKey = session.initialMediaId,
+            dialogTag = PLAYLIST_DETAIL_REORDER_DIALOG_TAG,
+            rowTagPrefix = PLAYLIST_DETAIL_REORDER_ROW_TAG_PREFIX,
+            onDismiss = { reorderSession = null },
+            onOrderCommitted = onSaveManualOrder
+        )
+    }
 }
 
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
 private fun PlaylistItemRow(
     item: PlaylistItemWithSubtitles,
     showSubtitleStamp: Boolean,
     onPlay: () -> Unit,
+    onLongPress: () -> Unit,
+    onMoveToTop: () -> Unit,
+    onMoveToBottom: () -> Unit,
     onRemove: () -> Unit
 ) {
-    val colorScheme = com.asmr.player.ui.theme.AsmrTheme.colorScheme
+    val colorScheme = AsmrTheme.colorScheme
     val materialColorScheme = MaterialTheme.colorScheme
     val dynamicContainerColor = dynamicPageContainerColor(colorScheme)
     var expanded by remember { mutableStateOf(false) }
+
     Row(
         modifier = Modifier
             .fillMaxWidth()
-            .clickable { onPlay() }
+            .testTag("$PLAYLIST_DETAIL_ITEM_TAG_PREFIX:${item.mediaId}")
+            .combinedClickable(
+                onClick = onPlay,
+                onLongClick = onLongPress
+            )
             .padding(horizontal = 16.dp, vertical = 10.dp),
         verticalAlignment = Alignment.CenterVertically
     ) {
@@ -188,25 +270,37 @@ private fun PlaylistItemRow(
             placeholderCornerRadius = 6,
             modifier = Modifier
                 .size(40.dp)
-                .clip(RoundedCornerShape(6.dp)),
+                .clip(RoundedCornerShape(6.dp))
         )
-        android.util.Log.d("PlaylistDetailScreen", "PlaylistItemRow - loading artwork for item: ${item.title}, artworkUri: '${item.artworkUri}'")
         Spacer(modifier = Modifier.width(12.dp))
         Column(modifier = Modifier.weight(1f)) {
             Text(
-                item.title.ifBlank { "未命名" }, 
-                maxLines = 2, 
+                text = item.title.ifBlank { "未命名" },
+                maxLines = 2,
                 overflow = TextOverflow.Ellipsis,
                 style = MaterialTheme.typography.bodyMedium,
                 color = colorScheme.textPrimary
             )
+            if (item.artist.isNotBlank()) {
+                Text(
+                    text = item.artist,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = colorScheme.textTertiary,
+                    modifier = Modifier.padding(top = 2.dp)
+                )
+            }
         }
         Spacer(modifier = Modifier.width(8.dp))
         if (showSubtitleStamp) {
             SubtitleStamp(modifier = Modifier.padding(end = 8.dp))
         }
         Box {
-            IconButton(onClick = { expanded = true }) {
+            IconButton(
+                onClick = { expanded = true },
+                modifier = Modifier.testTag("$PLAYLIST_DETAIL_ITEM_MENU_BUTTON_TAG_PREFIX:${item.mediaId}")
+            ) {
                 Icon(imageVector = Icons.Default.MoreVert, contentDescription = null)
             }
             MaterialTheme(
@@ -225,6 +319,22 @@ private fun PlaylistItemRow(
                         onClick = {
                             expanded = false
                             onPlay()
+                        }
+                    )
+                    DropdownMenuItem(
+                        text = { Text("移至顶部") },
+                        modifier = Modifier.testTag(PLAYLIST_DETAIL_MOVE_TOP_MENU_ITEM_TAG),
+                        onClick = {
+                            expanded = false
+                            onMoveToTop()
+                        }
+                    )
+                    DropdownMenuItem(
+                        text = { Text("移至末尾") },
+                        modifier = Modifier.testTag(PLAYLIST_DETAIL_MOVE_BOTTOM_MENU_ITEM_TAG),
+                        onClick = {
+                            expanded = false
+                            onMoveToBottom()
                         }
                     )
                     HorizontalDivider(

--- a/app/src/main/java/com/asmr/player/ui/playlists/PlaylistDetailViewModel.kt
+++ b/app/src/main/java/com/asmr/player/ui/playlists/PlaylistDetailViewModel.kt
@@ -1,22 +1,19 @@
 package com.asmr.player.ui.playlists
 
+import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.asmr.player.data.local.db.entities.PlaylistItemWithSubtitles
 import com.asmr.player.data.repository.PlaylistRepository
+import com.asmr.player.util.MessageManager
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.launch
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.stateIn
-import javax.inject.Inject
-
-import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.flatMapLatest
-
-import androidx.lifecycle.SavedStateHandle
-
-import com.asmr.player.util.MessageManager
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+import javax.inject.Inject
 
 @HiltViewModel
 class PlaylistDetailViewModel @Inject constructor(
@@ -48,7 +45,35 @@ class PlaylistDetailViewModel @Inject constructor(
         if (id <= 0L || mediaId.isBlank()) return
         viewModelScope.launch {
             playlistRepository.removeItemFromPlaylist(id, mediaId)
-            messageManager.showInfo("已从我的列表移除")
+            messageManager.showInfo("\u5DF2\u4ECE\u6211\u7684\u5217\u8868\u79FB\u9664")
+        }
+    }
+
+    fun moveItemToTop(mediaId: String) {
+        val id = playlistIdFlow.value
+        if (id <= 0L || mediaId.isBlank()) return
+        viewModelScope.launch {
+            if (playlistRepository.movePlaylistItemToTop(id, mediaId)) {
+                messageManager.showInfo("\u5DF2\u79FB\u81F3\u9876\u90E8")
+            }
+        }
+    }
+
+    fun moveItemToBottom(mediaId: String) {
+        val id = playlistIdFlow.value
+        if (id <= 0L || mediaId.isBlank()) return
+        viewModelScope.launch {
+            if (playlistRepository.movePlaylistItemToBottom(id, mediaId)) {
+                messageManager.showInfo("\u5DF2\u79FB\u81F3\u672B\u5C3E")
+            }
+        }
+    }
+
+    fun saveManualOrder(orderedMediaIds: List<String>) {
+        val id = playlistIdFlow.value
+        if (id <= 0L || orderedMediaIds.isEmpty()) return
+        viewModelScope.launch {
+            playlistRepository.reorderPlaylistItems(id, orderedMediaIds)
         }
     }
 }

--- a/app/src/main/java/com/asmr/player/util/ManualItemOrder.kt
+++ b/app/src/main/java/com/asmr/player/util/ManualItemOrder.kt
@@ -1,0 +1,53 @@
+package com.asmr.player.util
+
+object ManualItemOrder {
+    fun <T> move(items: List<T>, fromIndex: Int, toIndex: Int): List<T> {
+        if (items.isEmpty()) return items
+        if (fromIndex !in items.indices || toIndex !in items.indices || fromIndex == toIndex) {
+            return items
+        }
+        return items.toMutableList().apply {
+            add(toIndex, removeAt(fromIndex))
+        }
+    }
+
+    fun <T, K> moveKeyToStart(
+        items: List<T>,
+        targetKey: K,
+        keySelector: (T) -> K
+    ): List<T> {
+        val fromIndex = items.indexOfFirst { keySelector(it) == targetKey }
+        if (fromIndex <= 0) return items
+        return move(items, fromIndex = fromIndex, toIndex = 0)
+    }
+
+    fun <T, K> moveKeyToEnd(
+        items: List<T>,
+        targetKey: K,
+        keySelector: (T) -> K
+    ): List<T> {
+        val fromIndex = items.indexOfFirst { keySelector(it) == targetKey }
+        if (fromIndex < 0 || fromIndex == items.lastIndex) return items
+        return move(items, fromIndex = fromIndex, toIndex = items.lastIndex)
+    }
+
+    fun <T, K> reorderByKeys(
+        current: List<T>,
+        orderedKeys: List<K>,
+        keySelector: (T) -> K
+    ): List<T> {
+        if (current.isEmpty()) return current
+        val distinctKeys = orderedKeys.distinct()
+        if (distinctKeys.size != current.size) return current
+        val currentByKey = current.associateBy(keySelector)
+        val reordered = distinctKeys.mapNotNull { currentByKey[it] }
+        return if (reordered.size == current.size) reordered else current
+    }
+
+    fun <T> reindex(
+        items: List<T>,
+        orderUpdater: (T, Int) -> T
+    ): List<T> = items.mapIndexed { index, item ->
+        orderUpdater(item, index)
+    }
+}

--- a/app/src/test/java/com/asmr/player/data/repository/AlbumGroupRepositoryOrderTest.kt
+++ b/app/src/test/java/com/asmr/player/data/repository/AlbumGroupRepositoryOrderTest.kt
@@ -1,0 +1,117 @@
+package com.asmr.player.data.repository
+
+import androidx.room.Room
+import com.asmr.player.data.local.db.AppDatabase
+import com.asmr.player.data.local.db.entities.AlbumEntity
+import com.asmr.player.data.local.db.entities.AlbumGroupEntity
+import com.asmr.player.data.local.db.entities.AlbumGroupItemEntity
+import com.asmr.player.data.local.db.entities.TrackEntity
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+
+@RunWith(RobolectricTestRunner::class)
+class AlbumGroupRepositoryOrderTest {
+    private lateinit var db: AppDatabase
+    private lateinit var repository: AlbumGroupRepository
+
+    @Before
+    fun setUp() {
+        db = Room.inMemoryDatabaseBuilder(
+            RuntimeEnvironment.getApplication(),
+            AppDatabase::class.java
+        )
+            .allowMainThreadQueries()
+            .build()
+        repository = AlbumGroupRepository(
+            groupDao = db.albumGroupDao(),
+            groupItemDao = db.albumGroupItemDao(),
+            trackDao = db.trackDao()
+        )
+    }
+
+    @After
+    fun tearDown() {
+        db.close()
+    }
+
+    @Test
+    fun moveTrackToBottom_onlyChangesCurrentAlbumSection() = runBlocking {
+        val albumA = insertAlbum("Album A", "/albums/a")
+        val albumB = insertAlbum("Album B", "/albums/b")
+        insertTrack(albumA, "A1", "/albums/a/1.mp3")
+        insertTrack(albumA, "A2", "/albums/a/2.mp3")
+        insertTrack(albumB, "B1", "/albums/b/1.mp3")
+        insertTrack(albumB, "B2", "/albums/b/2.mp3")
+        val groupId = db.albumGroupDao().insertGroup(AlbumGroupEntity(name = "分组"))
+        db.albumGroupItemDao().upsertItems(
+            listOf(
+                AlbumGroupItemEntity(groupId = groupId, mediaId = "/albums/a/1.mp3", itemOrder = 0),
+                AlbumGroupItemEntity(groupId = groupId, mediaId = "/albums/a/2.mp3", itemOrder = 1),
+                AlbumGroupItemEntity(groupId = groupId, mediaId = "/albums/b/1.mp3", itemOrder = 0),
+                AlbumGroupItemEntity(groupId = groupId, mediaId = "/albums/b/2.mp3", itemOrder = 1)
+            )
+        )
+
+        repository.moveTrackToBottom(groupId, albumA, "/albums/a/1.mp3")
+
+        val albumAItems = db.albumGroupItemDao().getAlbumItemsOnce(groupId, albumA)
+        val albumBItems = db.albumGroupItemDao().getAlbumItemsOnce(groupId, albumB)
+        assertEquals(listOf("/albums/a/2.mp3", "/albums/a/1.mp3"), albumAItems.map { it.mediaId })
+        assertEquals(listOf(0, 1), albumAItems.map { it.itemOrder })
+        assertEquals(listOf("/albums/b/1.mp3", "/albums/b/2.mp3"), albumBItems.map { it.mediaId })
+        assertEquals(listOf(0, 1), albumBItems.map { it.itemOrder })
+    }
+
+    @Test
+    fun addAlbumToGroup_appendsOnlyMissingTracks_afterManualOrder() = runBlocking {
+        val albumId = insertAlbum("Album A", "/albums/a")
+        insertTrack(albumId, "A1", "/albums/a/1.mp3")
+        insertTrack(albumId, "A2", "/albums/a/2.mp3")
+        insertTrack(albumId, "A3", "/albums/a/3.mp3")
+        val groupId = db.albumGroupDao().insertGroup(AlbumGroupEntity(name = "分组"))
+        db.albumGroupItemDao().upsertItems(
+            listOf(
+                AlbumGroupItemEntity(groupId = groupId, mediaId = "/albums/a/2.mp3", itemOrder = 0),
+                AlbumGroupItemEntity(groupId = groupId, mediaId = "/albums/a/1.mp3", itemOrder = 1)
+            )
+        )
+
+        repository.addAlbumToGroup(groupId, albumId)
+
+        val items = db.albumGroupItemDao().getAlbumItemsOnce(groupId, albumId)
+        assertEquals(
+            listOf("/albums/a/2.mp3", "/albums/a/1.mp3", "/albums/a/3.mp3"),
+            items.map { it.mediaId }
+        )
+        assertEquals(listOf(0, 1, 2), items.map { it.itemOrder })
+    }
+
+    private suspend fun insertAlbum(title: String, path: String): Long {
+        return db.albumDao().insertAlbum(
+            AlbumEntity(
+                title = title,
+                path = path,
+                coverUrl = "",
+                coverPath = "",
+                coverThumbPath = ""
+            )
+        )
+    }
+
+    private suspend fun insertTrack(albumId: Long, title: String, path: String) {
+        db.trackDao().insertTrack(
+            TrackEntity(
+                albumId = albumId,
+                title = title,
+                path = path,
+                duration = 12.0
+            )
+        )
+    }
+}

--- a/app/src/test/java/com/asmr/player/data/repository/PlaylistRepositoryOrderTest.kt
+++ b/app/src/test/java/com/asmr/player/data/repository/PlaylistRepositoryOrderTest.kt
@@ -1,0 +1,111 @@
+package com.asmr.player.data.repository
+
+import androidx.media3.common.MediaItem
+import androidx.media3.common.MediaMetadata
+import androidx.room.Room
+import com.asmr.player.data.local.db.AppDatabase
+import com.asmr.player.data.local.db.entities.PlaylistEntity
+import com.asmr.player.data.local.db.entities.PlaylistItemEntity
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+
+@RunWith(RobolectricTestRunner::class)
+class PlaylistRepositoryOrderTest {
+    private lateinit var db: AppDatabase
+    private lateinit var repository: PlaylistRepository
+
+    @Before
+    fun setUp() {
+        db = Room.inMemoryDatabaseBuilder(
+            RuntimeEnvironment.getApplication(),
+            AppDatabase::class.java
+        )
+            .allowMainThreadQueries()
+            .build()
+        repository = PlaylistRepository(
+            playlistDao = db.playlistDao(),
+            playlistItemDao = db.playlistItemDao(),
+            trackDao = db.trackDao(),
+            albumDao = db.albumDao()
+        )
+    }
+
+    @After
+    fun tearDown() {
+        db.close()
+    }
+
+    @Test
+    fun movePlaylistItemToTop_reindexesContinuously() = runBlocking {
+        val playlistId = db.playlistDao().insertPlaylist(
+            PlaylistEntity(name = "我的列表", category = PlaylistRepository.CATEGORY_USER)
+        )
+        db.playlistItemDao().upsertItems(
+            listOf(
+                playlistItem(playlistId, "a", order = 0),
+                playlistItem(playlistId, "b", order = 1),
+                playlistItem(playlistId, "c", order = 2)
+            )
+        )
+
+        repository.movePlaylistItemToTop(playlistId, "c")
+
+        val items = db.playlistItemDao().getItemsOnce(playlistId)
+        assertEquals(listOf("c", "a", "b"), items.map { it.mediaId })
+        assertEquals(listOf(0, 1, 2), items.map { it.itemOrder })
+    }
+
+    @Test
+    fun reorderPlaylistItems_thenAddItem_appendsWithoutBreakingManualOrder() = runBlocking {
+        val playlistId = db.playlistDao().insertPlaylist(
+            PlaylistEntity(name = "我的列表", category = PlaylistRepository.CATEGORY_USER)
+        )
+        db.playlistItemDao().upsertItems(
+            listOf(
+                playlistItem(playlistId, "a", order = 3),
+                playlistItem(playlistId, "b", order = 8),
+                playlistItem(playlistId, "c", order = 12)
+            )
+        )
+
+        repository.reorderPlaylistItems(playlistId, listOf("b", "c", "a"))
+        repository.addItemToPlaylist(
+            playlistId = playlistId,
+            item = mediaItem(mediaId = "d", title = "Track D")
+        )
+
+        val items = db.playlistItemDao().getItemsOnce(playlistId)
+        assertEquals(listOf("b", "c", "a", "d"), items.map { it.mediaId })
+        assertEquals(listOf(0, 1, 2, 3), items.map { it.itemOrder })
+    }
+
+    private fun playlistItem(playlistId: Long, mediaId: String, order: Int): PlaylistItemEntity {
+        return PlaylistItemEntity(
+            playlistId = playlistId,
+            mediaId = mediaId,
+            title = mediaId.uppercase(),
+            artist = "",
+            uri = "file:///$mediaId.mp3",
+            artworkUri = "",
+            itemOrder = order
+        )
+    }
+
+    private fun mediaItem(mediaId: String, title: String): MediaItem {
+        return MediaItem.Builder()
+            .setMediaId(mediaId)
+            .setUri("file:///$mediaId.mp3")
+            .setMediaMetadata(
+                MediaMetadata.Builder()
+                    .setTitle(title)
+                    .build()
+            )
+            .build()
+    }
+}

--- a/app/src/test/java/com/asmr/player/ui/TestWindowSizeClass.kt
+++ b/app/src/test/java/com/asmr/player/ui/TestWindowSizeClass.kt
@@ -1,0 +1,11 @@
+package com.asmr.player.ui
+
+import androidx.compose.material3.windowsizeclass.ExperimentalMaterial3WindowSizeClassApi
+import androidx.compose.material3.windowsizeclass.WindowSizeClass
+import androidx.compose.ui.unit.DpSize
+import androidx.compose.ui.unit.dp
+
+@OptIn(ExperimentalMaterial3WindowSizeClassApi::class)
+internal fun testWindowSizeClass(): WindowSizeClass {
+    return WindowSizeClass.calculateFromSize(DpSize(390.dp, 844.dp))
+}

--- a/app/src/test/java/com/asmr/player/ui/groups/AlbumGroupDetailScreenTest.kt
+++ b/app/src/test/java/com/asmr/player/ui/groups/AlbumGroupDetailScreenTest.kt
@@ -1,0 +1,128 @@
+package com.asmr.player.ui.groups
+
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.test.SemanticsMatcher
+import androidx.compose.ui.test.assert
+import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onAllNodesWithTag
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTouchInput
+import androidx.media3.common.MediaItem
+import com.asmr.player.data.local.db.dao.AlbumGroupTrackRow
+import com.asmr.player.ui.testWindowSizeClass
+import com.asmr.player.ui.theme.AsmrPlayerTheme
+import org.junit.Rule
+import org.junit.Test
+
+class AlbumGroupDetailScreenTest {
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    @Test
+    fun longPressTrack_opensReorderDialogForCurrentAlbumOnly() {
+        composeRule.setContent {
+            AsmrPlayerTheme {
+                AlbumGroupDetailContent(
+                    windowSizeClass = testWindowSizeClass(),
+                    title = "我的分组",
+                    tracks = sampleTracks(),
+                    onPlayMediaItems = { _: List<MediaItem>, _: Int -> },
+                    onRemoveTrack = {},
+                    onRemoveAlbum = {},
+                    onMoveTrackToTop = { _, _ -> },
+                    onMoveTrackToBottom = { _, _ -> },
+                    onSaveAlbumTrackOrder = { _, _ -> }
+                )
+            }
+        }
+
+        composeRule.onNodeWithTag("$GROUP_DETAIL_SECTION_HEADER_TAG_PREFIX:101")
+            .performClick()
+        composeRule.onNodeWithTag("$GROUP_DETAIL_TRACK_TAG_PREFIX:/albums/a/1.mp3")
+            .performTouchInput {
+                down(center)
+                advanceEventTime(800)
+                up()
+            }
+
+        composeRule.onNodeWithTag(GROUP_DETAIL_REORDER_DIALOG_TAG).assert(
+            SemanticsMatcher.expectValue(SemanticsProperties.TestTag, GROUP_DETAIL_REORDER_DIALOG_TAG)
+        )
+        composeRule.onNodeWithTag("$GROUP_DETAIL_REORDER_ROW_TAG_PREFIX:/albums/a/1.mp3").assert(
+            SemanticsMatcher.expectValue(
+                SemanticsProperties.TestTag,
+                "$GROUP_DETAIL_REORDER_ROW_TAG_PREFIX:/albums/a/1.mp3"
+            )
+        )
+        composeRule.onNodeWithTag("$GROUP_DETAIL_REORDER_ROW_TAG_PREFIX:/albums/a/2.mp3").assert(
+            SemanticsMatcher.expectValue(
+                SemanticsProperties.TestTag,
+                "$GROUP_DETAIL_REORDER_ROW_TAG_PREFIX:/albums/a/2.mp3"
+            )
+        )
+        composeRule.onAllNodesWithTag("$GROUP_DETAIL_REORDER_ROW_TAG_PREFIX:/albums/b/1.mp3")
+            .assertCountEquals(0)
+    }
+
+    @Test
+    fun trackMenu_containsMoveActions() {
+        composeRule.setContent {
+            AsmrPlayerTheme {
+                AlbumGroupDetailContent(
+                    windowSizeClass = testWindowSizeClass(),
+                    title = "我的分组",
+                    tracks = sampleTracks(),
+                    onPlayMediaItems = { _: List<MediaItem>, _: Int -> },
+                    onRemoveTrack = {},
+                    onRemoveAlbum = {},
+                    onMoveTrackToTop = { _, _ -> },
+                    onMoveTrackToBottom = { _, _ -> },
+                    onSaveAlbumTrackOrder = { _, _ -> }
+                )
+            }
+        }
+
+        composeRule.onNodeWithTag("$GROUP_DETAIL_SECTION_HEADER_TAG_PREFIX:101")
+            .performClick()
+        composeRule.onNodeWithTag("$GROUP_DETAIL_TRACK_MENU_BUTTON_TAG_PREFIX:/albums/a/1.mp3")
+            .performClick()
+
+        composeRule.onNodeWithTag(GROUP_DETAIL_MOVE_TOP_MENU_ITEM_TAG).assert(
+            SemanticsMatcher.expectValue(SemanticsProperties.TestTag, GROUP_DETAIL_MOVE_TOP_MENU_ITEM_TAG)
+        )
+        composeRule.onNodeWithTag(GROUP_DETAIL_MOVE_BOTTOM_MENU_ITEM_TAG).assert(
+            SemanticsMatcher.expectValue(SemanticsProperties.TestTag, GROUP_DETAIL_MOVE_BOTTOM_MENU_ITEM_TAG)
+        )
+    }
+
+    private fun sampleTracks(): List<AlbumGroupTrackRow> {
+        return listOf(
+            track(albumId = 101L, mediaId = "/albums/a/1.mp3", title = "A1", albumTitle = "Album A"),
+            track(albumId = 101L, mediaId = "/albums/a/2.mp3", title = "A2", albumTitle = "Album A"),
+            track(albumId = 202L, mediaId = "/albums/b/1.mp3", title = "B1", albumTitle = "Album B")
+        )
+    }
+
+    private fun track(albumId: Long, mediaId: String, title: String, albumTitle: String): AlbumGroupTrackRow {
+        return AlbumGroupTrackRow(
+            groupId = 1L,
+            mediaId = mediaId,
+            itemOrder = 0,
+            createdAt = 0L,
+            trackId = mediaId.hashCode().toLong(),
+            albumId = albumId,
+            trackTitle = title,
+            trackDuration = 12.0,
+            trackPath = mediaId,
+            trackGroup = "",
+            albumTitle = albumTitle,
+            albumRjCode = "",
+            albumWorkId = "",
+            albumCoverThumbPath = "",
+            albumCoverPath = "",
+            albumCoverUrl = ""
+        )
+    }
+}

--- a/app/src/test/java/com/asmr/player/ui/groups/AlbumGroupDetailScreenTest.kt
+++ b/app/src/test/java/com/asmr/player/ui/groups/AlbumGroupDetailScreenTest.kt
@@ -21,7 +21,7 @@ class AlbumGroupDetailScreenTest {
     val composeRule = createComposeRule()
 
     @Test
-    fun longPressTrack_opensReorderDialogForCurrentAlbumOnly() {
+    fun longPressTrack_keepsReorderInlineInsteadOfOpeningDialog() {
         composeRule.setContent {
             AsmrPlayerTheme {
                 AlbumGroupDetailContent(
@@ -47,22 +47,20 @@ class AlbumGroupDetailScreenTest {
                 up()
             }
 
-        composeRule.onNodeWithTag(GROUP_DETAIL_REORDER_DIALOG_TAG).assert(
-            SemanticsMatcher.expectValue(SemanticsProperties.TestTag, GROUP_DETAIL_REORDER_DIALOG_TAG)
-        )
-        composeRule.onNodeWithTag("$GROUP_DETAIL_REORDER_ROW_TAG_PREFIX:/albums/a/1.mp3").assert(
+        composeRule.onAllNodesWithTag(GROUP_DETAIL_REORDER_DIALOG_TAG).assertCountEquals(0)
+        composeRule.onNodeWithTag("$GROUP_DETAIL_TRACK_TAG_PREFIX:/albums/a/1.mp3").assert(
             SemanticsMatcher.expectValue(
                 SemanticsProperties.TestTag,
-                "$GROUP_DETAIL_REORDER_ROW_TAG_PREFIX:/albums/a/1.mp3"
+                "$GROUP_DETAIL_TRACK_TAG_PREFIX:/albums/a/1.mp3"
             )
         )
-        composeRule.onNodeWithTag("$GROUP_DETAIL_REORDER_ROW_TAG_PREFIX:/albums/a/2.mp3").assert(
+        composeRule.onNodeWithTag("$GROUP_DETAIL_TRACK_TAG_PREFIX:/albums/a/2.mp3").assert(
             SemanticsMatcher.expectValue(
                 SemanticsProperties.TestTag,
-                "$GROUP_DETAIL_REORDER_ROW_TAG_PREFIX:/albums/a/2.mp3"
+                "$GROUP_DETAIL_TRACK_TAG_PREFIX:/albums/a/2.mp3"
             )
         )
-        composeRule.onAllNodesWithTag("$GROUP_DETAIL_REORDER_ROW_TAG_PREFIX:/albums/b/1.mp3")
+        composeRule.onAllNodesWithTag("$GROUP_DETAIL_TRACK_TAG_PREFIX:/albums/b/1.mp3")
             .assertCountEquals(0)
     }
 

--- a/app/src/test/java/com/asmr/player/ui/playlists/PlaylistDetailScreenTest.kt
+++ b/app/src/test/java/com/asmr/player/ui/playlists/PlaylistDetailScreenTest.kt
@@ -1,0 +1,105 @@
+package com.asmr.player.ui.playlists
+
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.test.SemanticsMatcher
+import androidx.compose.ui.test.assert
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTouchInput
+import com.asmr.player.data.local.db.entities.PlaylistItemEntity
+import com.asmr.player.data.local.db.entities.PlaylistItemWithSubtitles
+import com.asmr.player.ui.testWindowSizeClass
+import com.asmr.player.ui.theme.AsmrPlayerTheme
+import org.junit.Rule
+import org.junit.Test
+
+class PlaylistDetailScreenTest {
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    @Test
+    fun longPressItem_opensManualReorderDialog() {
+        composeRule.setContent {
+            AsmrPlayerTheme {
+                PlaylistDetailContent(
+                    windowSizeClass = testWindowSizeClass(),
+                    title = "我的收藏",
+                    items = sampleItems(),
+                    onPlayAll = { _: List<PlaylistItemEntity>, _: PlaylistItemEntity -> },
+                    onRemoveItem = {},
+                    onMoveItemToTop = {},
+                    onMoveItemToBottom = {},
+                    onSaveManualOrder = {}
+                )
+            }
+        }
+
+        composeRule.onNodeWithTag("$PLAYLIST_DETAIL_ITEM_TAG_PREFIX:b")
+            .performTouchInput {
+                down(center)
+                advanceEventTime(800)
+                up()
+            }
+
+        composeRule.onNodeWithTag(PLAYLIST_DETAIL_REORDER_DIALOG_TAG).assert(
+            SemanticsMatcher.expectValue(SemanticsProperties.TestTag, PLAYLIST_DETAIL_REORDER_DIALOG_TAG)
+        )
+    }
+
+    @Test
+    fun itemMenu_containsMoveActions() {
+        composeRule.setContent {
+            AsmrPlayerTheme {
+                PlaylistDetailContent(
+                    windowSizeClass = testWindowSizeClass(),
+                    title = "我的收藏",
+                    items = sampleItems(),
+                    onPlayAll = { _: List<PlaylistItemEntity>, _: PlaylistItemEntity -> },
+                    onRemoveItem = {},
+                    onMoveItemToTop = {},
+                    onMoveItemToBottom = {},
+                    onSaveManualOrder = {}
+                )
+            }
+        }
+
+        composeRule.onNodeWithTag("$PLAYLIST_DETAIL_ITEM_MENU_BUTTON_TAG_PREFIX:a")
+            .performClick()
+
+        composeRule.onNodeWithTag(PLAYLIST_DETAIL_MOVE_TOP_MENU_ITEM_TAG).assert(
+            SemanticsMatcher.expectValue(
+                SemanticsProperties.TestTag,
+                PLAYLIST_DETAIL_MOVE_TOP_MENU_ITEM_TAG
+            )
+        )
+        composeRule.onNodeWithTag(PLAYLIST_DETAIL_MOVE_BOTTOM_MENU_ITEM_TAG).assert(
+            SemanticsMatcher.expectValue(
+                SemanticsProperties.TestTag,
+                PLAYLIST_DETAIL_MOVE_BOTTOM_MENU_ITEM_TAG
+            )
+        )
+    }
+
+    private fun sampleItems(): List<PlaylistItemWithSubtitles> {
+        return listOf(
+            playlistItem(mediaId = "a", title = "Track A"),
+            playlistItem(mediaId = "b", title = "Track B"),
+            playlistItem(mediaId = "c", title = "Track C")
+        )
+    }
+
+    private fun playlistItem(mediaId: String, title: String): PlaylistItemWithSubtitles {
+        return PlaylistItemWithSubtitles(
+            playlistId = 1L,
+            mediaId = mediaId,
+            title = title,
+            artist = "Artist",
+            uri = "file:///$mediaId.mp3",
+            artworkUri = "",
+            playbackArtworkUri = "",
+            itemOrder = 0,
+            hasSubtitles = false
+        )
+    }
+}

--- a/app/src/test/java/com/asmr/player/ui/playlists/PlaylistDetailScreenTest.kt
+++ b/app/src/test/java/com/asmr/player/ui/playlists/PlaylistDetailScreenTest.kt
@@ -3,7 +3,9 @@ package com.asmr.player.ui.playlists
 import androidx.compose.ui.semantics.SemanticsProperties
 import androidx.compose.ui.test.SemanticsMatcher
 import androidx.compose.ui.test.assert
+import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performTouchInput
@@ -19,7 +21,7 @@ class PlaylistDetailScreenTest {
     val composeRule = createComposeRule()
 
     @Test
-    fun longPressItem_opensManualReorderDialog() {
+    fun longPressItem_keepsReorderInlineInsteadOfOpeningDialog() {
         composeRule.setContent {
             AsmrPlayerTheme {
                 PlaylistDetailContent(
@@ -42,8 +44,12 @@ class PlaylistDetailScreenTest {
                 up()
             }
 
-        composeRule.onNodeWithTag(PLAYLIST_DETAIL_REORDER_DIALOG_TAG).assert(
-            SemanticsMatcher.expectValue(SemanticsProperties.TestTag, PLAYLIST_DETAIL_REORDER_DIALOG_TAG)
+        composeRule.onAllNodesWithTag(PLAYLIST_DETAIL_REORDER_DIALOG_TAG).assertCountEquals(0)
+        composeRule.onNodeWithTag("$PLAYLIST_DETAIL_ITEM_TAG_PREFIX:b").assert(
+            SemanticsMatcher.expectValue(
+                SemanticsProperties.TestTag,
+                "$PLAYLIST_DETAIL_ITEM_TAG_PREFIX:b"
+            )
         )
     }
 

--- a/app/src/test/java/com/asmr/player/ui/search/SearchScreenChromeTest.kt
+++ b/app/src/test/java/com/asmr/player/ui/search/SearchScreenChromeTest.kt
@@ -92,7 +92,6 @@ class SearchScreenChromeTest {
                         canGoPrev = false,
                         canGoNext = false,
                         controlsLocked = true,
-                        showPagingSpinner = false,
                         onPrev = {},
                         onNext = {}
                     )
@@ -133,7 +132,6 @@ class SearchScreenChromeTest {
                         canGoPrev = true,
                         canGoNext = true,
                         controlsLocked = true,
-                        showPagingSpinner = true,
                         onPrev = {},
                         onNext = {}
                     )
@@ -146,9 +144,6 @@ class SearchScreenChromeTest {
         composeRule.onNodeWithTag(SEARCH_SUBMIT_BUTTON_TAG).assertIsNotEnabled()
         composeRule.onNodeWithTag(SEARCH_PREV_BUTTON_TAG).assertIsNotEnabled()
         composeRule.onNodeWithTag(SEARCH_NEXT_BUTTON_TAG).assertIsNotEnabled()
-        composeRule.onNodeWithTag(SEARCH_PAGINATION_SPINNER_TAG).assert(
-            SemanticsMatcher.expectValue(SemanticsProperties.TestTag, SEARCH_PAGINATION_SPINNER_TAG)
-        )
     }
 
     @Test
@@ -210,7 +205,6 @@ class SearchScreenChromeTest {
                     canGoPrev = true,
                     canGoNext = true,
                     controlsLocked = false,
-                    showPagingSpinner = false,
                     rightPanelToggle = null,
                     animatedOffsetPx = chromeState.offsetPx,
                     collapseFraction = chromeState.collapseFraction,

--- a/app/src/test/java/com/asmr/player/util/ManualItemOrderTest.kt
+++ b/app/src/test/java/com/asmr/player/util/ManualItemOrderTest.kt
@@ -1,0 +1,33 @@
+package com.asmr.player.util
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ManualItemOrderTest {
+    @Test
+    fun moveKeyToStart_movesTargetToFront() {
+        val items = listOf("a", "b", "c")
+
+        val moved = ManualItemOrder.moveKeyToStart(items, "c") { it }
+
+        assertEquals(listOf("c", "a", "b"), moved)
+    }
+
+    @Test
+    fun moveKeyToEnd_movesTargetToBack() {
+        val items = listOf("a", "b", "c")
+
+        val moved = ManualItemOrder.moveKeyToEnd(items, "a") { it }
+
+        assertEquals(listOf("b", "c", "a"), moved)
+    }
+
+    @Test
+    fun reorderByKeys_returnsRequestedOrderWhenKeysMatch() {
+        val items = listOf("a", "b", "c")
+
+        val reordered = ManualItemOrder.reorderByKeys(items, listOf("b", "c", "a")) { it }
+
+        assertEquals(listOf("b", "c", "a"), reordered)
+    }
+}


### PR DESCRIPTION
﻿feat: 手动排序支持我的收藏/我的列表/我的分组

## 变更内容
- 为我的收藏、我的列表和我的分组二级列表加入手动拖拽排序
- 支持从条目菜单直接移至顶部/移至末尾
- 排序结果持久化保存，并保持后续新增条目按尾部追加
- 将排序交互优化为在原列表内直接长按拖拽，而不是进入独立页面
- 修复拖拽过程中的首项动画、分割线、末尾跳动和自动滚动细节

## 验证
- ./gradlew compileDebugKotlin compileDebugUnitTestKotlin
