### PR TITLE
fix: 修复搜索异常提示刷屏与专辑页 Tab 滑块跟手

### DIFF
--- a/app/src/main/java/com/asmr/player/data/remote/dlsite/DlsitePlayLibraryClient.kt
+++ b/app/src/main/java/com/asmr/player/data/remote/dlsite/DlsitePlayLibraryClient.kt
@@ -130,6 +130,7 @@ class DlsitePlayLibraryClient @Inject constructor(
             .header("Accept", "application/json, text/plain, */*")
             .header("Accept-Language", NetworkHeaders.ACCEPT_LANGUAGE)
             .header("User-Agent", NetworkHeaders.USER_AGENT)
+            .header(NetworkHeaders.HEADER_SILENT_IO_ERROR, NetworkHeaders.SILENT_IO_ERROR_ON)
             .header("Cache-Control", "no-cache")
             .header("Pragma", "no-cache")
             .get()
@@ -165,6 +166,7 @@ class DlsitePlayLibraryClient @Inject constructor(
             "Accept" to "application/json, text/plain, */*",
             "Accept-Language" to NetworkHeaders.ACCEPT_LANGUAGE,
             "User-Agent" to NetworkHeaders.USER_AGENT,
+            NetworkHeaders.HEADER_SILENT_IO_ERROR to NetworkHeaders.SILENT_IO_ERROR_ON,
             "Cache-Control" to "no-cache",
             "Pragma" to "no-cache",
             "Content-Type" to "application/json"
@@ -266,6 +268,7 @@ class DlsitePlayLibraryClient @Inject constructor(
             .header("Accept", "application/json, text/plain, */*")
             .header("Accept-Language", NetworkHeaders.ACCEPT_LANGUAGE)
             .header("User-Agent", NetworkHeaders.USER_AGENT)
+            .header(NetworkHeaders.HEADER_SILENT_IO_ERROR, NetworkHeaders.SILENT_IO_ERROR_ON)
             .header("Cache-Control", "no-cache")
             .header("Pragma", "no-cache")
             .get()
@@ -285,6 +288,7 @@ class DlsitePlayLibraryClient @Inject constructor(
             .header("Referer", "https://play.dlsite.com/")
             .header("Accept-Language", NetworkHeaders.ACCEPT_LANGUAGE)
             .header("User-Agent", NetworkHeaders.USER_AGENT)
+            .header(NetworkHeaders.HEADER_SILENT_IO_ERROR, NetworkHeaders.SILENT_IO_ERROR_ON)
             .get()
             .build()
         okHttpClient.newCall(request).execute().use { resp ->

--- a/app/src/main/java/com/asmr/player/di/networkmodule.kt
+++ b/app/src/main/java/com/asmr/player/di/networkmodule.kt
@@ -39,12 +39,13 @@ object NetworkModule {
         val asmrHeaders = Interceptor { chain ->
             val request = chain.request()
             val host = request.url.host.lowercase()
-            val silentIoError = request.header(NetworkHeaders.HEADER_SILENT_IO_ERROR) == NetworkHeaders.SILENT_IO_ERROR_ON
+            val suppressAutoErrorMessage =
+                request.header(NetworkHeaders.HEADER_SILENT_IO_ERROR) == NetworkHeaders.SILENT_IO_ERROR_ON
             
             val builder = request.newBuilder()
                 .header("User-Agent", NetworkHeaders.USER_AGENT)
 
-            if (silentIoError) {
+            if (suppressAutoErrorMessage) {
                 builder.removeHeader(NetworkHeaders.HEADER_SILENT_IO_ERROR)
             }
 
@@ -62,7 +63,7 @@ object NetworkModule {
             
             try {
                 val response = chain.proceed(builder.build())
-                if (!response.isSuccessful) {
+                if (!response.isSuccessful && !suppressAutoErrorMessage) {
                     when (response.code) {
                         401 -> messageManager.showError("认证已过期，请重新登录")
                         403 -> messageManager.showError("访问被拒绝")
@@ -75,7 +76,7 @@ object NetworkModule {
             } catch (e: IOException) {
                 val canceled = runCatching { chain.call().isCanceled() }.getOrDefault(false)
                 val canceledByMessage = e.message?.contains("canceled", ignoreCase = true) == true
-                if (!silentIoError && !canceled && !canceledByMessage) {
+                if (!suppressAutoErrorMessage && !canceled && !canceledByMessage) {
                     messageManager.showError("网络连接失败，请检查网络")
                 }
                 throw e

--- a/app/src/main/java/com/asmr/player/ui/library/AlbumDetailScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/AlbumDetailScreen.kt
@@ -321,6 +321,9 @@ fun AlbumDetailScreen(
                         initialPage = selectedTab,
                         pageCount = { tabTitles.size }
                     )
+                    val tabIndicatorPageOffset =
+                        (tabPagerState.currentPage + tabPagerState.currentPageOffsetFraction)
+                            .coerceIn(0f, tabTitles.lastIndex.coerceAtLeast(0).toFloat())
     
                     LaunchedEffect(selectedTab) {
                         if (lastChromeResetTab != selectedTab) {
@@ -600,6 +603,7 @@ fun AlbumDetailScreen(
                             modifier = Modifier.align(Alignment.TopCenter),
                             titles = tabTitles,
                             selectedTab = selectedTab,
+                            indicatorPageOffset = tabIndicatorPageOffset,
                             animatedOffsetPx = animatedTabChromeOffsetPx,
                             collapseFraction = tabChromeState.collapseFraction,
                             onMeasured = { tabChromeState.updateHeight(it.height.toFloat()) },
@@ -758,6 +762,7 @@ private fun AlbumDetailTabChrome(
     modifier: Modifier = Modifier,
     titles: List<String>,
     selectedTab: Int,
+    indicatorPageOffset: Float,
     animatedOffsetPx: Float,
     collapseFraction: Float,
     onMeasured: (IntSize) -> Unit,
@@ -787,14 +792,8 @@ private fun AlbumDetailTabChrome(
         val segmentPadding = 6.dp
         val segmentHeight = 42.dp
         val slotWidth = (maxWidth - (segmentPadding * 2) - (segmentGap * (count - 1))) / count
-        val highlightX by animateDpAsState(
-            targetValue = (slotWidth + segmentGap) * selectedTab,
-            animationSpec = spring(
-                dampingRatio = Spring.DampingRatioNoBouncy,
-                stiffness = Spring.StiffnessMediumLow
-            ),
-            label = "albumDetailTabHighlightX"
-        )
+        val highlightX = (slotWidth + segmentGap) *
+            indicatorPageOffset.coerceIn(0f, (count - 1).coerceAtLeast(0).toFloat())
 
         Surface(
             modifier = Modifier

--- a/app/src/main/java/com/asmr/player/ui/search/SearchViewModel.kt
+++ b/app/src/main/java/com/asmr/player/ui/search/SearchViewModel.kt
@@ -12,6 +12,7 @@ import com.asmr.player.data.remote.dlsite.DlsitePlayLibraryClient
 import com.asmr.player.data.remote.scraper.DLSiteScraper
 import com.asmr.player.data.settings.SettingsRepository
 import com.asmr.player.domain.model.Album
+import com.asmr.player.util.AppErrorMessageFormatter
 import com.asmr.player.util.MessageManager
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.CancellationException
@@ -238,7 +239,11 @@ class SearchViewModel @Inject constructor(
             } catch (e: Exception) {
                 if (e is CancellationException) throw e
                 Log.e("SearchViewModel", "Search paging failed", e)
-                val msg = toUserMessage(e)
+                val msg = if (e is IllegalStateException) {
+                    AppErrorMessageFormatter.sanitize(e.message.orEmpty(), fallback = "搜索失败，请稍后重试")
+                } else {
+                    toUserMessage(e)
+                }
                 messageManager.showError(msg)
                 if (previousSuccess != null) {
                     currentOrder = previousSuccess.order


### PR DESCRIPTION
## 变更说明
- 修复在线搜索在网络异常时，后台静默请求仍触发全局错误提示，导致“服务器开小差了，请稍后重试”反复出现的问题
- 修复专辑详情页左右滑动切换 tab 时，tab 滑块只在切换完成后跳转的问题，改为跟随 Pager 手势实时移动

## 验证
- ./gradlew.bat :app:compileDebugKotlin