### PR TITLE
fix: restore album detail dl state and header motion

### DIFF
--- a/app/src/main/java/com/asmr/player/main/MainContainer.kt
+++ b/app/src/main/java/com/asmr/player/main/MainContainer.kt
@@ -38,6 +38,7 @@ import androidx.compose.material3.windowsizeclass.WindowSizeClass
 import androidx.compose.material3.windowsizeclass.calculateWindowSizeClass
 import androidx.compose.runtime.*
 import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.saveable.rememberSaveableStateHolder
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.Alignment
@@ -273,6 +274,7 @@ fun MainContainer(
         initialPage = initialPrimaryPage,
         pageCount = { primaryPagerRoutes.size }
     )
+    val primaryContentStateHolder = rememberSaveableStateHolder()
     var primaryPagerScrollLocked by remember { mutableStateOf(false) }
     val primaryNavSelectionProgresses by remember(
         primaryPagerState,
@@ -1040,14 +1042,17 @@ fun MainContainer(
                                 .fillMaxSize()
                                 .padding(top = padding.calculateTopPadding())
                         ) {
-                            if (currentPrimaryRoute != null) {
-                                HorizontalPager(
-                                    state = primaryPagerState,
-                                    modifier = Modifier.fillMaxSize(),
-                                    userScrollEnabled = !primaryPagerScrollLocked,
-                                    key = { primaryPagerRoutes[it] }
-                                ) { page ->
-                                    when (primaryPagerRoutes[page]) {
+                            primaryContentStateHolder.SaveableStateProvider("primary_pager") {
+                                if (currentPrimaryRoute != null) {
+                                    HorizontalPager(
+                                        state = primaryPagerState,
+                                        modifier = Modifier.fillMaxSize(),
+                                        userScrollEnabled = !primaryPagerScrollLocked,
+                                        key = { primaryPagerRoutes[it] }
+                                    ) { page ->
+                                        val route = primaryPagerRoutes[page]
+                                        primaryContentStateHolder.SaveableStateProvider("primary_route:$route") {
+                                            when (route) {
                                         Routes.Library -> {
                                             LibraryScreen(
                                                 windowSizeClass = windowSizeClass,
@@ -1158,7 +1163,9 @@ fun MainContainer(
                                             )
                                         }
                                     }
+                                    }
                                 }
+                            }
                             }
 
                             NavHost(

--- a/app/src/main/java/com/asmr/player/ui/library/AlbumDetailScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/AlbumDetailScreen.kt
@@ -893,6 +893,14 @@ private fun AlbumHeader(
     }
 
     val rj = album.rjCode.ifBlank { album.workId }
+    val headerAnimationScopeKey = remember(album.id, rj) { "albumHeader:${album.id}:$rj" }
+    var headerIntroPlayed by rememberSaveable(headerAnimationScopeKey) { mutableStateOf(false) }
+    LaunchedEffect(headerAnimationScopeKey) {
+        if (!headerIntroPlayed) {
+            delay(700)
+            headerIntroPlayed = true
+        }
+    }
     fun copy(label: String, value: String) {
         val v = value.trim()
         if (v.isBlank()) return
@@ -900,14 +908,18 @@ private fun AlbumHeader(
         messageManager.showSuccess("$label 已复制")
     }
 
+    val headerContainerModifier = Modifier
+        .fillMaxWidth()
+        .padding(16.dp)
+        .clip(RoundedCornerShape(24.dp))
+        .background(colorScheme.surface.copy(alpha = 0.5f))
+
     Column(
-        modifier = dlsiteElasticItemModifier(
-            Modifier
-                .fillMaxWidth()
-                .padding(16.dp)
-                .clip(RoundedCornerShape(24.dp))
-                .background(colorScheme.surface.copy(alpha = 0.5f))
-        )
+        modifier = if (headerIntroPlayed) {
+            headerContainerModifier
+        } else {
+            dlsiteElasticItemModifier(headerContainerModifier)
+        }
     ) {
         Column {
             Box(
@@ -956,7 +968,7 @@ private fun AlbumHeader(
                     verticalArrangement = Arrangement.spacedBy(6.dp)
                 ) {
                     AlbumHeaderInfoReveal(
-                        revealKey = "title:${album.rjCode}:${album.title}",
+                        revealKey = "$headerAnimationScopeKey:title",
                         delayMillis = 0
                     ) {
                     Text(
@@ -971,7 +983,7 @@ private fun AlbumHeader(
                     val circle = album.circle.trim()
                     if (rj.isNotBlank() || circle.isNotBlank()) {
                         AlbumHeaderInfoReveal(
-                            revealKey = "meta:${album.rjCode}:$circle",
+                            revealKey = "$headerAnimationScopeKey:meta",
                             delayMillis = 40
                         ) {
                     Row(
@@ -1009,7 +1021,7 @@ private fun AlbumHeader(
             Column(modifier = Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(12.dp)) {
                 if (album.cv.isNotBlank()) {
                     AlbumHeaderInfoReveal(
-                        revealKey = "cv:${album.rjCode}:${album.cv}",
+                        revealKey = "$headerAnimationScopeKey:cv",
                         delayMillis = 80
                     ) {
                         CvChipsFlow(
@@ -1062,7 +1074,7 @@ private fun AlbumHeader(
 
                 if (album.tags.isNotEmpty()) {
                     AlbumHeaderInfoReveal(
-                        revealKey = "tags:${album.rjCode}:${album.tags.joinToString(separator = "|")}",
+                        revealKey = "$headerAnimationScopeKey:tags",
                         delayMillis = 120
                     ) {
                     FlowRow(
@@ -1085,7 +1097,7 @@ private fun AlbumHeader(
                 }
 
                 AlbumHeaderInfoReveal(
-                    revealKey = "actions:${album.rjCode}:$canSaveOnline:$downloadEnabled:$saveEnabled:$showGroupButton:$dlsiteUrl:$asmrOneUrl",
+                    revealKey = "$headerAnimationScopeKey:actions",
                     delayMillis = 160
                 ) {
                 Row(
@@ -1194,14 +1206,25 @@ private fun AlbumHeaderInfoReveal(
     delayMillis: Int = 0,
     content: @Composable () -> Unit
 ) {
-    var visible by remember(revealKey) { mutableStateOf(false) }
+    var hasPlayed by rememberSaveable(revealKey) { mutableStateOf(false) }
+    var visible by remember(revealKey, hasPlayed) { mutableStateOf(hasPlayed) }
     LaunchedEffect(revealKey) {
+        if (hasPlayed) {
+            visible = true
+            return@LaunchedEffect
+        }
         visible = false
         if (delayMillis > 0) {
             delay(delayMillis.toLong())
         }
         withFrameNanos { }
         visible = true
+        delay(420)
+        hasPlayed = true
+    }
+    if (hasPlayed) {
+        content()
+        return
     }
     val alpha by animateFloatAsState(
         targetValue = if (visible) 1f else 0f,

--- a/app/src/main/java/com/asmr/player/ui/library/AlbumDetailScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/AlbumDetailScreen.kt
@@ -7,13 +7,17 @@ import androidx.activity.compose.BackHandler
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.animateContentSize
 import androidx.compose.animation.core.Spring
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.animation.core.spring
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.expandVertically
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
+import androidx.compose.animation.shrinkVertically
 import androidx.compose.animation.slideInHorizontally
 import androidx.compose.animation.slideOutHorizontally
 import androidx.compose.animation.togetherWith
@@ -108,6 +112,7 @@ import androidx.compose.material.icons.automirrored.filled.PlaylistPlay
 import androidx.compose.material.icons.automirrored.filled.QueueMusic
 import java.io.File
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.launch
@@ -300,11 +305,6 @@ fun AlbumDetailScreen(
                     }
                     val tabContentTopPadding = tabChromeVisibleHeight + AlbumDetailTabContentGap
     
-                    LaunchedEffect(model.rjCode, model.dlsiteWorkno, model.localAlbum?.id, selectedTab) {
-                        if (selectedTab != 0 && model.dlsiteInfo == null && model.dlsiteWorkno.isNotBlank()) {
-                            viewModel.ensureDlsiteLoaded()
-                        }
-                    }
                     LaunchedEffect(selectedTab) {
                         if (lastChromeResetTab != selectedTab) {
                             tabChromeState.expand()
@@ -349,7 +349,12 @@ fun AlbumDetailScreen(
                     }
                     
                     val tabTitles = remember { listOf("本地", "DL", "DL Play") }
-                    LaunchedEffect(selectedTab, model.rjCode, model.dlsiteWorkno) {
+                    LaunchedEffect(
+                        selectedTab,
+                        model.rjCode,
+                        model.dlsiteWorkno,
+                        model.hasResolvedInitialDlsiteTarget
+                    ) {
                         when (selectedTab) {
                             1 -> {
                                 viewModel.ensureDlsiteLoaded()
@@ -896,11 +901,13 @@ private fun AlbumHeader(
     }
 
     Column(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(16.dp)
-            .clip(RoundedCornerShape(24.dp))
-            .background(colorScheme.surface.copy(alpha = 0.5f))
+        modifier = dlsiteElasticItemModifier(
+            Modifier
+                .fillMaxWidth()
+                .padding(16.dp)
+                .clip(RoundedCornerShape(24.dp))
+                .background(colorScheme.surface.copy(alpha = 0.5f))
+        )
     ) {
         Column {
             Box(
@@ -948,6 +955,10 @@ private fun AlbumHeader(
                         .padding(16.dp),
                     verticalArrangement = Arrangement.spacedBy(6.dp)
                 ) {
+                    AlbumHeaderInfoReveal(
+                        revealKey = "title:${album.rjCode}:${album.title}",
+                        delayMillis = 0
+                    ) {
                     Text(
                         text = album.title,
                         modifier = Modifier.clickable { copy("标题", album.title) },
@@ -956,6 +967,13 @@ private fun AlbumHeader(
                         maxLines = 2,
                         overflow = TextOverflow.Ellipsis
                     )
+                    }
+                    val circle = album.circle.trim()
+                    if (rj.isNotBlank() || circle.isNotBlank()) {
+                        AlbumHeaderInfoReveal(
+                            revealKey = "meta:${album.rjCode}:$circle",
+                            delayMillis = 40
+                        ) {
                     Row(
                         horizontalArrangement = Arrangement.spacedBy(10.dp),
                         verticalAlignment = Alignment.CenterVertically
@@ -972,7 +990,6 @@ private fun AlbumHeader(
                                     .padding(horizontal = 6.dp, vertical = 2.dp)
                             )
                         }
-                        val circle = album.circle.trim()
                         if (circle.isNotBlank()) {
                             Text(
                                 text = circle,
@@ -984,16 +1001,25 @@ private fun AlbumHeader(
                             )
                         }
                     }
+                        }
+                    }
                 }
             }
 
             Column(modifier = Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(12.dp)) {
-                CvChipsFlow(
-                    cvText = album.cv,
-                    horizontalArrangement = Arrangement.spacedBy(8.dp),
-                    verticalArrangement = Arrangement.spacedBy(6.dp),
-                    onCvClick = { cv -> copy("CV", cv) },
-                )
+                if (album.cv.isNotBlank()) {
+                    AlbumHeaderInfoReveal(
+                        revealKey = "cv:${album.rjCode}:${album.cv}",
+                        delayMillis = 80
+                    ) {
+                        CvChipsFlow(
+                            cvText = album.cv,
+                            horizontalArrangement = Arrangement.spacedBy(8.dp),
+                            verticalArrangement = Arrangement.spacedBy(6.dp),
+                            onCvClick = { cv -> copy("CV", cv) },
+                        )
+                    }
+                }
 
                 val langCandidates = remember(dlsiteEditions) {
                     dlsiteEditions
@@ -1035,6 +1061,10 @@ private fun AlbumHeader(
                 }
 
                 if (album.tags.isNotEmpty()) {
+                    AlbumHeaderInfoReveal(
+                        revealKey = "tags:${album.rjCode}:${album.tags.joinToString(separator = "|")}",
+                        delayMillis = 120
+                    ) {
                     FlowRow(
                         horizontalArrangement = Arrangement.spacedBy(8.dp),
                         verticalArrangement = Arrangement.spacedBy(6.dp)
@@ -1051,8 +1081,13 @@ private fun AlbumHeader(
                             )
                         }
                     }
+                    }
                 }
 
+                AlbumHeaderInfoReveal(
+                    revealKey = "actions:${album.rjCode}:$canSaveOnline:$downloadEnabled:$saveEnabled:$showGroupButton:$dlsiteUrl:$asmrOneUrl",
+                    delayMillis = 160
+                ) {
                 Row(
                     modifier = Modifier.padding(top = 4.dp),
                     horizontalArrangement = Arrangement.spacedBy(10.dp)
@@ -1147,7 +1182,68 @@ private fun AlbumHeader(
                         }
                     }
                 }
+                }
             }
+        }
+    }
+}
+
+@Composable
+private fun AlbumHeaderInfoReveal(
+    revealKey: String,
+    delayMillis: Int = 0,
+    content: @Composable () -> Unit
+) {
+    var visible by remember(revealKey) { mutableStateOf(false) }
+    LaunchedEffect(revealKey) {
+        visible = false
+        if (delayMillis > 0) {
+            delay(delayMillis.toLong())
+        }
+        withFrameNanos { }
+        visible = true
+    }
+    val alpha by animateFloatAsState(
+        targetValue = if (visible) 1f else 0f,
+        animationSpec = spring(
+            dampingRatio = Spring.DampingRatioNoBouncy,
+            stiffness = Spring.StiffnessMediumLow
+        ),
+        label = "albumHeaderInfoAlpha"
+    )
+    val offsetY by animateDpAsState(
+        targetValue = if (visible) 0.dp else 10.dp,
+        animationSpec = spring(
+            dampingRatio = Spring.DampingRatioNoBouncy,
+            stiffness = Spring.StiffnessMediumLow
+        ),
+        label = "albumHeaderInfoOffsetY"
+    )
+    val density = LocalDensity.current
+    AnimatedVisibility(
+        visible = visible,
+        enter = fadeIn(animationSpec = tween(durationMillis = 220)) + expandVertically(
+            animationSpec = spring(
+                dampingRatio = Spring.DampingRatioLowBouncy,
+                stiffness = Spring.StiffnessLow
+            ),
+            expandFrom = Alignment.Top
+        ),
+        exit = fadeOut(animationSpec = tween(durationMillis = 120)) + shrinkVertically(
+            animationSpec = spring(
+                dampingRatio = Spring.DampingRatioNoBouncy,
+                stiffness = Spring.StiffnessMediumLow
+            ),
+            shrinkTowards = Alignment.Top
+        )
+    ) {
+        Box(
+            modifier = Modifier.graphicsLayer {
+                this.alpha = alpha
+                translationY = with(density) { offsetY.toPx() }
+            }
+        ) {
+            content()
         }
     }
 }

--- a/app/src/main/java/com/asmr/player/ui/library/AlbumDetailViewModel.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/AlbumDetailViewModel.kt
@@ -17,6 +17,7 @@ import com.asmr.player.data.local.db.entities.TrackEntity
 import com.asmr.player.data.local.db.entities.TagEntity
 import com.asmr.player.data.local.db.entities.TagSource
 import com.asmr.player.data.local.db.entities.TrackTagEntity
+import com.asmr.player.data.remote.api.AsmrOneOtherLanguageEditionInDb
 import com.asmr.player.data.remote.api.AsmrOneTrackNodeResponse
 import com.asmr.player.data.remote.crawler.AsmrOneCrawler
 import com.asmr.player.data.remote.dlsite.DlsiteCloudSyncCandidate
@@ -437,6 +438,8 @@ class AlbumDetailViewModel @Inject constructor(
                         dlsitePlayWorkno = "",
                         dlsiteEditions = defaultDlsiteEditions(rj),
                         dlsiteSelectedLang = "JPN",
+                        hasResolvedInitialDlsiteTarget = false,
+                        isDlsiteLanguageUserSelected = false,
                         asmrOneWorkId = null,
                         asmrOneSite = null,
                         asmrOneTree = emptyList(),
@@ -789,6 +792,106 @@ class AlbumDetailViewModel @Inject constructor(
         }
     }
 
+    private fun matchesAsmrOneChineseEdition(
+        edition: AsmrOneOtherLanguageEditionInDb,
+        workno: String,
+        langCode: String,
+        titleKeywords: List<String>
+    ): Boolean {
+        val normalizedWorkno = workno.trim().uppercase()
+        val normalizedLang = edition.lang.orEmpty().trim().uppercase()
+        val normalizedTitle = edition.title.orEmpty().trim()
+        val normalizedSourceId = edition.source_id.orEmpty().trim().uppercase()
+        return (normalizedWorkno.isNotBlank() && normalizedSourceId == normalizedWorkno) ||
+            normalizedLang.contains(langCode) ||
+            titleKeywords.any { keyword ->
+                normalizedLang.contains(keyword, ignoreCase = true) ||
+                    normalizedTitle.contains(keyword, ignoreCase = true)
+            }
+    }
+
+    private suspend fun resolveInitialDlsiteChinesePreference(
+        baseRj: String,
+        editions: List<DlsiteLanguageEdition>
+    ): DlsiteChinesePreference {
+        val clean = baseRj.trim().uppercase()
+        if (clean.isBlank()) return DlsiteChinesePreference.None
+        val hasHansEdition = editions.any { it.lang.equals("CHI_HANS", ignoreCase = true) }
+        val hasHantEdition = editions.any { it.lang.equals("CHI_HANT", ignoreCase = true) }
+        if (!hasHansEdition && !hasHantEdition) return DlsiteChinesePreference.None
+
+        val jpnWorkno = editions.firstOrNull { it.lang.equals("JPN", ignoreCase = true) }
+            ?.workno
+            ?.trim()
+            ?.uppercase()
+            .orEmpty()
+            .ifBlank { clean }
+        val resolved = resolveAsmrOneWork(jpnWorkno, timeoutMs = 1_200L)
+            ?: resolveAsmrOneWork(clean, timeoutMs = 1_200L)
+            ?: return DlsiteChinesePreference.None
+        val (workId, site) = resolved
+        val details = withTimeoutOrNull(1_500L) {
+            if (site != null) {
+                asmrOneCrawler.getDetailsFromSite(site, workId)
+            } else {
+                asmrOneCrawler.getDetails(workId)
+            }
+        } ?: return DlsiteChinesePreference.None
+        val otherEditions = details.other_language_editions_in_db.orEmpty()
+        val hansWorkno = editions.firstOrNull { it.lang.equals("CHI_HANS", ignoreCase = true) }
+            ?.workno
+            .orEmpty()
+        val hantWorkno = editions.firstOrNull { it.lang.equals("CHI_HANT", ignoreCase = true) }
+            ?.workno
+            .orEmpty()
+
+        return when {
+            hasHansEdition && otherEditions.any {
+                matchesAsmrOneChineseEdition(
+                    edition = it,
+                    workno = hansWorkno,
+                    langCode = "CHI_HANS",
+                    titleKeywords = listOf("简", "簡")
+                )
+            } -> DlsiteChinesePreference.Hans
+
+            hasHantEdition && otherEditions.any {
+                matchesAsmrOneChineseEdition(
+                    edition = it,
+                    workno = hantWorkno,
+                    langCode = "CHI_HANT",
+                    titleKeywords = listOf("繁")
+                )
+            } -> DlsiteChinesePreference.Hant
+
+            else -> DlsiteChinesePreference.None
+        }
+    }
+
+    private suspend fun resolveInitialDlsiteLoadTarget(
+        model: AlbumDetailModel
+    ): ResolvedDlsiteLoadTarget {
+        val clean = model.baseRjCode.trim().uppercase()
+        if (clean.isBlank()) {
+            return ResolvedDlsiteLoadTarget(
+                editions = model.dlsiteEditions,
+                selectedLang = model.dlsiteSelectedLang,
+                workno = model.dlsiteWorkno.trim().uppercase()
+            )
+        }
+        val editions = runCatching { dlsiteProductInfoClient.fetchLanguageEditions(clean) }
+            .getOrDefault(emptyList())
+        val merged = mergeDlsiteEditions(clean, editions)
+        val chinesePreference = resolveInitialDlsiteChinesePreference(clean, merged)
+        return resolveInitialDlsiteLoadTarget(
+            baseRj = clean,
+            editions = merged,
+            currentSelectedLang = model.dlsiteSelectedLang,
+            preserveCurrentSelection = model.isDlsiteLanguageUserSelected,
+            chinesePreference = chinesePreference
+        )
+    }
+
     private fun dlsiteLocaleForLang(lang: String): String {
         return when (lang.trim().uppercase()) {
             "CHI_HANS" -> "zh_CN"
@@ -818,21 +921,53 @@ class AlbumDetailViewModel @Inject constructor(
 
     fun ensureDlsiteLoaded() {
         val current = _uiState.value as? AlbumDetailUiState.Success ?: return
-        val workno = current.model.dlsiteWorkno.trim().uppercase().ifBlank { current.model.rjCode.trim().uppercase() }
-        if (workno.isBlank() || current.model.isLoadingDlsite) return
+        if (current.model.isLoadingDlsite) return
         
         // 如果还没有拉取过多语言列表，先拉取一次
-        if (current.model.dlsiteEditions.size <= 1) {
-            fetchDlsiteEditions(current.model.baseRjCode)
-        }
-
-        if (current.model.dlsiteInfo != null) return
-        
         val token = ++dlsiteLoadToken
-        val locale = dlsiteLocaleForLang(current.model.dlsiteSelectedLang)
         viewModelScope.launch {
-            _uiState.value = AlbumDetailUiState.Success(model = current.model.copy(isLoadingDlsite = true, isLoadingDlsiteTrial = false))
+            val latestBefore = (_uiState.value as? AlbumDetailUiState.Success)?.model ?: return@launch
+            _uiState.value = AlbumDetailUiState.Success(
+                model = latestBefore.copy(
+                    isLoadingDlsite = true,
+                    isLoadingDlsiteTrial = false
+                )
+            )
             try {
+                var loadModel = (_uiState.value as? AlbumDetailUiState.Success)?.model ?: return@launch
+                if (!loadModel.hasResolvedInitialDlsiteTarget) {
+                    val resolvedTarget = resolveInitialDlsiteLoadTarget(loadModel)
+                    val latestResolved = (_uiState.value as? AlbumDetailUiState.Success)?.model ?: return@launch
+                    if (token != dlsiteLoadToken) return@launch
+                    loadModel = latestResolved.copy(
+                        rjCode = resolvedTarget.workno,
+                        displayAlbum = buildDisplayAlbum(
+                            rjCode = resolvedTarget.workno,
+                            localAlbum = latestResolved.localAlbum,
+                            dlsiteInfo = latestResolved.dlsiteInfo,
+                            asmrOneWorkId = latestResolved.asmrOneWorkId
+                        ),
+                        dlsiteWorkno = resolvedTarget.workno,
+                        dlsiteEditions = resolvedTarget.editions,
+                        dlsiteSelectedLang = resolvedTarget.selectedLang,
+                        hasResolvedInitialDlsiteTarget = true,
+                        isLoadingDlsite = true,
+                        isLoadingDlsiteTrial = false
+                    )
+                    _uiState.value = AlbumDetailUiState.Success(model = loadModel)
+                }
+
+                if (loadModel.dlsiteInfo != null) {
+                    _uiState.value = AlbumDetailUiState.Success(model = loadModel.copy(isLoadingDlsite = false))
+                    return@launch
+                }
+
+                val workno = loadModel.dlsiteWorkno.trim().uppercase().ifBlank { loadModel.rjCode.trim().uppercase() }
+                if (workno.isBlank()) {
+                    _uiState.value = AlbumDetailUiState.Success(model = loadModel.copy(isLoadingDlsite = false))
+                    return@launch
+                }
+                val locale = dlsiteLocaleForLang(loadModel.dlsiteSelectedLang)
                 val (dlsiteWorkInfo, dlsiteRecommendationsFromV2, dlsiteTrialTracks) = coroutineScope {
                     val infoDeferred = async { runCatching { dlsiteScraper.getWorkInfo(workno, locale = locale) }.getOrNull() }
                     val recDeferred = async {
@@ -896,15 +1031,15 @@ class AlbumDetailViewModel @Inject constructor(
                     )
                 )
 
-                viewModelScope.launch {
-                    val current2 = _uiState.value as? AlbumDetailUiState.Success ?: return@launch
-                    if (token != dlsiteLoadToken) return@launch
+                viewModelScope.launch enrichLaunch@{
+                    val current2 = _uiState.value as? AlbumDetailUiState.Success ?: return@enrichLaunch
+                    if (token != dlsiteLoadToken) return@enrichLaunch
                     val recs = current2.model.dlsiteRecommendations
-                    if (recs.alsoBoughtWorks.isEmpty() && recs.circleWorks.isEmpty() && recs.sameVoiceWorks.isEmpty()) return@launch
+                    if (recs.alsoBoughtWorks.isEmpty() && recs.circleWorks.isEmpty() && recs.sameVoiceWorks.isEmpty()) return@enrichLaunch
                     val enriched = runCatching { enrichRecommendationsWithAsmrOne(recs) }
-                        .getOrNull() ?: return@launch
-                    val updated2 = (_uiState.value as? AlbumDetailUiState.Success)?.model ?: return@launch
-                    if (token != dlsiteLoadToken) return@launch
+                        .getOrNull() ?: return@enrichLaunch
+                    val updated2 = (_uiState.value as? AlbumDetailUiState.Success)?.model ?: return@enrichLaunch
+                    if (token != dlsiteLoadToken) return@enrichLaunch
                     _uiState.value = AlbumDetailUiState.Success(model = updated2.copy(dlsiteRecommendations = enriched))
                 }
             } catch (e: Exception) {
@@ -915,6 +1050,10 @@ class AlbumDetailViewModel @Inject constructor(
     }
 
     fun selectDlsiteLanguage(lang: String) {
+        selectDlsiteLanguageInternal(lang, isUserSelection = true)
+    }
+
+    private fun selectDlsiteLanguageInternal(lang: String, isUserSelection: Boolean) {
         val current = _uiState.value as? AlbumDetailUiState.Success ?: return
         val normalized = lang.trim().uppercase()
         if (normalized.isBlank()) return
@@ -940,10 +1079,18 @@ class AlbumDetailViewModel @Inject constructor(
                 dlsiteWorkno = workno,
                 dlsitePlayWorkno = "",
                 rjCode = workno,
+                displayAlbum = buildDisplayAlbum(
+                    rjCode = workno,
+                    localAlbum = current.model.localAlbum,
+                    dlsiteInfo = null,
+                    asmrOneWorkId = null
+                ),
                 dlsiteInfo = null,
                 dlsiteGalleryUrls = emptyList(),
                 dlsiteTrialTracks = emptyList(),
                 dlsiteRecommendations = DlsiteRecommendations(),
+                hasResolvedInitialDlsiteTarget = true,
+                isDlsiteLanguageUserSelected = current.model.isDlsiteLanguageUserSelected || isUserSelection,
                 asmrOneWorkId = null,
                 asmrOneSite = null,
                 asmrOneTree = emptyList(),
@@ -958,7 +1105,11 @@ class AlbumDetailViewModel @Inject constructor(
         clearTreeState("tree:dlsitePlay:$workno")
         clearTreeState("localTree:rj:$workno")
         viewModelScope.launch {
-            val local = runCatching { loadLocalAlbumByRj(workno) }.getOrNull()
+            val local = if (isUserSelection) {
+                runCatching { loadLocalAlbumByRj(workno) }.getOrNull() ?: current.model.localAlbum
+            } else {
+                current.model.localAlbum
+            }
             val updated = (_uiState.value as? AlbumDetailUiState.Success)?.model ?: return@launch
             if (!updated.rjCode.equals(workno, ignoreCase = true)) return@launch
             val displayAlbum = buildDisplayAlbum(updated.rjCode, local, updated.dlsiteInfo, updated.asmrOneWorkId)
@@ -1038,6 +1189,7 @@ class AlbumDetailViewModel @Inject constructor(
         val keyRj = current.model.rjCode.trim().uppercase()
         if (
             keyRj.isBlank() ||
+            !current.model.hasResolvedInitialDlsiteTarget ||
             current.model.asmrOneTree.isNotEmpty() ||
             current.model.isLoadingAsmrOne ||
             asmrOneAttemptedRj.contains(keyRj)
@@ -1088,14 +1240,18 @@ class AlbumDetailViewModel @Inject constructor(
                     }
                     val fallbackLang = preferred.firstOrNull { lang -> results[lang] == true }
                     val fallbackKey = "base:$baseKey|cur:$keyRj|to:${fallbackLang.orEmpty()}"
-                    if (!fallbackLang.isNullOrBlank() && !autoFallbackToJpnOnceByKey.contains(fallbackKey)) {
+                    if (
+                        !latest.isDlsiteLanguageUserSelected &&
+                        !fallbackLang.isNullOrBlank() &&
+                        !autoFallbackToJpnOnceByKey.contains(fallbackKey)
+                    ) {
                         autoFallbackToJpnOnceByKey.add(fallbackKey)
                         val updated0 = (_uiState.value as? AlbumDetailUiState.Success)?.model ?: return@launch
                         val updatedKey0 = updated0.rjCode.trim().uppercase()
                         if (updatedKey0.equals(keyRj, ignoreCase = true) && updated0.isLoadingAsmrOne) {
                             _uiState.value = AlbumDetailUiState.Success(model = updated0.copy(isLoadingAsmrOne = false))
                         }
-                        selectDlsiteLanguage(fallbackLang)
+                        selectDlsiteLanguageInternal(fallbackLang, isUserSelection = false)
                         return@launch
                     }
                     val updated = (_uiState.value as? AlbumDetailUiState.Success)?.model ?: return@launch

--- a/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailDirectorySupport.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailDirectorySupport.kt
@@ -1537,9 +1537,11 @@ internal fun DirectoryBrowserPanel(
         shape = RoundedCornerShape(18.dp),
         tonalElevation = 1.dp,
         color = AsmrTheme.colorScheme.surface.copy(alpha = 0.44f),
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(horizontal = 16.dp, vertical = 8.dp)
+        modifier = dlsiteElasticItemModifier(
+            Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp, vertical = 8.dp)
+        )
     ) {
         Column(modifier = Modifier.fillMaxWidth()) {
             CompactDirectoryBreadcrumbContent(
@@ -2506,9 +2508,11 @@ internal fun DirectoryBrowserPanelV4(
                 color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.18f)
             )
             Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = 12.dp, vertical = 8.dp),
+                modifier = dlsiteElasticItemModifier(
+                    Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 12.dp, vertical = 8.dp)
+                ),
                 verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.spacedBy(10.dp)
             ) {

--- a/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailDlsiteTabs.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailDlsiteTabs.kt
@@ -28,6 +28,7 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyItemScope
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
@@ -341,6 +342,20 @@ private fun DlsiteRecommendationsLoadingBlocks() {
     }
 }
 
+private val DlsiteSectionPlacementSpring = spring<IntOffset>(
+    dampingRatio = Spring.DampingRatioLowBouncy,
+    stiffness = Spring.StiffnessLow
+)
+
+@OptIn(ExperimentalFoundationApi::class)
+private fun LazyItemScope.dlsiteAnimatedSectionModifier(
+    modifier: Modifier = Modifier
+): Modifier {
+    return dlsiteElasticItemModifier(
+        modifier.animateItemPlacement(animationSpec = DlsiteSectionPlacementSpring)
+    )
+}
+
 @Composable
 internal fun AlbumDlsiteInfoBreadcrumbTabV2(
     album: Album,
@@ -415,7 +430,7 @@ internal fun AlbumDlsiteInfoBreadcrumbTabV2(
         item(key = "dlsite-header") { header() }
         if (isInitialDlsiteLoading) {
             item(key = "dlsite-gallery-section") {
-                Column(modifier = dlsiteElasticItemModifier(Modifier.fillMaxWidth())) {
+                Column(modifier = dlsiteAnimatedSectionModifier(Modifier.fillMaxWidth())) {
                     Text(
                         text = "Gallery",
                         modifier = Modifier.padding(horizontal = 16.dp, vertical = 10.dp),
@@ -427,7 +442,7 @@ internal fun AlbumDlsiteInfoBreadcrumbTabV2(
             }
             item(key = "dlsite-one-header") {
                 Row(
-                    modifier = dlsiteElasticItemModifier(
+                    modifier = dlsiteAnimatedSectionModifier(
                         Modifier
                             .fillMaxWidth()
                             .padding(horizontal = 16.dp, vertical = 10.dp)
@@ -442,12 +457,12 @@ internal fun AlbumDlsiteInfoBreadcrumbTabV2(
                 }
             }
             item(key = "dlsite-one-content") {
-                Box(modifier = dlsiteElasticItemModifier(Modifier.fillMaxWidth())) {
+                Box(modifier = dlsiteAnimatedSectionModifier(Modifier.fillMaxWidth())) {
                     DlsiteDirectoryLoadingPanel()
                 }
             }
             item(key = "dlsite-trial-loading") {
-                Column(modifier = dlsiteElasticItemModifier(Modifier.fillMaxWidth())) {
+                Column(modifier = dlsiteAnimatedSectionModifier(Modifier.fillMaxWidth())) {
                 Row(
                     modifier = Modifier
                             .fillMaxWidth()
@@ -464,14 +479,14 @@ internal fun AlbumDlsiteInfoBreadcrumbTabV2(
                 }
             }
             item(key = "dlsite-recommendations") {
-                Box(modifier = dlsiteElasticItemModifier(Modifier.fillMaxWidth())) {
+                Box(modifier = dlsiteAnimatedSectionModifier(Modifier.fillMaxWidth())) {
                     DlsiteRecommendationsLoadingBlocks()
                 }
             }
             return@LazyColumn
         }
         item(key = "dlsite-gallery-section") {
-            Column(modifier = dlsiteElasticItemModifier(Modifier.fillMaxWidth())) {
+            Column(modifier = dlsiteAnimatedSectionModifier(Modifier.fillMaxWidth())) {
             Text(
                 text = "Gallery",
                 modifier = Modifier.padding(horizontal = 16.dp, vertical = 10.dp),
@@ -514,7 +529,7 @@ internal fun AlbumDlsiteInfoBreadcrumbTabV2(
         }
         item(key = "dlsite-one-header") {
             Row(
-                modifier = dlsiteElasticItemModifier(
+                modifier = dlsiteAnimatedSectionModifier(
                     Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 10.dp)
                 ),
                 verticalAlignment = Alignment.CenterVertically
@@ -532,7 +547,7 @@ internal fun AlbumDlsiteInfoBreadcrumbTabV2(
         }
         if (asmrOneTree.isNotEmpty()) {
             item(key = "dlsite-one-content") {
-                Box(modifier = dlsiteElasticItemModifier(Modifier.fillMaxWidth())) {
+                Box(modifier = dlsiteAnimatedSectionModifier(Modifier.fillMaxWidth())) {
                     DirectoryBrowserPanelV4(
                     panelKey = treeStateKey,
                     currentPath = currentPath,
@@ -618,14 +633,14 @@ internal fun AlbumDlsiteInfoBreadcrumbTabV2(
             }
         } else if (isLoadingAsmrOne) {
             item(key = "dlsite-one-content") {
-                Box(modifier = dlsiteElasticItemModifier(Modifier.fillMaxWidth())) {
+                Box(modifier = dlsiteAnimatedSectionModifier(Modifier.fillMaxWidth())) {
                     DlsiteDirectoryLoadingPanel()
                 }
             }
         } else {
             item(key = "dlsite-one-content") {
                 Box(
-                    modifier = dlsiteElasticItemModifier(
+                    modifier = dlsiteAnimatedSectionModifier(
                         Modifier.fillMaxWidth().height(120.dp)
                     ),
                     contentAlignment = Alignment.Center
@@ -636,7 +651,7 @@ internal fun AlbumDlsiteInfoBreadcrumbTabV2(
         }
         item(key = "dlsite-trial-header") {
             Row(
-                modifier = dlsiteElasticItemModifier(
+                modifier = dlsiteAnimatedSectionModifier(
                     Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 10.dp)
                 ),
                 verticalAlignment = Alignment.CenterVertically
@@ -655,7 +670,7 @@ internal fun AlbumDlsiteInfoBreadcrumbTabV2(
         if (trialTracks.isEmpty()) {
             item(key = "dlsite-trial-content") {
                 Box(
-                    modifier = dlsiteElasticItemModifier(Modifier.fillMaxWidth()),
+                    modifier = dlsiteAnimatedSectionModifier(Modifier.fillMaxWidth()),
                     contentAlignment = Alignment.Center
                 ) {
                     if (isLoadingTrial) {
@@ -669,7 +684,7 @@ internal fun AlbumDlsiteInfoBreadcrumbTabV2(
             if (isLoadingTrial) {
                 item(key = "dlsite-trial-progress") {
                     LinearProgressIndicator(
-                        modifier = dlsiteElasticItemModifier(
+                        modifier = dlsiteAnimatedSectionModifier(
                             Modifier
                                 .fillMaxWidth()
                                 .padding(horizontal = 16.dp)
@@ -679,7 +694,7 @@ internal fun AlbumDlsiteInfoBreadcrumbTabV2(
             }
             items(items = videoTracks, key = { track -> if (track.id > 0L) track.id else track.path }, contentType = { "trialVideo" }) { track ->
                 Column(
-                    modifier = dlsiteElasticItemModifier(
+                    modifier = dlsiteAnimatedSectionModifier(
                         Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 8.dp)
                     )
                 ) {
@@ -698,7 +713,7 @@ internal fun AlbumDlsiteInfoBreadcrumbTabV2(
                 }
             }
             items(items = audioTracks, key = { track -> if (track.id > 0L) track.id else track.path }, contentType = { "trialAudioTrack" }) { track ->
-                Box(modifier = dlsiteElasticItemModifier(Modifier.fillMaxWidth())) {
+                Box(modifier = dlsiteAnimatedSectionModifier(Modifier.fillMaxWidth())) {
                     TrackItem(
                         track = track,
                         onClick = { onPlayTracks(album, audioTracks, track) },
@@ -708,7 +723,7 @@ internal fun AlbumDlsiteInfoBreadcrumbTabV2(
             }
         }
         item(key = "dlsite-recommendations") {
-            Box(modifier = dlsiteElasticItemModifier(Modifier.fillMaxWidth())) {
+            Box(modifier = dlsiteAnimatedSectionModifier(Modifier.fillMaxWidth())) {
                 DlsiteRecommendationsBlocks(
                     recommendations = dlsiteRecommendations,
                     onOpenAlbumByRj = onOpenAlbumByRj

--- a/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailDlsiteTabs.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailDlsiteTabs.kt
@@ -875,7 +875,7 @@ internal fun AlbumDlsitePlayBreadcrumbTabV2(
         state = listState,
         contentPadding = PaddingValues(top = topContentPadding, bottom = LocalBottomOverlayPadding.current)
     ) {
-        item { header() }
+        item(key = "dlplay-header:$treeStateKey") { header() }
         item {
             Row(
                 modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 10.dp),

--- a/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailLocalTab.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailLocalTab.kt
@@ -232,7 +232,7 @@ internal fun AlbumLocalBreadcrumbTabV2(
         state = listState,
         contentPadding = PaddingValues(top = topContentPadding, bottom = LocalBottomOverlayPadding.current)
     ) {
-        item { header() }
+        item(key = "local-header:$stateKey") { header() }
         val browserValue = browser
         if (browserValue == null) {
             item {

--- a/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailViewModelSupport.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailViewModelSupport.kt
@@ -156,6 +156,8 @@ data class AlbumDetailModel(
     val dlsitePlayWorkno: String,
     val dlsiteEditions: List<DlsiteLanguageEdition>,
     val dlsiteSelectedLang: String,
+    val hasResolvedInitialDlsiteTarget: Boolean,
+    val isDlsiteLanguageUserSelected: Boolean,
     val asmrOneWorkId: String?,
     val asmrOneSite: Int?,
     val asmrOneTree: List<AsmrOneTrackNodeResponse>,
@@ -165,6 +167,90 @@ data class AlbumDetailModel(
     val isLoadingAsmrOne: Boolean,
     val isLoadingDlsitePlay: Boolean
 )
+
+internal enum class DlsiteChinesePreference {
+    None,
+    Hans,
+    Hant
+}
+
+internal data class ResolvedDlsiteLoadTarget(
+    val editions: List<DlsiteLanguageEdition>,
+    val selectedLang: String,
+    val workno: String
+)
+
+internal fun defaultDlsiteEditions(baseRj: String): List<DlsiteLanguageEdition> {
+    val clean = baseRj.trim().uppercase()
+    if (clean.isBlank()) return emptyList()
+    return listOf(
+        DlsiteLanguageEdition(
+            workno = clean,
+            lang = "JPN",
+            label = "日本語",
+            displayOrder = 1
+        )
+    )
+}
+
+internal fun mergeDlsiteEditions(
+    baseRj: String,
+    editions: List<DlsiteLanguageEdition>
+): List<DlsiteLanguageEdition> {
+    val clean = baseRj.trim().uppercase()
+    if (clean.isBlank()) return emptyList()
+    return buildList {
+        val hasJpn = editions.any { it.lang.equals("JPN", ignoreCase = true) }
+        if (!hasJpn) addAll(defaultDlsiteEditions(clean))
+        addAll(editions)
+    }.distinctBy { it.lang.trim().uppercase() }
+        .sortedWith(compareBy({ it.displayOrder }, { it.lang }))
+}
+
+internal fun resolveInitialDlsiteLoadTarget(
+    baseRj: String,
+    editions: List<DlsiteLanguageEdition>,
+    currentSelectedLang: String = "JPN",
+    preserveCurrentSelection: Boolean = false,
+    chinesePreference: DlsiteChinesePreference = DlsiteChinesePreference.None
+): ResolvedDlsiteLoadTarget {
+    val clean = baseRj.trim().uppercase()
+    if (clean.isBlank()) {
+        return ResolvedDlsiteLoadTarget(
+            editions = emptyList(),
+            selectedLang = "JPN",
+            workno = ""
+        )
+    }
+    val merged = mergeDlsiteEditions(clean, editions)
+    val normalizedCurrentLang = currentSelectedLang.trim().uppercase().ifBlank { "JPN" }
+    val hasHans = merged.any { it.lang.equals("CHI_HANS", ignoreCase = true) }
+    val hasHant = merged.any { it.lang.equals("CHI_HANT", ignoreCase = true) }
+    val preservedTarget = if (preserveCurrentSelection) {
+        merged.firstOrNull { it.lang.equals(normalizedCurrentLang, ignoreCase = true) }
+    } else {
+        null
+    }
+    val preferredLang = when {
+        preservedTarget != null -> preservedTarget.lang
+        chinesePreference == DlsiteChinesePreference.Hans && hasHans -> "CHI_HANS"
+        chinesePreference == DlsiteChinesePreference.Hant && hasHant -> "CHI_HANT"
+        hasHans -> "CHI_HANS"
+        hasHant -> "CHI_HANT"
+        else -> "JPN"
+    }
+    val selected = preservedTarget
+        ?: merged.firstOrNull { it.lang.equals(preferredLang, ignoreCase = true) }
+        ?: merged.firstOrNull { it.lang.equals("JPN", ignoreCase = true) }
+        ?: merged.firstOrNull()
+    val selectedLang = selected?.lang?.trim().orEmpty().ifBlank { preferredLang }
+    val selectedWorkno = selected?.workno?.trim()?.uppercase().orEmpty().ifBlank { clean }
+    return ResolvedDlsiteLoadTarget(
+        editions = merged,
+        selectedLang = selectedLang,
+        workno = selectedWorkno
+    )
+}
 
 internal data class AsmrOneLeafDownload(
     val url: String,

--- a/app/src/test/java/com/asmr/player/MainContainerSaveableStateTest.kt
+++ b/app/src/test/java/com/asmr/player/MainContainerSaveableStateTest.kt
@@ -1,0 +1,109 @@
+package com.asmr.player
+
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.items
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.saveable.rememberSaveableStateHolder
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.assertTextContains
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.unit.dp
+import androidx.compose.material3.Text
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+private const val PRIMARY_PAGE_POSITION_TAG = "primary_page_position"
+
+@RunWith(AndroidJUnit4::class)
+class MainContainerSaveableStateTest {
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    @Test
+    fun primaryPagerSaveableHost_restoresLazyListStateAfterRemount() {
+        lateinit var setPrimaryVisible: (Boolean) -> Unit
+        lateinit var requestScroll: (Int, Int) -> Unit
+
+        composeRule.setContent {
+            var showPrimaryPage by remember { mutableStateOf(true) }
+            var pendingScroll by remember { mutableStateOf<Pair<Int, Int>?>(null) }
+            val stateHolder = rememberSaveableStateHolder()
+
+            setPrimaryVisible = { showPrimaryPage = it }
+            requestScroll = { index, offset -> pendingScroll = index to offset }
+
+            stateHolder.SaveableStateProvider("primary_pager") {
+                if (showPrimaryPage) {
+                    stateHolder.SaveableStateProvider("primary_route:search") {
+                        SaveablePrimaryPage(
+                            pendingScroll = pendingScroll,
+                            onScrollHandled = { pendingScroll = null }
+                        )
+                    }
+                }
+            }
+        }
+
+        composeRule.runOnIdle {
+            requestScroll(12, 24)
+        }
+        composeRule.waitForIdle()
+        composeRule.onNodeWithTag(PRIMARY_PAGE_POSITION_TAG).assertTextContains("12:24")
+
+        composeRule.runOnIdle {
+            setPrimaryVisible(false)
+        }
+        composeRule.waitForIdle()
+
+        composeRule.runOnIdle {
+            setPrimaryVisible(true)
+        }
+        composeRule.waitForIdle()
+        composeRule.onNodeWithTag(PRIMARY_PAGE_POSITION_TAG).assertTextContains("12:24")
+    }
+}
+
+@Composable
+private fun SaveablePrimaryPage(
+    pendingScroll: Pair<Int, Int>?,
+    onScrollHandled: () -> Unit
+) {
+    val listState = rememberSaveable(saver = LazyListState.Saver) {
+        LazyListState(0, 0)
+    }
+
+    LaunchedEffect(pendingScroll) {
+        val request = pendingScroll ?: return@LaunchedEffect
+        listState.scrollToItem(request.first, request.second)
+        onScrollHandled()
+    }
+
+    Text(
+        text = "${listState.firstVisibleItemIndex}:${listState.firstVisibleItemScrollOffset}",
+        modifier = Modifier.testTag(PRIMARY_PAGE_POSITION_TAG)
+    )
+    LazyColumn(
+        state = listState,
+        modifier = Modifier.height(120.dp)
+    ) {
+        items((0 until 40).toList()) { index ->
+            Text(
+                text = "Item $index",
+                modifier = Modifier.height(36.dp)
+            )
+        }
+    }
+}

--- a/app/src/test/java/com/asmr/player/ui/library/AlbumDetailDlsiteInitialTargetTest.kt
+++ b/app/src/test/java/com/asmr/player/ui/library/AlbumDetailDlsiteInitialTargetTest.kt
@@ -1,0 +1,71 @@
+package com.asmr.player.ui.library
+
+import com.asmr.player.data.remote.dlsite.DlsiteLanguageEdition
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class AlbumDetailDlsiteInitialTargetTest {
+
+    @Test
+    fun resolveInitialDlsiteLoadTarget_prefersHansWhenAvailable() {
+        val result = resolveInitialDlsiteLoadTarget(
+            baseRj = "RJ000001",
+            editions = listOf(
+                DlsiteLanguageEdition(workno = "RJ000001", lang = "JPN", label = "jp", displayOrder = 3),
+                DlsiteLanguageEdition(workno = "RJ000010", lang = "CHI_HANS", label = "zh-cn", displayOrder = 1),
+                DlsiteLanguageEdition(workno = "RJ000011", lang = "CHI_HANT", label = "zh-tw", displayOrder = 2)
+            ),
+            chinesePreference = DlsiteChinesePreference.None
+        )
+
+        assertEquals("CHI_HANS", result.selectedLang)
+        assertEquals("RJ000010", result.workno)
+    }
+
+    @Test
+    fun resolveInitialDlsiteLoadTarget_fallsBackToHantWhenHansMissing() {
+        val result = resolveInitialDlsiteLoadTarget(
+            baseRj = "RJ000002",
+            editions = listOf(
+                DlsiteLanguageEdition(workno = "RJ000002", lang = "JPN", label = "jp", displayOrder = 2),
+                DlsiteLanguageEdition(workno = "RJ000020", lang = "CHI_HANT", label = "zh-tw", displayOrder = 1)
+            ),
+            chinesePreference = DlsiteChinesePreference.None
+        )
+
+        assertEquals("CHI_HANT", result.selectedLang)
+        assertEquals("RJ000020", result.workno)
+    }
+
+    @Test
+    fun resolveInitialDlsiteLoadTarget_keepsJpnWhenNoChineseEditionExists() {
+        val result = resolveInitialDlsiteLoadTarget(
+            baseRj = "RJ000003",
+            editions = listOf(
+                DlsiteLanguageEdition(workno = "RJ000003", lang = "JPN", label = "jp", displayOrder = 1)
+            ),
+            chinesePreference = DlsiteChinesePreference.None
+        )
+
+        assertEquals("JPN", result.selectedLang)
+        assertEquals("RJ000003", result.workno)
+    }
+
+    @Test
+    fun resolveInitialDlsiteLoadTarget_preservesUserSelectionWhenRequested() {
+        val result = resolveInitialDlsiteLoadTarget(
+            baseRj = "RJ000004",
+            editions = listOf(
+                DlsiteLanguageEdition(workno = "RJ000004", lang = "JPN", label = "jp", displayOrder = 3),
+                DlsiteLanguageEdition(workno = "RJ000040", lang = "CHI_HANS", label = "zh-cn", displayOrder = 1),
+                DlsiteLanguageEdition(workno = "RJ000041", lang = "CHI_HANT", label = "zh-tw", displayOrder = 2)
+            ),
+            currentSelectedLang = "CHI_HANT",
+            preserveCurrentSelection = true,
+            chinesePreference = DlsiteChinesePreference.Hans
+        )
+
+        assertEquals("CHI_HANT", result.selectedLang)
+        assertEquals("RJ000041", result.workno)
+    }
+}


### PR DESCRIPTION
## Summary
- fix DL tab content motion so directory sections resize and shift smoothly
- avoid the initial JP -> CN/TW reload by resolving the DL locale target before the first request
- preserve primary-page scroll state when returning from album detail
- make album header intro motion play only once per detail screen instead of replaying after fast scroll back to top

## Testing
- ./gradlew :app:compileDebugKotlin --no-daemon
- ./gradlew :app:compileDebugUnitTestKotlin --no-daemon
