### PR TITLE
fix: stabilize album detail transitions and tree layout

### DIFF
--- a/app/src/main/java/com/asmr/player/ui/library/AlbumDetailScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/AlbumDetailScreen.kt
@@ -21,6 +21,8 @@ import androidx.compose.animation.shrinkVertically
 import androidx.compose.animation.slideInHorizontally
 import androidx.compose.animation.slideOutHorizontally
 import androidx.compose.animation.togetherWith
+import androidx.compose.animation.EnterTransition
+import androidx.compose.animation.ExitTransition
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
@@ -163,6 +165,7 @@ internal data class PreparedMediaPlayback(
 
 private val AlbumDetailTabContentGap = 12.dp
 private val AlbumDetailTabCollapseOvershoot = 10.dp
+private const val AlbumDetailInitialIntroDurationMs = 1200L
 
 private val DlsiteElasticResizeSpring = spring<IntSize>(
     dampingRatio = Spring.DampingRatioLowBouncy,
@@ -170,9 +173,14 @@ private val DlsiteElasticResizeSpring = spring<IntSize>(
 )
 
 internal fun dlsiteElasticItemModifier(
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true
 ): Modifier {
-    return modifier.animateContentSize(animationSpec = DlsiteElasticResizeSpring)
+    return if (enabled) {
+        modifier.animateContentSize(animationSpec = DlsiteElasticResizeSpring)
+    } else {
+        modifier
+    }
 }
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -210,7 +218,8 @@ fun AlbumDetailScreen(
     var lastChromeResetTab by rememberSaveable(screenKey) {
         mutableIntStateOf(selectedTab)
     }
-    var userSelectedTab by rememberSaveable(screenKey) { mutableStateOf(false) }
+    var userSelectedTab by remember(screenKey) { mutableStateOf(false) }
+    var initialIntroSettled by remember(screenKey) { mutableStateOf(false) }
     var showAsmrDownloadDialog by remember { mutableStateOf(false) }
     var showOnlineSaveDialog by remember { mutableStateOf(false) }
     var pendingOnlineSaveSelection by remember { mutableStateOf<Set<String>?>(null) }
@@ -258,9 +267,16 @@ fun AlbumDetailScreen(
                     }
                 }
                 is AlbumDetailUiState.Success -> {
+                    LaunchedEffect(screenKey, initialIntroSettled) {
+                        if (initialIntroSettled) return@LaunchedEffect
+                        delay(AlbumDetailInitialIntroDurationMs)
+                        initialIntroSettled = true
+                    }
                     val model = state.model
                     val album = model.displayAlbum
                     val asmrOneTree = model.asmrOneTree
+                    val shouldPlayInitialAnimations = !initialIntroSettled && !userSelectedTab
+                    val shouldAnimateHeaderIntro = !userSelectedTab
                     val canSaveOnline = selectedTab == 1 && asmrOneTree.isNotEmpty()
                     val showGroupButton = selectedTab == 0 && model.localAlbum != null
                     val availableTags by viewModel.availableTags.collectAsState()
@@ -344,6 +360,7 @@ fun AlbumDetailScreen(
                                 onPickLocalCover = if (selectedTab == 0 && model.localAlbum != null) {
                                     { coverPicker.launch(arrayOf("image/*")) }
                                 } else null,
+                                animateIntro = shouldAnimateHeaderIntro,
                                 messageManager = viewModel.messageManager
                         )
                     }
@@ -380,7 +397,9 @@ fun AlbumDetailScreen(
                             AnimatedContent(
                                 targetState = selectedTab,
                                 transitionSpec = {
-                                    if (targetState > initialState) {
+                                    if (!shouldPlayInitialAnimations) {
+                                        EnterTransition.None.togetherWith(ExitTransition.None)
+                                    } else if (targetState > initialState) {
                                         (slideInHorizontally { it } + fadeIn()).togetherWith(slideOutHorizontally { -it } + fadeOut())
                                     } else {
                                         (slideInHorizontally { -it } + fadeIn()).togetherWith(slideOutHorizontally { it } + fadeOut())
@@ -455,7 +474,8 @@ fun AlbumDetailScreen(
                                                 onSetCoverFromImage = { pathOrUri ->
                                                     viewModel.setLocalCoverPath(pathOrUri)
                                                 },
-                                                onPreviewFile = { localPreviewFile = it }
+                                                onPreviewFile = { localPreviewFile = it },
+                                                animateIntro = shouldPlayInitialAnimations
                                             )
                                         } else {
                                             Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
@@ -517,6 +537,7 @@ fun AlbumDetailScreen(
                                         initialCurrentPath = viewModel.getTreeCurrentPath("tree:asmrOne:${model.rjCode.trim().uppercase()}"),
                                         topContentPadding = tabContentTopPadding,
                                         chromeState = tabChromeState,
+                                        animateIntro = shouldPlayInitialAnimations,
                                         onPersistCurrentPath = { path ->
                                             val rj = model.rjCode.trim().uppercase()
                                             viewModel.persistTreeCurrentPath("tree:asmrOne:$rj", path)
@@ -554,6 +575,7 @@ fun AlbumDetailScreen(
                                         initialCurrentPath = viewModel.getTreeCurrentPath("tree:dlsitePlay:${model.baseRjCode.ifBlank { model.rjCode }.trim().uppercase()}"),
                                         topContentPadding = tabContentTopPadding,
                                         chromeState = tabChromeState,
+                                        animateIntro = shouldPlayInitialAnimations,
                                         onPersistCurrentPath = { path ->
                                             val rj = model.baseRjCode.ifBlank { model.rjCode }.trim().uppercase()
                                             viewModel.persistTreeCurrentPath("tree:dlsitePlay:$rj", path)
@@ -881,6 +903,7 @@ private fun AlbumHeader(
     showGroupButton: Boolean,
     onOpenGroupPicker: (albumId: Long) -> Unit,
     onPickLocalCover: (() -> Unit)? = null,
+    animateIntro: Boolean,
     messageManager: MessageManager
 ) {
     val context = LocalContext.current
@@ -893,13 +916,19 @@ private fun AlbumHeader(
     }
 
     val rj = album.rjCode.ifBlank { album.workId }
+    val normalizedTitle = album.title.trim()
+    val isPlaceholderTitle = normalizedTitle.isBlank() ||
+        (normalizedTitle.equals(rj, ignoreCase = true) && album.id <= 0L && album.path.isBlank())
     val headerAnimationScopeKey = remember(album.id, rj) { "albumHeader:${album.id}:$rj" }
-    var headerIntroPlayed by rememberSaveable(headerAnimationScopeKey) { mutableStateOf(false) }
-    LaunchedEffect(headerAnimationScopeKey) {
-        if (!headerIntroPlayed) {
-            delay(700)
+    var headerIntroPlayed by remember(headerAnimationScopeKey) { mutableStateOf(false) }
+    LaunchedEffect(headerAnimationScopeKey, animateIntro) {
+        if (headerIntroPlayed) return@LaunchedEffect
+        if (!animateIntro) {
             headerIntroPlayed = true
+            return@LaunchedEffect
         }
+        delay(700)
+        headerIntroPlayed = true
     }
     fun copy(label: String, value: String) {
         val v = value.trim()
@@ -915,11 +944,10 @@ private fun AlbumHeader(
         .background(colorScheme.surface.copy(alpha = 0.5f))
 
     Column(
-        modifier = if (headerIntroPlayed) {
-            headerContainerModifier
-        } else {
-            dlsiteElasticItemModifier(headerContainerModifier)
-        }
+        modifier = dlsiteElasticItemModifier(
+            modifier = headerContainerModifier,
+            enabled = animateIntro && !headerIntroPlayed
+        )
     ) {
         Column {
             Box(
@@ -969,7 +997,9 @@ private fun AlbumHeader(
                 ) {
                     AlbumHeaderInfoReveal(
                         revealKey = "$headerAnimationScopeKey:title",
-                        delayMillis = 0
+                        delayMillis = 0,
+                        enabled = animateIntro,
+                        ready = !isPlaceholderTitle
                     ) {
                     Text(
                         text = album.title,
@@ -984,7 +1014,8 @@ private fun AlbumHeader(
                     if (rj.isNotBlank() || circle.isNotBlank()) {
                         AlbumHeaderInfoReveal(
                             revealKey = "$headerAnimationScopeKey:meta",
-                            delayMillis = 40
+                            delayMillis = 40,
+                            enabled = animateIntro
                         ) {
                     Row(
                         horizontalArrangement = Arrangement.spacedBy(10.dp),
@@ -1022,7 +1053,8 @@ private fun AlbumHeader(
                 if (album.cv.isNotBlank()) {
                     AlbumHeaderInfoReveal(
                         revealKey = "$headerAnimationScopeKey:cv",
-                        delayMillis = 80
+                        delayMillis = 80,
+                        enabled = animateIntro
                     ) {
                         CvChipsFlow(
                             cvText = album.cv,
@@ -1075,7 +1107,8 @@ private fun AlbumHeader(
                 if (album.tags.isNotEmpty()) {
                     AlbumHeaderInfoReveal(
                         revealKey = "$headerAnimationScopeKey:tags",
-                        delayMillis = 120
+                        delayMillis = 120,
+                        enabled = animateIntro
                     ) {
                     FlowRow(
                         horizontalArrangement = Arrangement.spacedBy(8.dp),
@@ -1098,7 +1131,8 @@ private fun AlbumHeader(
 
                 AlbumHeaderInfoReveal(
                     revealKey = "$headerAnimationScopeKey:actions",
-                    delayMillis = 160
+                    delayMillis = 160,
+                    enabled = animateIntro
                 ) {
                 Row(
                     modifier = Modifier.padding(top = 4.dp),
@@ -1204,15 +1238,26 @@ private fun AlbumHeader(
 private fun AlbumHeaderInfoReveal(
     revealKey: String,
     delayMillis: Int = 0,
+    enabled: Boolean = true,
+    ready: Boolean = true,
     content: @Composable () -> Unit
 ) {
-    var hasPlayed by rememberSaveable(revealKey) { mutableStateOf(false) }
-    var visible by remember(revealKey, hasPlayed) { mutableStateOf(hasPlayed) }
-    LaunchedEffect(revealKey) {
-        if (hasPlayed) {
-            visible = true
-            return@LaunchedEffect
+    var hasPlayed by remember(revealKey) { mutableStateOf(false) }
+    LaunchedEffect(revealKey, enabled, ready) {
+        if (!enabled && !hasPlayed) {
+            hasPlayed = true
         }
+    }
+    if (!enabled || hasPlayed) {
+        content()
+        return
+    }
+    if (!ready) {
+        content()
+        return
+    }
+    var visible by remember(revealKey) { mutableStateOf(false) }
+    LaunchedEffect(revealKey, ready, enabled) {
         visible = false
         if (delayMillis > 0) {
             delay(delayMillis.toLong())
@@ -1221,10 +1266,6 @@ private fun AlbumHeaderInfoReveal(
         visible = true
         delay(420)
         hasPlayed = true
-    }
-    if (hasPlayed) {
-        content()
-        return
     }
     val alpha by animateFloatAsState(
         targetValue = if (visible) 1f else 0f,

--- a/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailDirectorySupport.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailDirectorySupport.kt
@@ -1957,7 +1957,7 @@ internal fun DirectoryBatchBarEmbeddedV3(
         ) {
             Text(
                 text = summaryText,
-                style = MaterialTheme.typography.titleSmall,
+                style = MaterialTheme.typography.titleSmall.copy(lineHeight = 18.sp),
                 color = AsmrTheme.colorScheme.textPrimary,
                 maxLines = 1,
                 overflow = TextOverflow.Ellipsis
@@ -2263,9 +2263,10 @@ internal fun DirectoryFolderRowV3(
     Row(
         modifier = Modifier
             .fillMaxWidth()
+            .defaultMinSize(minHeight = 56.dp)
             .background(colorScheme.primary.copy(alpha = 0.08f))
             .clickable(onClick = onClick)
-            .padding(horizontal = 12.dp, vertical = 10.dp),
+            .padding(horizontal = 12.dp, vertical = 12.dp),
         verticalAlignment = Alignment.CenterVertically
     ) {
         Icon(
@@ -2318,7 +2319,7 @@ internal fun DirectoryBatchBarEmbeddedV4(
         ) {
             Text(
                 text = summaryText,
-                style = MaterialTheme.typography.titleSmall,
+                style = MaterialTheme.typography.titleSmall.copy(lineHeight = 18.sp),
                 color = AsmrTheme.colorScheme.textPrimary,
                 maxLines = 1,
                 overflow = TextOverflow.Ellipsis
@@ -2384,7 +2385,7 @@ internal fun DirectoryBatchBarEmbeddedV5(
         ) {
             Text(
                 text = summaryText,
-                style = MaterialTheme.typography.titleSmall,
+                style = MaterialTheme.typography.titleSmall.copy(lineHeight = 18.sp),
                 color = AsmrTheme.colorScheme.textPrimary,
                 maxLines = 1,
                 overflow = TextOverflow.Ellipsis
@@ -2440,6 +2441,7 @@ internal fun DirectoryBrowserPanelV4(
     onAddToFavorites: (List<MediaItem>) -> Unit,
     onOpenBatchPlaylistPicker: (List<MediaItem>) -> Unit,
     onAddMediaItemsToQueue: (List<MediaItem>) -> Unit,
+    animateIntro: Boolean = true,
     preferredPath: String = "",
     onTogglePreferredPath: ((Boolean) -> Unit)? = null,
     folderKeyPrefix: String,
@@ -2509,9 +2511,10 @@ internal fun DirectoryBrowserPanelV4(
             )
             Row(
                 modifier = dlsiteElasticItemModifier(
-                    Modifier
+                    modifier = Modifier
                         .fillMaxWidth()
-                        .padding(horizontal = 12.dp, vertical = 8.dp)
+                        .padding(horizontal = 12.dp, vertical = 8.dp),
+                    enabled = animateIntro
                 ),
                 verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.spacedBy(10.dp)
@@ -2891,7 +2894,7 @@ internal fun DirectoryFileRow(
                     maxLines = 2,
                     overflow = TextOverflow.Ellipsis,
                     color = colorScheme.textPrimary,
-                    style = MaterialTheme.typography.bodyLarge.copy(fontWeight = FontWeight.Medium)
+                    style = MaterialTheme.typography.bodyMedium.copy(fontWeight = FontWeight.SemiBold)
                 )
             },
             supportingContent = {
@@ -3158,7 +3161,7 @@ internal fun TreeFileRow(
                     maxLines = 1, 
                     overflow = TextOverflow.Ellipsis,
                     color = colorScheme.textSecondary,
-                    style = MaterialTheme.typography.bodyMedium
+                    style = MaterialTheme.typography.bodyMedium.copy(fontWeight = FontWeight.SemiBold)
                 ) 
             },
             leadingContent = {

--- a/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailDlsiteTabs.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailDlsiteTabs.kt
@@ -349,10 +349,13 @@ private val DlsiteSectionPlacementSpring = spring<IntOffset>(
 
 @OptIn(ExperimentalFoundationApi::class)
 private fun LazyItemScope.dlsiteAnimatedSectionModifier(
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    animateIntro: Boolean = true
 ): Modifier {
+    if (!animateIntro) return modifier
     return dlsiteElasticItemModifier(
-        modifier.animateItemPlacement(animationSpec = DlsiteSectionPlacementSpring)
+        modifier = modifier.animateItemPlacement(animationSpec = DlsiteSectionPlacementSpring),
+        enabled = true
     )
 }
 
@@ -383,6 +386,7 @@ internal fun AlbumDlsiteInfoBreadcrumbTabV2(
     initialCurrentPath: String,
     topContentPadding: Dp,
     chromeState: com.asmr.player.ui.common.CollapsibleHeaderState,
+    animateIntro: Boolean,
     onPersistCurrentPath: (String) -> Unit,
     initialScroll: Pair<Int, Int>,
     onPersistScroll: (Int, Int) -> Unit,
@@ -430,7 +434,7 @@ internal fun AlbumDlsiteInfoBreadcrumbTabV2(
         item(key = "dlsite-header") { header() }
         if (isInitialDlsiteLoading) {
             item(key = "dlsite-gallery-section") {
-                Column(modifier = dlsiteAnimatedSectionModifier(Modifier.fillMaxWidth())) {
+                Column(modifier = dlsiteAnimatedSectionModifier(Modifier.fillMaxWidth(), animateIntro)) {
                     Text(
                         text = "Gallery",
                         modifier = Modifier.padding(horizontal = 16.dp, vertical = 10.dp),
@@ -445,7 +449,8 @@ internal fun AlbumDlsiteInfoBreadcrumbTabV2(
                     modifier = dlsiteAnimatedSectionModifier(
                         Modifier
                             .fillMaxWidth()
-                            .padding(horizontal = 16.dp, vertical = 10.dp)
+                            .padding(horizontal = 16.dp, vertical = 10.dp),
+                        animateIntro = animateIntro
                     ),
                     verticalAlignment = Alignment.CenterVertically
                 ) {
@@ -457,12 +462,12 @@ internal fun AlbumDlsiteInfoBreadcrumbTabV2(
                 }
             }
             item(key = "dlsite-one-content") {
-                Box(modifier = dlsiteAnimatedSectionModifier(Modifier.fillMaxWidth())) {
+                Box(modifier = dlsiteAnimatedSectionModifier(Modifier.fillMaxWidth(), animateIntro)) {
                     DlsiteDirectoryLoadingPanel()
                 }
             }
             item(key = "dlsite-trial-loading") {
-                Column(modifier = dlsiteAnimatedSectionModifier(Modifier.fillMaxWidth())) {
+                Column(modifier = dlsiteAnimatedSectionModifier(Modifier.fillMaxWidth(), animateIntro)) {
                 Row(
                     modifier = Modifier
                             .fillMaxWidth()
@@ -479,14 +484,14 @@ internal fun AlbumDlsiteInfoBreadcrumbTabV2(
                 }
             }
             item(key = "dlsite-recommendations") {
-                Box(modifier = dlsiteAnimatedSectionModifier(Modifier.fillMaxWidth())) {
+                Box(modifier = dlsiteAnimatedSectionModifier(Modifier.fillMaxWidth(), animateIntro)) {
                     DlsiteRecommendationsLoadingBlocks()
                 }
             }
             return@LazyColumn
         }
         item(key = "dlsite-gallery-section") {
-            Column(modifier = dlsiteAnimatedSectionModifier(Modifier.fillMaxWidth())) {
+            Column(modifier = dlsiteAnimatedSectionModifier(Modifier.fillMaxWidth(), animateIntro)) {
             Text(
                 text = "Gallery",
                 modifier = Modifier.padding(horizontal = 16.dp, vertical = 10.dp),
@@ -530,7 +535,8 @@ internal fun AlbumDlsiteInfoBreadcrumbTabV2(
         item(key = "dlsite-one-header") {
             Row(
                 modifier = dlsiteAnimatedSectionModifier(
-                    Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 10.dp)
+                    Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 10.dp),
+                    animateIntro = animateIntro
                 ),
                 verticalAlignment = Alignment.CenterVertically
             ) {
@@ -547,7 +553,7 @@ internal fun AlbumDlsiteInfoBreadcrumbTabV2(
         }
         if (asmrOneTree.isNotEmpty()) {
             item(key = "dlsite-one-content") {
-                Box(modifier = dlsiteAnimatedSectionModifier(Modifier.fillMaxWidth())) {
+                Box(modifier = dlsiteAnimatedSectionModifier(Modifier.fillMaxWidth(), animateIntro)) {
                     DirectoryBrowserPanelV4(
                     panelKey = treeStateKey,
                     currentPath = currentPath,
@@ -557,10 +563,11 @@ internal fun AlbumDlsiteInfoBreadcrumbTabV2(
                     files = browser.files,
                     onNavigate = { path -> currentPath = path },
                     onAddToFavorites = onAddMediaItemsToFavorites,
-                    onOpenBatchPlaylistPicker = onOpenBatchPlaylistPicker,
-                    onAddMediaItemsToQueue = onAddMediaItemsToQueue,
-                    folderKeyPrefix = "asmr-folder",
-                    fileKeyPrefix = "asmr-file",
+                        onOpenBatchPlaylistPicker = onOpenBatchPlaylistPicker,
+                        onAddMediaItemsToQueue = onAddMediaItemsToQueue,
+                        animateIntro = animateIntro,
+                        folderKeyPrefix = "asmr-folder",
+                        fileKeyPrefix = "asmr-file",
                     fileContent = { file, selectionMode, selected, enterSelectionMode, onSelectedChange ->
                         val leaf = asmrLeafByRelPath[file.path]
                         DirectoryFileRow(
@@ -633,7 +640,7 @@ internal fun AlbumDlsiteInfoBreadcrumbTabV2(
             }
         } else if (isLoadingAsmrOne) {
             item(key = "dlsite-one-content") {
-                Box(modifier = dlsiteAnimatedSectionModifier(Modifier.fillMaxWidth())) {
+                Box(modifier = dlsiteAnimatedSectionModifier(Modifier.fillMaxWidth(), animateIntro)) {
                     DlsiteDirectoryLoadingPanel()
                 }
             }
@@ -641,7 +648,8 @@ internal fun AlbumDlsiteInfoBreadcrumbTabV2(
             item(key = "dlsite-one-content") {
                 Box(
                     modifier = dlsiteAnimatedSectionModifier(
-                        Modifier.fillMaxWidth().height(120.dp)
+                        Modifier.fillMaxWidth().height(120.dp),
+                        animateIntro = animateIntro
                     ),
                     contentAlignment = Alignment.Center
                 ) {
@@ -652,7 +660,8 @@ internal fun AlbumDlsiteInfoBreadcrumbTabV2(
         item(key = "dlsite-trial-header") {
             Row(
                 modifier = dlsiteAnimatedSectionModifier(
-                    Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 10.dp)
+                    Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 10.dp),
+                    animateIntro = animateIntro
                 ),
                 verticalAlignment = Alignment.CenterVertically
             ) {
@@ -670,7 +679,7 @@ internal fun AlbumDlsiteInfoBreadcrumbTabV2(
         if (trialTracks.isEmpty()) {
             item(key = "dlsite-trial-content") {
                 Box(
-                    modifier = dlsiteAnimatedSectionModifier(Modifier.fillMaxWidth()),
+                    modifier = dlsiteAnimatedSectionModifier(Modifier.fillMaxWidth(), animateIntro),
                     contentAlignment = Alignment.Center
                 ) {
                     if (isLoadingTrial) {
@@ -687,7 +696,8 @@ internal fun AlbumDlsiteInfoBreadcrumbTabV2(
                         modifier = dlsiteAnimatedSectionModifier(
                             Modifier
                                 .fillMaxWidth()
-                                .padding(horizontal = 16.dp)
+                                .padding(horizontal = 16.dp),
+                            animateIntro = animateIntro
                         )
                     )
                 }
@@ -695,7 +705,8 @@ internal fun AlbumDlsiteInfoBreadcrumbTabV2(
             items(items = videoTracks, key = { track -> if (track.id > 0L) track.id else track.path }, contentType = { "trialVideo" }) { track ->
                 Column(
                     modifier = dlsiteAnimatedSectionModifier(
-                        Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 8.dp)
+                        Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 8.dp),
+                        animateIntro = animateIntro
                     )
                 ) {
                     Text(
@@ -713,7 +724,7 @@ internal fun AlbumDlsiteInfoBreadcrumbTabV2(
                 }
             }
             items(items = audioTracks, key = { track -> if (track.id > 0L) track.id else track.path }, contentType = { "trialAudioTrack" }) { track ->
-                Box(modifier = dlsiteAnimatedSectionModifier(Modifier.fillMaxWidth())) {
+                Box(modifier = dlsiteAnimatedSectionModifier(Modifier.fillMaxWidth(), animateIntro)) {
                     TrackItem(
                         track = track,
                         onClick = { onPlayTracks(album, audioTracks, track) },
@@ -723,7 +734,7 @@ internal fun AlbumDlsiteInfoBreadcrumbTabV2(
             }
         }
         item(key = "dlsite-recommendations") {
-            Box(modifier = dlsiteAnimatedSectionModifier(Modifier.fillMaxWidth())) {
+            Box(modifier = dlsiteAnimatedSectionModifier(Modifier.fillMaxWidth(), animateIntro)) {
                 DlsiteRecommendationsBlocks(
                     recommendations = dlsiteRecommendations,
                     onOpenAlbumByRj = onOpenAlbumByRj
@@ -800,6 +811,7 @@ internal fun AlbumDlsitePlayBreadcrumbTabV2(
     initialCurrentPath: String,
     topContentPadding: Dp,
     chromeState: com.asmr.player.ui.common.CollapsibleHeaderState,
+    animateIntro: Boolean,
     onPersistCurrentPath: (String) -> Unit,
     initialScroll: Pair<Int, Int>,
     onPersistScroll: (Int, Int) -> Unit,
@@ -926,6 +938,7 @@ internal fun AlbumDlsitePlayBreadcrumbTabV2(
                 onAddToFavorites = onAddMediaItemsToFavorites,
                 onOpenBatchPlaylistPicker = onOpenBatchPlaylistPicker,
                 onAddMediaItemsToQueue = onAddMediaItemsToQueue,
+                animateIntro = animateIntro,
                 folderKeyPrefix = "dlplay-folder",
                 fileKeyPrefix = "dlplay-file",
                 fileContent = { file, selectionMode, selected, enterSelectionMode, onSelectedChange ->

--- a/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailLocalTab.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailLocalTab.kt
@@ -144,6 +144,7 @@ internal fun AlbumLocalBreadcrumbTabV2(
     onPersistScroll: (Int, Int) -> Unit,
     topContentPadding: Dp,
     chromeState: com.asmr.player.ui.common.CollapsibleHeaderState,
+    animateIntro: Boolean,
     album: Album,
     header: @Composable () -> Unit,
     onPlayTracks: (Album, List<Track>, Track) -> Unit,
@@ -258,6 +259,7 @@ internal fun AlbumLocalBreadcrumbTabV2(
                     onAddToFavorites = onAddMediaItemsToFavorites,
                     onOpenBatchPlaylistPicker = onOpenBatchPlaylistPicker,
                     onAddMediaItemsToQueue = onAddMediaItemsToQueue,
+                    animateIntro = animateIntro,
                     preferredPath = preferredCurrentPath,
                     onTogglePreferredPath = { enabled ->
                         onTogglePreferredCurrentPath(currentPath, enabled)


### PR DESCRIPTION
## Summary
- keep album detail intro animations for the initial page load, but stop replaying tab transition and elastic layout motion after the user switches tabs
- make header reveal timing wait for real title data so title, CV, and tags animate in instead of popping in after async refresh
- tighten the directory tree summary line height, enlarge folder rows, and reduce file-item title size while keeping a bold weight

## Verification
- ./gradlew.bat :app:compileDebugKotlin