### PR TITLE
fix: 修复 v1.0.4 页面挤压与搜索加载状态

### DIFF
--- a/app/src/main/java/com/asmr/player/main/MainContainer.kt
+++ b/app/src/main/java/com/asmr/player/main/MainContainer.kt
@@ -847,8 +847,9 @@ fun MainContainer(
             alpha = if (colorScheme.isDark) 0.16f else 0.10f
         )
         val useLargeBottomChrome = windowSizeClass.widthSizeClass != WindowWidthSizeClass.Compact && !isPhone
+        val bottomOverlayPadding = bottomChromeOverlayHeight(useLargeBottomChrome)
         CompositionLocalProvider(
-            LocalBottomOverlayPadding provides (if (bottomChromeVisible) bottomChromeOverlayHeight(useLargeBottomChrome) else 0.dp),
+            LocalBottomOverlayPadding provides bottomOverlayPadding,
             LocalRightPanelExpandedState provides rightPanelExpandedState
         ) {
             Box(modifier = Modifier.fillMaxSize()) {

--- a/app/src/main/java/com/asmr/player/ui/library/LibraryScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/LibraryScreen.kt
@@ -267,12 +267,12 @@ fun LibraryScreen(
         animationSpec = tween(durationMillis = 220, easing = FastOutSlowInEasing),
         label = "libraryChromeOffset"
     )
-    val chromeVisibleHeightPx = if (chromeState.heightPx > 0f) {
-        (chromeState.heightPx + animatedChromeOffsetPx).coerceIn(0f, chromeState.heightPx)
+    val chromeReservedHeightPx = if (chromeState.heightPx > 0f) {
+        chromeState.heightPx
     } else {
         with(LocalDensity.current) { 80.dp.toPx() }
     }
-    val topPadding = with(LocalDensity.current) { chromeVisibleHeightPx.toDp() } + LibraryChromeContentGap
+    val topPadding = with(LocalDensity.current) { chromeReservedHeightPx.toDp() } + LibraryChromeContentGap
 
     LaunchedEffect(isTrackList) {
         if (!isTrackList) {

--- a/app/src/main/java/com/asmr/player/ui/search/SearchScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/search/SearchScreen.kt
@@ -175,7 +175,7 @@ fun SearchScreen(
     val interactionLocked = success?.isBusy == true
     val filterControlsLocked = success == null || interactionLocked
     val searchSubmitLocked = uiState is SearchUiState.Loading || interactionLocked
-    val showSearchSpinner = success?.isSearching == true
+    val showSearchSpinner = success?.isBusy == true
     val highlightedPage = success?.page ?: 1
     val canGoPrev = success?.canGoPrev == true && success?.isSearching != true
     val canGoNext = success?.canGoNext == true && success?.isSearching != true
@@ -184,12 +184,12 @@ fun SearchScreen(
         animationSpec = tween(durationMillis = 220, easing = FastOutSlowInEasing),
         label = "searchChromeOffset"
     )
-    val chromeVisibleHeightPx = when {
-        chromeState.heightPx > 0f -> (chromeState.heightPx + animatedChromeOffsetPx).coerceIn(0f, chromeState.heightPx)
+    val chromeReservedHeightPx = when {
+        chromeState.heightPx > 0f -> chromeState.heightPx
         success != null -> with(androidx.compose.ui.platform.LocalDensity.current) { 120.dp.toPx() }
         else -> with(androidx.compose.ui.platform.LocalDensity.current) { 80.dp.toPx() }
     }
-    val topPadding = with(androidx.compose.ui.platform.LocalDensity.current) { chromeVisibleHeightPx.toDp() } + SearchChromeContentGap
+    val topPadding = with(androidx.compose.ui.platform.LocalDensity.current) { chromeReservedHeightPx.toDp() } + SearchChromeContentGap
 
     fun scrollResultsToTop() {
         scope.launch {


### PR DESCRIPTION
## Summary
- stabilize bottom overlay padding so empty placeholder pages do not jump when opening now playing from the mini player
- reserve full top chrome space in library and search so collapsing search/pagination bars no longer push list content
- show the animated loading logo in the search submit slot during pagination requests as well as keyword searches

## Testing
- ./gradlew.bat :app:compileDebugKotlin