### PR TITLE
fix: center online search album list text block

### DIFF
--- a/app/src/main/java/com/asmr/player/ui/library/AlbumItem.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/AlbumItem.kt
@@ -133,7 +133,7 @@ fun AlbumItem(
                     modifier = Modifier
                         .fillMaxHeight()
                         .padding(top = 4.dp, bottom = 4.dp, end = 12.dp),
-                    verticalArrangement = Arrangement.spacedBy(2.dp, Alignment.Bottom)
+                    verticalArrangement = Arrangement.spacedBy(2.dp, Alignment.CenterVertically)
                 ) {
                     val rj = album.rjCode.ifBlank { album.workId }
                     Text(

--- a/app/src/main/java/com/asmr/player/ui/library/LibraryScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/LibraryScreen.kt
@@ -1038,7 +1038,7 @@ internal fun LibraryChrome(
                     modifier = Modifier.background(dynamicContainerColor)
                 ) {
                     DropdownMenuItem(
-                        text = { Text("最近") },
+                        text = { Text("最近播放") },
                         onClick = {
                             onSortMenuExpandedChange(false)
                             onSortLastPlayed()
@@ -1062,7 +1062,7 @@ internal fun LibraryChrome(
                         color = materialColorScheme.outlineVariant.copy(alpha = 0.3f)
                     )
                     DropdownMenuItem(
-                        text = { Text("标题") },
+                        text = { Text("专辑标题") },
                         onClick = {
                             onSortMenuExpandedChange(false)
                             onSortTitle()


### PR DESCRIPTION
## Summary
- center the text content area in online search album list mode
- keep the remaining fields vertically centered when some album metadata is missing

## Testing
- ./gradlew.bat :app:compileDebugKotlin