### PR TITLE
fix: 修复搜索页进入专辑详情时快速返回导致退回本地库

### DIFF
--- a/app/src/main/java/com/asmr/player/main/MainContainer.kt
+++ b/app/src/main/java/com/asmr/player/main/MainContainer.kt
@@ -313,6 +313,9 @@ fun MainContainer(
     var blockNavTouches by remember { mutableStateOf(false) }
     var lastRouteForTouchBlock by remember { mutableStateOf(currentPrimaryRoute ?: currentRoute) }
     var touchBlockSeq by remember { mutableIntStateOf(0) }
+    var pendingDetailNavigation by remember { mutableStateOf(false) }
+    var pendingDetailNavigationSeq by remember { mutableIntStateOf(0) }
+    var cancelPendingDetailNavigation by remember { mutableStateOf(false) }
     val drawerState = rememberDrawerState(initialValue = DrawerValue.Closed)
     val scope = rememberCoroutineScope()
     val searchViewModel: SearchViewModel = hiltViewModel()
@@ -445,6 +448,19 @@ fun MainContainer(
         }
     }
 
+    fun openAlbumDetailFromSearch(albumId: Long?, rj: String?) {
+        val seq = ++pendingDetailNavigationSeq
+        pendingDetailNavigation = true
+        cancelPendingDetailNavigation = false
+        navigator.openAlbumDetail(albumId = albumId, rj = rj)
+        scope.launch {
+            delay(700)
+            if (pendingDetailNavigationSeq == seq) {
+                pendingDetailNavigation = false
+            }
+        }
+    }
+
     LaunchedEffect(currentPrimaryRoute, primaryPagerRoutes, pendingPrimaryNavigationRoute) {
         val route = currentPrimaryRoute ?: return@LaunchedEffect
         val pendingRoute = pendingPrimaryNavigationRoute
@@ -478,6 +494,14 @@ fun MainContainer(
         hardwareVolumeOverlayBounds = null
         bottomChromeOverflowExpanded = false
         bottomChromeOverflowProtectedBounds = emptyList()
+        if (pendingDetailNavigation && currentRoute?.startsWith("album_detail") == true) {
+            pendingDetailNavigation = false
+        }
+        if (cancelPendingDetailNavigation && currentRoute?.startsWith("album_detail") == true) {
+            cancelPendingDetailNavigation = false
+            navController.popBackStack()
+            return@LaunchedEffect
+        }
         val normalizedCurrentRoute = currentPrimaryRoute ?: currentRoute
         val last = lastRouteForTouchBlock
         val seq = ++touchBlockSeq
@@ -674,6 +698,11 @@ fun MainContainer(
 
     BackHandler(drawerState.isOpen) {
         scope.launch { drawerState.close() }
+    }
+
+    BackHandler(pendingDetailNavigation && currentRoute == Routes.Search) {
+        pendingDetailNavigation = false
+        cancelPendingDetailNavigation = true
     }
 
     val drawerGesturesEnabled = false
@@ -1114,7 +1143,7 @@ fun MainContainer(
                                             SearchScreen(
                                                 windowSizeClass = windowSizeClass,
                                                 onAlbumClick = { album ->
-                                                    navigator.openAlbumDetail(
+                                                    openAlbumDetailFromSearch(
                                                         albumId = album.id,
                                                         rj = album.rjCode.ifBlank { album.workId }
                                                     )


### PR DESCRIPTION
## 变更说明
- 修复搜索页点击进入专辑详情后，在详情页尚未稳定入栈时立即返回会误退回本地库的问题
- 将这类返回操作解释为取消本次未完成的详情跳转
- 当详情页随后完成入栈时，立即自动返回到搜索页，保证用户仍停留在正确的上一级页面

## 验证
- ./gradlew.bat :app:compileDebugKotlin