### PR TITLE
fix: improve download stability and recovery for v1.0.4

### DIFF
--- a/app/src/main/java/com/asmr/player/AsmrApp.kt
+++ b/app/src/main/java/com/asmr/player/AsmrApp.kt
@@ -38,7 +38,7 @@ class AsmrApp : Application(), ImageLoaderFactory, Configuration.Provider {
         }
         CoroutineScope(SupervisorJob() + Dispatchers.IO).launch {
             runCatching { AppDatabaseProvider.get(applicationContext) }
-            runCatching { DownloadQueueCoordinator.recoverLegacyScheduledDownloads(applicationContext) }
+            runCatching { DownloadQueueCoordinator.recoverDownloadsOnAppLaunch(applicationContext) }
         }
     }
 

--- a/app/src/main/java/com/asmr/player/AsmrApp.kt
+++ b/app/src/main/java/com/asmr/player/AsmrApp.kt
@@ -1,11 +1,14 @@
 package com.asmr.player
 
 import android.app.Application
+import androidx.work.Configuration
 import coil.disk.DiskCache
 import coil.ImageLoader
 import coil.ImageLoaderFactory
 import coil.memory.MemoryCache
 import com.asmr.player.data.local.db.AppDatabaseProvider
+import com.asmr.player.data.remote.download.DownloadQueueCoordinator
+import com.asmr.player.data.remote.download.DownloadRuntimeConfig
 import com.asmr.player.data.settings.SettingsRepository
 import dagger.hilt.android.HiltAndroidApp
 import kotlinx.coroutines.CoroutineScope
@@ -19,7 +22,7 @@ import javax.inject.Inject
 import javax.inject.Named
 
 @HiltAndroidApp
-class AsmrApp : Application(), ImageLoaderFactory {
+class AsmrApp : Application(), ImageLoaderFactory, Configuration.Provider {
 
     @Inject
     @Named("image")
@@ -35,8 +38,20 @@ class AsmrApp : Application(), ImageLoaderFactory {
         }
         CoroutineScope(SupervisorJob() + Dispatchers.IO).launch {
             runCatching { AppDatabaseProvider.get(applicationContext) }
+            runCatching { DownloadQueueCoordinator.recoverLegacyScheduledDownloads(applicationContext) }
         }
     }
+
+    override fun onTrimMemory(level: Int) {
+        super.onTrimMemory(level)
+        DownloadQueueCoordinator.onTrimMemory(applicationContext, level)
+    }
+
+    override val workManagerConfiguration: Configuration
+        get() = Configuration.Builder()
+            .setExecutor(DownloadRuntimeConfig.createWorkManagerExecutor(this))
+            .setTaskExecutor(DownloadRuntimeConfig.createWorkManagerTaskExecutor())
+            .build()
 
     override fun newImageLoader(): ImageLoader {
         return ImageLoader.Builder(this)

--- a/app/src/main/java/com/asmr/player/data/local/db/AppDatabaseMigrations.kt
+++ b/app/src/main/java/com/asmr/player/data/local/db/AppDatabaseMigrations.kt
@@ -318,4 +318,17 @@ object AppDatabaseMigrations {
             db.execSQL("CREATE INDEX IF NOT EXISTS `index_track_playback_progress_updatedAt` ON `track_playback_progress` (`updatedAt`)")
         }
     }
+
+    val MIGRATION_18_19: Migration = object : Migration(18, 19) {
+        override fun migrate(db: SupportSQLiteDatabase) {
+            db.execSQL("ALTER TABLE download_tasks ADD COLUMN `albumTitle` TEXT NOT NULL DEFAULT ''")
+            db.execSQL("ALTER TABLE download_tasks ADD COLUMN `albumCircle` TEXT NOT NULL DEFAULT ''")
+            db.execSQL("ALTER TABLE download_tasks ADD COLUMN `albumCv` TEXT NOT NULL DEFAULT ''")
+            db.execSQL("ALTER TABLE download_tasks ADD COLUMN `albumTagsCsv` TEXT NOT NULL DEFAULT ''")
+            db.execSQL("ALTER TABLE download_tasks ADD COLUMN `albumCoverUrl` TEXT NOT NULL DEFAULT ''")
+            db.execSQL("ALTER TABLE download_tasks ADD COLUMN `albumDescription` TEXT NOT NULL DEFAULT ''")
+            db.execSQL("ALTER TABLE download_tasks ADD COLUMN `albumWorkId` TEXT NOT NULL DEFAULT ''")
+            db.execSQL("ALTER TABLE download_tasks ADD COLUMN `albumRjCode` TEXT NOT NULL DEFAULT ''")
+        }
+    }
 }

--- a/app/src/main/java/com/asmr/player/data/local/db/AppDatabaseProvider.kt
+++ b/app/src/main/java/com/asmr/player/data/local/db/AppDatabaseProvider.kt
@@ -33,7 +33,8 @@ object AppDatabaseProvider {
                 AppDatabaseMigrations.MIGRATION_14_15,
                 AppDatabaseMigrations.MIGRATION_15_16,
                 AppDatabaseMigrations.MIGRATION_16_17,
-                AppDatabaseMigrations.MIGRATION_17_18
+                AppDatabaseMigrations.MIGRATION_17_18,
+                AppDatabaseMigrations.MIGRATION_18_19
             )
             .fallbackToDestructiveMigration()
             .fallbackToDestructiveMigrationOnDowngrade()

--- a/app/src/main/java/com/asmr/player/data/local/db/appdatabase.kt
+++ b/app/src/main/java/com/asmr/player/data/local/db/appdatabase.kt
@@ -62,7 +62,7 @@ import com.asmr.player.data.local.db.entities.TrackPlaybackProgressEntity
         TrackSliceEntity::class,
         TrackPlaybackProgressEntity::class
     ],
-    version = 18,
+    version = 19,
     exportSchema = false
 )
 abstract class AppDatabase : RoomDatabase() {

--- a/app/src/main/java/com/asmr/player/data/local/db/dao/DownloadDao.kt
+++ b/app/src/main/java/com/asmr/player/data/local/db/dao/DownloadDao.kt
@@ -64,7 +64,16 @@ interface DownloadDao {
     @Query("SELECT * FROM download_items WHERE filePath = :filePath LIMIT 1")
     suspend fun getItemByFilePath(filePath: String): DownloadItemEntity?
 
-    @Query("SELECT * FROM download_items WHERE state = 'QUEUED' ORDER BY createdAt ASC LIMIT :limit")
+    @Query(
+        "SELECT * FROM download_items " +
+            "WHERE state = 'QUEUED' " +
+            "ORDER BY " +
+            "CASE WHEN downloaded > 0 THEN 0 ELSE 1 END ASC, " +
+            "downloaded DESC, " +
+            "updatedAt DESC, " +
+            "createdAt ASC " +
+            "LIMIT :limit"
+    )
     suspend fun getQueuedItems(limit: Int): List<DownloadItemEntity>
 
     @Query("SELECT * FROM download_items WHERE state IN ('RUNNING', 'ENQUEUED', 'BLOCKED')")

--- a/app/src/main/java/com/asmr/player/data/local/db/dao/DownloadDao.kt
+++ b/app/src/main/java/com/asmr/player/data/local/db/dao/DownloadDao.kt
@@ -27,6 +27,34 @@ interface DownloadDao {
     @Query("UPDATE download_tasks SET subtitle = :subtitle, updatedAt = :updatedAt WHERE id = :taskId")
     suspend fun updateTaskSubtitle(taskId: Long, subtitle: String, updatedAt: Long)
 
+    @Query(
+        "UPDATE download_tasks SET " +
+            "subtitle = :subtitle, " +
+            "albumTitle = :albumTitle, " +
+            "albumCircle = :albumCircle, " +
+            "albumCv = :albumCv, " +
+            "albumTagsCsv = :albumTagsCsv, " +
+            "albumCoverUrl = :albumCoverUrl, " +
+            "albumDescription = :albumDescription, " +
+            "albumWorkId = :albumWorkId, " +
+            "albumRjCode = :albumRjCode, " +
+            "updatedAt = :updatedAt " +
+            "WHERE id = :taskId"
+    )
+    suspend fun updateTaskMetadata(
+        taskId: Long,
+        subtitle: String,
+        albumTitle: String,
+        albumCircle: String,
+        albumCv: String,
+        albumTagsCsv: String,
+        albumCoverUrl: String,
+        albumDescription: String,
+        albumWorkId: String,
+        albumRjCode: String,
+        updatedAt: Long
+    )
+
     @Query("SELECT * FROM download_items WHERE taskId = :taskId ORDER BY relativePath ASC")
     suspend fun getItemsForTask(taskId: Long): List<DownloadItemEntity>
 
@@ -35,6 +63,12 @@ interface DownloadDao {
 
     @Query("SELECT * FROM download_items WHERE filePath = :filePath LIMIT 1")
     suspend fun getItemByFilePath(filePath: String): DownloadItemEntity?
+
+    @Query("SELECT * FROM download_items WHERE state = 'QUEUED' ORDER BY createdAt ASC LIMIT :limit")
+    suspend fun getQueuedItems(limit: Int): List<DownloadItemEntity>
+
+    @Query("SELECT * FROM download_items WHERE state IN ('RUNNING', 'ENQUEUED', 'BLOCKED')")
+    suspend fun getActiveItems(): List<DownloadItemEntity>
 
     @Query("SELECT COUNT(*) FROM download_items WHERE taskId = :taskId")
     suspend fun countItemsForTask(taskId: Long): Int
@@ -90,7 +124,7 @@ interface DownloadDao {
     @Query("UPDATE download_items SET state = :state, updatedAt = :updatedAt WHERE taskId = :taskId AND state NOT IN ('SUCCEEDED', 'PAUSED')")
     suspend fun pauseAllItemsInTask(taskId: Long, state: String, updatedAt: Long)
 
-    @Query("SELECT * FROM download_items WHERE state = 'PAUSED' OR state IN ('RUNNING', 'ENQUEUED', 'BLOCKED')")
+    @Query("SELECT * FROM download_items WHERE state = 'PAUSED' OR state IN ('RUNNING', 'ENQUEUED', 'BLOCKED', 'QUEUED')")
     suspend fun getAllActiveOrPausedItems(): List<DownloadItemEntity>
 
     @Query("SELECT COUNT(*) FROM download_items WHERE state IN ('RUNNING', 'ENQUEUED', 'BLOCKED')")

--- a/app/src/main/java/com/asmr/player/data/local/db/entities/DownloadTaskEntity.kt
+++ b/app/src/main/java/com/asmr/player/data/local/db/entities/DownloadTaskEntity.kt
@@ -16,6 +16,14 @@ data class DownloadTaskEntity(
     val title: String,
     val subtitle: String = "",
     val rootDir: String,
+    val albumTitle: String = "",
+    val albumCircle: String = "",
+    val albumCv: String = "",
+    val albumTagsCsv: String = "",
+    val albumCoverUrl: String = "",
+    val albumDescription: String = "",
+    val albumWorkId: String = "",
+    val albumRjCode: String = "",
     val createdAt: Long,
     val updatedAt: Long
 )

--- a/app/src/main/java/com/asmr/player/data/remote/dlsite/DlsitePlayLibraryClient.kt
+++ b/app/src/main/java/com/asmr/player/data/remote/dlsite/DlsitePlayLibraryClient.kt
@@ -143,10 +143,11 @@ class DlsitePlayLibraryClient @Inject constructor(
                 }
                 throw IllegalStateException("获取已购列表失败（${resp.code}）")
             }
-            val body = resp.body?.string().orEmpty()
+            val body = resp.body ?: return emptyMap()
             val type = object : TypeToken<List<Map<String, Any?>>>() {}.type
-            val parsed = runCatching { gson.fromJson<Any>(body, type) }.getOrNull()
-            val list: List<Map<String, Any?>> = (parsed as? List<*>)?.mapNotNull { it as? Map<String, Any?> }.orEmpty()
+            val list = body.charStream().use { reader ->
+                runCatching { gson.fromJson<List<Map<String, Any?>>>(reader, type) }.getOrNull().orEmpty()
+            }
             val out = LinkedHashMap<String, String>()
             list.forEach { item ->
                 val workno = pickString(item["workno"]).uppercase().trim()
@@ -181,16 +182,17 @@ class DlsitePlayLibraryClient @Inject constructor(
             val reqBuilder = Request.Builder().url("https://play.dlsite.com/api/v3/content/works").post(body)
             headers.forEach { (k, v) -> reqBuilder.header(k, v) }
             okHttpClient.newCall(reqBuilder.build()).execute().use { resp ->
-                if (!resp.isSuccessful) {
-                    if (resp.code == 401) {
-                        throw IllegalStateException("已购库鉴权失败（401），请重新登录 DLsite")
+                    if (!resp.isSuccessful) {
+                        if (resp.code == 401) {
+                            throw IllegalStateException("已购库鉴权失败（401），请重新登录 DLsite")
+                        }
+                        return@use
                     }
-                    return@use
-                }
-                val raw = resp.body?.string().orEmpty()
-                val parsed = runCatching { gson.fromJson<Any>(raw, type) }.getOrNull()
-                val obj = parsed as? Map<*, *> ?: emptyMap<Any, Any>()
-                val works = obj["works"] as? List<*>
+                    val body = resp.body ?: return@use
+                    val obj = body.charStream().use { reader ->
+                        runCatching { gson.fromJson<Map<String, Any?>>(reader, type) }.getOrNull().orEmpty()
+                    }
+                    val works = obj["works"] as? List<*>
                 works?.forEach { w ->
                     if (w is Map<*, *>) {
                         @Suppress("UNCHECKED_CAST")

--- a/app/src/main/java/com/asmr/player/data/remote/dlsite/DlsitePlayWorkClient.kt
+++ b/app/src/main/java/com/asmr/player/data/remote/dlsite/DlsitePlayWorkClient.kt
@@ -205,12 +205,15 @@ class DlsitePlayWorkClient @Inject constructor(
             .build()
 
         okHttpClient.newCall(request).execute().use { resp ->
-            val body = resp.body?.string().orEmpty()
             if (!resp.isSuccessful) {
+                val body = resp.body?.string().orEmpty()
                 Log.w(TAG, "sign/url failed: ${resp.code}, body=${body.take(300)}")
                 throw IllegalStateException("DLsite Play 获取签名失败（${resp.code}）")
             }
-            val obj = runCatching { gson.fromJson(body, Map::class.java) as? Map<*, *> }.getOrNull().orEmpty()
+            val body = resp.body ?: throw IllegalStateException("DLsite Play 获取签名返回为空")
+            val obj = body.charStream().use { reader ->
+                runCatching { gson.fromJson(reader, Map::class.java) as? Map<*, *> }.getOrNull().orEmpty()
+            }
             val baseUrl = (obj["url"] as? String).orEmpty().trim()
             val paramsAny = obj["params"] as? Map<*, *>
             val params = paramsAny?.entries
@@ -247,13 +250,16 @@ class DlsitePlayWorkClient @Inject constructor(
             .build()
 
         okHttpClient.newCall(request).execute().use { resp ->
-            val body = resp.body?.string().orEmpty()
             if (!resp.isSuccessful) {
+                val body = resp.body?.string().orEmpty()
                 Log.w(TAG, "ziptree.json failed: ${resp.code}, body=${body.take(300)}")
                 throw IllegalStateException("DLsite Play 获取目录树失败（${resp.code}）")
             }
+            val body = resp.body ?: throw IllegalStateException("DLsite Play 获取目录树为空")
             @Suppress("UNCHECKED_CAST")
-            return runCatching { gson.fromJson(body, Map::class.java) as? Map<String, Any?> }.getOrNull().orEmpty()
+            return body.charStream().use { reader ->
+                runCatching { gson.fromJson(reader, Map::class.java) as? Map<String, Any?> }.getOrNull().orEmpty()
+            }
         }
     }
 

--- a/app/src/main/java/com/asmr/player/data/remote/download/DownloadManager.kt
+++ b/app/src/main/java/com/asmr/player/data/remote/download/DownloadManager.kt
@@ -17,7 +17,6 @@ import com.asmr.player.data.local.db.AppDatabaseProvider
 import com.asmr.player.util.SubtitleParser
 import com.asmr.player.util.TrackKeyNormalizer
 import com.asmr.player.work.AlbumCoverThumbWorker
-import com.asmr.player.BuildConfig
 import dagger.hilt.EntryPoint
 import dagger.hilt.InstallIn
 import dagger.hilt.android.EntryPointAccessors
@@ -26,11 +25,24 @@ import dagger.hilt.android.qualifiers.ApplicationContext
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.ExecutorCoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.asCoroutineDispatcher
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import java.io.File
 import java.io.FileOutputStream
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+import java.util.UUID
+import java.util.concurrent.Executors
+import kotlin.math.max
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -59,11 +71,7 @@ class DownloadManager @Inject constructor(
         albumWorkId: String = "",
         albumRjCode: String = ""
     ) {
-        val uniqueName = "${targetDir.trimEnd('/', '\\')}\\$fileName"
-        val uniqueWorkName = uniqueName.hashCode().toString()
-
         scope.launch {
-            val wm = WorkManager.getInstance(context)
             val now = System.currentTimeMillis()
 
             val taskKey = tags.firstOrNull { it.startsWith("album:") } ?: "dir:$taskRootDir"
@@ -79,10 +87,24 @@ class DownloadManager @Inject constructor(
             val safeAlbumDescription = albumDescription.trim().take(0)
             val safeAlbumWorkId = albumWorkId.trim().take(40)
             val safeAlbumRjCode = albumRjCode.trim().take(40)
+            val taskId = ensureTask(
+                taskKey = taskKey,
+                title = taskTitle,
+                subtitle = safeTaskSubtitle,
+                rootDir = taskRootDir,
+                albumTitle = safeAlbumTitle,
+                albumCircle = safeAlbumCircle,
+                albumCv = safeAlbumCv,
+                albumTagsCsv = safeAlbumTagsCsv,
+                albumCoverUrl = safeAlbumCoverUrl,
+                albumDescription = safeAlbumDescription,
+                albumWorkId = safeAlbumWorkId,
+                albumRjCode = safeAlbumRjCode,
+                now = now
+            )
 
             val existingFile = File(filePath)
             if (existingFile.exists() && existingFile.isFile) {
-                val taskId = ensureTask(taskKey = taskKey, title = taskTitle, subtitle = safeTaskSubtitle, rootDir = taskRootDir, now = now)
                 val size = existingFile.length().coerceAtLeast(0L)
                 val existingItem = downloadDao.getItemByFilePath(filePath)
                 if (existingItem != null) {
@@ -95,7 +117,7 @@ class DownloadManager @Inject constructor(
                         updatedAt = now
                     )
                 } else {
-                    val localWorkId = "local_$uniqueWorkName"
+                    val localWorkId = "local_${UUID.randomUUID()}"
                     downloadDao.upsertItem(
                         DownloadItemEntity(
                             taskId = taskId,
@@ -149,92 +171,39 @@ class DownloadManager @Inject constructor(
             }
 
             val existingItem = downloadDao.getItemByFilePath(filePath)
-            val workInfos = runCatching { wm.getWorkInfosForUniqueWork(uniqueWorkName).get() }.getOrDefault(emptyList())
-            val hasActiveWork = workInfos.any { info ->
-                info.state == WorkInfo.State.ENQUEUED || info.state == WorkInfo.State.RUNNING || info.state == WorkInfo.State.BLOCKED
-            }
-            val hasSucceededWork = workInfos.any { it.state == WorkInfo.State.SUCCEEDED }
-
-            if (hasActiveWork) return@launch
-            if (hasSucceededWork && existingItem != null) {
+            val existingBytes = runCatching { File(filePath).length() }.getOrDefault(0L).coerceAtLeast(0L)
+            if (existingItem != null) {
                 val file = File(existingItem.filePath.ifBlank { filePath })
-                if (file.exists() && file.isFile) {
-                    val size = file.length().coerceAtLeast(0L)
-                    downloadDao.updateItemProgress(
-                        workId = existingItem.workId,
-                        state = WorkInfo.State.SUCCEEDED.name,
-                        downloaded = size,
-                        total = size,
-                        speed = 0L,
-                        updatedAt = now
-                    )
+                if (existingItem.state == WorkInfo.State.SUCCEEDED.name && file.exists() && file.isFile) {
                     return@launch
                 }
-            }
-            if (existingItem != null && existingItem.state == WorkInfo.State.SUCCEEDED.name) {
-                val file = File(existingItem.filePath.ifBlank { filePath })
-                if (file.exists() && file.isFile) return@launch
-            }
-
-            val inputData = workDataOf(
-                "url" to url,
-                "fileName" to fileName,
-                "targetDir" to targetDir,
-                "taskRootDir" to taskRootDir,
-                "relativePath" to relativePath,
-                "taskKey" to taskKey,
-                "taskTitle" to taskTitle,
-                "taskSubtitle" to safeTaskSubtitle,
-                "albumTitle" to safeAlbumTitle,
-                "albumCircle" to safeAlbumCircle,
-                "albumCv" to safeAlbumCv,
-                "albumTagsCsv" to safeAlbumTagsCsv,
-                "albumCoverUrl" to safeAlbumCoverUrl,
-                "albumDescription" to safeAlbumDescription,
-                "albumWorkId" to safeAlbumWorkId,
-                "albumRjCode" to safeAlbumRjCode
-            )
-
-            val downloadRequest = OneTimeWorkRequestBuilder<DownloadWorker>()
-                .setInputData(inputData)
-                .addTag("download")
-                .apply {
-                    addTag(taskKey)
-                    tags.asSequence().filter { it != taskKey }.distinct().forEach { addTag(it) }
+                if (
+                    existingItem.state == WorkInfo.State.RUNNING.name ||
+                    existingItem.state == WorkInfo.State.ENQUEUED.name ||
+                    existingItem.state == WorkInfo.State.BLOCKED.name ||
+                    existingItem.state == DOWNLOAD_STATE_QUEUED
+                ) {
+                    return@launch
                 }
-                .setConstraints(
-                    Constraints.Builder()
-                        .setRequiredNetworkType(NetworkType.CONNECTED)
-                        .build()
-                )
-                .build()
-
-            val policy = if (workInfos.isNotEmpty()) ExistingWorkPolicy.REPLACE else ExistingWorkPolicy.KEEP
-            wm.enqueueUniqueWork(uniqueWorkName, policy, downloadRequest)
-
-            val taskId = ensureTask(taskKey = taskKey, title = taskTitle, subtitle = safeTaskSubtitle, rootDir = taskRootDir, now = now)
-            val workId = downloadRequest.id.toString()
-            val existingBytes = runCatching { File(filePath).length() }.getOrDefault(0L).coerceAtLeast(0L)
-
-            if (existingItem != null) {
-                downloadDao.replaceWorkIdForResume(
-                    oldWorkId = existingItem.workId,
-                    newWorkId = workId,
-                    state = WorkInfo.State.ENQUEUED.name,
+                downloadDao.updateItemProgress(
+                    workId = existingItem.workId,
+                    state = DOWNLOAD_STATE_QUEUED,
                     downloaded = existingBytes,
+                    total = existingItem.total,
+                    speed = 0L,
                     updatedAt = now
                 )
             } else {
                 downloadDao.upsertItem(
                     DownloadItemEntity(
                         taskId = taskId,
-                        workId = workId,
+                        workId = "queued_${UUID.randomUUID()}",
                         url = url,
                         relativePath = safeRelativePath,
                         fileName = fileName,
                         targetDir = targetDir,
                         filePath = filePath,
-                        state = WorkInfo.State.ENQUEUED.name,
+                        state = DOWNLOAD_STATE_QUEUED,
                         downloaded = existingBytes,
                         total = -1L,
                         speed = 0L,
@@ -243,14 +212,62 @@ class DownloadManager @Inject constructor(
                     )
                 )
             }
+            DownloadQueueCoordinator.requestSchedule(context)
         }
     }
 
-    private suspend fun ensureTask(taskKey: String, title: String, subtitle: String, rootDir: String, now: Long): Long {
+    private suspend fun ensureTask(
+        taskKey: String,
+        title: String,
+        subtitle: String,
+        rootDir: String,
+        albumTitle: String,
+        albumCircle: String,
+        albumCv: String,
+        albumTagsCsv: String,
+        albumCoverUrl: String,
+        albumDescription: String,
+        albumWorkId: String,
+        albumRjCode: String,
+        now: Long
+    ): Long {
         val existing = downloadDao.getTaskByKey(taskKey)
         if (existing != null) {
-            if (existing.subtitle.isBlank() && subtitle.isNotBlank()) {
-                runCatching { downloadDao.updateTaskSubtitle(existing.id, subtitle, now) }
+            val resolvedSubtitle = existing.subtitle.ifBlank { subtitle }
+            val resolvedAlbumTitle = existing.albumTitle.ifBlank { albumTitle }
+            val resolvedAlbumCircle = existing.albumCircle.ifBlank { albumCircle }
+            val resolvedAlbumCv = existing.albumCv.ifBlank { albumCv }
+            val resolvedAlbumTagsCsv = existing.albumTagsCsv.ifBlank { albumTagsCsv }
+            val resolvedAlbumCoverUrl = existing.albumCoverUrl.ifBlank { albumCoverUrl }
+            val resolvedAlbumDescription = existing.albumDescription.ifBlank { albumDescription }
+            val resolvedAlbumWorkId = existing.albumWorkId.ifBlank { albumWorkId }
+            val resolvedAlbumRjCode = existing.albumRjCode.ifBlank { albumRjCode }
+            if (
+                resolvedSubtitle != existing.subtitle ||
+                resolvedAlbumTitle != existing.albumTitle ||
+                resolvedAlbumCircle != existing.albumCircle ||
+                resolvedAlbumCv != existing.albumCv ||
+                resolvedAlbumTagsCsv != existing.albumTagsCsv ||
+                resolvedAlbumCoverUrl != existing.albumCoverUrl ||
+                resolvedAlbumDescription != existing.albumDescription ||
+                resolvedAlbumWorkId != existing.albumWorkId ||
+                resolvedAlbumRjCode != existing.albumRjCode
+            ) {
+                runCatching {
+                    downloadDao.updateTaskMetadata(
+                        taskId = existing.id,
+                        subtitle = resolvedSubtitle,
+                        albumTitle = resolvedAlbumTitle,
+                        albumCircle = resolvedAlbumCircle,
+                        albumCv = resolvedAlbumCv,
+                        albumTagsCsv = resolvedAlbumTagsCsv,
+                        albumCoverUrl = resolvedAlbumCoverUrl,
+                        albumDescription = resolvedAlbumDescription,
+                        albumWorkId = resolvedAlbumWorkId,
+                        albumRjCode = resolvedAlbumRjCode,
+                        updatedAt = now
+                    )
+                }
             }
             return existing.id
         }
@@ -260,12 +277,253 @@ class DownloadManager @Inject constructor(
                 title = title,
                 subtitle = subtitle,
                 rootDir = rootDir,
+                albumTitle = albumTitle,
+                albumCircle = albumCircle,
+                albumCv = albumCv,
+                albumTagsCsv = albumTagsCsv,
+                albumCoverUrl = albumCoverUrl,
+                albumDescription = albumDescription,
+                albumWorkId = albumWorkId,
+                albumRjCode = albumRjCode,
                 createdAt = now,
                 updatedAt = now
             )
         )
         if (created > 0) return created
         return downloadDao.getTaskByKey(taskKey)?.id ?: 0L
+    }
+}
+
+object DownloadQueueCoordinator {
+    private const val ACTIVE_WORK_RECONCILE_GRACE_MS = 30_000L
+    private const val RECOVERY_PREFS = "download_queue_recovery"
+    private const val RECOVERY_KEY = "download_queue_recovery_v2_done"
+    private const val MEMORY_RETRY_DELAY_MS = 15_000L
+    private const val TRIM_MEMORY_RUNNING_LOW_BACKOFF_MS = 20_000L
+    private const val TRIM_MEMORY_RUNNING_CRITICAL_BACKOFF_MS = 45_000L
+
+    private val scheduleMutex = Mutex()
+    private val requestMutex = Any()
+    @Volatile
+    private var scheduleRequested = false
+    @Volatile
+    private var scheduleLoopRunning = false
+    @Volatile
+    private var memoryRetryScheduled = false
+    @Volatile
+    private var memoryPauseUntilMs = 0L
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
+    fun requestSchedule(context: Context) {
+        val appContext = context.applicationContext
+        synchronized(requestMutex) {
+            scheduleRequested = true
+            if (scheduleLoopRunning) return
+            scheduleLoopRunning = true
+        }
+        scope.launch {
+            while (true) {
+                synchronized(requestMutex) {
+                    scheduleRequested = false
+                }
+                runCatching { schedulePendingDownloads(appContext) }
+                val shouldContinue = synchronized(requestMutex) {
+                    if (scheduleRequested) {
+                        true
+                    } else {
+                        scheduleLoopRunning = false
+                        false
+                    }
+                }
+                if (!shouldContinue) break
+            }
+        }
+    }
+
+    suspend fun recoverLegacyScheduledDownloads(context: Context) {
+        val appContext = context.applicationContext
+        val prefs = appContext.getSharedPreferences(RECOVERY_PREFS, Context.MODE_PRIVATE)
+        if (prefs.getBoolean(RECOVERY_KEY, false)) {
+            requestSchedule(appContext)
+            return
+        }
+
+        val wm = WorkManager.getInstance(appContext)
+        runCatching { wm.cancelAllWorkByTag("download") }
+        val dao = AppDatabaseProvider.get(appContext).downloadDao()
+        val now = System.currentTimeMillis()
+        dao.getAllActiveOrPausedItems()
+            .filter { it.state != "PAUSED" && it.state != WorkInfo.State.SUCCEEDED.name }
+            .forEach { item ->
+                runCatching {
+                    dao.updateItemProgress(
+                        workId = item.workId,
+                        state = DOWNLOAD_STATE_QUEUED,
+                        downloaded = resolveExistingBytes(item),
+                        total = item.total,
+                        speed = 0L,
+                        updatedAt = now
+                    )
+                }
+            }
+        prefs.edit().putBoolean(RECOVERY_KEY, true).apply()
+        requestSchedule(appContext)
+    }
+
+    fun onTrimMemory(context: Context, level: Int) {
+        val now = System.currentTimeMillis()
+        val backoffMs = when {
+            level >= android.content.ComponentCallbacks2.TRIM_MEMORY_RUNNING_CRITICAL -> TRIM_MEMORY_RUNNING_CRITICAL_BACKOFF_MS
+            level >= android.content.ComponentCallbacks2.TRIM_MEMORY_RUNNING_LOW -> TRIM_MEMORY_RUNNING_LOW_BACKOFF_MS
+            else -> 0L
+        }
+        if (backoffMs > 0L) {
+            memoryPauseUntilMs = max(memoryPauseUntilMs, now + backoffMs)
+            scheduleMemoryRetry(context, backoffMs)
+        }
+    }
+
+    suspend fun schedulePendingDownloads(context: Context) {
+        val appContext = context.applicationContext
+        scheduleMutex.withLock {
+            val wm = WorkManager.getInstance(appContext)
+            val dao = AppDatabaseProvider.get(appContext).downloadDao()
+            reconcileActiveItems(wm, dao)
+
+            val availableSlots = DownloadRuntimeConfig.maxConcurrentDownloads(appContext) - dao.countActiveItems()
+            if (availableSlots <= 0) return
+
+            val hasQueuedItems = dao.getQueuedItems(limit = 1).isNotEmpty()
+            if (!hasQueuedItems) return
+
+            val now = System.currentTimeMillis()
+            val memoryPaused = now < memoryPauseUntilMs
+            val memoryConstrained = DownloadRuntimeConfig.isMemoryConstrained(appContext)
+            if (memoryPaused || memoryConstrained) {
+                scheduleMemoryRetry(appContext, MEMORY_RETRY_DELAY_MS)
+                return
+            }
+
+            dao.getQueuedItems(availableSlots).forEach { item ->
+                val task = dao.getTaskById(item.taskId) ?: run {
+                    dao.updateItemState(item.workId, WorkInfo.State.FAILED.name, System.currentTimeMillis())
+                    return@forEach
+                }
+                val request = OneTimeWorkRequestBuilder<DownloadWorker>()
+                    .setInputData(
+                        workDataOf(
+                            "url" to item.url,
+                            "fileName" to item.fileName,
+                            "targetDir" to item.targetDir,
+                            "taskRootDir" to task.rootDir,
+                            "relativePath" to item.relativePath,
+                            "taskKey" to task.taskKey,
+                            "taskTitle" to task.title,
+                            "taskSubtitle" to task.subtitle,
+                            "albumTitle" to task.albumTitle,
+                            "albumCircle" to task.albumCircle,
+                            "albumCv" to task.albumCv,
+                            "albumTagsCsv" to task.albumTagsCsv,
+                            "albumCoverUrl" to task.albumCoverUrl,
+                            "albumDescription" to task.albumDescription,
+                            "albumWorkId" to task.albumWorkId,
+                            "albumRjCode" to task.albumRjCode
+                        )
+                    )
+                    .addTag("download")
+                    .addTag(task.taskKey)
+                    .setConstraints(
+                        Constraints.Builder()
+                            .setRequiredNetworkType(NetworkType.CONNECTED)
+                            .build()
+                    )
+                    .build()
+
+                wm.enqueue(request)
+
+                val existingBytes = runCatching {
+                    File(item.filePath.ifBlank { File(item.targetDir, item.fileName).absolutePath }).length()
+                }.getOrDefault(item.downloaded).coerceAtLeast(0L)
+
+                dao.replaceWorkIdForResume(
+                    oldWorkId = item.workId,
+                    newWorkId = request.id.toString(),
+                    state = WorkInfo.State.ENQUEUED.name,
+                    downloaded = existingBytes,
+                    updatedAt = System.currentTimeMillis()
+                )
+            }
+        }
+    }
+
+    private suspend fun reconcileActiveItems(workManager: WorkManager, dao: DownloadDao) {
+        val now = System.currentTimeMillis()
+        dao.getActiveItems().forEach { item ->
+            val workId = runCatching { UUID.fromString(item.workId) }.getOrNull()
+            if (workId == null) {
+                dao.updateItemProgress(
+                    workId = item.workId,
+                    state = DOWNLOAD_STATE_QUEUED,
+                    downloaded = resolveExistingBytes(item),
+                    total = item.total,
+                    speed = 0L,
+                    updatedAt = now
+                )
+                return@forEach
+            }
+
+                val info = runCatching { workManager.getWorkInfoById(workId).get() }.getOrNull()
+            when (info?.state) {
+                null -> {
+                    val recentlyScheduled = now - item.updatedAt <= ACTIVE_WORK_RECONCILE_GRACE_MS
+                    if (!recentlyScheduled) {
+                        dao.updateItemProgress(
+                            workId = item.workId,
+                            state = DOWNLOAD_STATE_QUEUED,
+                            downloaded = resolveExistingBytes(item),
+                            total = item.total,
+                            speed = 0L,
+                            updatedAt = now
+                        )
+                    }
+                }
+                WorkInfo.State.SUCCEEDED -> {
+                    val size = resolveExistingBytes(item)
+                    dao.updateItemProgress(
+                        workId = item.workId,
+                        state = WorkInfo.State.SUCCEEDED.name,
+                        downloaded = size,
+                        total = size.coerceAtLeast(item.total),
+                        speed = 0L,
+                        updatedAt = now
+                    )
+                }
+                WorkInfo.State.FAILED -> dao.updateItemState(item.workId, WorkInfo.State.FAILED.name, now)
+                WorkInfo.State.CANCELLED -> dao.updateItemState(item.workId, WorkInfo.State.CANCELLED.name, now)
+                else -> Unit
+            }
+        }
+    }
+
+    private fun scheduleMemoryRetry(context: Context, delayMs: Long) {
+        val appContext = context.applicationContext
+        synchronized(requestMutex) {
+            if (memoryRetryScheduled) return
+            memoryRetryScheduled = true
+        }
+        scope.launch {
+            delay(delayMs.coerceAtLeast(1_000L))
+            synchronized(requestMutex) {
+                memoryRetryScheduled = false
+            }
+            requestSchedule(appContext)
+        }
+    }
+
+    private fun resolveExistingBytes(item: DownloadItemEntity): Long {
+        return runCatching {
+            File(item.filePath.ifBlank { File(item.targetDir, item.fileName).absolutePath }).length()
+        }.getOrDefault(item.downloaded).coerceAtLeast(0L)
     }
 }
 
@@ -276,7 +534,11 @@ class DownloadWorker(context: Context, parameters: WorkerParameters) : Coroutine
         fun okHttpClient(): OkHttpClient
     }
 
-    override suspend fun doWork(): ListenableWorker.Result {
+    override suspend fun doWork(): ListenableWorker.Result = withContext(downloadDispatcher(applicationContext)) {
+        executeDownloadWork()
+    }
+
+    private suspend fun executeDownloadWork(): ListenableWorker.Result {
         val url = inputData.getString("url") ?: return ListenableWorker.Result.failure()
         val fileName = inputData.getString("fileName") ?: return ListenableWorker.Result.failure()
         val targetDir = inputData.getString("targetDir") ?: return ListenableWorker.Result.failure()
@@ -296,7 +558,9 @@ class DownloadWorker(context: Context, parameters: WorkerParameters) : Coroutine
 
         return try {
             val workId = id.toString()
-            val dao = AppDatabaseProvider.get(applicationContext).downloadDao()
+            val appDb = AppDatabaseProvider.get(applicationContext)
+            val dao = appDb.downloadDao()
+            val dailyStatDao = appDb.dailyStatDao()
             val now0 = System.currentTimeMillis()
             val resolvedTaskKey = taskKey.ifBlank { "dir:${taskRootDir.ifBlank { targetDir }}" }
             val resolvedRootDir = taskRootDir.ifBlank { targetDir }
@@ -305,8 +569,41 @@ class DownloadWorker(context: Context, parameters: WorkerParameters) : Coroutine
             val taskId = run {
                 val existing = dao.getTaskByKey(resolvedTaskKey)
                 if (existing != null) {
-                    if (existing.subtitle.isBlank() && resolvedSubtitle.isNotBlank()) {
-                        runCatching { dao.updateTaskSubtitle(existing.id, resolvedSubtitle, now0) }
+                    val mergedSubtitle = existing.subtitle.ifBlank { resolvedSubtitle }
+                    val mergedAlbumTitle = existing.albumTitle.ifBlank { albumTitle }
+                    val mergedAlbumCircle = existing.albumCircle.ifBlank { albumCircle }
+                    val mergedAlbumCv = existing.albumCv.ifBlank { albumCv }
+                    val mergedAlbumTagsCsv = existing.albumTagsCsv.ifBlank { albumTagsCsv }
+                    val mergedAlbumCoverUrl = existing.albumCoverUrl.ifBlank { albumCoverUrl }
+                    val mergedAlbumDescription = existing.albumDescription.ifBlank { albumDescription }
+                    val mergedAlbumWorkId = existing.albumWorkId.ifBlank { albumWorkId }
+                    val mergedAlbumRjCode = existing.albumRjCode.ifBlank { albumRjCode }
+                    if (
+                        mergedSubtitle != existing.subtitle ||
+                        mergedAlbumTitle != existing.albumTitle ||
+                        mergedAlbumCircle != existing.albumCircle ||
+                        mergedAlbumCv != existing.albumCv ||
+                        mergedAlbumTagsCsv != existing.albumTagsCsv ||
+                        mergedAlbumCoverUrl != existing.albumCoverUrl ||
+                        mergedAlbumDescription != existing.albumDescription ||
+                        mergedAlbumWorkId != existing.albumWorkId ||
+                        mergedAlbumRjCode != existing.albumRjCode
+                    ) {
+                        runCatching {
+                            dao.updateTaskMetadata(
+                                taskId = existing.id,
+                                subtitle = mergedSubtitle,
+                                albumTitle = mergedAlbumTitle,
+                                albumCircle = mergedAlbumCircle,
+                                albumCv = mergedAlbumCv,
+                                albumTagsCsv = mergedAlbumTagsCsv,
+                                albumCoverUrl = mergedAlbumCoverUrl,
+                                albumDescription = mergedAlbumDescription,
+                                albumWorkId = mergedAlbumWorkId,
+                                albumRjCode = mergedAlbumRjCode,
+                                updatedAt = now0
+                            )
+                        }
                     }
                     existing.id
                 } else {
@@ -316,6 +613,14 @@ class DownloadWorker(context: Context, parameters: WorkerParameters) : Coroutine
                             title = resolvedTitle,
                             subtitle = resolvedSubtitle,
                             rootDir = resolvedRootDir,
+                            albumTitle = albumTitle,
+                            albumCircle = albumCircle,
+                            albumCv = albumCv,
+                            albumTagsCsv = albumTagsCsv,
+                            albumCoverUrl = albumCoverUrl,
+                            albumDescription = albumDescription,
+                            albumWorkId = albumWorkId,
+                            albumRjCode = albumRjCode,
                             createdAt = now0,
                             updatedAt = now0
                         )
@@ -367,6 +672,15 @@ class DownloadWorker(context: Context, parameters: WorkerParameters) : Coroutine
 
             var total = -1L
             var downloaded = existingBytes
+            val today = SimpleDateFormat("yyyy-MM-dd", Locale.US).format(Date(now0))
+            var pendingTrafficBytes = 0L
+
+            suspend fun flushTrafficStats() {
+                if (pendingTrafficBytes <= 0L) return
+                dailyStatDao.addTraffic(today, pendingTrafficBytes)
+                pendingTrafficBytes = 0L
+            }
+
             client.newCall(requestBuilder.build()).execute().use { response ->
                 if (!response.isSuccessful) return ListenableWorker.Result.failure()
                 val body = response.body ?: return ListenableWorker.Result.failure()
@@ -381,7 +695,7 @@ class DownloadWorker(context: Context, parameters: WorkerParameters) : Coroutine
                     contentLen > 0 -> contentLen
                     else -> -1L
                 }
-                val buffer = ByteArray(DEFAULT_BUFFER_SIZE)
+                val buffer = ByteArray(DOWNLOAD_BUFFER_SIZE)
                 var lastProgressAt = 0L
                 var lastBytes = 0L
                 var lastTs = System.currentTimeMillis()
@@ -409,7 +723,9 @@ class DownloadWorker(context: Context, parameters: WorkerParameters) : Coroutine
                         while (true) {
                             if (isStopped) {
                                 val now = System.currentTimeMillis()
+                                flushTrafficStats()
                                 dao.updateItemState(workId, "PAUSED", now)
+                                DownloadQueueCoordinator.requestSchedule(applicationContext)
                                 return ListenableWorker.Result.success(
                                     workDataOf(
                                         "fileName" to fileName,
@@ -424,14 +740,12 @@ class DownloadWorker(context: Context, parameters: WorkerParameters) : Coroutine
                             if (read <= 0) break
                             output.write(buffer, 0, read)
                             downloaded += read
-                            
-                            // Track daily traffic
-                            val today = java.text.SimpleDateFormat("yyyy-MM-dd", java.util.Locale.getDefault()).format(java.util.Date())
-                            AppDatabaseProvider.get(applicationContext).dailyStatDao().addTraffic(today, read.toLong())
+                            pendingTrafficBytes += read.toLong()
 
                             val now = System.currentTimeMillis()
-                            val shouldUpdate = downloaded - lastProgressAt >= 256 * 1024 || now - lastTs >= 1000
+                            val shouldUpdate = downloaded - lastProgressAt >= PROGRESS_UPDATE_BYTES || now - lastTs >= PROGRESS_UPDATE_INTERVAL_MS
                             if (shouldUpdate) {
+                                flushTrafficStats()
                                 val dt = (now - lastTs).coerceAtLeast(1)
                                 val speed = ((downloaded - lastBytes) * 1000 / dt).coerceAtLeast(0)
                                 dao.updateItemProgress(
@@ -442,15 +756,6 @@ class DownloadWorker(context: Context, parameters: WorkerParameters) : Coroutine
                                     speed = speed,
                                     updatedAt = now
                                 )
-                                setProgress(
-                                    workDataOf(
-                                        "fileName" to fileName,
-                                        "targetDir" to targetDir,
-                                        "downloaded" to downloaded,
-                                        "total" to total,
-                                        "speed" to speed
-                                    )
-                                )
                                 lastProgressAt = downloaded
                                 lastBytes = downloaded
                                 lastTs = now
@@ -460,6 +765,10 @@ class DownloadWorker(context: Context, parameters: WorkerParameters) : Coroutine
                 }
             }
             val now = System.currentTimeMillis()
+            try {
+                flushTrafficStats()
+            } catch (_: Exception) {
+            }
             val finalTotal = if (total > 0) total else downloaded
             dao.updateItemProgress(
                 workId = workId,
@@ -493,6 +802,7 @@ class DownloadWorker(context: Context, parameters: WorkerParameters) : Coroutine
                 WorkManager.getInstance(applicationContext)
                     .enqueueUniqueWork(unique, ExistingWorkPolicy.REPLACE, request)
             }
+            DownloadQueueCoordinator.requestSchedule(applicationContext)
             ListenableWorker.Result.success(
                 workDataOf(
                     "fileName" to fileName,
@@ -509,6 +819,7 @@ class DownloadWorker(context: Context, parameters: WorkerParameters) : Coroutine
                 val dao = AppDatabaseProvider.get(applicationContext).downloadDao()
                 dao.updateItemState(workId, WorkInfo.State.FAILED.name, now)
             }
+            DownloadQueueCoordinator.requestSchedule(applicationContext)
             ListenableWorker.Result.failure(
                 workDataOf(
                     "fileName" to fileName,
@@ -518,6 +829,45 @@ class DownloadWorker(context: Context, parameters: WorkerParameters) : Coroutine
                     "taskKey" to taskKey
                 )
             )
+        }
+    }
+
+    companion object {
+        private const val DOWNLOAD_BUFFER_SIZE = 64 * 1024
+        private const val PROGRESS_UPDATE_BYTES = 256 * 1024L
+        private const val PROGRESS_UPDATE_INTERVAL_MS = 1_000L
+
+        @Volatile
+        private var lowRamDispatcher: ExecutorCoroutineDispatcher? = null
+
+        @Volatile
+        private var defaultDispatcher: ExecutorCoroutineDispatcher? = null
+
+        private val dispatcherLock = Any()
+
+        private fun downloadDispatcher(context: Context): CoroutineDispatcher {
+            val lowRamDevice = DownloadRuntimeConfig.isLowRamDevice(context)
+            val existing = if (lowRamDevice) lowRamDispatcher else defaultDispatcher
+            if (existing != null) return existing
+
+            return synchronized(dispatcherLock) {
+                val cached = if (lowRamDevice) lowRamDispatcher else defaultDispatcher
+                if (cached != null) {
+                    cached
+                } else {
+                    // Each file maps to its own worker, so we cap download execution here to
+                    // avoid dozens of concurrent network streams overwhelming low-memory phones.
+                    val created = Executors
+                        .newFixedThreadPool(DownloadRuntimeConfig.maxConcurrentDownloads(context))
+                        .asCoroutineDispatcher()
+                    if (lowRamDevice) {
+                        lowRamDispatcher = created
+                    } else {
+                        defaultDispatcher = created
+                    }
+                    created
+                }
+            }
         }
     }
 }

--- a/app/src/main/java/com/asmr/player/data/remote/download/DownloadManager.kt
+++ b/app/src/main/java/com/asmr/player/data/remote/download/DownloadManager.kt
@@ -296,8 +296,6 @@ class DownloadManager @Inject constructor(
 
 object DownloadQueueCoordinator {
     private const val ACTIVE_WORK_RECONCILE_GRACE_MS = 30_000L
-    private const val RECOVERY_PREFS = "download_queue_recovery"
-    private const val RECOVERY_KEY = "download_queue_recovery_v2_done"
     private const val MEMORY_RETRY_DELAY_MS = 15_000L
     private const val TRIM_MEMORY_RUNNING_LOW_BACKOFF_MS = 20_000L
     private const val TRIM_MEMORY_RUNNING_CRITICAL_BACKOFF_MS = 45_000L
@@ -340,34 +338,31 @@ object DownloadQueueCoordinator {
         }
     }
 
-    suspend fun recoverLegacyScheduledDownloads(context: Context) {
+    suspend fun recoverDownloadsOnAppLaunch(context: Context) {
         val appContext = context.applicationContext
-        val prefs = appContext.getSharedPreferences(RECOVERY_PREFS, Context.MODE_PRIVATE)
-        if (prefs.getBoolean(RECOVERY_KEY, false)) {
-            requestSchedule(appContext)
-            return
-        }
-
         val wm = WorkManager.getInstance(appContext)
         runCatching { wm.cancelAllWorkByTag("download") }
         val dao = AppDatabaseProvider.get(appContext).downloadDao()
         val now = System.currentTimeMillis()
         dao.getAllActiveOrPausedItems()
-            .filter { it.state != "PAUSED" && it.state != WorkInfo.State.SUCCEEDED.name }
             .forEach { item ->
+                val resolvedBytes = resolveExistingBytes(item)
+                val resolvedState = when (item.state) {
+                    WorkInfo.State.SUCCEEDED.name -> WorkInfo.State.SUCCEEDED.name
+                    "PAUSED" -> "PAUSED"
+                    else -> "PAUSED"
+                }
                 runCatching {
                     dao.updateItemProgress(
                         workId = item.workId,
-                        state = DOWNLOAD_STATE_QUEUED,
-                        downloaded = resolveExistingBytes(item),
+                        state = resolvedState,
+                        downloaded = resolvedBytes,
                         total = item.total,
                         speed = 0L,
                         updatedAt = now
                     )
                 }
             }
-        prefs.edit().putBoolean(RECOVERY_KEY, true).apply()
-        requestSchedule(appContext)
     }
 
     fun onTrimMemory(context: Context, level: Int) {

--- a/app/src/main/java/com/asmr/player/data/remote/download/DownloadManager.kt
+++ b/app/src/main/java/com/asmr/player/data/remote/download/DownloadManager.kt
@@ -17,6 +17,11 @@ import com.asmr.player.data.local.db.AppDatabaseProvider
 import com.asmr.player.util.SubtitleParser
 import com.asmr.player.util.TrackKeyNormalizer
 import com.asmr.player.work.AlbumCoverThumbWorker
+import com.asmr.player.BuildConfig
+import dagger.hilt.EntryPoint
+import dagger.hilt.InstallIn
+import dagger.hilt.android.EntryPointAccessors
+import dagger.hilt.components.SingletonComponent
 import dagger.hilt.android.qualifiers.ApplicationContext
 import okhttp3.OkHttpClient
 import okhttp3.Request
@@ -32,7 +37,8 @@ import javax.inject.Singleton
 @Singleton
 class DownloadManager @Inject constructor(
     @ApplicationContext private val context: Context,
-    private val downloadDao: DownloadDao
+    private val downloadDao: DownloadDao,
+    private val okHttpClient: OkHttpClient
 ) {
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
 
@@ -264,6 +270,12 @@ class DownloadManager @Inject constructor(
 }
 
 class DownloadWorker(context: Context, parameters: WorkerParameters) : CoroutineWorker(context, parameters) {
+    @EntryPoint
+    @InstallIn(SingletonComponent::class)
+    interface DownloadWorkerEntryPoint {
+        fun okHttpClient(): OkHttpClient
+    }
+
     override suspend fun doWork(): ListenableWorker.Result {
         val url = inputData.getString("url") ?: return ListenableWorker.Result.failure()
         val fileName = inputData.getString("fileName") ?: return ListenableWorker.Result.failure()
@@ -324,7 +336,8 @@ class DownloadWorker(context: Context, parameters: WorkerParameters) : Coroutine
                 if (!marker.exists()) marker.createNewFile()
             }
 
-            val client = OkHttpClient()
+            val entryPoint = EntryPointAccessors.fromApplication(applicationContext, DownloadWorkerEntryPoint::class.java)
+            val client = entryPoint.okHttpClient()
             val requestBuilder = Request.Builder()
                 .url(url)
                 .header("User-Agent", NetworkHeaders.USER_AGENT)

--- a/app/src/main/java/com/asmr/player/data/remote/download/DownloadRuntimeConfig.kt
+++ b/app/src/main/java/com/asmr/player/data/remote/download/DownloadRuntimeConfig.kt
@@ -1,0 +1,79 @@
+package com.asmr.player.data.remote.download
+
+import android.app.ActivityManager
+import android.content.Context
+import java.util.concurrent.Executor
+import java.util.concurrent.Executors
+import java.util.concurrent.ThreadFactory
+import java.util.concurrent.atomic.AtomicInteger
+
+const val DOWNLOAD_STATE_QUEUED = "QUEUED"
+
+object DownloadRuntimeConfig {
+    private const val LOW_RAM_DOWNLOAD_PARALLELISM = 1
+    private const val DEFAULT_DOWNLOAD_PARALLELISM = 2
+    private const val LOW_RAM_WORK_MANAGER_PARALLELISM = 1
+    private const val DEFAULT_WORK_MANAGER_PARALLELISM = 2
+    private const val WORK_MANAGER_TASK_PARALLELISM = 2
+    private const val MB = 1024L * 1024L
+    private const val LOW_RAM_MIN_HEAP_HEADROOM_MB = 32L
+    private const val DEFAULT_MIN_HEAP_HEADROOM_MB = 48L
+    private const val LOW_RAM_MIN_SYSTEM_AVAIL_MB = 192L
+    private const val DEFAULT_MIN_SYSTEM_AVAIL_MB = 256L
+
+    fun isLowRamDevice(context: Context): Boolean {
+        val activityManager = context.getSystemService(Context.ACTIVITY_SERVICE) as? ActivityManager
+        val memoryClass = activityManager?.memoryClass ?: Int.MAX_VALUE
+        return activityManager?.isLowRamDevice == true || memoryClass <= 192
+    }
+
+    fun maxConcurrentDownloads(context: Context): Int {
+        return if (isLowRamDevice(context)) LOW_RAM_DOWNLOAD_PARALLELISM else DEFAULT_DOWNLOAD_PARALLELISM
+    }
+
+    fun isMemoryConstrained(context: Context): Boolean {
+        val lowRamDevice = isLowRamDevice(context)
+        val activityManager = context.getSystemService(Context.ACTIVITY_SERVICE) as? ActivityManager
+        val memoryInfo = ActivityManager.MemoryInfo()
+        activityManager?.getMemoryInfo(memoryInfo)
+
+        val runtime = Runtime.getRuntime()
+        val usedHeap = runtime.totalMemory() - runtime.freeMemory()
+        val heapHeadroom = (runtime.maxMemory() - usedHeap).coerceAtLeast(0L)
+        val minHeapHeadroom = if (lowRamDevice) {
+            LOW_RAM_MIN_HEAP_HEADROOM_MB * MB
+        } else {
+            DEFAULT_MIN_HEAP_HEADROOM_MB * MB
+        }
+
+        val minSystemAvail = if (lowRamDevice) {
+            LOW_RAM_MIN_SYSTEM_AVAIL_MB * MB
+        } else {
+            DEFAULT_MIN_SYSTEM_AVAIL_MB * MB
+        }
+
+        return memoryInfo.lowMemory ||
+            heapHeadroom < minHeapHeadroom ||
+            memoryInfo.availMem in 1 until minSystemAvail
+    }
+
+    fun createWorkManagerExecutor(context: Context): Executor {
+        val threadCount = if (isLowRamDevice(context)) {
+            LOW_RAM_WORK_MANAGER_PARALLELISM
+        } else {
+            DEFAULT_WORK_MANAGER_PARALLELISM
+        }
+        return Executors.newFixedThreadPool(threadCount, namedThreadFactory("wm-download-"))
+    }
+
+    fun createWorkManagerTaskExecutor(): Executor {
+        return Executors.newFixedThreadPool(WORK_MANAGER_TASK_PARALLELISM, namedThreadFactory("wm-task-"))
+    }
+
+    private fun namedThreadFactory(prefix: String): ThreadFactory {
+        val threadId = AtomicInteger(0)
+        return ThreadFactory { runnable ->
+            Thread(runnable, "$prefix${threadId.incrementAndGet()}")
+        }
+    }
+}

--- a/app/src/main/java/com/asmr/player/ui/common/EaraBrandedEmptyState.kt
+++ b/app/src/main/java/com/asmr/player/ui/common/EaraBrandedEmptyState.kt
@@ -1,13 +1,9 @@
 package com.asmr.player.ui.common
 
-import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
-import androidx.compose.foundation.border
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -15,17 +11,12 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Brush
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.style.TextAlign
@@ -45,14 +36,6 @@ fun EaraBrandedEmptyState(
     footer: (@Composable () -> Unit)? = null
 ) {
     val colorScheme = AsmrTheme.colorScheme
-    val panelShape = RoundedCornerShape(36.dp)
-    val panelBorder = colorScheme.primary.copy(alpha = if (colorScheme.isDark) 0.26f else 0.14f)
-    val panelGradient = Brush.linearGradient(
-        colors = listOf(
-            colorScheme.surface.copy(alpha = if (colorScheme.isDark) 0.98f else 0.94f),
-            colorScheme.primarySoft.copy(alpha = if (colorScheme.isDark) 0.22f else 0.14f)
-        )
-    )
 
     Box(
         modifier = modifier
@@ -75,64 +58,30 @@ fun EaraBrandedEmptyState(
             ) {
                 Box(
                     modifier = Modifier
-                        .size(196.dp)
-                        .clip(panelShape)
-                        .background(panelGradient, panelShape)
-                        .border(width = 1.dp, color = panelBorder, shape = panelShape)
-                        .padding(24.dp)
+                        .size(96.dp)
+                        .background(
+                            color = colorScheme.primary.copy(alpha = if (colorScheme.isDark) 0.12f else 0.08f),
+                            shape = CircleShape
+                        ),
+                    contentAlignment = Alignment.Center
                 ) {
-                    Box(
-                        modifier = Modifier
-                            .align(Alignment.TopStart)
-                            .size(56.dp)
-                            .clip(CircleShape)
-                            .background(
-                                color = colorScheme.primary.copy(alpha = if (colorScheme.isDark) 0.10f else 0.08f)
-                            )
-                    )
                     Icon(
                         imageVector = sectionIcon,
                         contentDescription = null,
-                        tint = colorScheme.primary.copy(alpha = if (colorScheme.isDark) 0.18f else 0.14f),
-                        modifier = Modifier
-                            .align(Alignment.BottomEnd)
-                            .size(60.dp)
-                    )
-                    EaraLogoLoadingIndicator(
-                        size = 92.dp,
-                        tint = colorScheme.primary,
-                        trackColor = colorScheme.primary.copy(alpha = if (colorScheme.isDark) 0.18f else 0.12f),
-                        glowColor = colorScheme.primarySoft,
-                        modifier = Modifier.align(Alignment.Center)
+                        tint = colorScheme.primary.copy(alpha = if (colorScheme.isDark) 0.7f else 0.6f),
+                        modifier = Modifier.size(48.dp)
                     )
                 }
 
-                Spacer(modifier = Modifier.size(20.dp))
+                Spacer(modifier = Modifier.size(24.dp))
 
-                Surface(
-                    color = colorScheme.primary.copy(alpha = if (colorScheme.isDark) 0.16f else 0.10f),
-                    contentColor = colorScheme.primary,
-                    shape = RoundedCornerShape(999.dp),
-                    border = BorderStroke(1.dp, panelBorder)
-                ) {
-                    Row(
-                        modifier = Modifier.padding(horizontal = 14.dp, vertical = 8.dp),
-                        horizontalArrangement = Arrangement.spacedBy(8.dp),
-                        verticalAlignment = Alignment.CenterVertically
-                    ) {
-                        Icon(
-                            imageVector = sectionIcon,
-                            contentDescription = null,
-                            modifier = Modifier.size(16.dp)
-                        )
-                        Text(
-                            text = sectionTitle,
-                            style = MaterialTheme.typography.labelLarge
-                        )
-                    }
-                }
+                Text(
+                    text = sectionTitle,
+                    style = MaterialTheme.typography.labelLarge,
+                    color = colorScheme.primary.copy(alpha = if (colorScheme.isDark) 0.8f else 0.7f)
+                )
 
-                Spacer(modifier = Modifier.size(18.dp))
+                Spacer(modifier = Modifier.size(12.dp))
 
                 Text(
                     text = headline,
@@ -140,15 +89,18 @@ fun EaraBrandedEmptyState(
                     color = colorScheme.textPrimary,
                     textAlign = TextAlign.Center
                 )
-                Spacer(modifier = Modifier.size(10.dp))
+
+                Spacer(modifier = Modifier.size(8.dp))
+
                 Text(
                     text = description,
                     style = MaterialTheme.typography.bodyMedium,
                     color = colorScheme.textSecondary,
                     textAlign = TextAlign.Center
                 )
+
                 if (footer != null) {
-                    Spacer(modifier = Modifier.size(18.dp))
+                    Spacer(modifier = Modifier.size(24.dp))
                     footer()
                 }
             }

--- a/app/src/main/java/com/asmr/player/ui/downloads/DownloadsViewModel.kt
+++ b/app/src/main/java/com/asmr/player/ui/downloads/DownloadsViewModel.kt
@@ -6,26 +6,26 @@ import androidx.lifecycle.viewModelScope
 import androidx.room.withTransaction
 import androidx.work.WorkInfo
 import androidx.work.OneTimeWorkRequestBuilder
-import androidx.work.Constraints
 import androidx.work.ExistingWorkPolicy
-import androidx.work.NetworkType
 import androidx.work.WorkManager
 import com.asmr.player.data.local.db.AppDatabaseProvider
 import com.asmr.player.data.local.db.dao.DownloadDao
-import com.asmr.player.data.remote.download.DownloadWorker
+import com.asmr.player.data.remote.download.DOWNLOAD_STATE_QUEUED
+import com.asmr.player.data.remote.download.DownloadQueueCoordinator
 import com.asmr.player.data.remote.download.FinalizeDownloadTaskWorker
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import java.io.File
-import javax.inject.Inject
 import java.util.UUID
 import androidx.work.workDataOf
+import javax.inject.Inject
 import com.asmr.player.util.MessageManager
 
 enum class DownloadItemState {
@@ -78,6 +78,7 @@ class DownloadsViewModel @Inject constructor(
                     val items = taskWithItems.items.map { item ->
                         val state = when (item.state) {
                             "PAUSED" -> DownloadItemState.PAUSED
+                            DOWNLOAD_STATE_QUEUED -> DownloadItemState.ENQUEUED
                             else -> when (runCatching { WorkInfo.State.valueOf(item.state) }.getOrDefault(WorkInfo.State.ENQUEUED)) {
                                 WorkInfo.State.RUNNING -> DownloadItemState.RUNNING
                                 WorkInfo.State.SUCCEEDED -> DownloadItemState.SUCCEEDED
@@ -134,61 +135,43 @@ class DownloadsViewModel @Inject constructor(
                     )
                 }
             }
+            .flowOn(Dispatchers.Default)
             .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyList())
 
     fun cancelItem(workId: String) {
-        runCatching { 
-            workManager.cancelWorkById(java.util.UUID.fromString(workId))
+        viewModelScope.launch(Dispatchers.IO) {
+            runCatching { workManager.cancelWorkById(java.util.UUID.fromString(workId)) }
+            runCatching { downloadDao.updateItemState(workId, WorkInfo.State.CANCELLED.name, System.currentTimeMillis()) }
+            DownloadQueueCoordinator.requestSchedule(context)
         }
     }
 
     fun pauseItem(workId: String) {
         viewModelScope.launch(Dispatchers.IO) {
             runCatching { workManager.cancelWorkById(UUID.fromString(workId)) }
-            runCatching { 
+            runCatching {
                 downloadDao.updateItemState(workId, "PAUSED", System.currentTimeMillis())
             }
+            DownloadQueueCoordinator.requestSchedule(context)
         }
     }
 
     fun resumeItem(workId: String) {
         viewModelScope.launch(Dispatchers.IO) {
             val item = downloadDao.getItemByWorkId(workId) ?: return@launch
-            val task = downloadDao.getTaskById(item.taskId) ?: return@launch
-            val targetDir = item.targetDir
-            val fileName = item.fileName
-            val inputData = workDataOf(
-                "url" to item.url,
-                "fileName" to fileName,
-                "targetDir" to targetDir,
-                "taskRootDir" to task.rootDir,
-                "relativePath" to item.relativePath,
-                "taskKey" to task.taskKey,
-                "taskTitle" to task.title,
-                "taskSubtitle" to task.subtitle
-            )
-            val request = OneTimeWorkRequestBuilder<DownloadWorker>()
-                .setInputData(inputData)
-                .addTag("download")
-                .addTag(task.taskKey)
-                .setConstraints(
-                    Constraints.Builder()
-                        .setRequiredNetworkType(NetworkType.CONNECTED)
-                        .build()
-                )
-                .build()
-            val uniqueName = "${targetDir.trimEnd('/', '\\')}\\$fileName"
-            workManager.enqueueUniqueWork(uniqueName.hashCode().toString(), ExistingWorkPolicy.REPLACE, request)
-
-            val existingBytes = runCatching { File(item.filePath.ifBlank { File(targetDir, fileName).absolutePath }).length() }.getOrDefault(0L)
+            val existingBytes = runCatching {
+                File(item.filePath.ifBlank { File(item.targetDir, item.fileName).absolutePath }).length()
+            }.getOrDefault(0L)
             val updatedAt = System.currentTimeMillis()
-            downloadDao.replaceWorkIdForResume(
-                oldWorkId = workId,
-                newWorkId = request.id.toString(),
-                state = WorkInfo.State.ENQUEUED.name,
+            downloadDao.updateItemProgress(
+                workId = workId,
+                state = DOWNLOAD_STATE_QUEUED,
                 downloaded = existingBytes.coerceAtLeast(0L),
+                total = item.total,
+                speed = 0L,
                 updatedAt = updatedAt
             )
+            DownloadQueueCoordinator.requestSchedule(context)
         }
     }
 
@@ -212,14 +195,15 @@ class DownloadsViewModel @Inject constructor(
             val items = downloadDao.getItemsForTask(taskId)
             items.filter { 
                 it.state == WorkInfo.State.RUNNING.name || 
-                it.state == WorkInfo.State.ENQUEUED.name 
+                it.state == WorkInfo.State.ENQUEUED.name ||
+                it.state == DOWNLOAD_STATE_QUEUED
             }.forEach { item ->
                 runCatching { workManager.cancelWorkById(UUID.fromString(item.workId)) }
-                runCatching { 
+                runCatching {
                     downloadDao.updateItemState(item.workId, "PAUSED", System.currentTimeMillis())
                 }
             }
-
+            DownloadQueueCoordinator.requestSchedule(context)
         }
     }
 
@@ -238,14 +222,15 @@ class DownloadsViewModel @Inject constructor(
             val items = downloadDao.getAllActiveOrPausedItems()
             items.filter { 
                 it.state == WorkInfo.State.RUNNING.name || 
-                it.state == WorkInfo.State.ENQUEUED.name 
+                it.state == WorkInfo.State.ENQUEUED.name ||
+                it.state == DOWNLOAD_STATE_QUEUED
             }.forEach { item ->
                 runCatching { workManager.cancelWorkById(UUID.fromString(item.workId)) }
-                runCatching { 
+                runCatching {
                     downloadDao.updateItemState(item.workId, "PAUSED", System.currentTimeMillis())
                 }
             }
-
+            DownloadQueueCoordinator.requestSchedule(context)
         }
     }
 
@@ -261,14 +246,31 @@ class DownloadsViewModel @Inject constructor(
 
     fun cancelTask(taskKey: String) {
         if (taskKey.isBlank()) return
-        runCatching { 
-            workManager.cancelAllWorkByTag(taskKey)
+        viewModelScope.launch(Dispatchers.IO) {
+            val task = downloadDao.getTaskByKey(taskKey)
+            val now = System.currentTimeMillis()
+            task?.let {
+                downloadDao.getItemsForTask(it.id).forEach { item ->
+                    runCatching { workManager.cancelWorkById(UUID.fromString(item.workId)) }
+                    if (item.state != WorkInfo.State.SUCCEEDED.name) {
+                        runCatching { downloadDao.updateItemState(item.workId, WorkInfo.State.CANCELLED.name, now) }
+                    }
+                }
+            }
+            DownloadQueueCoordinator.requestSchedule(context)
         }
     }
 
     fun cancelAll() {
-        runCatching { 
-            workManager.cancelAllWorkByTag("download")
+        viewModelScope.launch(Dispatchers.IO) {
+            val now = System.currentTimeMillis()
+            downloadDao.getAllActiveOrPausedItems().forEach { item ->
+                runCatching { workManager.cancelWorkById(UUID.fromString(item.workId)) }
+                if (item.state != WorkInfo.State.SUCCEEDED.name) {
+                    runCatching { downloadDao.updateItemState(item.workId, WorkInfo.State.CANCELLED.name, now) }
+                }
+            }
+            DownloadQueueCoordinator.requestSchedule(context)
         }
     }
 
@@ -287,6 +289,7 @@ class DownloadsViewModel @Inject constructor(
             syncLibraryAfterDownloadRootDeleted(task.rootDir)
             downloadDao.deleteItemsForTask(taskId)
             downloadDao.deleteTaskById(taskId)
+            DownloadQueueCoordinator.requestSchedule(context)
             messageManager.showInfo("已删除任务：${task.title}")
         }
     }
@@ -328,6 +331,7 @@ class DownloadsViewModel @Inject constructor(
             if (remaining == 0) {
                 downloadDao.deleteTaskById(item.taskId)
             }
+            DownloadQueueCoordinator.requestSchedule(context)
             messageManager.showInfo("已删除文件：${item.fileName}")
         }
     }

--- a/app/src/main/java/com/asmr/player/ui/downloads/DownloadsViewModel.kt
+++ b/app/src/main/java/com/asmr/player/ui/downloads/DownloadsViewModel.kt
@@ -103,24 +103,26 @@ class DownloadsViewModel @Inject constructor(
 
                     val hasRunning = items.any { it.state == DownloadItemState.RUNNING || it.state == DownloadItemState.ENQUEUED }
                     val hasFailed = items.any { it.state == DownloadItemState.FAILED }
+                    val hasPaused = items.any { it.state == DownloadItemState.PAUSED }
+                    val allCancelled = items.isNotEmpty() && items.all { it.state == DownloadItemState.CANCELLED }
                     val allSucceeded = items.isNotEmpty() && items.all { it.state == DownloadItemState.SUCCEEDED }
                     val state = when {
                         hasRunning -> DownloadItemState.RUNNING
                         hasFailed -> DownloadItemState.FAILED
                         allSucceeded -> DownloadItemState.SUCCEEDED
+                        hasPaused -> DownloadItemState.PAUSED
+                        allCancelled -> DownloadItemState.CANCELLED
                         else -> DownloadItemState.ENQUEUED
                     }
 
-                    val knownTotal = items.filter { it.total > 0 }.sumOf { it.total }
-                    val knownDownloaded = items.filter { it.total > 0 }.sumOf { it.downloaded.coerceAtMost(it.total) }
-                    val progressFraction = when {
-                        allSucceeded -> 1f
-                        knownTotal > 0 -> (knownDownloaded.toDouble() / knownTotal.toDouble()).toFloat().coerceIn(0f, 1f)
-                        else -> null
-                    }
                     val hasUnknownTotalRunning = items.any {
                         (it.state == DownloadItemState.RUNNING || it.state == DownloadItemState.ENQUEUED) && it.total <= 0
                     }
+                    val progressFraction = resolveTaskProgress(
+                        items = items,
+                        allSucceeded = allSucceeded,
+                        hasUnknownTotalRunning = hasUnknownTotalRunning
+                    )
 
                     DownloadTaskUi(
                         taskId = task.id,
@@ -137,6 +139,50 @@ class DownloadsViewModel @Inject constructor(
             }
             .flowOn(Dispatchers.Default)
             .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyList())
+
+    private fun resolveTaskProgress(
+        items: List<DownloadItemUi>,
+        allSucceeded: Boolean,
+        hasUnknownTotalRunning: Boolean
+    ): Float? {
+        if (allSucceeded) return 1f
+        if (items.isEmpty()) return null
+
+        val hasResolvableTotalsForAllItems = items.all { item ->
+            item.total > 0L || item.state == DownloadItemState.SUCCEEDED
+        }
+        if (hasResolvableTotalsForAllItems) {
+            val resolvedTotal = items.sumOf { item ->
+                when {
+                    item.total > 0L -> item.total
+                    item.state == DownloadItemState.SUCCEEDED -> item.downloaded.coerceAtLeast(0L)
+                    else -> 0L
+                }
+            }
+            if (resolvedTotal > 0L) {
+                val resolvedDownloaded = items.sumOf { item ->
+                    when {
+                        item.total > 0L -> item.downloaded.coerceIn(0L, item.total)
+                        item.state == DownloadItemState.SUCCEEDED -> item.downloaded.coerceAtLeast(0L)
+                        else -> 0L
+                    }
+                }
+                return (resolvedDownloaded.toDouble() / resolvedTotal.toDouble()).toFloat().coerceIn(0f, 1f)
+            }
+        }
+
+        val totalItems = items.size.toDouble()
+        val aggregateProgress = items.sumOf { item ->
+            when {
+                item.state == DownloadItemState.SUCCEEDED -> 1.0
+                item.total > 0L -> item.downloaded.coerceIn(0L, item.total).toDouble() / item.total.toDouble()
+                else -> 0.0
+            }
+        } / totalItems
+
+        if (aggregateProgress <= 0.0 && hasUnknownTotalRunning) return null
+        return aggregateProgress.toFloat().coerceIn(0f, 1f)
+    }
 
     fun cancelItem(workId: String) {
         viewModelScope.launch(Dispatchers.IO) {

--- a/app/src/main/java/com/asmr/player/ui/library/AlbumDetailViewModel.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/AlbumDetailViewModel.kt
@@ -2119,10 +2119,10 @@ class AlbumDetailViewModel @Inject constructor(
                 if (w <= 0 || h <= 0) return fail("decode_bounds_invalid")
                 val maxDim = maxOf(w, h)
                 var sample = 1
-                while (maxDim / sample > 2048) sample *= 2
+                while (maxDim / sample > 1280) sample *= 2 // 减小最大尺寸从 2048 到 1280
                 val opts = BitmapFactory.Options().apply {
                     inSampleSize = sample
-                    inPreferredConfig = Bitmap.Config.ARGB_8888
+                    inPreferredConfig = Bitmap.Config.RGB_565 // 使用 RGB_565 减少一半内存占用
                 }
                 BitmapFactory.decodeFile(tmpFile.absolutePath, opts) ?: return fail("decode_failed_sample_$sample")
             } finally {
@@ -2142,10 +2142,10 @@ class AlbumDetailViewModel @Inject constructor(
                 if (w <= 0 || h <= 0) return fail("file_decode_bounds_invalid")
                 val maxDim = maxOf(w, h)
                 var sample = 1
-                while (maxDim / sample > 2048) sample *= 2
+                while (maxDim / sample > 1280) sample *= 2
                 val opts = BitmapFactory.Options().apply {
                     inSampleSize = sample
-                    inPreferredConfig = Bitmap.Config.ARGB_8888
+                    inPreferredConfig = Bitmap.Config.RGB_565
                 }
                 BitmapFactory.decodeFile(f.absolutePath, opts) ?: return fail("file_decode_failed_sample_$sample")
             } else {
@@ -2160,10 +2160,10 @@ class AlbumDetailViewModel @Inject constructor(
                 if (w <= 0 || h <= 0) return fail("content_decode_bounds_invalid")
                 val maxDim = maxOf(w, h)
                 var sample = 1
-                while (maxDim / sample > 2048) sample *= 2
+                while (maxDim / sample > 1280) sample *= 2
                 val opts = BitmapFactory.Options().apply {
                     inSampleSize = sample
-                    inPreferredConfig = Bitmap.Config.ARGB_8888
+                    inPreferredConfig = Bitmap.Config.RGB_565
                 }
                 context.contentResolver.openInputStream(uri)?.use { input ->
                     BitmapFactory.decodeStream(input, null, opts)


### PR DESCRIPTION
## Summary
- reduce memory pressure during DLsite parsing and download preparation to lower OOM risk
- stabilize the download queue with runtime config, persistence, and DAO/schema updates
- improve download recovery and resume prioritization in the downloads flow
- simplify the branded empty state layout as a small UI polish

## Included Commits
- be38f22 perf: optimize memory usage to prevent OOM during download and large JSON parsing
- 66244e0 Optimize download queue stability
- 49912c0 Fix download recovery and resume prioritization
- eff160c refactor: simplify empty state layout

## Testing
- run locally