### PR TITLE
fix: 修复消息提示文案未垂直居中

### DIFF
--- a/app/src/main/java/com/asmr/player/ui/common/AppSnackbar.kt
+++ b/app/src/main/java/com/asmr/player/ui/common/AppSnackbar.kt
@@ -102,7 +102,8 @@ fun AppSnackbar(
             Row(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(bottom = 3.dp)
+                    .padding(bottom = 3.dp),
+                verticalAlignment = Alignment.CenterVertically
             ) {
                 Box(
                     modifier = Modifier


### PR DESCRIPTION
## 变更说明
- 修复 app 内消息提示组件内容区未按容器垂直居中的问题
- 让图标、文案和计数在消息容器中线对齐
- 优化单行提示时看起来偏上、不在容器中央的视觉问题

## 验证
- ./gradlew :app:compileDebugKotlin
- 本地检查消息提示单行场景布局实现