### PR TITLE
feat: add branded empty states for library and search pages

### DIFF
--- a/app/src/main/java/com/asmr/player/ui/common/EaraBrandedEmptyState.kt
+++ b/app/src/main/java/com/asmr/player/ui/common/EaraBrandedEmptyState.kt
@@ -1,0 +1,200 @@
+package com.asmr.player.ui.common
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import com.asmr.player.ui.theme.AsmrTheme
+
+internal const val EARA_EMPTY_STATE_TAG = "earaEmptyState"
+
+@Composable
+fun EaraBrandedEmptyState(
+    sectionTitle: String,
+    headline: String,
+    description: String,
+    sectionIcon: ImageVector,
+    modifier: Modifier = Modifier,
+    contentPadding: PaddingValues = PaddingValues(0.dp),
+    footer: (@Composable () -> Unit)? = null
+) {
+    val colorScheme = AsmrTheme.colorScheme
+    val panelShape = RoundedCornerShape(36.dp)
+    val panelBorder = colorScheme.primary.copy(alpha = if (colorScheme.isDark) 0.26f else 0.14f)
+    val panelGradient = Brush.linearGradient(
+        colors = listOf(
+            colorScheme.surface.copy(alpha = if (colorScheme.isDark) 0.98f else 0.94f),
+            colorScheme.primarySoft.copy(alpha = if (colorScheme.isDark) 0.22f else 0.14f)
+        )
+    )
+
+    Box(
+        modifier = modifier
+            .fillMaxSize()
+            .testTag(EARA_EMPTY_STATE_TAG),
+        contentAlignment = Alignment.Center
+    ) {
+        Box(modifier = Modifier.fillMaxSize()) {
+            DecorativeOrb(
+                modifier = Modifier
+                    .align(Alignment.TopStart)
+                    .offset(x = (-28).dp, y = 28.dp),
+                size = 196.dp,
+                color = colorScheme.primarySoft,
+                alpha = if (colorScheme.isDark) 0.22f else 0.16f
+            )
+            DecorativeOrb(
+                modifier = Modifier
+                    .align(Alignment.BottomEnd)
+                    .offset(x = 36.dp, y = (-12).dp),
+                size = 220.dp,
+                color = colorScheme.primary,
+                alpha = if (colorScheme.isDark) 0.18f else 0.12f
+            )
+        }
+
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(contentPadding),
+            contentAlignment = Alignment.Center
+        ) {
+            Column(
+                modifier = Modifier
+                    .widthIn(max = 440.dp)
+                    .fillMaxWidth()
+                    .padding(horizontal = 24.dp, vertical = 32.dp),
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
+                Box(
+                    modifier = Modifier
+                        .size(196.dp)
+                        .clip(panelShape)
+                        .background(panelGradient, panelShape)
+                        .border(width = 1.dp, color = panelBorder, shape = panelShape)
+                        .padding(24.dp)
+                ) {
+                    Box(
+                        modifier = Modifier
+                            .align(Alignment.TopStart)
+                            .size(56.dp)
+                            .clip(CircleShape)
+                            .background(
+                                color = colorScheme.primary.copy(alpha = if (colorScheme.isDark) 0.10f else 0.08f)
+                            )
+                    )
+                    Icon(
+                        imageVector = sectionIcon,
+                        contentDescription = null,
+                        tint = colorScheme.primary.copy(alpha = if (colorScheme.isDark) 0.18f else 0.14f),
+                        modifier = Modifier
+                            .align(Alignment.BottomEnd)
+                            .size(60.dp)
+                    )
+                    EaraLogoLoadingIndicator(
+                        size = 92.dp,
+                        tint = colorScheme.primary,
+                        trackColor = colorScheme.primary.copy(alpha = if (colorScheme.isDark) 0.18f else 0.12f),
+                        glowColor = colorScheme.primarySoft,
+                        modifier = Modifier.align(Alignment.Center)
+                    )
+                }
+
+                Spacer(modifier = Modifier.size(20.dp))
+
+                Surface(
+                    color = colorScheme.primary.copy(alpha = if (colorScheme.isDark) 0.16f else 0.10f),
+                    contentColor = colorScheme.primary,
+                    shape = RoundedCornerShape(999.dp),
+                    border = BorderStroke(1.dp, panelBorder)
+                ) {
+                    Row(
+                        modifier = Modifier.padding(horizontal = 14.dp, vertical = 8.dp),
+                        horizontalArrangement = Arrangement.spacedBy(8.dp),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Icon(
+                            imageVector = sectionIcon,
+                            contentDescription = null,
+                            modifier = Modifier.size(16.dp)
+                        )
+                        Text(
+                            text = sectionTitle,
+                            style = MaterialTheme.typography.labelLarge
+                        )
+                    }
+                }
+
+                Spacer(modifier = Modifier.size(18.dp))
+
+                Text(
+                    text = headline,
+                    style = MaterialTheme.typography.titleLarge,
+                    color = colorScheme.textPrimary,
+                    textAlign = TextAlign.Center
+                )
+                Spacer(modifier = Modifier.size(10.dp))
+                Text(
+                    text = description,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = colorScheme.textSecondary,
+                    textAlign = TextAlign.Center
+                )
+                if (footer != null) {
+                    Spacer(modifier = Modifier.size(18.dp))
+                    footer()
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun DecorativeOrb(
+    modifier: Modifier,
+    size: Dp,
+    color: Color,
+    alpha: Float
+) {
+    Box(
+        modifier = modifier
+            .size(size)
+            .clip(CircleShape)
+            .background(
+                brush = Brush.radialGradient(
+                    colors = listOf(
+                        color.copy(alpha = alpha),
+                        color.copy(alpha = 0f)
+                    )
+                )
+            )
+    )
+}

--- a/app/src/main/java/com/asmr/player/ui/groups/AlbumGroupDetailScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/groups/AlbumGroupDetailScreen.kt
@@ -27,6 +27,7 @@ import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Folder
 import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.DropdownMenu
@@ -63,6 +64,7 @@ import androidx.media3.common.MediaItem
 import androidx.media3.common.MediaMetadata
 import com.asmr.player.data.local.db.dao.AlbumGroupTrackRow
 import com.asmr.player.ui.common.AsmrAsyncImage
+import com.asmr.player.ui.common.EaraBrandedEmptyState
 import com.asmr.player.ui.common.LocalBottomOverlayPadding
 import com.asmr.player.ui.common.StableWindowInsets
 import com.asmr.player.ui.common.thinScrollbar
@@ -193,87 +195,100 @@ internal fun AlbumGroupDetailContent(
                     .fillMaxWidth()
             }
         ) {
-            Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(16.dp),
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                Text(
-                    text = title,
-                    style = MaterialTheme.typography.titleLarge,
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis,
-                    color = colorScheme.textPrimary
-                )
+            if (tracks.isNotEmpty()) {
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(16.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Text(
+                        text = title,
+                        style = MaterialTheme.typography.titleLarge,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                        color = colorScheme.textPrimary
+                    )
+                }
             }
 
-            LazyColumn(
-                state = listState,
-                modifier = Modifier
-                    .fillMaxSize()
-                    .reorderable(reorderState)
-                    .thinScrollbar(listState),
-                contentPadding = PaddingValues(bottom = LocalBottomOverlayPadding.current)
-            ) {
-                item(key = GROUP_DETAIL_REORDER_SENTINEL_KEY) {
-                    Spacer(modifier = Modifier.height(1.dp))
-                }
-                itemsIndexed(localRows, key = { _, row -> row.key }) { index, row ->
-                    when (row) {
-                        is GroupDetailHeaderRow -> {
-                            AlbumSectionHeader(
-                                albumId = row.albumId,
-                                albumTitle = row.albumTitle,
-                                rjCode = row.rjCode,
-                                coverModel = row.coverModel,
-                                expanded = row.expanded,
-                                onToggle = {
-                                    expandedAlbumIds.value = if (row.expanded) {
-                                        expandedAlbumIds.value - row.albumId
-                                    } else {
-                                        expandedAlbumIds.value + row.albumId
-                                    }
-                                },
-                                onRemoveAlbum = {
-                                    pendingRemoveAlbum = row.albumId to row.albumTitle
-                                }
-                            )
-                        }
-
-                        is GroupDetailTrackRow -> {
-                            ReorderableItem(
-                                reorderableState = reorderState,
-                                key = row.track.mediaId
-                            ) { isDragging ->
-                                val albumTracks = localRows.tracksForAlbum(row.albumId)
-                                val startIndex = albumTracks.indexOfFirst { it.mediaId == row.track.mediaId }
-                                    .coerceAtLeast(0)
-                                GroupTrackRow(
-                                    item = row.track,
+            if (tracks.isEmpty()) {
+                EaraBrandedEmptyState(
+                    sectionTitle = title.ifBlank { "我的分组" },
+                    headline = "这个分组还没有内容",
+                    description = "把专辑加入分组后，它们会按专辑整理展示在这里。",
+                    sectionIcon = Icons.Default.Folder,
+                    modifier = Modifier.fillMaxSize(),
+                    contentPadding = PaddingValues(bottom = LocalBottomOverlayPadding.current + 88.dp)
+                )
+            } else {
+                LazyColumn(
+                    state = listState,
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .reorderable(reorderState)
+                        .thinScrollbar(listState),
+                    contentPadding = PaddingValues(bottom = LocalBottomOverlayPadding.current)
+                ) {
+                    item(key = GROUP_DETAIL_REORDER_SENTINEL_KEY) {
+                        Spacer(modifier = Modifier.height(1.dp))
+                    }
+                    itemsIndexed(localRows, key = { _, row -> row.key }) { index, row ->
+                        when (row) {
+                            is GroupDetailHeaderRow -> {
+                                AlbumSectionHeader(
+                                    albumId = row.albumId,
+                                    albumTitle = row.albumTitle,
+                                    rjCode = row.rjCode,
                                     coverModel = row.coverModel,
-                                    showTopDivider = index > 0 && localRows[index - 1] is GroupDetailTrackRow,
-                                    isDragging = isDragging,
-                                    modifier = Modifier
-                                        .fillMaxWidth()
-                                        .testTag("$GROUP_DETAIL_TRACK_TAG_PREFIX:${row.track.mediaId}")
-                                        .detectReorderAfterLongPress(reorderState)
-                                        .clickable {
+                                    expanded = row.expanded,
+                                    onToggle = {
+                                        expandedAlbumIds.value = if (row.expanded) {
+                                            expandedAlbumIds.value - row.albumId
+                                        } else {
+                                            expandedAlbumIds.value + row.albumId
+                                        }
+                                    },
+                                    onRemoveAlbum = {
+                                        pendingRemoveAlbum = row.albumId to row.albumTitle
+                                    }
+                                )
+                            }
+
+                            is GroupDetailTrackRow -> {
+                                ReorderableItem(
+                                    reorderableState = reorderState,
+                                    key = row.track.mediaId
+                                ) { isDragging ->
+                                    val albumTracks = localRows.tracksForAlbum(row.albumId)
+                                    val startIndex = albumTracks.indexOfFirst { it.mediaId == row.track.mediaId }
+                                        .coerceAtLeast(0)
+                                    GroupTrackRow(
+                                        item = row.track,
+                                        coverModel = row.coverModel,
+                                        showTopDivider = index > 0 && localRows[index - 1] is GroupDetailTrackRow,
+                                        isDragging = isDragging,
+                                        modifier = Modifier
+                                            .fillMaxWidth()
+                                            .testTag("$GROUP_DETAIL_TRACK_TAG_PREFIX:${row.track.mediaId}")
+                                            .detectReorderAfterLongPress(reorderState)
+                                            .clickable {
+                                                onPlayMediaItems(
+                                                    albumTracks.map { it.toMediaItem() },
+                                                    startIndex
+                                                )
+                                            },
+                                        onPlay = {
                                             onPlayMediaItems(
                                                 albumTracks.map { it.toMediaItem() },
                                                 startIndex
                                             )
                                         },
-                                    onPlay = {
-                                        onPlayMediaItems(
-                                            albumTracks.map { it.toMediaItem() },
-                                            startIndex
-                                        )
-                                    },
-                                    onMoveToTop = { onMoveTrackToTop(row.albumId, row.track.mediaId) },
-                                    onMoveToBottom = { onMoveTrackToBottom(row.albumId, row.track.mediaId) },
-                                    onRemove = { pendingRemoveTrack = row.track }
-                                )
+                                        onMoveToTop = { onMoveTrackToTop(row.albumId, row.track.mediaId) },
+                                        onMoveToBottom = { onMoveTrackToBottom(row.albumId, row.track.mediaId) },
+                                        onRemove = { pendingRemoveTrack = row.track }
+                                    )
+                                }
                             }
                         }
                     }

--- a/app/src/main/java/com/asmr/player/ui/groups/AlbumGroupsScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/groups/AlbumGroupsScreen.kt
@@ -25,6 +25,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material.icons.filled.Folder
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.FloatingActionButton
@@ -54,6 +55,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import com.asmr.player.data.local.db.dao.AlbumGroupStatsRow
 import com.asmr.player.data.local.db.entities.AlbumGroupEntity
 import com.asmr.player.ui.common.AsmrAsyncImage
+import com.asmr.player.ui.common.EaraBrandedEmptyState
 import com.asmr.player.ui.common.LocalBottomOverlayPadding
 import com.asmr.player.ui.common.StableWindowInsets
 import com.asmr.player.ui.common.thinScrollbar
@@ -92,27 +94,38 @@ fun AlbumGroupsScreen(
                     .fillMaxWidth()
             }
             Box(modifier = contentModifier) {
-                LazyColumn(
-                    state = listState,
-                    modifier = Modifier.fillMaxSize().thinScrollbar(listState),
-                    contentPadding = PaddingValues(horizontal = 16.dp, vertical = 8.dp)
-                        .withAddedBottomPadding(LocalBottomOverlayPadding.current + 72.dp),
-                    verticalArrangement = Arrangement.spacedBy(12.dp)
-                ) {
-                    items(groups, key = { it.id }) { group ->
-                        val entity = remember(group.id, group.name, group.createdAt) {
-                            AlbumGroupEntity(
-                                id = group.id,
-                                name = group.name,
-                                createdAt = group.createdAt
+                if (groups.isEmpty()) {
+                    EaraBrandedEmptyState(
+                        sectionTitle = "我的分组",
+                        headline = "还没有创建分组",
+                        description = "按主题或场景建立分组，让收藏的专辑更容易整理和回看。",
+                        sectionIcon = Icons.Default.Folder,
+                        modifier = Modifier.fillMaxSize(),
+                        contentPadding = PaddingValues(bottom = LocalBottomOverlayPadding.current + 88.dp)
+                    )
+                } else {
+                    LazyColumn(
+                        state = listState,
+                        modifier = Modifier.fillMaxSize().thinScrollbar(listState),
+                        contentPadding = PaddingValues(horizontal = 16.dp, vertical = 8.dp)
+                            .withAddedBottomPadding(LocalBottomOverlayPadding.current + 72.dp),
+                        verticalArrangement = Arrangement.spacedBy(12.dp)
+                    ) {
+                        items(groups, key = { it.id }) { group ->
+                            val entity = remember(group.id, group.name, group.createdAt) {
+                                AlbumGroupEntity(
+                                    id = group.id,
+                                    name = group.name,
+                                    createdAt = group.createdAt
+                                )
+                            }
+                            AlbumGroupRow(
+                                group = group,
+                                onClick = { onGroupClick(entity) },
+                                onDelete = { viewModel.deleteGroup(entity) },
+                                onRename = { newName -> viewModel.renameGroup(entity.id, newName) }
                             )
                         }
-                        AlbumGroupRow(
-                            group = group,
-                            onClick = { onGroupClick(entity) },
-                            onDelete = { viewModel.deleteGroup(entity) },
-                            onRename = { newName -> viewModel.renameGroup(entity.id, newName) }
-                        )
                     }
                 }
 

--- a/app/src/main/java/com/asmr/player/ui/library/LibraryScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/LibraryScreen.kt
@@ -55,12 +55,15 @@ import com.asmr.player.ui.common.LocalBottomOverlayPadding
 import com.asmr.player.ui.common.CoverContentRow
 import com.asmr.player.ui.common.CvChipsFlow
 import com.asmr.player.ui.common.CvChipsSingleLine
+import com.asmr.player.ui.common.EaraBrandedEmptyState
 import com.asmr.player.ui.common.EaraLogoLoadingIndicator
 import com.asmr.player.ui.common.StableWindowInsets
 import com.asmr.player.ui.common.withAddedBottomPadding
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.ListItem
 import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.FilledTonalButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.DropdownMenu
@@ -458,6 +461,49 @@ fun LibraryScreen(
                                             querySpec.cvs.isNotEmpty() ||
                                             querySpec.source != null
 
+                                    EaraBrandedEmptyState(
+                                        sectionTitle = if (hasAnyQuery) "本地库结果" else "本地库",
+                                        headline = if (hasAnyQuery) "没有匹配的本地内容" else "还没有扫描到本地专辑",
+                                        description = if (hasAnyQuery) {
+                                            "可以调整关键词或筛选条件，也可以直接重置后重新查看全部内容。"
+                                        } else {
+                                            "到设置里的本地库添加目录后，再执行同步或刷新，这里就会出现内容。"
+                                        },
+                                        sectionIcon = if (hasAnyQuery) Icons.Default.Search else Icons.Default.FolderOpen,
+                                        modifier = Modifier.fillMaxSize(),
+                                        contentPadding = PaddingValues(
+                                            top = topPadding,
+                                            bottom = LocalBottomOverlayPadding.current + 24.dp
+                                        ),
+                                        footer = if (hasAnyQuery) {
+                                            {
+                                                FilledTonalButton(
+                                                    onClick = {
+                                                        searchText = ""
+                                                        viewModel.setSearchQuery("")
+                                                        viewModel.clearFilters()
+                                                    },
+                                                    colors = ButtonDefaults.filledTonalButtonColors(
+                                                        containerColor = colorScheme.primaryContainer,
+                                                        contentColor = colorScheme.onPrimaryContainer
+                                                    )
+                                                ) {
+                                                    Text("重置筛选")
+                                                }
+                                            }
+                                        } else {
+                                            null
+                                        }
+                                    )
+                                } /* else if (false) {
+                                    val hasAnyQuery =
+                                        !querySpec.textQuery.isNullOrBlank() ||
+                                            querySpec.includeTagIds.isNotEmpty() ||
+                                            querySpec.excludeTagIds.isNotEmpty() ||
+                                            querySpec.circles.isNotEmpty() ||
+                                            querySpec.cvs.isNotEmpty() ||
+                                            querySpec.source != null
+
                                     Box(modifier = Modifier.fillMaxSize()) {
                                         Column(
                                             modifier = Modifier
@@ -494,7 +540,7 @@ fun LibraryScreen(
                                             }
                                         }
                                     }
-                                } else if (isTrackList) {
+                                } */ else if (isTrackList) {
                                     LazyColumn(
                                         state = listState,
                                         modifier = Modifier

--- a/app/src/main/java/com/asmr/player/ui/playlists/PlaylistDetailScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/playlists/PlaylistDetailScreen.kt
@@ -22,6 +22,8 @@ import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.QueueMusic
+import androidx.compose.material.icons.filled.Favorite
 import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.DropdownMenu
@@ -56,7 +58,9 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.asmr.player.data.local.db.entities.PlaylistItemEntity
 import com.asmr.player.data.local.db.entities.PlaylistItemWithSubtitles
+import com.asmr.player.data.repository.PlaylistRepository
 import com.asmr.player.ui.common.AsmrAsyncImage
+import com.asmr.player.ui.common.EaraBrandedEmptyState
 import com.asmr.player.ui.common.LocalBottomOverlayPadding
 import com.asmr.player.ui.common.StableWindowInsets
 import com.asmr.player.ui.common.SubtitleStamp
@@ -141,6 +145,18 @@ internal fun PlaylistDetailContent(
     val playItems = localItems.map { item -> item.toPlaybackEntity() }
     val isCompact = windowSizeClass.widthSizeClass == WindowWidthSizeClass.Compact
     val colorScheme = AsmrTheme.colorScheme
+    val isFavorites = title == PlaylistRepository.PLAYLIST_FAVORITES
+    val emptyHeadline = if (isFavorites) {
+        "收藏的内容会在这里出现"
+    } else {
+        "这个列表还没有内容"
+    }
+    val emptyDescription = if (isFavorites) {
+        "看到喜欢的专辑或音轨时点一下收藏，它们就会回到这里。"
+    } else {
+        "把常听内容添加进来，后续就能从这里快速播放。"
+    }
+    val emptySectionTitle = if (isFavorites) "我的收藏" else title.ifBlank { "我的列表" }
 
     Scaffold(
         contentWindowInsets = StableWindowInsets.navigationBars,
@@ -161,36 +177,47 @@ internal fun PlaylistDetailContent(
                     .widthIn(max = 720.dp)
                     .fillMaxWidth()
             }
-            LazyColumn(
-                state = listState,
-                modifier = contentModifier
-                    .reorderable(reorderState)
-                    .thinScrollbar(listState),
-                contentPadding = PaddingValues(top = 6.dp, bottom = LocalBottomOverlayPadding.current)
-            ) {
-                item(key = PLAYLIST_DETAIL_REORDER_SENTINEL_KEY) {
-                    Spacer(modifier = Modifier.height(1.dp))
-                }
-                itemsIndexed(localItems, key = { _, item -> item.mediaId }) { index, item ->
-                    ReorderableItem(
-                        reorderableState = reorderState,
-                        key = item.mediaId
-                    ) { isDragging ->
-                        PlaylistItemRow(
-                            item = item,
-                            showSubtitleStamp = item.hasSubtitles,
-                            showTopDivider = index > 0,
-                            isDragging = isDragging,
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .testTag("$PLAYLIST_DETAIL_ITEM_TAG_PREFIX:${item.mediaId}")
-                                .detectReorderAfterLongPress(reorderState)
-                                .clickable { onPlayAll(playItems, item.toPlaybackEntity()) },
-                            onPlay = { onPlayAll(playItems, item.toPlaybackEntity()) },
-                            onMoveToTop = { onMoveItemToTop(item.mediaId) },
-                            onMoveToBottom = { onMoveItemToBottom(item.mediaId) },
-                            onRemove = { pendingRemoveItem = item }
-                        )
+            if (localItems.isEmpty()) {
+                EaraBrandedEmptyState(
+                    sectionTitle = emptySectionTitle,
+                    headline = emptyHeadline,
+                    description = emptyDescription,
+                    sectionIcon = if (isFavorites) Icons.Default.Favorite else Icons.AutoMirrored.Filled.QueueMusic,
+                    modifier = contentModifier,
+                    contentPadding = PaddingValues(bottom = LocalBottomOverlayPadding.current + 88.dp)
+                )
+            } else {
+                LazyColumn(
+                    state = listState,
+                    modifier = contentModifier
+                        .reorderable(reorderState)
+                        .thinScrollbar(listState),
+                    contentPadding = PaddingValues(top = 6.dp, bottom = LocalBottomOverlayPadding.current)
+                ) {
+                    item(key = PLAYLIST_DETAIL_REORDER_SENTINEL_KEY) {
+                        Spacer(modifier = Modifier.height(1.dp))
+                    }
+                    itemsIndexed(localItems, key = { _, item -> item.mediaId }) { index, item ->
+                        ReorderableItem(
+                            reorderableState = reorderState,
+                            key = item.mediaId
+                        ) { isDragging ->
+                            PlaylistItemRow(
+                                item = item,
+                                showSubtitleStamp = item.hasSubtitles,
+                                showTopDivider = index > 0,
+                                isDragging = isDragging,
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .testTag("$PLAYLIST_DETAIL_ITEM_TAG_PREFIX:${item.mediaId}")
+                                    .detectReorderAfterLongPress(reorderState)
+                                    .clickable { onPlayAll(playItems, item.toPlaybackEntity()) },
+                                onPlay = { onPlayAll(playItems, item.toPlaybackEntity()) },
+                                onMoveToTop = { onMoveItemToTop(item.mediaId) },
+                                onMoveToBottom = { onMoveItemToBottom(item.mediaId) },
+                                onRemove = { pendingRemoveItem = item }
+                            )
+                        }
                     }
                 }
             }

--- a/app/src/main/java/com/asmr/player/ui/playlists/PlaylistsScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/playlists/PlaylistsScreen.kt
@@ -20,6 +20,7 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.clickable
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.QueueMusic
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Edit
@@ -53,6 +54,7 @@ import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.ui.graphics.Color
 import com.asmr.player.ui.common.LocalBottomOverlayPadding
 import com.asmr.player.ui.common.StableWindowInsets
+import com.asmr.player.ui.common.EaraBrandedEmptyState
 import com.asmr.player.ui.common.thinScrollbar
 import com.asmr.player.ui.common.withAddedBottomPadding
 
@@ -91,28 +93,39 @@ fun PlaylistsScreen(
                     .fillMaxWidth()
             }
             Box(modifier = contentModifier) {
-                LazyColumn(
-                    state = listState,
-                    modifier = Modifier.fillMaxSize().thinScrollbar(listState),
-                    contentPadding = PaddingValues(horizontal = 16.dp, vertical = 8.dp)
-                        .withAddedBottomPadding(LocalBottomOverlayPadding.current + 72.dp),
-                    verticalArrangement = Arrangement.spacedBy(12.dp)
-                ) {
-                    items(userPlaylists, key = { it.id }) { playlist ->
-                        val entity = remember(playlist.id, playlist.name, playlist.category, playlist.createdAt) {
-                            PlaylistEntity(
-                                id = playlist.id,
-                                name = playlist.name,
-                                category = playlist.category,
-                                createdAt = playlist.createdAt
+                if (userPlaylists.isEmpty()) {
+                    EaraBrandedEmptyState(
+                        sectionTitle = "我的列表",
+                        headline = "还没有创建列表",
+                        description = "从右下角新建一个列表，把常听内容整理成自己的播放集合。",
+                        sectionIcon = Icons.AutoMirrored.Filled.QueueMusic,
+                        modifier = Modifier.fillMaxSize(),
+                        contentPadding = PaddingValues(bottom = LocalBottomOverlayPadding.current + 88.dp)
+                    )
+                } else {
+                    LazyColumn(
+                        state = listState,
+                        modifier = Modifier.fillMaxSize().thinScrollbar(listState),
+                        contentPadding = PaddingValues(horizontal = 16.dp, vertical = 8.dp)
+                            .withAddedBottomPadding(LocalBottomOverlayPadding.current + 72.dp),
+                        verticalArrangement = Arrangement.spacedBy(12.dp)
+                    ) {
+                        items(userPlaylists, key = { it.id }) { playlist ->
+                            val entity = remember(playlist.id, playlist.name, playlist.category, playlist.createdAt) {
+                                PlaylistEntity(
+                                    id = playlist.id,
+                                    name = playlist.name,
+                                    category = playlist.category,
+                                    createdAt = playlist.createdAt
+                                )
+                            }
+                            PlaylistRow(
+                                playlist = playlist,
+                                onClick = { onPlaylistClick(entity) },
+                                onDelete = { viewModel.deletePlaylist(entity) },
+                                onRename = { newName -> viewModel.renamePlaylist(entity.id, newName) }
                             )
                         }
-                        PlaylistRow(
-                            playlist = playlist,
-                            onClick = { onPlaylistClick(entity) },
-                            onDelete = { viewModel.deletePlaylist(entity) },
-                            onRename = { newName -> viewModel.renamePlaylist(entity.id, newName) }
-                        )
                     }
                 }
 

--- a/app/src/main/java/com/asmr/player/ui/search/SearchScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/search/SearchScreen.kt
@@ -83,6 +83,7 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.asmr.player.domain.model.Album
 import com.asmr.player.ui.common.CustomSearchBar
+import com.asmr.player.ui.common.EaraBrandedEmptyState
 import com.asmr.player.ui.common.EaraLogoLoadingIndicator
 import com.asmr.player.ui.common.LocalBottomOverlayPadding
 import com.asmr.player.ui.common.StableWindowInsets
@@ -354,7 +355,23 @@ fun SearchScreen(
                             }
 
                             is SearchUiState.Success -> {
-                                if (viewMode == 0) {
+                                if (state.results.isEmpty()) {
+                                    EaraBrandedEmptyState(
+                                        sectionTitle = "在线搜索",
+                                        headline = if (state.keyword.isBlank()) "还没有搜索结果" else "没有找到匹配结果",
+                                        description = if (state.keyword.isBlank()) {
+                                            "输入作品号、社团或 CV 后，匹配结果会显示在这里。"
+                                        } else {
+                                            "没有找到和当前关键词相关的内容，试试更换关键词、语言或排序方式。"
+                                        },
+                                        sectionIcon = Icons.Default.Search,
+                                        modifier = Modifier.fillMaxSize(),
+                                        contentPadding = PaddingValues(
+                                            top = topPadding,
+                                            bottom = LocalBottomOverlayPadding.current + 24.dp
+                                        )
+                                    )
+                                } else if (viewMode == 0) {
                                     LazyColumn(
                                         state = listState,
                                         modifier = Modifier
@@ -409,8 +426,29 @@ fun SearchScreen(
                                 }
                             }
 
-                            is SearchUiState.Error -> Column(
-                                modifier = Modifier
+                            is SearchUiState.Error -> EaraBrandedEmptyState(
+                                sectionTitle = "在线搜索",
+                                headline = "网络连接出了点问题",
+                                description = state.message,
+                                sectionIcon = Icons.Filled.WifiOff,
+                                modifier = Modifier.fillMaxSize(),
+                                contentPadding = PaddingValues(
+                                    top = topPadding,
+                                    bottom = LocalBottomOverlayPadding.current + 24.dp
+                                ),
+                                footer = {
+                                    FilledTonalButton(
+                                        onClick = { viewModel.retry() },
+                                        colors = ButtonDefaults.filledTonalButtonColors(
+                                            containerColor = colorScheme.primaryContainer,
+                                            contentColor = colorScheme.onPrimaryContainer
+                                        )
+                                    ) {
+                                        Text("重试")
+                                    }
+                                }
+                            )
+                                /* modifier = Modifier
                                     .fillMaxSize()
                                     .verticalScroll(rememberScrollState())
                                     .padding(top = topPadding),
@@ -435,7 +473,7 @@ fun SearchScreen(
                                 ) {
                                     Text("刷新")
                                 }
-                            }
+                            } */
 
                             else -> Column(
                                 modifier = Modifier

--- a/app/src/test/java/com/asmr/player/ui/groups/AlbumGroupDetailScreenTest.kt
+++ b/app/src/test/java/com/asmr/player/ui/groups/AlbumGroupDetailScreenTest.kt
@@ -11,6 +11,7 @@ import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performTouchInput
 import androidx.media3.common.MediaItem
 import com.asmr.player.data.local.db.dao.AlbumGroupTrackRow
+import com.asmr.player.ui.common.EARA_EMPTY_STATE_TAG
 import com.asmr.player.ui.testWindowSizeClass
 import com.asmr.player.ui.theme.AsmrPlayerTheme
 import org.junit.Rule
@@ -92,6 +93,32 @@ class AlbumGroupDetailScreenTest {
         )
         composeRule.onNodeWithTag(GROUP_DETAIL_MOVE_BOTTOM_MENU_ITEM_TAG).assert(
             SemanticsMatcher.expectValue(SemanticsProperties.TestTag, GROUP_DETAIL_MOVE_BOTTOM_MENU_ITEM_TAG)
+        )
+    }
+
+    @Test
+    fun emptyGroup_showsBrandedEmptyState() {
+        composeRule.setContent {
+            AsmrPlayerTheme {
+                AlbumGroupDetailContent(
+                    windowSizeClass = testWindowSizeClass(),
+                    title = "我的分组",
+                    tracks = emptyList(),
+                    onPlayMediaItems = { _: List<MediaItem>, _: Int -> },
+                    onRemoveTrack = {},
+                    onRemoveAlbum = {},
+                    onMoveTrackToTop = { _, _ -> },
+                    onMoveTrackToBottom = { _, _ -> },
+                    onSaveAlbumTrackOrder = { _, _ -> }
+                )
+            }
+        }
+
+        composeRule.onNodeWithTag(EARA_EMPTY_STATE_TAG).assert(
+            SemanticsMatcher.expectValue(
+                SemanticsProperties.TestTag,
+                EARA_EMPTY_STATE_TAG
+            )
         )
     }
 

--- a/app/src/test/java/com/asmr/player/ui/playlists/PlaylistDetailScreenTest.kt
+++ b/app/src/test/java/com/asmr/player/ui/playlists/PlaylistDetailScreenTest.kt
@@ -11,6 +11,8 @@ import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performTouchInput
 import com.asmr.player.data.local.db.entities.PlaylistItemEntity
 import com.asmr.player.data.local.db.entities.PlaylistItemWithSubtitles
+import com.asmr.player.data.repository.PlaylistRepository
+import com.asmr.player.ui.common.EARA_EMPTY_STATE_TAG
 import com.asmr.player.ui.testWindowSizeClass
 import com.asmr.player.ui.theme.AsmrPlayerTheme
 import org.junit.Rule
@@ -83,6 +85,31 @@ class PlaylistDetailScreenTest {
             SemanticsMatcher.expectValue(
                 SemanticsProperties.TestTag,
                 PLAYLIST_DETAIL_MOVE_BOTTOM_MENU_ITEM_TAG
+            )
+        )
+    }
+
+    @Test
+    fun emptyFavorites_showsBrandedEmptyState() {
+        composeRule.setContent {
+            AsmrPlayerTheme {
+                PlaylistDetailContent(
+                    windowSizeClass = testWindowSizeClass(),
+                    title = PlaylistRepository.PLAYLIST_FAVORITES,
+                    items = emptyList(),
+                    onPlayAll = { _: List<PlaylistItemEntity>, _: PlaylistItemEntity -> },
+                    onRemoveItem = {},
+                    onMoveItemToTop = {},
+                    onMoveItemToBottom = {},
+                    onSaveManualOrder = {}
+                )
+            }
+        }
+
+        composeRule.onNodeWithTag(EARA_EMPTY_STATE_TAG).assert(
+            SemanticsMatcher.expectValue(
+                SemanticsProperties.TestTag,
+                EARA_EMPTY_STATE_TAG
             )
         )
     }


### PR DESCRIPTION
﻿## Summary
- add a shared Eara-branded empty-state component for collection, playlist, and group pages
- extend the same branded empty/error states to the local library and online search screens
- normalize empty-state vertical alignment so the content sits at a consistent height across pages

## Testing
- .\\gradlew.bat :app:compileDebugKotlin :app:compileDebugUnitTestKotlin
