### PR TITLE
feat: replace spinner loaders with animated logo indicator

### DIFF
--- a/app/src/main/java/com/asmr/player/ui/common/EaraLogoLoadingIndicator.kt
+++ b/app/src/main/java/com/asmr/player/ui/common/EaraLogoLoadingIndicator.kt
@@ -1,0 +1,193 @@
+package com.asmr.player.ui.common
+
+import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.LocalContentColor
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.graphics.drawscope.DrawScope
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import com.asmr.player.ui.theme.AsmrTheme
+import kotlin.math.PI
+import kotlin.math.sin
+
+private data class LogoBarSpec(
+    val x: Float,
+    val startY: Float,
+    val endY: Float
+)
+
+private val LogoBars = listOf(
+    LogoBarSpec(x = 2f, startY = 10f, endY = 13f),
+    LogoBarSpec(x = 6f, startY = 6f, endY = 17f),
+    LogoBarSpec(x = 10f, startY = 3f, endY = 21f),
+    LogoBarSpec(x = 14f, startY = 8f, endY = 15f),
+    LogoBarSpec(x = 18f, startY = 5f, endY = 18f),
+    LogoBarSpec(x = 22f, startY = 10f, endY = 13f)
+)
+
+@Composable
+fun EaraLogoLoadingIndicator(
+    modifier: Modifier = Modifier,
+    size: Dp = 40.dp,
+    tint: Color = Color.Unspecified,
+    trackColor: Color = Color.Unspecified,
+    glowColor: Color = Color.Unspecified,
+    showGlow: Boolean = true
+) {
+    val colorScheme = AsmrTheme.colorScheme
+    val localContentColor = LocalContentColor.current
+    val resolvedTint = when {
+        tint != Color.Unspecified -> tint
+        localContentColor != Color.Unspecified -> localContentColor
+        else -> colorScheme.primary
+    }.copy(alpha = 1f)
+    val resolvedTrackColor = if (trackColor != Color.Unspecified) {
+        trackColor
+    } else {
+        resolvedTint.copy(alpha = if (colorScheme.isDark) 0.26f else 0.18f)
+    }
+    val resolvedGlowColor = if (glowColor != Color.Unspecified) {
+        glowColor
+    } else if (resolvedTint.approxLuminance() > 0.7f) {
+        resolvedTint
+    } else {
+        colorScheme.primarySoft
+    }
+
+    val infinite = rememberInfiniteTransition(label = "eara_logo_loading")
+    val wavePhase by infinite.animateFloat(
+        initialValue = 0f,
+        targetValue = 1f,
+        animationSpec = infiniteRepeatable(
+            animation = tween(durationMillis = 1050, easing = LinearEasing),
+            repeatMode = RepeatMode.Restart
+        ),
+        label = "wave_phase"
+    )
+    val glowPulse by infinite.animateFloat(
+        initialValue = 0f,
+        targetValue = 1f,
+        animationSpec = infiniteRepeatable(
+            animation = tween(durationMillis = 900, easing = FastOutSlowInEasing),
+            repeatMode = RepeatMode.Reverse
+        ),
+        label = "glow_pulse"
+    )
+
+    Box(
+        modifier = modifier.size(size),
+        contentAlignment = Alignment.Center
+    ) {
+        if (showGlow && size > 20.dp) {
+            Box(
+                modifier = Modifier
+                    .fillMaxSize(0.92f)
+                    .graphicsLayer(
+                        alpha = if (colorScheme.isDark) 0.14f + glowPulse * 0.18f else 0.10f + glowPulse * 0.12f,
+                        scaleX = 0.86f + glowPulse * 0.18f,
+                        scaleY = 0.86f + glowPulse * 0.18f
+                    )
+                    .background(
+                        brush = Brush.radialGradient(
+                            colors = listOf(
+                                resolvedGlowColor.copy(alpha = if (colorScheme.isDark) 0.44f else 0.26f),
+                                resolvedGlowColor.copy(alpha = 0f)
+                            )
+                        ),
+                        shape = CircleShape
+                    )
+            )
+        }
+
+        Canvas(
+            modifier = Modifier
+                .fillMaxSize(if (size <= 18.dp) 0.94f else 0.82f)
+                .graphicsLayer(alpha = 0.86f + glowPulse * 0.14f)
+        ) {
+            drawEaraLogoBars(
+                phase = wavePhase,
+                tint = resolvedTint,
+                trackColor = resolvedTrackColor
+            )
+        }
+    }
+}
+
+private fun DrawScope.drawEaraLogoBars(
+    phase: Float,
+    tint: Color,
+    trackColor: Color
+) {
+    val viewportSize = 24f
+    val scale = size.minDimension / viewportSize
+    val offsetX = (size.width - viewportSize * scale) / 2f
+    val offsetY = (size.height - viewportSize * scale) / 2f
+    val strokeWidth = 2f * scale
+
+    LogoBars.forEachIndexed { index, bar ->
+        val x = offsetX + bar.x * scale
+        val baseStartY = offsetY + bar.startY * scale
+        val baseEndY = offsetY + bar.endY * scale
+
+        drawLine(
+            color = trackColor,
+            start = Offset(x, baseStartY),
+            end = Offset(x, baseEndY),
+            strokeWidth = strokeWidth,
+            cap = StrokeCap.Round
+        )
+
+        val activity = waveAmount(phase = phase, index = index)
+        val centerY = (bar.startY + bar.endY) / 2f
+        val halfHeight = (bar.endY - bar.startY) / 2f
+        val animatedHalfHeight = halfHeight * lerp(0.72f, 1.18f, activity)
+        val animatedColor = tint.copy(alpha = lerp(0.56f, 1f, activity))
+
+        drawLine(
+            color = animatedColor,
+            start = Offset(x, offsetY + (centerY - animatedHalfHeight) * scale),
+            end = Offset(x, offsetY + (centerY + animatedHalfHeight) * scale),
+            strokeWidth = strokeWidth,
+            cap = StrokeCap.Round
+        )
+    }
+}
+
+private fun waveAmount(
+    phase: Float,
+    index: Int
+): Float {
+    val shifted = (phase + index * 0.12f) % 1f
+    val radians = shifted * 2f * PI.toFloat() - (PI.toFloat() / 2f)
+    return ((sin(radians.toDouble()).toFloat() + 1f) / 2f).coerceIn(0f, 1f)
+}
+
+private fun lerp(
+    start: Float,
+    end: Float,
+    fraction: Float
+): Float = start + (end - start) * fraction
+
+private fun Color.approxLuminance(): Float {
+    return (0.2126f * red + 0.7152f * green + 0.0722f * blue).coerceIn(0f, 1f)
+}

--- a/app/src/main/java/com/asmr/player/ui/dlsite/DlsiteLoginScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/dlsite/DlsiteLoginScreen.kt
@@ -17,6 +17,7 @@ import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.Alignment
+import com.asmr.player.ui.common.EaraLogoLoadingIndicator
 import com.asmr.player.ui.common.StableWindowInsets
 import java.text.SimpleDateFormat
 import java.util.Date
@@ -130,7 +131,10 @@ fun DlsiteLoginScreen(
                             .height(44.dp)
                     ) {
                         if (uiState.isLoading) {
-                            CircularProgressIndicator(modifier = Modifier.align(Alignment.CenterVertically), strokeWidth = 2.dp)
+                            EaraLogoLoadingIndicator(
+                                modifier = Modifier.align(Alignment.CenterVertically),
+                                size = 18.dp
+                            )
                         } else {
                             Text("登录")
                         }

--- a/app/src/main/java/com/asmr/player/ui/library/AlbumDetailScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/AlbumDetailScreen.kt
@@ -118,6 +118,7 @@ import com.asmr.player.ui.common.DiscPlaceholder
 import com.asmr.player.ui.common.AsmrAsyncImage
 import com.asmr.player.ui.common.AsmrShimmerPlaceholder
 import com.asmr.player.ui.common.CvChipsFlow
+import com.asmr.player.ui.common.EaraLogoLoadingIndicator
 import com.asmr.player.ui.common.collapsibleHeaderUiState
 import com.asmr.player.ui.common.rememberCollapsibleHeaderState
 import com.asmr.player.ui.theme.AsmrTheme
@@ -228,7 +229,7 @@ fun AlbumDetailScreen(
             when (val state = uiState) {
                 is AlbumDetailUiState.Loading -> {
                     Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-                        CircularProgressIndicator()
+                        EaraLogoLoadingIndicator(tint = AsmrTheme.colorScheme.primary)
                     }
                 }
                 is AlbumDetailUiState.Success -> {
@@ -1897,7 +1898,7 @@ private fun AlbumAsmrOneTab(
                     contentAlignment = Alignment.Center
                 ) {
                     if (isLoading) {
-                        CircularProgressIndicator()
+                        EaraLogoLoadingIndicator(tint = AsmrTheme.colorScheme.primary)
                     } else {
                         Text("暂无在线音频")
                     }
@@ -3653,7 +3654,7 @@ private fun AlbumDlsiteInfoTab(
                         .height(160.dp),
                     contentAlignment = Alignment.Center
                 ) {
-                    CircularProgressIndicator()
+                    EaraLogoLoadingIndicator(tint = AsmrTheme.colorScheme.primary)
                 }
             }
             return@LazyColumn
@@ -3810,7 +3811,7 @@ private fun AlbumDlsiteInfoTab(
                         .height(120.dp),
                     contentAlignment = Alignment.Center
                 ) {
-                    CircularProgressIndicator()
+                    EaraLogoLoadingIndicator(tint = AsmrTheme.colorScheme.primary)
                 }
             } else {
                 Box(
@@ -3853,7 +3854,7 @@ private fun AlbumDlsiteInfoTab(
                     contentAlignment = Alignment.Center
                 ) {
                     if (isLoadingTrial) {
-                        CircularProgressIndicator()
+                        EaraLogoLoadingIndicator(tint = AsmrTheme.colorScheme.primary)
                     } else {
                         Text("暂无试听")
                     }
@@ -3868,7 +3869,7 @@ private fun AlbumDlsiteInfoTab(
                             .height(120.dp),
                         contentAlignment = Alignment.Center
                     ) {
-                        CircularProgressIndicator()
+                        EaraLogoLoadingIndicator(tint = AsmrTheme.colorScheme.primary)
                     }
                 }
             }
@@ -4107,7 +4108,7 @@ private fun AlbumDlsitePlayTreeTab(
                     contentAlignment = Alignment.Center
                 ) {
                     if (isLoading) {
-                        CircularProgressIndicator()
+                        EaraLogoLoadingIndicator(tint = AsmrTheme.colorScheme.primary)
                     } else {
                         Text("暂无可播放资源")
                     }

--- a/app/src/main/java/com/asmr/player/ui/library/LibraryScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/LibraryScreen.kt
@@ -55,6 +55,7 @@ import com.asmr.player.ui.common.LocalBottomOverlayPadding
 import com.asmr.player.ui.common.CoverContentRow
 import com.asmr.player.ui.common.CvChipsFlow
 import com.asmr.player.ui.common.CvChipsSingleLine
+import com.asmr.player.ui.common.EaraLogoLoadingIndicator
 import com.asmr.player.ui.common.StableWindowInsets
 import com.asmr.player.ui.common.withAddedBottomPadding
 import androidx.compose.material3.HorizontalDivider
@@ -71,7 +72,6 @@ import androidx.compose.material3.TextButton
 import androidx.compose.material3.Text
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.TopAppBar
-import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -366,7 +366,7 @@ fun LibraryScreen(
                     when (val state = uiState) {
                     is LibraryUiState.Loading -> {
                         Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-                            CircularProgressIndicator()
+                            EaraLogoLoadingIndicator(tint = colorScheme.primary)
                         }
                     }
                     is LibraryUiState.BulkInProgress -> {
@@ -428,7 +428,7 @@ fun LibraryScreen(
                     is LibraryUiState.Success -> {
                         if (viewMode == null) {
                             Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-                                CircularProgressIndicator()
+                                EaraLogoLoadingIndicator(tint = colorScheme.primary)
                             }
                         } else {
                             // Main content area
@@ -447,7 +447,7 @@ fun LibraryScreen(
                                 }
                                 if (isLoading) {
                                     Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-                                        CircularProgressIndicator(color = colorScheme.primary)
+                                        EaraLogoLoadingIndicator(tint = colorScheme.primary)
                                     }
                                 } else if (isEmpty) {
                                     val hasAnyQuery =
@@ -1284,10 +1284,11 @@ private fun AlbumGridItem(
                         .blur(4.dp),
                     contentAlignment = Alignment.Center
                 ) {
-                    CircularProgressIndicator(
-                        modifier = Modifier.size(24.dp),
-                        color = Color.White,
-                        strokeWidth = 2.dp
+                    EaraLogoLoadingIndicator(
+                        size = 24.dp,
+                        tint = Color.White,
+                        glowColor = Color.White,
+                        showGlow = false
                     )
                 }
             } else if (syncStatus is SyncStatus.Error) {
@@ -1458,10 +1459,11 @@ private fun AlbumItem(
                                 .blur(2.dp),
                             contentAlignment = Alignment.Center
                         ) {
-                            CircularProgressIndicator(
-                                modifier = Modifier.size(16.dp),
-                                color = Color.White,
-                                strokeWidth = 2.dp
+                            EaraLogoLoadingIndicator(
+                                size = 16.dp,
+                                tint = Color.White,
+                                glowColor = Color.White,
+                                showGlow = false
                             )
                         }
                     } else if (syncStatus is SyncStatus.Error) {

--- a/app/src/main/java/com/asmr/player/ui/playlists/SystemPlaylistScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/playlists/SystemPlaylistScreen.kt
@@ -2,17 +2,17 @@ package com.asmr.player.ui.playlists
 
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.compose.material3.windowsizeclass.WindowSizeClass
 import com.asmr.player.data.local.db.entities.PlaylistItemEntity
 import com.asmr.player.data.repository.PlaylistRepository
-import androidx.compose.material3.windowsizeclass.WindowSizeClass
-import androidx.hilt.navigation.compose.hiltViewModel
+import com.asmr.player.ui.common.EaraLogoLoadingIndicator
+import com.asmr.player.ui.theme.AsmrTheme
 
 @Composable
 fun SystemPlaylistScreen(
@@ -27,7 +27,7 @@ fun SystemPlaylistScreen(
 
     if (playlist == null) {
         Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-            CircularProgressIndicator()
+            EaraLogoLoadingIndicator(tint = AsmrTheme.colorScheme.primary)
         }
         return
     }

--- a/app/src/main/java/com/asmr/player/ui/search/SearchScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/search/SearchScreen.kt
@@ -30,6 +30,7 @@ import androidx.compose.foundation.lazy.staggeredgrid.LazyStaggeredGridState
 import androidx.compose.foundation.lazy.staggeredgrid.LazyVerticalStaggeredGrid
 import androidx.compose.foundation.lazy.staggeredgrid.StaggeredGridCells
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
@@ -39,7 +40,6 @@ import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material.icons.filled.WifiOff
 import androidx.compose.material3.ButtonDefaults
-import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -51,7 +51,6 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
-import androidx.compose.material3.pulltorefresh.PullToRefreshContainer
 import androidx.compose.material3.pulltorefresh.rememberPullToRefreshState
 import androidx.compose.material3.windowsizeclass.WindowSizeClass
 import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
@@ -84,6 +83,7 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.asmr.player.domain.model.Album
 import com.asmr.player.ui.common.CustomSearchBar
+import com.asmr.player.ui.common.EaraLogoLoadingIndicator
 import com.asmr.player.ui.common.LocalBottomOverlayPadding
 import com.asmr.player.ui.common.StableWindowInsets
 import com.asmr.player.ui.common.collapsibleHeaderUiState
@@ -205,15 +205,17 @@ fun SearchScreen(
     }
 
     val pullToRefreshState = rememberPullToRefreshState()
+    val refreshGestureEnabled = !pullToRefreshState.isRefreshing
     val topPaddingPx = with(androidx.compose.ui.platform.LocalDensity.current) { topPadding.toPx() }
-    val refreshIndicatorSizePx = with(androidx.compose.ui.platform.LocalDensity.current) {
-        SearchPullRefreshIndicatorSize.toPx()
-    }
-    val refreshIndicatorHalfSizePx = with(androidx.compose.ui.platform.LocalDensity.current) {
-        refreshIndicatorSizePx / 2f
+    val refreshIndicatorHoverOffsetPx = with(androidx.compose.ui.platform.LocalDensity.current) {
+        16.dp.toPx()
     }
     val pullContentOffsetTargetPx = (
-        pullToRefreshState.verticalOffset * SearchPullRefreshContentShiftRatio
+        if (pullToRefreshState.isRefreshing) {
+            0f
+        } else {
+            pullToRefreshState.verticalOffset * SearchPullRefreshContentShiftRatio
+        }
         ).coerceIn(
         minimumValue = 0f,
         maximumValue = pullToRefreshState.positionalThreshold * SearchPullRefreshContentShiftRatio
@@ -227,14 +229,10 @@ fun SearchScreen(
         },
         label = "searchPullContentOffset"
     )
-    val pullIndicatorTopOffsetPx = minOf(
-        pullContentOffsetPx / 2f - refreshIndicatorHalfSizePx,
-        pullContentOffsetPx - refreshIndicatorSizePx
-    )
-    val pullIndicatorBaseOffsetPx = topPaddingPx +
-        pullIndicatorTopOffsetPx -
-        pullToRefreshState.verticalOffset +
-        refreshIndicatorSizePx
+    val pullIndicatorBaseOffsetPx =
+        topPaddingPx +
+            refreshIndicatorHoverOffsetPx +
+            (pullContentOffsetPx / 2f)
     val latestKeyword by rememberUpdatedState(keyword)
     LaunchedEffect(pullToRefreshState.isRefreshing) {
         if (!pullToRefreshState.isRefreshing) return@LaunchedEffect
@@ -330,13 +328,18 @@ fun SearchScreen(
                     Box(
                         modifier = Modifier
                             .fillMaxSize()
-                            .nestedScroll(pullToRefreshState.nestedScrollConnection)
+                            .then(
+                                if (refreshGestureEnabled) {
+                                    Modifier.nestedScroll(pullToRefreshState.nestedScrollConnection)
+                                } else {
+                                    Modifier
+                                }
+                            )
                             .clipToBounds()
                     ) {
                         Box(
                             modifier = Modifier
                                 .fillMaxSize()
-                                .graphicsLayer { translationY = pullContentOffsetPx }
                         ) {
                             when (val state = uiState) {
                             is SearchUiState.Loading -> Column(
@@ -347,7 +350,7 @@ fun SearchScreen(
                                 horizontalAlignment = Alignment.CenterHorizontally,
                                 verticalArrangement = Arrangement.Center
                             ) {
-                                CircularProgressIndicator(color = colorScheme.primary)
+                                EaraLogoLoadingIndicator(tint = colorScheme.primary)
                             }
 
                             is SearchUiState.Success -> {
@@ -442,8 +445,9 @@ fun SearchScreen(
                             }
                         }
 
-                        PullToRefreshContainer(
-                            state = pullToRefreshState,
+                        SearchPullRefreshIndicator(
+                            progress = pullToRefreshState.progress,
+                            isRefreshing = pullToRefreshState.isRefreshing,
                             modifier = Modifier
                                 .align(Alignment.TopCenter)
                                 .graphicsLayer { translationY = pullIndicatorBaseOffsetPx }
@@ -515,6 +519,59 @@ fun SearchScreen(
                 }
             }
         }
+    }
+}
+
+@Composable
+private fun SearchPullRefreshIndicator(
+    progress: Float,
+    isRefreshing: Boolean,
+    modifier: Modifier = Modifier
+) {
+    val colorScheme = AsmrTheme.colorScheme
+    val resolvedProgress = if (isRefreshing) 1f else progress.coerceIn(0f, 1f)
+    val indicatorScale by animateFloatAsState(
+        targetValue = 0.82f + resolvedProgress * 0.18f,
+        animationSpec = tween(durationMillis = 180, easing = FastOutSlowInEasing),
+        label = "search_pull_refresh_scale"
+    )
+    val indicatorAlpha by animateFloatAsState(
+        targetValue = 0.48f + resolvedProgress * 0.52f,
+        animationSpec = tween(durationMillis = 180, easing = FastOutSlowInEasing),
+        label = "search_pull_refresh_alpha"
+    )
+    val containerColor = colorScheme.surface.copy(alpha = if (colorScheme.isDark) 0.92f else 0.98f)
+    val borderColor = if (colorScheme.isDark) {
+        Color.White.copy(alpha = 0.14f)
+    } else {
+        colorScheme.primary.copy(alpha = 0.16f)
+    }
+
+    Box(
+        modifier = modifier
+            .size(SearchPullRefreshIndicatorSize)
+            .graphicsLayer(
+                alpha = indicatorAlpha,
+                scaleX = indicatorScale,
+                scaleY = indicatorScale
+            )
+            .shadow(
+                elevation = if (colorScheme.isDark) 12.dp else 8.dp,
+                shape = CircleShape,
+                spotColor = if (colorScheme.isDark) Color.Black.copy(alpha = 0.6f) else Color.Black.copy(alpha = 0.18f),
+                ambientColor = if (colorScheme.isDark) Color.Black.copy(alpha = 0.6f) else Color.Black.copy(alpha = 0.18f)
+            )
+            .clip(CircleShape)
+            .background(containerColor)
+            .border(width = 1.dp, color = borderColor, shape = CircleShape),
+        contentAlignment = Alignment.Center
+    ) {
+        EaraLogoLoadingIndicator(
+            size = 20.dp,
+            tint = colorScheme.primary,
+            glowColor = colorScheme.primarySoft,
+            showGlow = isRefreshing || resolvedProgress > 0.45f
+        )
     }
 }
 
@@ -751,12 +808,11 @@ internal fun SearchToolbar(
                             .testTag(SEARCH_SUBMIT_BUTTON_TAG)
                     ) {
                         if (showSearchSpinner) {
-                            CircularProgressIndicator(
+                            EaraLogoLoadingIndicator(
+                                size = 14.dp,
+                                tint = colorScheme.primary,
                                 modifier = Modifier
-                                    .size(14.dp)
-                                    .testTag(SEARCH_SUBMIT_SPINNER_TAG),
-                                strokeWidth = 2.dp,
-                                color = colorScheme.primary
+                                    .testTag(SEARCH_SUBMIT_SPINNER_TAG)
                             )
                         } else {
                             Icon(

--- a/app/src/main/java/com/asmr/player/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/settings/SettingsScreen.kt
@@ -61,6 +61,7 @@ import com.asmr.player.data.settings.LyricsPageSettings
 import com.asmr.player.ui.library.BulkPhase
 import com.asmr.player.ui.library.LibraryViewModel
 import com.asmr.player.ui.common.AppSupportStatusSection
+import com.asmr.player.ui.common.EaraLogoLoadingIndicator
 import com.asmr.player.ui.theme.AsmrTheme
 import com.asmr.player.ui.common.LocalBottomOverlayPadding
 import com.asmr.player.ui.common.StableWindowInsets
@@ -663,7 +664,7 @@ fun SettingsScreen(
                             enabled = !busy
                         ) {
                             if (updateState is AppUpdateState.Checking) {
-                                CircularProgressIndicator(modifier = Modifier.size(18.dp), strokeWidth = 2.dp)
+                                EaraLogoLoadingIndicator(size = 18.dp)
                                 Spacer(modifier = Modifier.width(10.dp))
                                 Text("检查中…")
                             } else {


### PR DESCRIPTION
## Summary
- replace existing spinner-based loading indicators with a reusable animated Eara logo loader
- adapt loader colors for light/dark themes and current theme hues across page, button, and card loading states
- customize the search pull-to-refresh indicator so the list stays fixed while the floating loader handles refresh feedback

## Testing
- `./gradlew.bat :app:compileDebugKotlin`