### PR TITLE
fix: 修复播放页添加到我的列表弹窗层级

### DIFF
--- a/app/src/main/java/com/asmr/player/MainActivity.kt
+++ b/app/src/main/java/com/asmr/player/MainActivity.kt
@@ -188,6 +188,8 @@ import androidx.lifecycle.lifecycleScope
 import com.asmr.player.data.settings.SettingsRepository
 import com.asmr.player.playback.AppVolume
 import com.asmr.player.ui.common.AppVolumeVerticalSlider
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 
@@ -195,6 +197,17 @@ private enum class OverlaySheet {
     Queue,
     SleepTimer
 }
+
+private data class PlaylistPickerRequest(
+    val mediaId: String,
+    val uri: String,
+    val title: String,
+    val artist: String,
+    val artworkUri: String,
+    val albumId: Long,
+    val trackId: Long,
+    val rjCode: String
+)
 
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
@@ -584,6 +597,7 @@ fun MainContainer(
     var nowPlayingBackdropExitDurationMs by rememberSaveable {
         mutableIntStateOf(NowPlayingMotionSpec.totalExitDurationMs(NowPlayingMotionLayout.PORTRAIT))
     }
+    var nowPlayingPlaylistPickerRequest by remember { mutableStateOf<PlaylistPickerRequest?>(null) }
     val playerImmersive = nowPlayingVisible
     val openNowPlaying = openNowPlaying@{
         if (nowPlayingVisible) return@openNowPlaying
@@ -591,6 +605,7 @@ fun MainContainer(
         nowPlayingVisible = true
     }
     val closeNowPlaying: () -> Unit = {
+        nowPlayingPlaylistPickerRequest = null
         nowPlayingBackdropActive = false
         nowPlayingVisible = false
     }
@@ -1947,16 +1962,15 @@ fun MainContainer(
                     onShowQueue = onShowQueue,
                     onShowSleepTimer = onShowSleepTimer,
                     onOpenPlaylistPicker = { mediaId, uri, title, artist, artworkUri, albumId, trackId, rjCode ->
-                        navController.navigateSingleTop(
-                            "playlist_picker" +
-                                "?mediaId=${encodeRouteArg(mediaId)}" +
-                                "&uri=${encodeRouteArg(uri)}" +
-                                "&title=${encodeRouteArg(title)}" +
-                                "&artist=${encodeRouteArg(artist)}" +
-                                "&artworkUri=${encodeRouteArg(artworkUri)}" +
-                                "&albumId=$albumId" +
-                                "&trackId=$trackId" +
-                                "&rjCode=${encodeRouteArg(rjCode)}"
+                        nowPlayingPlaylistPickerRequest = PlaylistPickerRequest(
+                            mediaId = mediaId,
+                            uri = uri,
+                            title = title,
+                            artist = artist,
+                            artworkUri = artworkUri,
+                            albumId = albumId,
+                            trackId = trackId,
+                            rjCode = rjCode
                         )
                     },
                     viewModel = playerViewModel,
@@ -1970,6 +1984,39 @@ fun MainContainer(
                     sharedArtworkAlignment = sharedPlayerBackdropAlignment,
                     sharedCoverDragPreviewState = sharedCoverDragPreviewState
                 )
+                nowPlayingPlaylistPickerRequest?.let { request ->
+                    Dialog(
+                        onDismissRequest = { nowPlayingPlaylistPickerRequest = null },
+                        properties = DialogProperties(usePlatformDefaultWidth = false)
+                    ) {
+                        Surface(
+                            modifier = Modifier.fillMaxSize(),
+                            color = colorScheme.background.copy(alpha = 0.96f),
+                            contentColor = colorScheme.onBackground
+                        ) {
+                            Box(
+                                modifier = Modifier
+                                    .fillMaxSize()
+                                    .windowInsetsPadding(StableWindowInsets.statusBars)
+                                    .windowInsetsPadding(StableWindowInsets.navigationBars)
+                            ) {
+                                PlaylistPickerScreen(
+                                    windowSizeClass = windowSizeClass,
+                                    mediaId = request.mediaId,
+                                    uri = request.uri,
+                                    title = request.title,
+                                    artist = request.artist,
+                                    artworkUri = request.artworkUri,
+                                    albumId = request.albumId,
+                                    trackId = request.trackId,
+                                    rjCode = request.rjCode,
+                                    onBack = { nowPlayingPlaylistPickerRequest = null },
+                                    embeddedInDialog = true
+                                )
+                            }
+                        }
+                    }
+                }
             }
         }
     }

--- a/app/src/main/java/com/asmr/player/ui/playlists/PlaylistPickerDialog.kt
+++ b/app/src/main/java/com/asmr/player/ui/playlists/PlaylistPickerDialog.kt
@@ -29,9 +29,9 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -42,8 +42,8 @@ import androidx.compose.ui.unit.dp
 import androidx.core.net.toUri
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.asmr.player.ui.theme.AsmrTheme
-import kotlinx.coroutines.launch
 import java.io.File
+import kotlinx.coroutines.launch
 
 @Composable
 fun PlaylistPickerScreen(
@@ -57,6 +57,7 @@ fun PlaylistPickerScreen(
     trackId: Long = 0L,
     rjCode: String = "",
     onBack: () -> Unit,
+    embeddedInDialog: Boolean = false,
     viewModel: PlaylistsViewModel = hiltViewModel()
 ) {
     val playlists by viewModel.playlists.collectAsState()
@@ -108,6 +109,20 @@ fun PlaylistPickerScreen(
                     color = colorScheme.textPrimary
                 )
 
+                if (embeddedInDialog) {
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.End
+                    ) {
+                        TextButton(
+                            onClick = onBack,
+                            colors = ButtonDefaults.textButtonColors(contentColor = colorScheme.primary)
+                        ) {
+                            Text("关闭")
+                        }
+                    }
+                }
+
                 Row(verticalAlignment = Alignment.CenterVertically) {
                     OutlinedTextField(
                         value = createName,
@@ -143,7 +158,10 @@ fun PlaylistPickerScreen(
             } else {
                 LazyColumn(
                     modifier = Modifier.fillMaxSize(),
-                    contentPadding = androidx.compose.foundation.layout.PaddingValues(horizontal = 16.dp, vertical = 8.dp),
+                    contentPadding = androidx.compose.foundation.layout.PaddingValues(
+                        horizontal = 16.dp,
+                        vertical = 8.dp
+                    ),
                     verticalArrangement = Arrangement.spacedBy(10.dp)
                 ) {
                     items(userPlaylists, key = { it.id }) { playlist ->
@@ -186,8 +204,11 @@ private fun buildPlaylistAddMediaItem(
     trackId: Long = 0L,
     rjCode: String = ""
 ): androidx.media3.common.MediaItem {
-    android.util.Log.d("PlaylistPicker", "buildPlaylistAddMediaItem - mediaId: $mediaId, uri: $uri, title: $title, artist: $artist, artworkUri: $artworkUri, albumId: $albumId, trackId: $trackId, rjCode: $rjCode")
-    
+    android.util.Log.d(
+        "PlaylistPicker",
+        "buildPlaylistAddMediaItem - mediaId: $mediaId, uri: $uri, title: $title, artist: $artist, artworkUri: $artworkUri, albumId: $albumId, trackId: $trackId, rjCode: $rjCode"
+    )
+
     val metadata = androidx.media3.common.MediaMetadata.Builder()
         .setTitle(title)
         .setArtist(artist)
@@ -200,7 +221,7 @@ private fun buildPlaylistAddMediaItem(
             }
         )
         .build()
-    
+
     val mimeType = guessMimeType(uri)
     val mediaItem = androidx.media3.common.MediaItem.Builder()
         .setMediaId(mediaId)
@@ -208,9 +229,12 @@ private fun buildPlaylistAddMediaItem(
         .setMimeType(mimeType)
         .setMediaMetadata(metadata)
         .build()
-    
-    android.util.Log.d("PlaylistPicker", "buildPlaylistAddMediaItem - created MediaItem with extras: ${mediaItem.mediaMetadata.extras}, artworkUri: ${mediaItem.mediaMetadata.artworkUri}")
-    
+
+    android.util.Log.d(
+        "PlaylistPicker",
+        "buildPlaylistAddMediaItem - created MediaItem with extras: ${mediaItem.mediaMetadata.extras}, artworkUri: ${mediaItem.mediaMetadata.artworkUri}"
+    )
+
     return mediaItem
 }
 


### PR DESCRIPTION
## 说明
- 修复播放页点击“添加到我的列表”后，列表选择层被当前播放页遮挡、实际不可见的问题
- 保持资料库等其他入口原有的 `playlist_picker` 导航行为不变

## 原因
当前播放页是盖在 `NavHost` 之上的独立 overlay，而“添加到我的列表”之前通过普通导航路由打开，导致列表选择页渲染在播放页下层

## 修复
- 在播放页 overlay 内新增专用的列表选择请求状态
- 点击“添加到我的列表”时，直接在播放页上方弹出顶层 `Dialog`
- 为 `PlaylistPickerScreen` 增加弹窗嵌入模式和关闭入口，复用现有列表选择逻辑

## 验证
- `./gradlew.bat :app:compileDebugKotlin`