### PR TITLE
feat: add thin scrollbars to long lists

### DIFF
--- a/app/src/main/java/com/asmr/player/ui/common/ManualReorderDialog.kt
+++ b/app/src/main/java/com/asmr/player/ui/common/ManualReorderDialog.kt
@@ -168,7 +168,8 @@ internal fun ManualReorderDialog(
                     modifier = Modifier
                         .fillMaxSize()
                         .reorderable(reorderState)
-                        .detectReorderAfterLongPress(reorderState),
+                        .detectReorderAfterLongPress(reorderState)
+                        .thinScrollbar(listState),
                     contentPadding = PaddingValues(
                         start = 16.dp,
                         top = 12.dp,

--- a/app/src/main/java/com/asmr/player/ui/common/ThinScrollbar.kt
+++ b/app/src/main/java/com/asmr/player/ui/common/ThinScrollbar.kt
@@ -1,0 +1,233 @@
+package com.asmr.player.ui.common
+
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.ScrollState
+import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.foundation.lazy.staggeredgrid.LazyStaggeredGridState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawWithContent
+import androidx.compose.ui.geometry.CornerRadius
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import com.asmr.player.ui.theme.AsmrTheme
+import kotlin.math.ceil
+
+private data class ThinScrollbarMetrics(
+    val offsetFraction: Float,
+    val thumbFraction: Float,
+)
+
+@Composable
+fun Modifier.thinScrollbar(
+    state: LazyListState,
+    thickness: Dp = 3.dp,
+    endPadding: Dp = 3.dp,
+    topPadding: Dp = 8.dp,
+    bottomPadding: Dp = 8.dp,
+    minThumbLength: Dp = 32.dp,
+): Modifier {
+    val metrics = state.thinScrollbarMetrics()
+    val canScroll = state.canScrollBackward || state.canScrollForward
+    val scrollbarColor = AsmrTheme.colorScheme.textSecondary
+    val alpha by animateFloatAsState(
+        targetValue = when {
+            metrics == null || !canScroll -> 0f
+            state.isScrollInProgress -> 0.72f
+            else -> 0.34f
+        },
+        animationSpec = tween(durationMillis = 180),
+        label = "lazyListThinScrollbarAlpha"
+    )
+    return drawThinScrollbar(
+        metrics = metrics,
+        color = scrollbarColor,
+        alpha = alpha,
+        thickness = thickness,
+        endPadding = endPadding,
+        topPadding = topPadding,
+        bottomPadding = bottomPadding,
+        minThumbLength = minThumbLength
+    )
+}
+
+@Composable
+fun Modifier.thinScrollbar(
+    state: LazyStaggeredGridState,
+    thickness: Dp = 3.dp,
+    endPadding: Dp = 3.dp,
+    topPadding: Dp = 8.dp,
+    bottomPadding: Dp = 8.dp,
+    minThumbLength: Dp = 32.dp,
+): Modifier {
+    val metrics = state.thinScrollbarMetrics()
+    val canScroll = state.canScrollBackward || state.canScrollForward
+    val scrollbarColor = AsmrTheme.colorScheme.textSecondary
+    val alpha by animateFloatAsState(
+        targetValue = when {
+            metrics == null || !canScroll -> 0f
+            state.isScrollInProgress -> 0.72f
+            else -> 0.34f
+        },
+        animationSpec = tween(durationMillis = 180),
+        label = "lazyGridThinScrollbarAlpha"
+    )
+    return drawThinScrollbar(
+        metrics = metrics,
+        color = scrollbarColor,
+        alpha = alpha,
+        thickness = thickness,
+        endPadding = endPadding,
+        topPadding = topPadding,
+        bottomPadding = bottomPadding,
+        minThumbLength = minThumbLength
+    )
+}
+
+@Composable
+fun Modifier.thinScrollbar(
+    state: ScrollState,
+    thickness: Dp = 3.dp,
+    endPadding: Dp = 3.dp,
+    topPadding: Dp = 8.dp,
+    bottomPadding: Dp = 8.dp,
+    minThumbLength: Dp = 32.dp,
+): Modifier {
+    val metrics = state.thinScrollbarMetrics()
+    val canScroll = state.canScrollBackward || state.canScrollForward
+    val scrollbarColor = AsmrTheme.colorScheme.textSecondary
+    val alpha by animateFloatAsState(
+        targetValue = when {
+            metrics == null || !canScroll -> 0f
+            state.isScrollInProgress -> 0.72f
+            else -> 0.34f
+        },
+        animationSpec = tween(durationMillis = 180),
+        label = "scrollStateThinScrollbarAlpha"
+    )
+    return drawThinScrollbar(
+        metrics = metrics,
+        color = scrollbarColor,
+        alpha = alpha,
+        thickness = thickness,
+        endPadding = endPadding,
+        topPadding = topPadding,
+        bottomPadding = bottomPadding,
+        minThumbLength = minThumbLength
+    )
+}
+
+private fun Modifier.drawThinScrollbar(
+    metrics: ThinScrollbarMetrics?,
+    color: androidx.compose.ui.graphics.Color,
+    alpha: Float,
+    thickness: Dp,
+    endPadding: Dp,
+    topPadding: Dp,
+    bottomPadding: Dp,
+    minThumbLength: Dp,
+): Modifier {
+    return then(
+        Modifier.drawWithContent {
+            drawContent()
+            val resolvedMetrics = metrics ?: return@drawWithContent
+            if (alpha <= 0f) return@drawWithContent
+
+            val resolvedColor = color.copy(alpha = alpha)
+            val barWidth = thickness.toPx()
+            val barX = size.width - endPadding.toPx() - barWidth
+            if (barWidth <= 0f || barX < 0f) return@drawWithContent
+
+            val trackTop = topPadding.toPx()
+            val trackBottom = size.height - bottomPadding.toPx()
+            val trackHeight = (trackBottom - trackTop).coerceAtLeast(0f)
+            if (trackHeight <= 0f) return@drawWithContent
+
+            val thumbHeight = (trackHeight * resolvedMetrics.thumbFraction)
+                .coerceIn(minThumbLength.toPx(), trackHeight)
+            val thumbOffsetY = trackTop + (trackHeight - thumbHeight) * resolvedMetrics.offsetFraction
+
+            drawRoundRect(
+                color = resolvedColor,
+                topLeft = Offset(barX, thumbOffsetY),
+                size = Size(barWidth, thumbHeight),
+                cornerRadius = CornerRadius(barWidth / 2f, barWidth / 2f)
+            )
+        }
+    )
+}
+
+private fun LazyListState.thinScrollbarMetrics(): ThinScrollbarMetrics? {
+    val layoutInfo = layoutInfo
+    val totalItems = layoutInfo.totalItemsCount
+    val visibleItems = layoutInfo.visibleItemsInfo
+    if (totalItems <= 0 || visibleItems.isEmpty()) return null
+
+    val viewportHeight = (layoutInfo.viewportEndOffset - layoutInfo.viewportStartOffset).toFloat()
+        .coerceAtLeast(1f)
+    val averageItemSize = visibleItems.sumOf { it.size }.toFloat() / visibleItems.size
+    val estimatedContentHeight =
+        averageItemSize * totalItems + layoutInfo.beforeContentPadding + layoutInfo.afterContentPadding
+    if (estimatedContentHeight <= viewportHeight) return null
+
+    val estimatedScrollOffset = firstVisibleItemIndex * averageItemSize + firstVisibleItemScrollOffset
+    return buildThinScrollbarMetrics(
+        scrollOffset = estimatedScrollOffset,
+        viewportHeight = viewportHeight,
+        contentHeight = estimatedContentHeight
+    )
+}
+
+private fun LazyStaggeredGridState.thinScrollbarMetrics(): ThinScrollbarMetrics? {
+    val layoutInfo = layoutInfo
+    val totalItems = layoutInfo.totalItemsCount
+    val visibleItems = layoutInfo.visibleItemsInfo
+    if (totalItems <= 0 || visibleItems.isEmpty()) return null
+
+    val viewportHeight = (layoutInfo.viewportEndOffset - layoutInfo.viewportStartOffset).toFloat()
+        .coerceAtLeast(1f)
+    val averageItemHeight = visibleItems.sumOf { it.size.height }.toFloat() / visibleItems.size
+    val laneCount = visibleItems.map { it.offset.x }.distinct().size.coerceAtLeast(1)
+    val estimatedRowCount = ceil(totalItems / laneCount.toFloat())
+    val estimatedContentHeight =
+        averageItemHeight * estimatedRowCount + layoutInfo.beforeContentPadding + layoutInfo.afterContentPadding
+    if (estimatedContentHeight <= viewportHeight) return null
+
+    val estimatedScrollOffset =
+        (firstVisibleItemIndex / laneCount.toFloat()) * averageItemHeight + firstVisibleItemScrollOffset
+    return buildThinScrollbarMetrics(
+        scrollOffset = estimatedScrollOffset,
+        viewportHeight = viewportHeight,
+        contentHeight = estimatedContentHeight
+    )
+}
+
+private fun ScrollState.thinScrollbarMetrics(): ThinScrollbarMetrics? {
+    val viewportHeight = viewportSize.toFloat().coerceAtLeast(1f)
+    val contentHeight = viewportHeight + maxValue
+    if (contentHeight <= viewportHeight) return null
+    return buildThinScrollbarMetrics(
+        scrollOffset = value.toFloat(),
+        viewportHeight = viewportHeight,
+        contentHeight = contentHeight
+    )
+}
+
+private fun buildThinScrollbarMetrics(
+    scrollOffset: Float,
+    viewportHeight: Float,
+    contentHeight: Float,
+): ThinScrollbarMetrics {
+    val resolvedContentHeight = contentHeight.coerceAtLeast(viewportHeight)
+    val maxScroll = (resolvedContentHeight - viewportHeight).coerceAtLeast(1f)
+    val resolvedThumbFraction = (viewportHeight / resolvedContentHeight).coerceIn(0.08f, 1f)
+    val resolvedOffsetFraction = (scrollOffset / maxScroll).coerceIn(0f, 1f)
+    return ThinScrollbarMetrics(
+        offsetFraction = resolvedOffsetFraction,
+        thumbFraction = resolvedThumbFraction
+    )
+}

--- a/app/src/main/java/com/asmr/player/ui/downloads/DownloadsScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/downloads/DownloadsScreen.kt
@@ -20,6 +20,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
@@ -61,6 +62,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
+import com.asmr.player.ui.common.thinScrollbar
 import java.io.File
 
 @Composable
@@ -76,6 +78,7 @@ fun DownloadsScreen(
     val downloadRoot = remember {
         File(context.getExternalFilesDir(null), "albums").absolutePath
     }
+    val listState = rememberLazyListState()
 
     // 屏幕尺寸判断
     val isCompact = windowSizeClass.widthSizeClass == WindowWidthSizeClass.Compact
@@ -135,6 +138,8 @@ fun DownloadsScreen(
                 }
             } else {
                 LazyColumn(
+                    state = listState,
+                    modifier = Modifier.thinScrollbar(listState),
                     verticalArrangement = Arrangement.spacedBy(10.dp),
                     contentPadding = PaddingValues(
                         top = 4.dp,

--- a/app/src/main/java/com/asmr/player/ui/groups/AlbumGroupDetailScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/groups/AlbumGroupDetailScreen.kt
@@ -65,6 +65,7 @@ import com.asmr.player.data.local.db.dao.AlbumGroupTrackRow
 import com.asmr.player.ui.common.AsmrAsyncImage
 import com.asmr.player.ui.common.LocalBottomOverlayPadding
 import com.asmr.player.ui.common.StableWindowInsets
+import com.asmr.player.ui.common.thinScrollbar
 import com.asmr.player.ui.common.reorderable.ItemPosition
 import com.asmr.player.ui.common.reorderable.ReorderableItem
 import com.asmr.player.ui.common.reorderable.detectReorderAfterLongPress
@@ -211,7 +212,8 @@ internal fun AlbumGroupDetailContent(
                 state = listState,
                 modifier = Modifier
                     .fillMaxSize()
-                    .reorderable(reorderState),
+                    .reorderable(reorderState)
+                    .thinScrollbar(listState),
                 contentPadding = PaddingValues(bottom = LocalBottomOverlayPadding.current)
             ) {
                 item(key = GROUP_DETAIL_REORDER_SENTINEL_KEY) {

--- a/app/src/main/java/com/asmr/player/ui/groups/AlbumGroupPickerScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/groups/AlbumGroupPickerScreen.kt
@@ -15,6 +15,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.MaterialTheme
@@ -38,6 +39,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import com.asmr.player.ui.common.thinScrollbar
 import com.asmr.player.ui.theme.AsmrTheme
 
 @Composable
@@ -49,6 +51,7 @@ fun AlbumGroupPickerScreen(
 ) {
     val groups by viewModel.groups.collectAsState()
     val colorScheme = AsmrTheme.colorScheme
+    val listState = rememberLazyListState()
     var createName by rememberSaveable { mutableStateOf("") }
     val canCreate = remember(createName) { createName.trim().isNotBlank() }
 
@@ -115,7 +118,8 @@ fun AlbumGroupPickerScreen(
                 }
             } else {
                 LazyColumn(
-                    modifier = Modifier.fillMaxSize(),
+                    state = listState,
+                    modifier = Modifier.fillMaxSize().thinScrollbar(listState),
                     contentPadding = androidx.compose.foundation.layout.PaddingValues(horizontal = 16.dp, vertical = 8.dp),
                     verticalArrangement = Arrangement.spacedBy(10.dp)
                 ) {

--- a/app/src/main/java/com/asmr/player/ui/groups/AlbumGroupsScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/groups/AlbumGroupsScreen.kt
@@ -19,6 +19,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
@@ -55,6 +56,7 @@ import com.asmr.player.data.local.db.entities.AlbumGroupEntity
 import com.asmr.player.ui.common.AsmrAsyncImage
 import com.asmr.player.ui.common.LocalBottomOverlayPadding
 import com.asmr.player.ui.common.StableWindowInsets
+import com.asmr.player.ui.common.thinScrollbar
 import com.asmr.player.ui.common.withAddedBottomPadding
 import com.asmr.player.ui.theme.AsmrTheme
 
@@ -66,6 +68,7 @@ fun AlbumGroupsScreen(
 ) {
     val groups by viewModel.groups.collectAsState()
     val colorScheme = AsmrTheme.colorScheme
+    val listState = rememberLazyListState()
     var showCreate by remember { mutableStateOf(false) }
 
     val isCompact = windowSizeClass.widthSizeClass == WindowWidthSizeClass.Compact
@@ -90,7 +93,8 @@ fun AlbumGroupsScreen(
             }
             Box(modifier = contentModifier) {
                 LazyColumn(
-                    modifier = Modifier.fillMaxSize(),
+                    state = listState,
+                    modifier = Modifier.fillMaxSize().thinScrollbar(listState),
                     contentPadding = PaddingValues(horizontal = 16.dp, vertical = 8.dp)
                         .withAddedBottomPadding(LocalBottomOverlayPadding.current + 72.dp),
                     verticalArrangement = Arrangement.spacedBy(12.dp)

--- a/app/src/main/java/com/asmr/player/ui/library/AlbumDetailScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/AlbumDetailScreen.kt
@@ -29,6 +29,7 @@ import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
@@ -121,6 +122,7 @@ import com.asmr.player.ui.common.collapsibleHeaderUiState
 import com.asmr.player.ui.common.rememberCollapsibleHeaderState
 import com.asmr.player.ui.theme.AsmrTheme
 import com.asmr.player.ui.common.LocalBottomOverlayPadding
+import com.asmr.player.ui.common.thinScrollbar
 import com.asmr.player.ui.theme.AsmrPlayerTheme
 import com.asmr.player.ui.theme.dynamicPageContainerColor
 import com.asmr.player.util.Formatting
@@ -1353,6 +1355,7 @@ private fun dlsiteCoverUrlForRj(rj: String): String {
 fun AlbumTracks(album: Album, onTrackClick: (Track) -> Unit) {
     val groupedTracks = album.getGroupedTracks()
     val context = LocalContext.current
+    val listState = rememberLazyListState()
     val ids = remember(album.tracks) { album.tracks.map { it.id }.filter { it > 0L }.distinct() }
     val subtitleTrackIds by produceState(
         initialValue = emptySet<Long>(),
@@ -1379,7 +1382,8 @@ fun AlbumTracks(album: Album, onTrackClick: (Track) -> Unit) {
         }
     } else {
         LazyColumn(
-            modifier = Modifier.fillMaxSize(),
+            state = listState,
+            modifier = Modifier.fillMaxSize().thinScrollbar(listState),
             contentPadding = PaddingValues(bottom = LocalBottomOverlayPadding.current)
         ) {
             groupedTracks.forEach { (group, tracks) ->
@@ -1707,7 +1711,8 @@ private fun AlbumLocalTab(
     LazyColumn(
         modifier = Modifier
             .fillMaxSize()
-            .nestedScroll(chromeState.nestedScrollConnection),
+            .nestedScroll(chromeState.nestedScrollConnection)
+            .thinScrollbar(listState),
         state = listState,
         contentPadding = PaddingValues(top = topContentPadding, bottom = LocalBottomOverlayPadding.current)
     ) {
@@ -1874,10 +1879,12 @@ private fun AlbumAsmrOneTab(
     val leafByRelPath = remember(leafTracks) { leafTracks.associateBy { it.relativePath } }
     val expanded = remember { mutableStateListOf<String>() }
     val scope = rememberCoroutineScope()
+    val listState = rememberLazyListState()
     val treeResult = remember(trackTree, expanded.toList()) { flattenAsmrOneTreeForUi(trackTree, expanded.toSet()) }
 
     LazyColumn(
-        modifier = Modifier.fillMaxSize(),
+        state = listState,
+        modifier = Modifier.fillMaxSize().thinScrollbar(listState),
         contentPadding = PaddingValues(bottom = LocalBottomOverlayPadding.current)
     ) {
         item { header() }
@@ -3088,6 +3095,7 @@ private fun AsmrOneDownloadDialog(
     val leafPathsByFolder = remember(trackTree) { buildLeafPathIndex(trackTree) }
     val expanded = remember { mutableStateListOf<String>() }
     val selected = remember(trackTree) { mutableStateListOf<String>().apply { addAll(leaves.map { it.relativePath }) } }
+    val listState = rememberLazyListState()
 
     Dialog(
         onDismissRequest = onDismiss,
@@ -3141,7 +3149,10 @@ private fun AsmrOneDownloadDialog(
                         }
                     } else {
                         val entries = flattenAsmrOneTreeForUi(trackTree, expanded.toSet()).entries
-                        LazyColumn(modifier = Modifier.fillMaxSize()) {
+                        LazyColumn(
+                            state = listState,
+                            modifier = Modifier.fillMaxSize().thinScrollbar(listState)
+                        ) {
                             itemsIndexed(items = entries, key = { _, it -> it.path }) { index, entry ->
                                 when (entry) {
                                     is AsmrTreeUiEntry.Folder -> {
@@ -3345,6 +3356,7 @@ private fun OnlineSaveDialog(
     val leafPathsByFolder = remember(trackTree) { buildMediaLeafPathIndex(trackTree) }
     val expanded = remember { mutableStateListOf<String>() }
     val selected = remember(trackTree) { mutableStateListOf<String>().apply { addAll(leaves.map { it.relativePath }) } }
+    val listState = rememberLazyListState()
 
     Dialog(
         onDismissRequest = onDismiss,
@@ -3398,7 +3410,10 @@ private fun OnlineSaveDialog(
                         }
                     } else {
                         val entries = flattenAsmrOneMediaTreeForUi(trackTree, expanded.toSet()).entries
-                        LazyColumn(modifier = Modifier.fillMaxSize()) {
+                        LazyColumn(
+                            state = listState,
+                            modifier = Modifier.fillMaxSize().thinScrollbar(listState)
+                        ) {
                             itemsIndexed(items = entries, key = { _, it -> it.path }) { index, entry ->
                                 when (entry) {
                                     is AsmrTreeUiEntry.Folder -> {
@@ -3624,7 +3639,8 @@ private fun AlbumDlsiteInfoTab(
     LazyColumn(
         modifier = Modifier
             .fillMaxSize()
-            .nestedScroll(chromeState.nestedScrollConnection),
+            .nestedScroll(chromeState.nestedScrollConnection)
+            .thinScrollbar(listState),
         state = listState,
         contentPadding = PaddingValues(top = topContentPadding, bottom = LocalBottomOverlayPadding.current)
     ) {
@@ -4044,7 +4060,8 @@ private fun AlbumDlsitePlayTreeTab(
     LazyColumn(
         modifier = Modifier
             .fillMaxSize()
-            .nestedScroll(chromeState.nestedScrollConnection),
+            .nestedScroll(chromeState.nestedScrollConnection)
+            .thinScrollbar(listState),
         state = listState,
         contentPadding = PaddingValues(top = topContentPadding, bottom = LocalBottomOverlayPadding.current)
     ) {

--- a/app/src/main/java/com/asmr/player/ui/library/CloudSyncSelectionDialog.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/CloudSyncSelectionDialog.kt
@@ -20,6 +20,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Card
@@ -60,6 +61,7 @@ import com.asmr.player.data.remote.dlsite.DlsiteCloudSyncCandidate
 import com.asmr.player.ui.common.AsmrShimmerPlaceholder
 import com.asmr.player.ui.common.CvChipsSingleLine
 import com.asmr.player.ui.common.DiscPlaceholder
+import com.asmr.player.ui.common.thinScrollbar
 import com.asmr.player.ui.theme.AsmrTheme
 import com.asmr.player.util.DlsiteAntiHotlink
 import dagger.hilt.android.EntryPointAccessors
@@ -115,6 +117,7 @@ internal fun CloudSyncSelectionDialog(
     onIgnoreAll: (() -> Unit)? = null
 ) {
     val colorScheme = AsmrTheme.colorScheme
+    val listState = rememberLazyListState()
     Dialog(
         onDismissRequest = onCancel,
         properties = DialogProperties(usePlatformDefaultWidth = false)
@@ -179,10 +182,12 @@ internal fun CloudSyncSelectionDialog(
                 HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.34f))
                 Spacer(modifier = Modifier.height(CLOUD_SYNC_SELECTION_SECTION_SPACING))
                 LazyColumn(
+                    state = listState,
                     modifier = Modifier
                         .fillMaxWidth()
                         .height(CLOUD_SYNC_SELECTION_LIST_HEIGHT)
-                        .testTag(CLOUD_SYNC_SELECTION_LIST_TAG),
+                        .testTag(CLOUD_SYNC_SELECTION_LIST_TAG)
+                        .thinScrollbar(listState),
                     verticalArrangement = Arrangement.spacedBy(CLOUD_SYNC_SELECTION_ROW_SPACING)
                 ) {
                     items(state.candidates, key = { it.workno }) { candidate ->

--- a/app/src/main/java/com/asmr/player/ui/library/LibraryFilterSheet.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/LibraryFilterSheet.kt
@@ -18,6 +18,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
@@ -55,6 +56,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.asmr.player.data.local.db.dao.TagWithCount
 import com.asmr.player.ui.common.LocalBottomOverlayPadding
+import com.asmr.player.ui.common.thinScrollbar
 import com.asmr.player.ui.common.withAddedBottomPadding
 import com.asmr.player.ui.theme.AsmrTheme
 import com.asmr.player.ui.theme.dynamicPageContainerColor
@@ -163,6 +165,7 @@ fun LibraryFilterSheet(
     var tagSearch by rememberSaveable { mutableStateOf("") }
     var showSavePreset by remember { mutableStateOf(false) }
     var presetName by rememberSaveable { mutableStateOf("") }
+    val listState = rememberLazyListState()
 
     Column(modifier = modifier.fillMaxWidth()) {
         if (showHeader) {
@@ -190,7 +193,8 @@ fun LibraryFilterSheet(
         }
 
         LazyColumn(
-            modifier = Modifier.fillMaxWidth(),
+            state = listState,
+            modifier = Modifier.fillMaxWidth().thinScrollbar(listState),
             contentPadding = PaddingValues(bottom = 16.dp).withAddedBottomPadding(LocalBottomOverlayPadding.current),
             verticalArrangement = Arrangement.spacedBy(10.dp)
         ) {
@@ -246,6 +250,7 @@ fun LibraryFilterSheet(
                                 .fillMaxWidth()
                                 .height(300.dp)
                                 .verticalScroll(scrollState)
+                                .thinScrollbar(scrollState)
                                 .padding(12.dp)
                         ) {
                             FlowRow(

--- a/app/src/main/java/com/asmr/player/ui/library/LibraryScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/LibraryScreen.kt
@@ -155,6 +155,7 @@ import com.asmr.player.ui.common.CustomSearchBar
 import com.asmr.player.ui.common.ActionButton
 import com.asmr.player.ui.common.collapsibleHeaderUiState
 import com.asmr.player.ui.common.rememberCollapsibleHeaderState
+import com.asmr.player.ui.common.thinScrollbar
 
 internal const val LIBRARY_CHROME_TAG = "library_chrome"
 internal const val LIBRARY_SEARCH_INPUT_TAG = "library_search_input"
@@ -498,7 +499,8 @@ fun LibraryScreen(
                                         state = listState,
                                         modifier = Modifier
                                             .fillMaxSize()
-                                            .nestedScroll(chromeState.nestedScrollConnection),
+                                            .nestedScroll(chromeState.nestedScrollConnection)
+                                            .thinScrollbar(listState),
                                         contentPadding = PaddingValues(top = topPadding, bottom = 8.dp)
                                             .withAddedBottomPadding(LocalBottomOverlayPadding.current)
                                     ) {
@@ -666,7 +668,8 @@ fun LibraryScreen(
                                         state = gridState,
                                         modifier = Modifier
                                             .fillMaxSize()
-                                            .nestedScroll(chromeState.nestedScrollConnection),
+                                            .nestedScroll(chromeState.nestedScrollConnection)
+                                            .thinScrollbar(gridState),
                                         contentPadding = PaddingValues(top = topPadding, start = 16.dp, end = 16.dp, bottom = 16.dp)
                                             .withAddedBottomPadding(LocalBottomOverlayPadding.current),
                                         verticalItemSpacing = 16.dp,
@@ -720,7 +723,8 @@ fun LibraryScreen(
                                         state = listState,
                                         modifier = Modifier
                                             .fillMaxSize()
-                                            .nestedScroll(chromeState.nestedScrollConnection),
+                                            .nestedScroll(chromeState.nestedScrollConnection)
+                                            .thinScrollbar(listState),
                                         contentPadding = PaddingValues(top = topPadding, bottom = 8.dp)
                                             .withAddedBottomPadding(LocalBottomOverlayPadding.current)
                                     ) {

--- a/app/src/main/java/com/asmr/player/ui/library/TagManagerSheet.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/TagManagerSheet.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -28,6 +29,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import com.asmr.player.data.local.db.dao.TagWithCount
+import com.asmr.player.ui.common.thinScrollbar
 
 @Composable
 fun TagManagerSheet(
@@ -41,6 +43,7 @@ fun TagManagerSheet(
     var filter by rememberSaveable { mutableStateOf("") }
     var showRenameDialog by remember { mutableStateOf(false) }
     var showDeleteDialog by remember { mutableStateOf(false) }
+    val listState = rememberLazyListState()
 
     val visibleTags = remember(tags, filter) {
         val q = filter.trim().lowercase()
@@ -69,9 +72,11 @@ fun TagManagerSheet(
         )
 
         LazyColumn(
+            state = listState,
             modifier = Modifier
                 .fillMaxWidth()
                 .weight(1f, fill = true)
+                .thinScrollbar(listState)
         ) {
             items(visibleTags, key = { it.id }) { tag ->
                 ListItem(

--- a/app/src/main/java/com/asmr/player/ui/player/AppleLyricsView.kt
+++ b/app/src/main/java/com/asmr/player/ui/player/AppleLyricsView.kt
@@ -53,6 +53,7 @@ import androidx.compose.ui.unit.Constraints
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.asmr.player.data.settings.LyricsPageSettings
+import com.asmr.player.ui.common.thinScrollbar
 import com.asmr.player.ui.theme.AsmrTheme
 import com.asmr.player.util.SubtitleEntry
 import com.asmr.player.util.SubtitleIndexFinder
@@ -342,7 +343,8 @@ internal fun AppleLyricsView(
                 state = listState,
                 modifier = Modifier
                     .fillMaxSize()
-                    .nestedScroll(nestedScrollConnection),
+                    .nestedScroll(nestedScrollConnection)
+                    .thinScrollbar(listState),
                 horizontalAlignment = Alignment.CenterHorizontally,
                 contentPadding = PaddingValues(
                     bottom = centeredActiveBottomDp

--- a/app/src/main/java/com/asmr/player/ui/player/LyricsScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/player/LyricsScreen.kt
@@ -14,6 +14,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.asmr.player.service.PlaybackState
+import com.asmr.player.ui.common.thinScrollbar
 import com.asmr.player.util.SubtitleEntry
 import com.asmr.player.util.SubtitleIndexFinder
 import kotlinx.coroutines.launch
@@ -52,7 +53,7 @@ fun LyricsScreen(
         } else {
             LazyColumn(
                 state = listState,
-                modifier = Modifier.fillMaxSize(),
+                modifier = Modifier.fillMaxSize().thinScrollbar(listState),
                 contentPadding = PaddingValues(vertical = if (isLandscape) 100.dp else 200.dp),
                 horizontalAlignment = Alignment.CenterHorizontally
             ) {

--- a/app/src/main/java/com/asmr/player/ui/player/NowPlayingScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/player/NowPlayingScreen.kt
@@ -78,6 +78,7 @@ import com.asmr.player.data.settings.CoverPreviewMode
 import com.asmr.player.data.settings.LyricsPageSettings
 import com.asmr.player.ui.common.AsmrAsyncImage
 import com.asmr.player.ui.common.AudioOutputRouteIcon
+import com.asmr.player.ui.common.thinScrollbar
 import com.asmr.player.ui.common.DismissOutsideBoundsOverlay
 import com.asmr.player.ui.common.AppVolumeHearingWarningDialog
 import com.asmr.player.ui.common.AppVolumeSlider
@@ -1207,8 +1208,13 @@ internal fun NowPlayingScreen(
                             modifier = Modifier.padding(vertical = 18.dp)
                         )
                     } else {
+                        val sliceListState = rememberLazyListState()
                         LazyColumn(
-                            modifier = Modifier.fillMaxWidth().weight(1f, fill = true),
+                            state = sliceListState,
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .weight(1f, fill = true)
+                                .thinScrollbar(sliceListState),
                             verticalArrangement = Arrangement.spacedBy(10.dp)
                         ) {
                             itemsIndexed(sliceUiState.slices, key = { _, s -> s.id }) { index, slice ->

--- a/app/src/main/java/com/asmr/player/ui/player/QueueSheet.kt
+++ b/app/src/main/java/com/asmr/player/ui/player/QueueSheet.kt
@@ -20,6 +20,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -38,6 +39,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import com.asmr.player.ui.common.thinScrollbar
 import com.asmr.player.ui.theme.AsmrTheme
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -50,6 +52,7 @@ fun QueueSheetContent(
     val playback by viewModel.playback.collectAsState()
     val queue by viewModel.queue.collectAsState()
     val colorScheme = AsmrTheme.colorScheme
+    val listState = rememberLazyListState()
 
     val currentId = playback.currentMediaItem?.mediaId.orEmpty()
     val currentIndex = remember(queue, currentId) { queue.indexOfFirst { it.mediaId == currentId } }
@@ -62,9 +65,11 @@ fun QueueSheetContent(
             color = colorScheme.textSecondary
         )
         LazyColumn(
+            state = listState,
             modifier = Modifier
                 .fillMaxWidth()
-                .weight(1f, fill = true),
+                .weight(1f, fill = true)
+                .thinScrollbar(listState),
             contentPadding = PaddingValues(bottom = 24.dp)
         ) {
             itemsIndexed(queue, key = { idx, it -> "${it.mediaId}#$idx" }) { index, mediaItem ->

--- a/app/src/main/java/com/asmr/player/ui/playlists/PlaylistDetailScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/playlists/PlaylistDetailScreen.kt
@@ -60,6 +60,7 @@ import com.asmr.player.ui.common.AsmrAsyncImage
 import com.asmr.player.ui.common.LocalBottomOverlayPadding
 import com.asmr.player.ui.common.StableWindowInsets
 import com.asmr.player.ui.common.SubtitleStamp
+import com.asmr.player.ui.common.thinScrollbar
 import com.asmr.player.ui.common.reorderable.ItemPosition
 import com.asmr.player.ui.common.reorderable.ReorderableItem
 import com.asmr.player.ui.common.reorderable.detectReorderAfterLongPress
@@ -162,7 +163,9 @@ internal fun PlaylistDetailContent(
             }
             LazyColumn(
                 state = listState,
-                modifier = contentModifier.reorderable(reorderState),
+                modifier = contentModifier
+                    .reorderable(reorderState)
+                    .thinScrollbar(listState),
                 contentPadding = PaddingValues(top = 6.dp, bottom = LocalBottomOverlayPadding.current)
             ) {
                 item(key = PLAYLIST_DETAIL_REORDER_SENTINEL_KEY) {

--- a/app/src/main/java/com/asmr/player/ui/playlists/PlaylistPickerDialog.kt
+++ b/app/src/main/java/com/asmr/player/ui/playlists/PlaylistPickerDialog.kt
@@ -16,6 +16,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.MaterialTheme
@@ -41,6 +42,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.core.net.toUri
 import androidx.hilt.navigation.compose.hiltViewModel
+import com.asmr.player.ui.common.thinScrollbar
 import com.asmr.player.ui.theme.AsmrTheme
 import java.io.File
 import kotlinx.coroutines.launch
@@ -64,6 +66,7 @@ fun PlaylistPickerScreen(
     val userPlaylists = remember(playlists) { playlists.filter { it.category == "user" } }
     val colorScheme = AsmrTheme.colorScheme
     val scope = rememberCoroutineScope()
+    val listState = rememberLazyListState()
     var createName by rememberSaveable { mutableStateOf("") }
     val canCreate = remember(createName) { createName.trim().isNotBlank() }
 
@@ -157,7 +160,8 @@ fun PlaylistPickerScreen(
                 }
             } else {
                 LazyColumn(
-                    modifier = Modifier.fillMaxSize(),
+                    state = listState,
+                    modifier = Modifier.fillMaxSize().thinScrollbar(listState),
                     contentPadding = androidx.compose.foundation.layout.PaddingValues(
                         horizontal = 16.dp,
                         vertical = 8.dp

--- a/app/src/main/java/com/asmr/player/ui/playlists/PlaylistsScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/playlists/PlaylistsScreen.kt
@@ -17,6 +17,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.clickable
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
@@ -52,6 +53,7 @@ import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.ui.graphics.Color
 import com.asmr.player.ui.common.LocalBottomOverlayPadding
 import com.asmr.player.ui.common.StableWindowInsets
+import com.asmr.player.ui.common.thinScrollbar
 import com.asmr.player.ui.common.withAddedBottomPadding
 
 @Composable
@@ -62,6 +64,7 @@ fun PlaylistsScreen(
 ) {
     val playlists by viewModel.playlists.collectAsState()
     val colorScheme = AsmrTheme.colorScheme
+    val listState = rememberLazyListState()
     var showCreate by remember { mutableStateOf(false) }
     val userPlaylists = remember(playlists) { playlists.filter { it.category == "user" } }
 
@@ -89,7 +92,8 @@ fun PlaylistsScreen(
             }
             Box(modifier = contentModifier) {
                 LazyColumn(
-                    modifier = Modifier.fillMaxSize(),
+                    state = listState,
+                    modifier = Modifier.fillMaxSize().thinScrollbar(listState),
                     contentPadding = PaddingValues(horizontal = 16.dp, vertical = 8.dp)
                         .withAddedBottomPadding(LocalBottomOverlayPadding.current + 72.dp),
                     verticalArrangement = Arrangement.spacedBy(12.dp)

--- a/app/src/main/java/com/asmr/player/ui/search/SearchScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/search/SearchScreen.kt
@@ -88,6 +88,7 @@ import com.asmr.player.ui.common.LocalBottomOverlayPadding
 import com.asmr.player.ui.common.StableWindowInsets
 import com.asmr.player.ui.common.collapsibleHeaderUiState
 import com.asmr.player.ui.common.rememberCollapsibleHeaderState
+import com.asmr.player.ui.common.thinScrollbar
 import com.asmr.player.ui.common.withAddedBottomPadding
 import com.asmr.player.ui.library.AlbumGridItem
 import com.asmr.player.ui.library.AlbumItem
@@ -355,7 +356,8 @@ fun SearchScreen(
                                         state = listState,
                                         modifier = Modifier
                                             .fillMaxSize()
-                                            .nestedScroll(chromeState.nestedScrollConnection),
+                                            .nestedScroll(chromeState.nestedScrollConnection)
+                                            .thinScrollbar(listState),
                                         contentPadding = PaddingValues(top = topPadding, bottom = 8.dp)
                                             .withAddedBottomPadding(LocalBottomOverlayPadding.current)
                                     ) {
@@ -377,7 +379,8 @@ fun SearchScreen(
                                         state = gridState,
                                         modifier = Modifier
                                             .fillMaxSize()
-                                            .nestedScroll(chromeState.nestedScrollConnection),
+                                            .nestedScroll(chromeState.nestedScrollConnection)
+                                            .thinScrollbar(gridState),
                                         contentPadding = PaddingValues(
                                             top = topPadding,
                                             start = 16.dp,

--- a/app/src/main/java/com/asmr/player/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/settings/SettingsScreen.kt
@@ -16,6 +16,7 @@ import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
@@ -63,6 +64,7 @@ import com.asmr.player.ui.common.AppSupportStatusSection
 import com.asmr.player.ui.theme.AsmrTheme
 import com.asmr.player.ui.common.LocalBottomOverlayPadding
 import com.asmr.player.ui.common.StableWindowInsets
+import com.asmr.player.ui.common.thinScrollbar
 import com.asmr.player.ui.common.withAddedBottomPadding
 import java.io.File
 import kotlin.math.abs
@@ -100,6 +102,7 @@ fun SettingsScreen(
     val density = LocalDensity.current
     val context = LocalContext.current
     val colorScheme = AsmrTheme.colorScheme
+    val listState = rememberLazyListState()
     val segmentedButtonColors = SegmentedButtonDefaults.colors(
         activeContainerColor = colorScheme.primarySoft,
         activeContentColor = if (colorScheme.isDark) colorScheme.onPrimaryContainer else colorScheme.primaryStrong,
@@ -155,7 +158,8 @@ fun SettingsScreen(
             }
 
             LazyColumn(
-                modifier = contentModifier,
+                state = listState,
+                modifier = contentModifier.thinScrollbar(listState),
                 contentPadding = PaddingValues(horizontal = 16.dp, vertical = 10.dp)
                     .withAddedBottomPadding(LocalBottomOverlayPadding.current),
                 verticalArrangement = Arrangement.spacedBy(16.dp)


### PR DESCRIPTION
## Summary
- add a reusable thin scrollbar modifier for `LazyListState`, `LazyStaggeredGridState`, and `ScrollState`
- apply the right-side scrollbar to long list screens across library, search, settings, downloads, playlists, groups, and player flows
- keep the scrollbar visually slim and low-profile, with stronger visibility while scrolling

## Testing
- `.\gradlew.bat :app:compileDebugKotlin`