### PR TITLE
fix: remove queued download progress bars

### DIFF
--- a/app/src/main/java/com/asmr/player/ui/downloads/DownloadsScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/downloads/DownloadsScreen.kt
@@ -366,6 +366,10 @@ private fun DownloadTaskCard(
                 }
             }
 
+            val hasUnknownTotalRunningItem = task.items.any {
+                it.state == DownloadItemState.RUNNING && it.total <= 0
+            }
+
             when {
                 task.progressFraction != null -> {
                     Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
@@ -408,7 +412,7 @@ private fun DownloadTaskCard(
                         }
                     }
                 }
-                task.hasUnknownTotalRunning -> {
+                hasUnknownTotalRunningItem -> {
                     Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
                         Text(
                             text = "下载中...",
@@ -780,7 +784,7 @@ private fun DownloadFileRow(
                         .background(colors.primary.copy(alpha = 0.3f))
                 )
             }
-            item.total <= 0 && (item.state == DownloadItemState.RUNNING || item.state == DownloadItemState.ENQUEUED) -> {
+            item.total <= 0 && item.state == DownloadItemState.RUNNING -> {
                 Spacer(modifier = Modifier.height(8.dp))
                 LinearProgressIndicator(
                     modifier = Modifier


### PR DESCRIPTION
## Summary
- stop showing per-file progress bars for queued download items
- only show the task-level indeterminate progress bar when there is an actually running item with unknown total size
- reduce visual noise in the downloads page when many items are waiting

## Verification
- ./gradlew assembleDebug
- installed debug build on connected adb device for manual testing