### PR TITLE
feat: 补充专辑详情页 DL 标签 baseline profile

### DIFF
--- a/app/src/main/java/com/asmr/player/main/MainContainer.kt
+++ b/app/src/main/java/com/asmr/player/main/MainContainer.kt
@@ -236,8 +236,11 @@ fun MainContainer(
     val navBackStackEntry by navController.currentBackStackEntryAsState()
     val currentRoute = navBackStackEntry?.destination?.route
     val currentPlaylistSystemType = navBackStackEntry?.arguments?.getString("type")
-    val initialDestination = remember(startRouteFromIntent) {
-        if (startRouteFromIntent == "search") "search" else "library"
+    val startRoute = remember(startRouteFromIntent) {
+        startRouteFromIntent?.trim().orEmpty()
+    }
+    val initialDestination = remember(startRoute) {
+        if (startRoute == Routes.Search) Routes.Search else Routes.Library
     }
     var lastPrimaryRoute by rememberSaveable { mutableStateOf(initialDestination) }
     val currentPrimaryRoute = resolveCurrentPrimaryDestinationRoute(
@@ -294,6 +297,12 @@ fun MainContainer(
         withFrameNanos { }
         withFrameNanos { }
         onContentReady()
+    }
+    LaunchedEffect(navController, startRoute, initialDestination) {
+        if (startRoute.isBlank() || startRoute == initialDestination) return@LaunchedEffect
+        withFrameNanos { }
+        withFrameNanos { }
+        navController.navigateSingleTop(startRoute)
     }
     var blockNavTouches by remember { mutableStateOf(false) }
     var lastRouteForTouchBlock by remember { mutableStateOf(currentPrimaryRoute ?: currentRoute) }

--- a/baselineprofile/src/main/java/com/asmr/player/baselineprofile/BaselineProfileGenerator.kt
+++ b/baselineprofile/src/main/java/com/asmr/player/baselineprofile/BaselineProfileGenerator.kt
@@ -60,4 +60,10 @@ class BaselineProfileGenerator {
         waitForSearchRefresh()
         device.performLongListScrollProfile()
     }
+
+    @Test
+    fun albumDetailDlTabLongScroll() = baselineProfileRule.collectBaselineProfile {
+        startAlbumDetailDlTabExample()
+        device.performLongListScrollProfile()
+    }
 }

--- a/baselineprofile/src/main/java/com/asmr/player/baselineprofile/BenchmarkDriver.kt
+++ b/baselineprofile/src/main/java/com/asmr/player/baselineprofile/BenchmarkDriver.kt
@@ -16,9 +16,11 @@ private const val BenchmarkReadyPrefix = "benchmark-ready:"
 private const val BenchmarkWaitTimeoutMs = 45_000L
 private const val SearchNetworkLoadWaitMs = 3_500L
 private const val SearchRefreshWaitMs = 2_500L
+private const val AlbumDetailDlLoadWaitMs = 6_500L
 private const val SceneSettleWaitMs = 600L
 private const val BaselineProfileMaxIterations = 3
 private const val BaselineProfileStableIterations = 1
+internal const val AlbumDetailDlExampleRj = "RJ01554925"
 
 internal object BenchmarkScenarioValue {
     const val LibraryAlbums = "library_albums"
@@ -77,6 +79,13 @@ internal fun MacrobenchmarkScope.startMainActivity(
     waitForSceneToSettle()
 }
 
+internal fun MacrobenchmarkScope.startAlbumDetailDlTabExample(
+    rjCode: String = AlbumDetailDlExampleRj
+) {
+    startMainActivity(startRoute = "album_detail_online/$rjCode")
+    waitForAlbumDetailDlLoad()
+}
+
 internal fun MacrobenchmarkScope.startHarnessScenario(
     scenario: String
 ) {
@@ -124,6 +133,10 @@ internal fun waitForSearchNetworkLoad() {
 
 internal fun waitForSearchRefresh() {
     SystemClock.sleep(SearchRefreshWaitMs)
+}
+
+internal fun waitForAlbumDetailDlLoad() {
+    SystemClock.sleep(AlbumDetailDlLoadWaitMs)
 }
 
 internal fun UiDevice.performLongListScrollProfile() {

--- a/baselineprofile/src/main/java/com/asmr/player/baselineprofile/LongListPerformanceBenchmark.kt
+++ b/baselineprofile/src/main/java/com/asmr/player/baselineprofile/LongListPerformanceBenchmark.kt
@@ -77,6 +77,21 @@ class LongListPerformanceBenchmark {
         }
     }
 
+    @Test
+    fun albumDetailDlTabFrameTiming() {
+        benchmarkRule.measureRepeated(
+            packageName = PackageName,
+            metrics = listOf(FrameTimingMetric()),
+            compilationMode = CompilationMode.Partial(BaselineProfileMode.Require),
+            startupMode = defaultFrameTimingStartupMode(),
+            iterations = 1
+        ) {
+            device.pressHome()
+            startAlbumDetailDlTabExample()
+            device.performSlowDragAndFling()
+        }
+    }
+
     private fun measureScenarioFrameTiming(
         scenario: String
     ) {


### PR DESCRIPTION
## 变更说明
- 为 benchmark 启动流程补充任意应用内路由跳转能力，支持直接进入专辑详情页目标场景
- 新增专辑详情页 DL 标签页 baseline profile 场景
- 新增对应的 frame timing benchmark 用例，便于后续单独验证该滚动场景
- 将本次生成出的 profile 结果增量补充到 `app/src/main/baseline-prof.txt`，不重写已有 profile

## 验证
- `./gradlew.bat --% :baselineprofile:connectedNonMinifiedReleaseAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=com.asmr.player.baselineprofile.BaselineProfileGenerator#albumDetailDlTabLongScroll`