### PR TITLE
Add configurable background effects to v1.0.4

### DIFF
--- a/app/src/main/java/com/asmr/player/MainActivity.kt
+++ b/app/src/main/java/com/asmr/player/MainActivity.kt
@@ -149,6 +149,7 @@ import com.asmr.player.ui.player.SleepTimerSheetContent
 import com.asmr.player.ui.player.MiniPlayerDisplayMode
 
 import com.asmr.player.data.local.datastore.SettingsDataStore
+import com.asmr.player.data.settings.BackgroundEffectType
 import com.asmr.player.data.settings.CoverPreviewMode
 import com.asmr.player.data.settings.LyricsPageSettings
 import com.asmr.player.util.MessageManager
@@ -242,6 +243,8 @@ class MainActivity : ComponentActivity() {
             val isVideo = themeMediaSource.isVideo
             val globalDynamicHueEnabled by settingsDataStore.dynamicPlayerHueEnabled.collectAsState(initial = false)
             val staticHueArgb by settingsDataStore.staticHueArgb.collectAsState(initial = null)
+            val backgroundEffectEnabled by settingsDataStore.backgroundEffectEnabled.collectAsState(initial = false)
+            val backgroundEffectType by settingsDataStore.backgroundEffectType.collectAsState(initial = BackgroundEffectType.Flow)
             val coverBackgroundEnabled by settingsDataStore.coverBackgroundEnabled.collectAsState(initial = true)
             val coverBackgroundClarity by settingsDataStore.coverBackgroundClarity.collectAsState(initial = 0.35f)
             val coverPreviewMode by settingsDataStore.coverPreviewMode.collectAsState(initial = CoverPreviewMode.Disabled)
@@ -376,6 +379,8 @@ class MainActivity : ComponentActivity() {
                         onContentReady = { contentReady = true },
                         visibleMessages = visibleMessagesSnapshot,
                         showMiniPlayerBar = showMiniPlayerBar,
+                        backgroundEffectEnabled = backgroundEffectEnabled,
+                        backgroundEffectType = backgroundEffectType,
                         coverBackgroundEnabled = coverBackgroundEnabled,
                         coverBackgroundClarity = coverBackgroundClarity,
                         coverPreviewMode = coverPreviewMode,

--- a/app/src/main/java/com/asmr/player/data/local/datastore/SettingsDataStore.kt
+++ b/app/src/main/java/com/asmr/player/data/local/datastore/SettingsDataStore.kt
@@ -2,6 +2,7 @@ package com.asmr.player.data.local.datastore
 
 import android.content.Context
 import androidx.datastore.preferences.core.*
+import com.asmr.player.data.settings.BackgroundEffectType
 import com.asmr.player.data.settings.CoverPreviewMode
 import com.asmr.player.data.settings.LyricsPageSettings
 import com.asmr.player.data.settings.settingsDataStore
@@ -21,6 +22,8 @@ class SettingsDataStore @Inject constructor(
     private val dynamicPlayerHueEnabledKey = booleanPreferencesKey("dynamic_player_hue_enabled")
     private val staticHueArgbLightKey = intPreferencesKey("static_hue_argb_light")
     private val staticHueArgbDarkKey = intPreferencesKey("static_hue_argb_dark")
+    private val backgroundEffectEnabledKey = booleanPreferencesKey("background_effect_enabled")
+    private val backgroundEffectTypeKey = stringPreferencesKey("background_effect_type")
     private val coverBackgroundEnabledKey = booleanPreferencesKey("cover_background_enabled")
     private val coverBackgroundClarityKey = floatPreferencesKey("cover_background_clarity")
     private val coverPreviewModeKey = stringPreferencesKey("cover_preview_mode")
@@ -48,6 +51,12 @@ class SettingsDataStore @Inject constructor(
         val isDark = themeMode == "dark" || themeMode == "soft_dark"
         val key = if (isDark) staticHueArgbDarkKey else staticHueArgbLightKey
         if (prefs.contains(key)) prefs[key] else null
+    }
+    val backgroundEffectEnabled: Flow<Boolean> = context.settingsDataStore.data.map {
+        it[backgroundEffectEnabledKey] ?: false
+    }
+    val backgroundEffectType: Flow<BackgroundEffectType> = context.settingsDataStore.data.map {
+        BackgroundEffectType.fromStorageValue(it[backgroundEffectTypeKey])
     }
     val coverBackgroundEnabled: Flow<Boolean> = context.settingsDataStore.data.map { it[coverBackgroundEnabledKey] ?: true }
     val coverBackgroundClarity: Flow<Float> = context.settingsDataStore.data.map { it[coverBackgroundClarityKey] ?: 0.35f }
@@ -94,6 +103,14 @@ class SettingsDataStore @Inject constructor(
                 prefs[key] = argb
             }
         }
+    }
+
+    suspend fun setBackgroundEffectEnabled(enabled: Boolean) {
+        context.settingsDataStore.edit { it[backgroundEffectEnabledKey] = enabled }
+    }
+
+    suspend fun setBackgroundEffectType(type: BackgroundEffectType) {
+        context.settingsDataStore.edit { it[backgroundEffectTypeKey] = type.storageValue }
     }
 
     suspend fun setCoverBackgroundEnabled(enabled: Boolean) {

--- a/app/src/main/java/com/asmr/player/data/settings/BackgroundEffectType.kt
+++ b/app/src/main/java/com/asmr/player/data/settings/BackgroundEffectType.kt
@@ -1,0 +1,11 @@
+package com.asmr.player.data.settings
+
+enum class BackgroundEffectType(val storageValue: String) {
+    Flow("flow");
+
+    companion object {
+        fun fromStorageValue(value: String?): BackgroundEffectType {
+            return entries.firstOrNull { it.storageValue == value } ?: Flow
+        }
+    }
+}

--- a/app/src/main/java/com/asmr/player/main/MainContainer.kt
+++ b/app/src/main/java/com/asmr/player/main/MainContainer.kt
@@ -150,6 +150,7 @@ import com.asmr.player.ui.player.SleepTimerSheetContent
 import com.asmr.player.ui.player.MiniPlayerDisplayMode
 
 import com.asmr.player.data.local.datastore.SettingsDataStore
+import com.asmr.player.data.settings.BackgroundEffectType
 import com.asmr.player.data.settings.CoverPreviewMode
 import com.asmr.player.data.settings.LyricsPageSettings
 import com.asmr.player.util.MessageManager
@@ -163,7 +164,10 @@ import com.asmr.player.ui.theme.DefaultBrandPrimaryDark
 import com.asmr.player.ui.theme.DefaultBrandPrimaryLight
 import com.asmr.player.ui.theme.deriveHuePalette
 import kotlin.math.roundToInt
+import com.asmr.player.ui.theme.AppBackgroundLayer
+import com.asmr.player.ui.theme.BackgroundEffectSurface
 import com.asmr.player.ui.theme.neutralPaletteForMode
+import com.asmr.player.ui.theme.shouldRenderBackgroundEffect
 import com.asmr.player.ui.theme.rememberDynamicHuePalette
 import com.asmr.player.ui.theme.rememberDynamicHuePaletteFromVideoFrame
 import com.asmr.player.ui.theme.dynamicPageContainerColor
@@ -224,6 +228,8 @@ fun MainContainer(
     onContentReady: () -> Unit,
     visibleMessages: List<VisibleAppMessage>,
     showMiniPlayerBar: Boolean,
+    backgroundEffectEnabled: Boolean,
+    backgroundEffectType: BackgroundEffectType,
     coverBackgroundEnabled: Boolean,
     coverBackgroundClarity: Float,
     coverPreviewMode: CoverPreviewMode,
@@ -527,6 +533,16 @@ fun MainContainer(
     val colorScheme = AsmrTheme.colorScheme
     val materialColorScheme = MaterialTheme.colorScheme
     val dynamicContainerColor = dynamicPageContainerColor(colorScheme)
+    val showAppBackgroundEffect = shouldRenderBackgroundEffect(
+        surface = BackgroundEffectSurface.AppPage,
+        effectEnabled = backgroundEffectEnabled,
+        coverBackgroundEnabled = coverBackgroundEnabled
+    )
+    val showNowPlayingBackgroundEffect = shouldRenderBackgroundEffect(
+        surface = BackgroundEffectSurface.NowPlayingPlayer,
+        effectEnabled = backgroundEffectEnabled,
+        coverBackgroundEnabled = coverBackgroundEnabled
+    )
     val topBarContentColor = colorScheme.onSurface
     val drawerContainerColor = if (colorScheme.isDark) Color(0xFF121212) else Color.White
 
@@ -808,15 +824,10 @@ fun MainContainer(
         ) {
             Box(modifier = Modifier.fillMaxSize()) {
                 Box(modifier = Modifier.fillMaxSize()) {
-                    Box(
-                        modifier = Modifier
-                            .fillMaxSize()
-                            .background(colorScheme.background.copy(alpha = 0.88f))
-                    )
-                    Box(
-                        modifier = Modifier
-                            .fillMaxSize()
-                            .background(colorScheme.primarySoft.copy(alpha = 0.16f))
+                    AppBackgroundLayer(
+                        effectEnabled = showAppBackgroundEffect,
+                        effectType = backgroundEffectType,
+                        modifier = Modifier.fillMaxSize()
                     )
                     Scaffold(
                         contentWindowInsets = WindowInsets(0, 0, 0, 0),
@@ -1720,13 +1731,16 @@ fun MainContainer(
                 Box(
                     modifier = Modifier
                         .fillMaxSize()
-                        .background(colorScheme.background.copy(alpha = 0.92f * nowPlayingBackdropAlpha))
-                )
-                Box(
-                    modifier = Modifier
-                        .fillMaxSize()
-                        .background(colorScheme.primarySoft.copy(alpha = 0.22f * nowPlayingBackdropAlpha))
-                )
+                        .graphicsLayer { alpha = nowPlayingBackdropAlpha }
+                ) {
+                    AppBackgroundLayer(
+                        effectEnabled = showNowPlayingBackgroundEffect,
+                        effectType = backgroundEffectType,
+                        baseBackgroundAlpha = 1f,
+                        tintAlpha = if (colorScheme.isDark) 0.18f else 0.14f,
+                        modifier = Modifier.fillMaxSize()
+                    )
+                }
                 Box(
                     modifier = Modifier
                         .fillMaxSize()

--- a/app/src/main/java/com/asmr/player/ui/common/EaraBrandedEmptyState.kt
+++ b/app/src/main/java/com/asmr/player/ui/common/EaraBrandedEmptyState.kt
@@ -11,7 +11,6 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.widthIn
@@ -30,7 +29,6 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.asmr.player.ui.theme.AsmrTheme
 
@@ -62,25 +60,6 @@ fun EaraBrandedEmptyState(
             .testTag(EARA_EMPTY_STATE_TAG),
         contentAlignment = Alignment.Center
     ) {
-        Box(modifier = Modifier.fillMaxSize()) {
-            DecorativeOrb(
-                modifier = Modifier
-                    .align(Alignment.TopStart)
-                    .offset(x = (-28).dp, y = 28.dp),
-                size = 196.dp,
-                color = colorScheme.primarySoft,
-                alpha = if (colorScheme.isDark) 0.22f else 0.16f
-            )
-            DecorativeOrb(
-                modifier = Modifier
-                    .align(Alignment.BottomEnd)
-                    .offset(x = 36.dp, y = (-12).dp),
-                size = 220.dp,
-                color = colorScheme.primary,
-                alpha = if (colorScheme.isDark) 0.18f else 0.12f
-            )
-        }
-
         Box(
             modifier = Modifier
                 .fillMaxSize()
@@ -175,26 +154,4 @@ fun EaraBrandedEmptyState(
             }
         }
     }
-}
-
-@Composable
-private fun DecorativeOrb(
-    modifier: Modifier,
-    size: Dp,
-    color: Color,
-    alpha: Float
-) {
-    Box(
-        modifier = modifier
-            .size(size)
-            .clip(CircleShape)
-            .background(
-                brush = Brush.radialGradient(
-                    colors = listOf(
-                        color.copy(alpha = alpha),
-                        color.copy(alpha = 0f)
-                    )
-                )
-            )
-    )
 }

--- a/app/src/main/java/com/asmr/player/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/settings/SettingsScreen.kt
@@ -9,6 +9,7 @@ import android.provider.DocumentsContract
 import android.provider.Settings
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.collectIsDraggedAsState
 import androidx.compose.foundation.interaction.collectIsPressedAsState
@@ -45,8 +46,10 @@ import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.unit.IntOffset
@@ -56,6 +59,7 @@ import androidx.core.content.ContextCompat
 import androidx.core.content.FileProvider
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.asmr.player.BuildConfig
+import com.asmr.player.data.settings.BackgroundEffectType
 import com.asmr.player.data.settings.CoverPreviewMode
 import com.asmr.player.data.settings.FloatingLyricsSettings
 import com.asmr.player.data.settings.LyricsPageSettings
@@ -68,8 +72,12 @@ import com.asmr.player.ui.common.LocalBottomOverlayPadding
 import com.asmr.player.ui.common.StableWindowInsets
 import com.asmr.player.ui.common.thinScrollbar
 import com.asmr.player.ui.common.withAddedBottomPadding
+import com.asmr.player.ui.theme.dynamicPageContainerColor
 import java.io.File
 import kotlin.math.abs
+
+internal const val BACKGROUND_EFFECT_TYPE_ROW_TAG = "settings_background_effect_type_row"
+internal const val BACKGROUND_EFFECT_VALUE_TAG = "settings_background_effect_value"
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -87,6 +95,8 @@ fun SettingsScreen(
     val staticHueArgb by viewModel.staticHueArgb.collectAsState()
     val staticHueArgbLight by viewModel.staticHueArgbLight.collectAsState()
     val staticHueArgbDark by viewModel.staticHueArgbDark.collectAsState()
+    val backgroundEffectEnabled by viewModel.backgroundEffectEnabled.collectAsState()
+    val backgroundEffectType by viewModel.backgroundEffectType.collectAsState()
     val coverBackgroundEnabled by viewModel.coverBackgroundEnabled.collectAsState()
     val coverBackgroundClarity by viewModel.coverBackgroundClarity.collectAsState()
     val coverPreviewMode by viewModel.coverPreviewMode.collectAsState()
@@ -370,6 +380,13 @@ fun SettingsScreen(
                     text = "封面动态主题（全局）",
                     checked = dynamicPlayerHueEnabled,
                     onCheckedChange = viewModel::setDynamicPlayerHueEnabled
+                )
+
+                BackgroundEffectSettingsControls(
+                    backgroundEffectEnabled = backgroundEffectEnabled,
+                    backgroundEffectType = backgroundEffectType,
+                    onBackgroundEffectEnabledChange = viewModel::setBackgroundEffectEnabled,
+                    onBackgroundEffectTypeChange = viewModel::setBackgroundEffectType
                 )
 
                 SettingsToggleRow(
@@ -965,6 +982,120 @@ private fun SettingsGroup(title: String, content: @Composable ColumnScope.() -> 
                 verticalArrangement = Arrangement.spacedBy(16.dp)
             ) {
                 content()
+            }
+        }
+    }
+}
+
+@Composable
+internal fun BackgroundEffectSettingsControls(
+    backgroundEffectEnabled: Boolean,
+    backgroundEffectType: BackgroundEffectType,
+    onBackgroundEffectEnabledChange: (Boolean) -> Unit,
+    onBackgroundEffectTypeChange: (BackgroundEffectType) -> Unit
+) {
+    BackgroundEffectTypeSelectorRow(
+        backgroundEffectEnabled = backgroundEffectEnabled,
+        selectedType = backgroundEffectType,
+        onBackgroundEffectEnabledChange = onBackgroundEffectEnabledChange,
+        onSelected = onBackgroundEffectTypeChange
+    )
+}
+
+@Composable
+internal fun BackgroundEffectTypeSelectorRow(
+    backgroundEffectEnabled: Boolean,
+    selectedType: BackgroundEffectType,
+    onBackgroundEffectEnabledChange: (Boolean) -> Unit,
+    onSelected: (BackgroundEffectType) -> Unit
+) {
+    val colorScheme = AsmrTheme.colorScheme
+    val dynamicContainerColor = dynamicPageContainerColor(colorScheme)
+    val selectorShape = RoundedCornerShape(12.dp)
+    val selectorBorderColor = MaterialTheme.colorScheme.outline.copy(
+        alpha = if (colorScheme.isDark) 0.26f else 0.18f
+    )
+    var expanded by remember { mutableStateOf(false) }
+    val selectedLabel = if (!backgroundEffectEnabled) {
+        "无"
+    } else {
+        when (selectedType) {
+            BackgroundEffectType.Flow -> "光点"
+        }
+    }
+
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .testTag(BACKGROUND_EFFECT_TYPE_ROW_TAG),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Text("背景特效", style = MaterialTheme.typography.bodyMedium)
+        Spacer(modifier = Modifier.weight(1f))
+        Box(
+            modifier = Modifier.wrapContentSize(Alignment.TopEnd)
+        ) {
+            Surface(
+                shape = selectorShape,
+                color = dynamicContainerColor,
+                contentColor = colorScheme.onSurface,
+                border = BorderStroke(1.dp, selectorBorderColor),
+                modifier = Modifier
+                    .clip(selectorShape)
+                    .clickable { expanded = true }
+            ) {
+                Row(
+                    modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(8.dp)
+                ) {
+                    Text(
+                        text = selectedLabel,
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = colorScheme.textSecondary,
+                        modifier = Modifier.testTag(BACKGROUND_EFFECT_VALUE_TAG)
+                    )
+                    Text(
+                        text = "▾",
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = colorScheme.onSurfaceVariant
+                    )
+                }
+            }
+
+            MaterialTheme(
+                colorScheme = MaterialTheme.colorScheme.copy(
+                    surface = dynamicContainerColor,
+                    surfaceContainer = dynamicContainerColor
+                )
+            ) {
+                DropdownMenu(
+                    expanded = expanded,
+                    onDismissRequest = { expanded = false },
+                    offset = DpOffset(x = 0.dp, y = 6.dp),
+                    modifier = Modifier.background(dynamicContainerColor)
+                ) {
+                    DropdownMenuItem(
+                        text = { Text("无") },
+                        onClick = {
+                            expanded = false
+                            onBackgroundEffectEnabledChange(false)
+                        }
+                    )
+                    HorizontalDivider(
+                        modifier = Modifier.padding(horizontal = 8.dp),
+                        thickness = 0.5.dp,
+                        color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.3f)
+                    )
+                    DropdownMenuItem(
+                        text = { Text("光点") },
+                        onClick = {
+                            expanded = false
+                            onSelected(BackgroundEffectType.Flow)
+                            onBackgroundEffectEnabledChange(true)
+                        }
+                    )
+                }
             }
         }
     }

--- a/app/src/main/java/com/asmr/player/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/asmr/player/ui/settings/SettingsViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.viewModelScope
 import com.asmr.player.BuildConfig
 import com.asmr.player.data.local.datastore.SettingsDataStore
 import com.asmr.player.data.remote.update.GitHubUpdateClient
+import com.asmr.player.data.settings.BackgroundEffectType
 import com.asmr.player.data.settings.CoverPreviewMode
 import com.asmr.player.data.remote.update.UpdateRelease
 import com.asmr.player.data.settings.FloatingLyricsSettings
@@ -71,6 +72,12 @@ class SettingsViewModel @Inject constructor(
     val staticHueArgbDark: StateFlow<Int?> = settingsDataStore.staticHueArgbDark
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), null)
 
+    val backgroundEffectEnabled: StateFlow<Boolean> = settingsDataStore.backgroundEffectEnabled
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), false)
+
+    val backgroundEffectType: StateFlow<BackgroundEffectType> = settingsDataStore.backgroundEffectType
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), BackgroundEffectType.Flow)
+
     val coverBackgroundEnabled: StateFlow<Boolean> = settingsDataStore.coverBackgroundEnabled
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), true)
 
@@ -128,6 +135,14 @@ class SettingsViewModel @Inject constructor(
 
     fun setStaticHueArgb(argb: Int?) {
         viewModelScope.launch { settingsDataStore.setStaticHueArgb(argb) }
+    }
+
+    fun setBackgroundEffectEnabled(enabled: Boolean) {
+        viewModelScope.launch { settingsDataStore.setBackgroundEffectEnabled(enabled) }
+    }
+
+    fun setBackgroundEffectType(type: BackgroundEffectType) {
+        viewModelScope.launch { settingsDataStore.setBackgroundEffectType(type) }
     }
 
     fun setCoverBackgroundEnabled(enabled: Boolean) {

--- a/app/src/main/java/com/asmr/player/ui/theme/AppBackgroundEffect.kt
+++ b/app/src/main/java/com/asmr/player/ui/theme/AppBackgroundEffect.kt
@@ -1,0 +1,247 @@
+package com.asmr.player.ui.theme
+
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import com.asmr.player.data.settings.BackgroundEffectType
+
+internal enum class BackgroundEffectSurface {
+    AppPage,
+    NowPlayingPlayer,
+    NowPlayingLyrics
+}
+
+internal fun shouldRenderBackgroundEffect(
+    surface: BackgroundEffectSurface,
+    effectEnabled: Boolean,
+    coverBackgroundEnabled: Boolean
+): Boolean {
+    if (!effectEnabled) return false
+    return when (surface) {
+        BackgroundEffectSurface.AppPage -> true
+        BackgroundEffectSurface.NowPlayingPlayer,
+        BackgroundEffectSurface.NowPlayingLyrics -> !coverBackgroundEnabled
+    }
+}
+
+@Composable
+internal fun AppBackgroundLayer(
+    effectEnabled: Boolean,
+    effectType: BackgroundEffectType,
+    baseBackgroundAlpha: Float = 0.88f,
+    tintAlpha: Float = 0.16f,
+    modifier: Modifier = Modifier
+) {
+    val colorScheme = AsmrTheme.colorScheme
+
+    Box(modifier = modifier.background(colorScheme.background.copy(alpha = baseBackgroundAlpha))) {
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(colorScheme.primarySoft.copy(alpha = tintAlpha))
+        )
+
+        if (effectEnabled) {
+            when (effectType) {
+                BackgroundEffectType.Flow -> FlowBackgroundEffect(
+                    modifier = Modifier.fillMaxSize()
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun FlowBackgroundEffect(modifier: Modifier = Modifier) {
+    val colorScheme = AsmrTheme.colorScheme
+    val transition = rememberInfiniteTransition(label = "appBackgroundFlow")
+    val leadDriftDurationMs = 7_600
+    val supportDriftDurationMs = 9_000
+    val verticalWaveDurationMs = 5_800
+    val diagonalWaveDurationMs = 6_400
+    val orbitDurationMs = 8_800
+    val counterOrbitDurationMs = 7_800
+    val sparkPulseDurationMs = 4_200
+    val leadDrift by transition.animateFloat(
+        initialValue = -0.18f,
+        targetValue = 1.18f,
+        animationSpec = infiniteRepeatable(
+            animation = tween(durationMillis = leadDriftDurationMs, easing = LinearEasing),
+            repeatMode = RepeatMode.Reverse
+        ),
+        label = "appBackgroundLeadDrift"
+    )
+    val supportDrift by transition.animateFloat(
+        initialValue = 1.1f,
+        targetValue = -0.12f,
+        animationSpec = infiniteRepeatable(
+            animation = tween(durationMillis = supportDriftDurationMs, easing = LinearEasing),
+            repeatMode = RepeatMode.Reverse
+        ),
+        label = "appBackgroundSupportDrift"
+    )
+    val verticalWave by transition.animateFloat(
+        initialValue = 0f,
+        targetValue = 1f,
+        animationSpec = infiniteRepeatable(
+            animation = tween(durationMillis = verticalWaveDurationMs, easing = LinearEasing),
+            repeatMode = RepeatMode.Reverse
+        ),
+        label = "appBackgroundVerticalWave"
+    )
+    val diagonalWave by transition.animateFloat(
+        initialValue = 0f,
+        targetValue = 1f,
+        animationSpec = infiniteRepeatable(
+            animation = tween(durationMillis = diagonalWaveDurationMs, easing = LinearEasing),
+            repeatMode = RepeatMode.Reverse
+        ),
+        label = "appBackgroundDiagonalWave"
+    )
+    val orbitWave by transition.animateFloat(
+        initialValue = 0f,
+        targetValue = 1f,
+        animationSpec = infiniteRepeatable(
+            animation = tween(durationMillis = orbitDurationMs, easing = LinearEasing),
+            repeatMode = RepeatMode.Reverse
+        ),
+        label = "appBackgroundOrbitWave"
+    )
+    val counterOrbitWave by transition.animateFloat(
+        initialValue = 1f,
+        targetValue = 0f,
+        animationSpec = infiniteRepeatable(
+            animation = tween(durationMillis = counterOrbitDurationMs, easing = LinearEasing),
+            repeatMode = RepeatMode.Reverse
+        ),
+        label = "appBackgroundCounterOrbitWave"
+    )
+    val sparkPulse by transition.animateFloat(
+        initialValue = 0f,
+        targetValue = 1f,
+        animationSpec = infiniteRepeatable(
+            animation = tween(durationMillis = sparkPulseDurationMs, easing = LinearEasing),
+            repeatMode = RepeatMode.Reverse
+        ),
+        label = "appBackgroundSparkPulse"
+    )
+
+    val leadGlowColor = if (colorScheme.isDark) {
+        colorScheme.primaryStrong.copy(alpha = 0.17f)
+    } else {
+        colorScheme.primaryStrong.copy(alpha = 0.14f)
+    }
+    val supportGlowColor = if (colorScheme.isDark) {
+        colorScheme.primarySoft.copy(alpha = 0.14f)
+    } else {
+        colorScheme.primarySoft.copy(alpha = 0.11f)
+    }
+    val ribbonStart = if (colorScheme.isDark) {
+        colorScheme.primaryStrong.copy(alpha = 0.10f)
+    } else {
+        colorScheme.primaryStrong.copy(alpha = 0.10f)
+    }
+    val ribbonEnd = if (colorScheme.isDark) {
+        colorScheme.primarySoft.copy(alpha = 0.08f)
+    } else {
+        colorScheme.primarySoft.copy(alpha = 0.08f)
+    }
+    val accentGlowColor = if (colorScheme.isDark) {
+        colorScheme.primaryStrong.copy(alpha = 0.10f)
+    } else {
+        colorScheme.primaryStrong.copy(alpha = 0.16f)
+    }
+    val veilColor = if (colorScheme.isDark) {
+        Color.White.copy(alpha = 0.02f)
+    } else {
+        Color.White.copy(alpha = 0.07f)
+    }
+    val leadRadiusFactor = if (colorScheme.isDark) 0.82f else 0.72f
+    val supportRadiusFactor = if (colorScheme.isDark) 0.92f else 0.78f
+    val accentRadiusFactor = if (colorScheme.isDark) 0.58f else 0.46f
+
+    Canvas(modifier = modifier) {
+        val minDimension = size.minDimension
+        val width = size.width
+        val height = size.height
+        val leadCenter = Offset(
+            x = width * (leadDrift + 0.12f * (counterOrbitWave - 0.5f) + 0.05f * (sparkPulse - 0.5f)),
+            y = height * (0.12f + 0.64f * orbitWave + 0.12f * (verticalWave - 0.5f))
+        )
+        val supportCenter = Offset(
+            x = width * (supportDrift + 0.14f * (verticalWave - 0.5f) - 0.05f * (sparkPulse - 0.5f)),
+            y = height * (0.84f - 0.58f * counterOrbitWave + 0.10f * (diagonalWave - 0.5f))
+        )
+        val accentCenter = Offset(
+            x = width * (0.14f + 0.72f * diagonalWave),
+            y = height * (0.18f + 0.58f * verticalWave + 0.04f * (sparkPulse - 0.5f))
+        )
+
+        drawRect(
+            brush = Brush.linearGradient(
+                colors = listOf(
+                    ribbonStart,
+                    Color.Transparent,
+                    ribbonEnd
+                ),
+                start = Offset(
+                    x = width * (-0.18f + 0.82f * counterOrbitWave),
+                    y = height * (-0.10f + 0.42f * orbitWave)
+                ),
+                end = Offset(
+                    x = width * (1.12f - 0.68f * diagonalWave),
+                    y = height * (1.08f - 0.38f * counterOrbitWave)
+                )
+            )
+        )
+
+        drawCircle(
+            brush = Brush.radialGradient(
+                colors = listOf(leadGlowColor, Color.Transparent),
+                center = leadCenter,
+                radius = minDimension * leadRadiusFactor
+            ),
+            radius = minDimension * leadRadiusFactor,
+            center = leadCenter
+        )
+
+        drawCircle(
+            brush = Brush.radialGradient(
+                colors = listOf(supportGlowColor, Color.Transparent),
+                center = supportCenter,
+                radius = minDimension * supportRadiusFactor
+            ),
+            radius = minDimension * supportRadiusFactor,
+            center = supportCenter
+        )
+
+        drawCircle(
+            brush = Brush.radialGradient(
+                colors = listOf(accentGlowColor, Color.Transparent),
+                center = accentCenter,
+                radius = minDimension * accentRadiusFactor
+            ),
+            radius = minDimension * accentRadiusFactor,
+            center = accentCenter
+        )
+
+        drawRect(
+            brush = Brush.verticalGradient(
+                colors = listOf(veilColor, Color.Transparent)
+            )
+        )
+    }
+}

--- a/app/src/test/java/com/asmr/player/data/local/datastore/SettingsDataStoreTest.kt
+++ b/app/src/test/java/com/asmr/player/data/local/datastore/SettingsDataStoreTest.kt
@@ -1,0 +1,47 @@
+package com.asmr.player.data.local.datastore
+
+import androidx.datastore.preferences.core.edit
+import com.asmr.player.data.settings.BackgroundEffectType
+import com.asmr.player.data.settings.settingsDataStore
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+
+@RunWith(RobolectricTestRunner::class)
+class SettingsDataStoreTest {
+    private val context = RuntimeEnvironment.getApplication()
+    private val dataStore = SettingsDataStore(context)
+
+    @Before
+    fun setUp() = runBlocking {
+        context.settingsDataStore.edit { it.clear() }
+    }
+
+    @After
+    fun tearDown() = runBlocking {
+        context.settingsDataStore.edit { it.clear() }
+    }
+
+    @Test
+    fun backgroundEffectSettings_returnDefaultsWhenUnset() = runBlocking {
+        assertFalse(dataStore.backgroundEffectEnabled.first())
+        assertEquals(BackgroundEffectType.Flow, dataStore.backgroundEffectType.first())
+    }
+
+    @Test
+    fun backgroundEffectSettings_roundTripStoredValues() = runBlocking {
+        dataStore.setBackgroundEffectEnabled(true)
+        dataStore.setBackgroundEffectType(BackgroundEffectType.Flow)
+
+        assertTrue(dataStore.backgroundEffectEnabled.first())
+        assertEquals(BackgroundEffectType.Flow, dataStore.backgroundEffectType.first())
+    }
+}

--- a/app/src/test/java/com/asmr/player/ui/settings/BackgroundEffectSettingsControlsTest.kt
+++ b/app/src/test/java/com/asmr/player/ui/settings/BackgroundEffectSettingsControlsTest.kt
@@ -1,0 +1,55 @@
+package com.asmr.player.ui.settings
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.test.SemanticsMatcher
+import androidx.compose.ui.test.assert
+import androidx.compose.ui.test.assertTextEquals
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.asmr.player.data.settings.BackgroundEffectType
+import com.asmr.player.ui.theme.AsmrPlayerTheme
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class BackgroundEffectSettingsControlsTest {
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    @Test
+    fun effectSelector_usesSingleRowDropdownAndUpdatesDisplayedValue() {
+        composeRule.setContent {
+            var enabled by mutableStateOf(false)
+            var type by mutableStateOf(BackgroundEffectType.Flow)
+
+            AsmrPlayerTheme {
+                BackgroundEffectSettingsControls(
+                    backgroundEffectEnabled = enabled,
+                    backgroundEffectType = type,
+                    onBackgroundEffectEnabledChange = { enabled = it },
+                    onBackgroundEffectTypeChange = { type = it }
+                )
+            }
+        }
+
+        composeRule.onNodeWithTag(BACKGROUND_EFFECT_TYPE_ROW_TAG).assert(
+            SemanticsMatcher.expectValue(SemanticsProperties.TestTag, BACKGROUND_EFFECT_TYPE_ROW_TAG)
+        )
+        composeRule.onNodeWithTag(BACKGROUND_EFFECT_VALUE_TAG).assertTextEquals("无")
+
+        composeRule.onNodeWithTag(BACKGROUND_EFFECT_TYPE_ROW_TAG).performClick()
+        composeRule.onNodeWithText("光点").performClick()
+        composeRule.onNodeWithTag(BACKGROUND_EFFECT_VALUE_TAG).assertTextEquals("光点")
+
+        composeRule.onNodeWithTag(BACKGROUND_EFFECT_TYPE_ROW_TAG).performClick()
+        composeRule.onNodeWithText("无").performClick()
+        composeRule.onNodeWithTag(BACKGROUND_EFFECT_VALUE_TAG).assertTextEquals("无")
+    }
+}

--- a/app/src/test/java/com/asmr/player/ui/theme/AppBackgroundEffectVisibilityTest.kt
+++ b/app/src/test/java/com/asmr/player/ui/theme/AppBackgroundEffectVisibilityTest.kt
@@ -1,0 +1,57 @@
+package com.asmr.player.ui.theme
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class AppBackgroundEffectVisibilityTest {
+    @Test
+    fun appPages_followGlobalEffectToggle() {
+        assertFalse(
+            shouldRenderBackgroundEffect(
+                surface = BackgroundEffectSurface.AppPage,
+                effectEnabled = false,
+                coverBackgroundEnabled = false
+            )
+        )
+        assertTrue(
+            shouldRenderBackgroundEffect(
+                surface = BackgroundEffectSurface.AppPage,
+                effectEnabled = true,
+                coverBackgroundEnabled = true
+            )
+        )
+    }
+
+    @Test
+    fun nowPlayingAndLyrics_hideEffectWhenCoverBackgroundIsEnabled() {
+        assertFalse(
+            shouldRenderBackgroundEffect(
+                surface = BackgroundEffectSurface.NowPlayingPlayer,
+                effectEnabled = true,
+                coverBackgroundEnabled = true
+            )
+        )
+        assertTrue(
+            shouldRenderBackgroundEffect(
+                surface = BackgroundEffectSurface.NowPlayingPlayer,
+                effectEnabled = true,
+                coverBackgroundEnabled = false
+            )
+        )
+        assertFalse(
+            shouldRenderBackgroundEffect(
+                surface = BackgroundEffectSurface.NowPlayingLyrics,
+                effectEnabled = true,
+                coverBackgroundEnabled = true
+            )
+        )
+        assertTrue(
+            shouldRenderBackgroundEffect(
+                surface = BackgroundEffectSurface.NowPlayingLyrics,
+                effectEnabled = true,
+                coverBackgroundEnabled = false
+            )
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- add configurable app background effects with a new flow implementation
- apply the background layer across normal pages and now playing/lyrics with proper cover-background overrides
- update Settings UI to use a single themed dropdown selector for background effects and remove empty-state corner orbs

## Testing
- ./gradlew.bat compileDebugKotlin compileDebugUnitTestKotlin
