### PR TITLE
fix: show local tree sizes and swipe album tabs

### DIFF
--- a/app/src/main/java/com/asmr/player/ui/library/AlbumDetailScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/AlbumDetailScreen.kt
@@ -6,7 +6,6 @@ import android.provider.DocumentsContract
 import androidx.activity.compose.BackHandler
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
-import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.animateContentSize
 import androidx.compose.animation.core.Spring
@@ -18,17 +17,14 @@ import androidx.compose.animation.expandVertically
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.shrinkVertically
-import androidx.compose.animation.slideInHorizontally
-import androidx.compose.animation.slideOutHorizontally
-import androidx.compose.animation.togetherWith
-import androidx.compose.animation.EnterTransition
-import androidx.compose.animation.ExitTransition
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.pager.HorizontalPager
+import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
@@ -184,7 +180,7 @@ internal fun dlsiteElasticItemModifier(
     }
 }
 
-@OptIn(ExperimentalMaterial3Api::class)
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalFoundationApi::class)
 @Composable
 fun AlbumDetailScreen(
     windowSizeClass: WindowSizeClass,
@@ -279,8 +275,6 @@ fun AlbumDetailScreen(
                     val asmrOneTree = model.asmrOneTree
                     val shouldPlayInitialAnimations = !initialIntroSettled && !userSelectedTab
                     val shouldAnimateHeaderIntro = !userSelectedTab
-                    val canSaveOnline = selectedTab == 1 && asmrOneTree.isNotEmpty()
-                    val showGroupButton = selectedTab == 0 && model.localAlbum != null
                     val availableTags by viewModel.availableTags.collectAsState()
                     val userTagsByTrackId by viewModel.userTagsByTrackId.collectAsState()
                     val libraryViewModel: LibraryViewModel = hiltViewModel()
@@ -322,6 +316,11 @@ fun AlbumDetailScreen(
                         56.dp
                     }
                     val tabContentTopPadding = tabChromeVisibleHeight + AlbumDetailTabContentGap
+                    val tabTitles = remember { listOf("本地", "DL", "DL Play") }
+                    val tabPagerState = rememberPagerState(
+                        initialPage = selectedTab,
+                        pageCount = { tabTitles.size }
+                    )
     
                     LaunchedEffect(selectedTab) {
                         if (lastChromeResetTab != selectedTab) {
@@ -329,19 +328,34 @@ fun AlbumDetailScreen(
                             lastChromeResetTab = selectedTab
                         }
                     }
+
+                    LaunchedEffect(tabPagerState) {
+                        snapshotFlow { tabPagerState.isScrollInProgress }
+                            .collect { scrolling ->
+                                if (!scrolling) {
+                                    val page = tabPagerState.currentPage
+                                    if (selectedTab != page) {
+                                        selectedTab = page
+                                        userSelectedTab = true
+                                    }
+                                }
+                            }
+                    }
     
                     Column(modifier = Modifier.fillMaxSize()) {
-                        val headerContent: @Composable () -> Unit = {
+                        val headerContent: @Composable (Int) -> Unit = { tab ->
+                            val isLocalTab = tab == 0
+                            val canSaveOnlineForTab = tab == 1 && asmrOneTree.isNotEmpty()
                             AlbumHeader(
-                                album = if (selectedTab == 0) (model.localAlbum ?: album) else album,
+                                album = if (isLocalTab) (model.localAlbum ?: album) else album,
                                 dlsiteUrl = model.dlsiteWorkno.takeIf { it.isNotBlank() }?.let { "https://www.dlsite.com/maniax/work/=/product_id/$it.html" }.orEmpty(),
                                 asmrOneUrl = model.asmrOneWorkId?.takeIf { it.isNotBlank() }?.let { "https://asmr.one/work/$it" }.orEmpty(),
-                                dlsiteEditions = if (selectedTab == 0) emptyList() else model.dlsiteEditions,
+                                dlsiteEditions = if (isLocalTab) emptyList() else model.dlsiteEditions,
                                 dlsiteSelectedLang = model.dlsiteSelectedLang,
                                 onDlsiteLangSelected = { viewModel.selectDlsiteLanguage(it) },
-                                canSaveOnline = canSaveOnline,
+                                canSaveOnline = canSaveOnlineForTab,
                                 onDownloadClick = {
-                                    downloadSource = if (selectedTab == 2) {
+                                    downloadSource = if (tab == 2) {
                                         OnlineDownloadSource.DlsitePlay
                                     } else {
                                         OnlineDownloadSource.AsmrOne
@@ -351,15 +365,15 @@ fun AlbumDetailScreen(
                                 onSaveClick = {
                                     showOnlineSaveDialog = true
                                 },
-                                downloadEnabled = when (selectedTab) {
+                                downloadEnabled = when (tab) {
                                     1 -> asmrOneTree.isNotEmpty()
                                     2 -> model.dlsitePlayTree.isNotEmpty()
                                     else -> false
                                 },
-                                saveEnabled = canSaveOnline,
-                                showGroupButton = showGroupButton,
+                                saveEnabled = canSaveOnlineForTab,
+                                showGroupButton = isLocalTab && model.localAlbum != null,
                                 onOpenGroupPicker = onOpenGroupPicker,
-                                onPickLocalCover = if (selectedTab == 0 && model.localAlbum != null) {
+                                onPickLocalCover = if (isLocalTab && model.localAlbum != null) {
                                     { coverPicker.launch(arrayOf("image/*")) }
                                 } else null,
                                 introSessionKey = introSessionKey,
@@ -368,7 +382,6 @@ fun AlbumDetailScreen(
                         )
                     }
                     
-                    val tabTitles = remember { listOf("本地", "DL", "DL Play") }
                     LaunchedEffect(
                         selectedTab,
                         model.rjCode,
@@ -397,18 +410,9 @@ fun AlbumDetailScreen(
                             tonalElevation = 0.dp,
                             shadowElevation = 0.dp
                         ) {
-                            AnimatedContent(
-                                targetState = selectedTab,
-                                transitionSpec = {
-                                    if (!shouldPlayInitialAnimations) {
-                                        EnterTransition.None.togetherWith(ExitTransition.None)
-                                    } else if (targetState > initialState) {
-                                        (slideInHorizontally { it } + fadeIn()).togetherWith(slideOutHorizontally { -it } + fadeOut())
-                                    } else {
-                                        (slideInHorizontally { -it } + fadeIn()).togetherWith(slideOutHorizontally { it } + fadeOut())
-                                    }
-                                },
-                                label = "albumDetailTabContent"
+                            HorizontalPager(
+                                state = tabPagerState,
+                                modifier = Modifier.fillMaxSize()
                             ) { tab ->
                                 when (tab) {
                                     0 -> {
@@ -436,7 +440,7 @@ fun AlbumDetailScreen(
                                                 topContentPadding = tabContentTopPadding,
                                                 chromeState = tabChromeState,
                                                 album = local,
-                                                header = headerContent,
+                                                header = { headerContent(tab) },
                                                 onPlayTracks = onPlayTracks,
                                                 onPlayMediaItems = onPlayMediaItems,
                                                 onPlayVideo = onPlayVideo,
@@ -488,7 +492,7 @@ fun AlbumDetailScreen(
                                     }
                                     1 -> AlbumDlsiteInfoBreadcrumbTabV2(
                                         album = album,
-                                        header = headerContent,
+                                        header = { headerContent(tab) },
                                         dlsiteInfo = model.dlsiteInfo,
                                         galleryUrls = model.dlsiteGalleryUrls,
                                         trialTracks = model.dlsiteTrialTracks,
@@ -554,7 +558,7 @@ fun AlbumDetailScreen(
                                         loadRemoteFileSize = { viewModel.loadRemoteFileSize(it) }
                                     )
                                     else -> AlbumDlsitePlayBreadcrumbTabV2(
-                                        header = headerContent,
+                                        header = { headerContent(tab) },
                                         album = album,
                                         rjCode = model.rjCode,
                                         tree = model.dlsitePlayTree,
@@ -600,13 +604,21 @@ fun AlbumDetailScreen(
                             collapseFraction = tabChromeState.collapseFraction,
                             onMeasured = { tabChromeState.updateHeight(it.height.toFloat()) },
                             onTabSelected = { index ->
-                                selectedTab = index
                                 userSelectedTab = true
+                                if (selectedTab != index) {
+                                    selectedTab = index
+                                }
+                                if (tabPagerState.currentPage != index) {
+                                    scope.launch {
+                                        tabPagerState.animateScrollToPage(index)
+                                    }
+                                }
                             }
                         )
                     }
                 }
 
+                val canSaveOnline = selectedTab == 1 && asmrOneTree.isNotEmpty()
                 if (showAsmrDownloadDialog) {
                     val downloadTree = if (downloadSource == OnlineDownloadSource.DlsitePlay) {
                         model.dlsitePlayTree

--- a/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailDirectorySupport.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailDirectorySupport.kt
@@ -3,6 +3,7 @@ package com.asmr.player.ui.library
 import android.content.Intent
 import android.net.Uri
 import android.provider.DocumentsContract
+import android.provider.OpenableColumns
 import androidx.activity.compose.BackHandler
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
@@ -262,7 +263,7 @@ internal fun buildVideoMediaItem(
 
 internal sealed class FileSizeSource {
     data object None : FileSizeSource()
-    data class Local(val path: String) : FileSizeSource()
+    data class Local(val path: String, val sizeBytes: Long? = null) : FileSizeSource()
     data class Remote(val url: String) : FileSizeSource()
 }
 
@@ -360,7 +361,8 @@ internal class LocalTreeNode(
     val children: MutableMap<String, LocalTreeNode> = linkedMapOf(),
     var absolutePath: String? = null,
     var fileType: TreeFileType = TreeFileType.Other,
-    var track: Track? = null
+    var track: Track? = null,
+    var sizeBytes: Long? = null
 )
 
 internal data class LocalFolderStats(
@@ -447,7 +449,7 @@ internal fun buildLocalDirectoryBrowser(
                 fileType = child.fileType,
                 isPlayable = child.track != null || child.fileType == TreeFileType.Video,
                 durationSeconds = child.track?.duration?.takeIf { it > 0.0 },
-                sizeSource = FileSizeSource.Local(absolutePath),
+                sizeSource = FileSizeSource.Local(path = absolutePath, sizeBytes = child.sizeBytes),
                 absolutePath = absolutePath,
                 url = absolutePath,
                 track = child.track,
@@ -665,7 +667,8 @@ internal fun buildRemoteDirectoryBrowser(
 internal data class LocalTreeLeafCacheEntry(
     val relativePath: String,
     val absolutePath: String,
-    val fileType: TreeFileType
+    val fileType: TreeFileType,
+    val sizeBytes: Long? = null
 )
 
 internal data class LocalTreeIndexBuildResult(
@@ -751,7 +754,13 @@ internal suspend fun loadOrBuildLocalTreeIndex(
         val leaves = runCatching { gson.fromJson<List<LocalTreeLeafCacheEntry>>(cached.payloadJson, type) }
             .getOrDefault(emptyList())
         val merged = mergeLeaves(localLeaves = leaves, onlineLeaves = onlineLeaves)
-        if (merged.isNotEmpty()) {
+        val missingLocalSizeMetadata = leaves.any { leaf ->
+            val abs = leaf.absolutePath.trim()
+            abs.isNotBlank() &&
+                !abs.startsWith("http", ignoreCase = true) &&
+                leaf.sizeBytes == null
+        }
+        if (merged.isNotEmpty() && !missingLocalSizeMetadata) {
             return buildLocalTreeIndexFromLeaves(leaves = merged, tracks = tracks)
         }
     }
@@ -844,15 +853,18 @@ internal fun buildLocalTreeIndexByScanning(
                 context.contentResolver.query(childrenUri, arrayOf(
                     DocumentsContract.Document.COLUMN_DOCUMENT_ID,
                     DocumentsContract.Document.COLUMN_DISPLAY_NAME,
-                    DocumentsContract.Document.COLUMN_MIME_TYPE
+                    DocumentsContract.Document.COLUMN_MIME_TYPE,
+                    DocumentsContract.Document.COLUMN_SIZE
                 ), null, null, null)?.use { cursor ->
                     val idIdx = cursor.getColumnIndex(DocumentsContract.Document.COLUMN_DOCUMENT_ID)
                     val nameIdx = cursor.getColumnIndex(DocumentsContract.Document.COLUMN_DISPLAY_NAME)
                     val mimeIdx = cursor.getColumnIndex(DocumentsContract.Document.COLUMN_MIME_TYPE)
+                    val sizeIdx = cursor.getColumnIndex(DocumentsContract.Document.COLUMN_SIZE)
                     while (cursor.moveToNext()) {
                         val id = cursor.getString(idIdx)
                         val name = cursor.getString(nameIdx)
                         val mime = cursor.getString(mimeIdx)
+                        val sizeBytes = if (sizeIdx >= 0 && !cursor.isNull(sizeIdx)) cursor.getLong(sizeIdx) else 0L
                         val rel = if (parentRel.isEmpty()) name else "$parentRel/$name"
                         
                         val segments = rel.split('/').filter { it.isNotBlank() }
@@ -869,9 +881,11 @@ internal fun buildLocalTreeIndexByScanning(
                                     if (ft == TreeFileType.Audio && track == null) {
                                         child.absolutePath = null
                                         child.track = null
+                                        child.sizeBytes = null
                                     } else {
                                         child.absolutePath = fileUri
                                         child.track = track
+                                        child.sizeBytes = sizeBytes.takeIf { it > 0L }
                                     }
                                     if (ft == TreeFileType.Video || (ft == TreeFileType.Audio && track != null)) {
                                         updateFolderStats(segments, ft, name.substringAfterLast('.', "").lowercase())
@@ -879,6 +893,7 @@ internal fun buildLocalTreeIndexByScanning(
                                 } else {
                                     child.absolutePath = null
                                     child.track = null
+                                    child.sizeBytes = null
                                 }
                             }
                             cur = child
@@ -915,6 +930,7 @@ internal fun buildLocalTreeIndexByScanning(
                             child.absolutePath = file.absolutePath
                             child.fileType = type
                             child.track = track
+                            child.sizeBytes = file.length().takeIf { it > 0L }
                             if (type == TreeFileType.Audio || type == TreeFileType.Video) {
                                 updateFolderStats(segments, type, file.extension.lowercase())
                             }
@@ -932,7 +948,8 @@ internal fun buildLocalTreeIndexByScanning(
                 LocalTreeLeafCacheEntry(
                     relativePath = node.path,
                     absolutePath = node.absolutePath ?: return,
-                    fileType = node.fileType
+                    fileType = node.fileType,
+                    sizeBytes = node.sizeBytes
                 )
             )
             return
@@ -971,6 +988,7 @@ internal fun buildLocalTreeIndexFromLeaves(
                 child.absolutePath = leaf.absolutePath
                 child.fileType = leaf.fileType
                 child.track = track
+                child.sizeBytes = leaf.sizeBytes
             }
             cur = child
         }
@@ -1269,13 +1287,22 @@ internal fun queryLocalFileSize(context: android.content.Context, path: String):
             runCatching {
                 context.contentResolver.query(
                     Uri.parse(trimmed),
-                    arrayOf(DocumentsContract.Document.COLUMN_SIZE),
+                    arrayOf(DocumentsContract.Document.COLUMN_SIZE, OpenableColumns.SIZE),
                     null,
                     null,
                     null
                 )?.use { cursor ->
-                    val index = cursor.getColumnIndex(DocumentsContract.Document.COLUMN_SIZE)
-                    if (index < 0 || !cursor.moveToFirst()) null else cursor.getLong(index)
+                    if (!cursor.moveToFirst()) {
+                        null
+                    } else {
+                        val documentIndex = cursor.getColumnIndex(DocumentsContract.Document.COLUMN_SIZE)
+                        val openableIndex = cursor.getColumnIndex(OpenableColumns.SIZE)
+                        when {
+                            documentIndex >= 0 && !cursor.isNull(documentIndex) -> cursor.getLong(documentIndex)
+                            openableIndex >= 0 && !cursor.isNull(openableIndex) -> cursor.getLong(openableIndex)
+                            else -> null
+                        }
+                    }
                 }
             }.getOrNull()
         }
@@ -2849,9 +2876,9 @@ internal fun DirectoryFileRow(
     val sizeText by produceState<String?>(initialValue = null, file.sizeSource) {
         value = when (val sizeSource = file.sizeSource) {
             FileSizeSource.None -> null
-            is FileSizeSource.Local -> withContext(Dispatchers.IO) {
+            is FileSizeSource.Local -> (sizeSource.sizeBytes ?: withContext(Dispatchers.IO) {
                 queryLocalFileSize(context, sizeSource.path)
-            }?.let(Formatting::formatFileSize)
+            })?.let(Formatting::formatFileSize)
             is FileSizeSource.Remote -> loadRemoteFileSize(sizeSource.url)?.let(Formatting::formatFileSize)
         }
     }

--- a/app/src/test/java/com/asmr/player/ui/library/AlbumDetailDirectorySupportTest.kt
+++ b/app/src/test/java/com/asmr/player/ui/library/AlbumDetailDirectorySupportTest.kt
@@ -1,5 +1,7 @@
 package com.asmr.player.ui.library
 
+import com.asmr.player.domain.model.Album
+import com.asmr.player.domain.model.Track
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
@@ -21,6 +23,45 @@ class AlbumDetailDirectorySupportTest {
         assertEquals(
             listOf("disc1", "disc1/cd2", "disc1/cd2/finale"),
             folderPathPrefixes("disc1/cd2/finale")
+        )
+    }
+
+    @Test
+    fun buildLocalDirectoryBrowser_preservesCachedLocalSizeBytes() {
+        val track = Track(
+            albumId = 7L,
+            title = "Track 1",
+            path = "/album/disc1/track1.mp3",
+            duration = 12.0
+        )
+        val album = Album(
+            id = 7L,
+            title = "Album",
+            path = "/album",
+            tracks = listOf(track)
+        )
+        val index = buildLocalTreeIndexFromLeaves(
+            leaves = listOf(
+                LocalTreeLeafCacheEntry(
+                    relativePath = "disc1/track1.mp3",
+                    absolutePath = track.path,
+                    fileType = TreeFileType.Audio,
+                    sizeBytes = 2_048L
+                )
+            ),
+            tracks = album.tracks
+        )
+
+        val browser = buildLocalDirectoryBrowser(
+            index = index,
+            currentPath = "disc1",
+            album = album,
+            shouldShowSubtitleStamp = { false }
+        )
+
+        assertEquals(
+            FileSizeSource.Local(path = track.path, sizeBytes = 2_048L),
+            browser.files.single().sizeSource
         )
     }
 }


### PR DESCRIPTION
## Summary
- persist local file size metadata in the album detail directory tree so local files show size consistently with DL entries
- rebuild stale local tree caches that are missing local size metadata
- switch album detail tabs to `HorizontalPager` so the detail page supports left/right swipe switching

## Testing
- `./gradlew :app:compileDebugKotlin :app:compileDebugUnitTestKotlin`

## Notes
- `./gradlew testDebugUnitTest --tests com.asmr.player.ui.library.AlbumDetailDirectorySupportTest` could not complete in this environment because the Gradle test worker failed to start (`worker.org.gradle.process.internal.worker.GradleWorkerMain` not found)
