### PR TITLE
Fix playlist picker add cancellation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ keystore.properties
 .gradle-home
 **/build/
 .build_asmr_player_android/
+.debug_device_db/
 captures/
 
 app/.cxx/

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .idea/
 .vscode/
+.claude/
 .trae/
 *.iml
 .worktrees/

--- a/app/src/main/java/com/asmr/player/data/repository/AlbumGroupRepository.kt
+++ b/app/src/main/java/com/asmr/player/data/repository/AlbumGroupRepository.kt
@@ -9,6 +9,8 @@ import com.asmr.player.data.local.db.entities.AlbumGroupEntity
 import com.asmr.player.data.local.db.entities.AlbumGroupItemEntity
 import com.asmr.player.util.ManualItemOrder
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -18,6 +20,8 @@ class AlbumGroupRepository @Inject constructor(
     private val groupItemDao: AlbumGroupItemDao,
     private val trackDao: TrackDao
 ) {
+    private val addAlbumMutex = Mutex()
+
     fun observeGroupsWithStats(): Flow<List<AlbumGroupStatsRow>> = groupDao.observeGroupsWithStats()
 
     fun observeGroupTracks(groupId: Long): Flow<List<AlbumGroupTrackRow>> = groupItemDao.observeGroupTracks(groupId)
@@ -49,7 +53,7 @@ class AlbumGroupRepository @Inject constructor(
         return RenameAlbumGroupResult.RENAMED
     }
 
-    suspend fun addAlbumToGroup(groupId: Long, albumId: Long) {
+    suspend fun addAlbumToGroup(groupId: Long, albumId: Long) = addAlbumMutex.withLock {
         if (groupId <= 0L || albumId <= 0L) return
         val tracks = trackDao.getTracksForAlbumOnce(albumId).filter { it.path.isNotBlank() }
         if (tracks.isEmpty()) return

--- a/app/src/main/java/com/asmr/player/data/repository/PlaylistRepository.kt
+++ b/app/src/main/java/com/asmr/player/data/repository/PlaylistRepository.kt
@@ -15,6 +15,8 @@ import com.asmr.player.util.ManualItemOrder
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -32,6 +34,8 @@ class PlaylistRepository @Inject constructor(
     private val trackDao: TrackDao,
     private val albumDao: AlbumDao
 ) {
+    private val addItemsMutex = Mutex()
+
     companion object {
         const val CATEGORY_SYSTEM = "system"
         const val CATEGORY_USER = "user"
@@ -103,9 +107,9 @@ class PlaylistRepository @Inject constructor(
         return addItemsToPlaylist(playlistId, listOf(item)).addedCount > 0
     }
 
-    suspend fun addItemsToPlaylist(playlistId: Long, items: List<MediaItem>): PlaylistAddSummary {
+    suspend fun addItemsToPlaylist(playlistId: Long, items: List<MediaItem>): PlaylistAddSummary = addItemsMutex.withLock {
         if (playlistId <= 0L || items.isEmpty()) {
-            return PlaylistAddSummary(addedCount = 0, skippedCount = items.size)
+            return@withLock PlaylistAddSummary(addedCount = 0, skippedCount = items.size)
         }
         val currentItems = playlistItemDao.getItemsOnce(playlistId)
         val existingIds = currentItems.map { it.mediaId }.toHashSet()
@@ -134,7 +138,7 @@ class PlaylistRepository @Inject constructor(
         if (toInsert.isNotEmpty()) {
             playlistItemDao.upsertItems(toInsert)
         }
-        return PlaylistAddSummary(
+        return@withLock PlaylistAddSummary(
             addedCount = toInsert.size,
             skippedCount = skipped
         )

--- a/app/src/main/java/com/asmr/player/main/MainContainer.kt
+++ b/app/src/main/java/com/asmr/player/main/MainContainer.kt
@@ -1258,9 +1258,7 @@ fun MainContainer(
                             playerViewModel.addMediaItemsToQueue(items)
                         },
                         onAddMediaItemsToFavorites = { items ->
-                            scope.launch {
-                                playlistsViewModel.addItemsToFavorites(items)
-                            }
+                            playlistsViewModel.addItemsToFavoritesInBackground(items)
                         },
                         onOpenPlaylistPicker = { mediaId, uri, title, artist, artworkUri, albumId, trackId, rjCode ->
                             navController.navigateSingleTop(
@@ -1323,9 +1321,7 @@ fun MainContainer(
                             playerViewModel.addMediaItemsToQueue(items)
                         },
                         onAddMediaItemsToFavorites = { items ->
-                            scope.launch {
-                                playlistsViewModel.addItemsToFavorites(items)
-                            }
+                            playlistsViewModel.addItemsToFavoritesInBackground(items)
                         },
                         onOpenPlaylistPicker = { mediaId, uri, title, artist, artworkUri, albumId, trackId, rjCode ->
                             navController.navigateSingleTop(
@@ -1457,7 +1453,8 @@ fun MainContainer(
                     com.asmr.player.ui.groups.AlbumGroupPickerScreen(
                         windowSizeClass = windowSizeClass,
                         albumId = albumId,
-                        onBack = { navController.popBackStack() }
+                        onBack = { navController.popBackStack() },
+                        viewModel = albumGroupsViewModel
                     )
                 }
                 composable(
@@ -1526,7 +1523,8 @@ fun MainContainer(
                         albumId = albumId,
                         trackId = trackId,
                         rjCode = rjCode,
-                        onBack = { navController.popBackStack() }
+                        onBack = { navController.popBackStack() },
+                        viewModel = playlistsViewModel
                     )
                 }
                 composable("settings") {
@@ -1839,7 +1837,8 @@ fun MainContainer(
                                     trackId = request.trackId,
                                     rjCode = request.rjCode,
                                     onBack = { nowPlayingPlaylistPickerRequest = null },
-                                    embeddedInDialog = true
+                                    embeddedInDialog = true,
+                                    viewModel = playlistsViewModel
                                 )
                             }
                         }
@@ -1865,7 +1864,8 @@ fun MainContainer(
                                     windowSizeClass = windowSizeClass,
                                     items = request.items,
                                     onBack = { albumBatchPlaylistPickerRequest = null },
-                                    embeddedInDialog = true
+                                    embeddedInDialog = true,
+                                    viewModel = playlistsViewModel
                                 )
                             }
                         }
@@ -1893,7 +1893,8 @@ fun MainContainer(
                                     windowSizeClass = windowSizeClass,
                                     items = request.items,
                                     onBack = { albumBatchPlaylistPickerRequest = null },
-                                    embeddedInDialog = true
+                                    embeddedInDialog = true,
+                                    viewModel = playlistsViewModel
                                 )
                             }
                         }

--- a/app/src/main/java/com/asmr/player/ui/groups/AlbumGroupPickerScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/groups/AlbumGroupPickerScreen.kt
@@ -1,5 +1,6 @@
 package com.asmr.player.ui.groups
 
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -25,6 +26,7 @@ import androidx.compose.material3.TextButton
 import androidx.compose.material3.windowsizeclass.WindowSizeClass
 import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -52,8 +54,17 @@ fun AlbumGroupPickerScreen(
     val groups by viewModel.groups.collectAsState()
     val colorScheme = AsmrTheme.colorScheme
     val listState = rememberLazyListState()
+    val screenActive = remember { mutableStateOf(true) }
     var createName by rememberSaveable { mutableStateOf("") }
+    var addingGroupId by rememberSaveable { mutableStateOf<Long?>(null) }
     val canCreate = remember(createName) { createName.trim().isNotBlank() }
+    val isAdding = addingGroupId != null
+
+    BackHandler(enabled = isAdding) {}
+
+    DisposableEffect(Unit) {
+        onDispose { screenActive.value = false }
+    }
 
     val isCompact = windowSizeClass.widthSizeClass == WindowWidthSizeClass.Compact
     Box(
@@ -89,6 +100,7 @@ fun AlbumGroupPickerScreen(
                         value = createName,
                         onValueChange = { createName = it },
                         modifier = Modifier.weight(1f),
+                        enabled = !isAdding,
                         singleLine = true,
                         placeholder = { Text("新建分组名称") }
                     )
@@ -100,7 +112,7 @@ fun AlbumGroupPickerScreen(
                             viewModel.createGroup(trimmed)
                             createName = ""
                         },
-                        enabled = canCreate,
+                        enabled = canCreate && !isAdding,
                         colors = ButtonDefaults.textButtonColors(contentColor = colorScheme.primary)
                     ) {
                         Text("创建")
@@ -129,9 +141,23 @@ fun AlbumGroupPickerScreen(
                                 .fillMaxWidth()
                                 .clip(RoundedCornerShape(16.dp))
                                 .background(colorScheme.surface.copy(alpha = 0.5f))
-                                .clickable {
-                                    viewModel.addAlbumToGroup(group.id, albumId)
-                                    onBack()
+                                .clickable(enabled = !isAdding) {
+                                    addingGroupId = group.id
+                                    viewModel.addAlbumToGroupInBackground(
+                                        groupId = group.id,
+                                        albumId = albumId,
+                                        onComplete = {
+                                            if (screenActive.value) {
+                                                addingGroupId = null
+                                                onBack()
+                                            }
+                                        },
+                                        onFailure = {
+                                            if (screenActive.value) {
+                                                addingGroupId = null
+                                            }
+                                        }
+                                    )
                                 }
                                 .padding(horizontal = 16.dp, vertical = 12.dp)
                         ) {

--- a/app/src/main/java/com/asmr/player/ui/groups/AlbumGroupsViewModel.kt
+++ b/app/src/main/java/com/asmr/player/ui/groups/AlbumGroupsViewModel.kt
@@ -8,6 +8,7 @@ import com.asmr.player.data.repository.AlbumGroupRepository
 import com.asmr.player.data.repository.RenameAlbumGroupResult
 import com.asmr.player.util.MessageManager
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.stateIn
@@ -54,13 +55,29 @@ class AlbumGroupsViewModel @Inject constructor(
         }
     }
 
-    fun addAlbumToGroup(groupId: Long, albumId: Long) {
-        if (groupId <= 0L || albumId <= 0L) return
+    fun addAlbumToGroupInBackground(
+        groupId: Long,
+        albumId: Long,
+        onComplete: () -> Unit = {},
+        onFailure: (Throwable) -> Unit = {}
+    ) {
         viewModelScope.launch {
-            groupRepository.addAlbumToGroup(groupId, albumId)
-            val group = groupRepository.getGroupById(groupId)
-            val name = group?.name.orEmpty()
-            messageManager.showSuccess("已添加到分组：$name")
+            try {
+                addAlbumToGroup(groupId, albumId)
+                onComplete()
+            } catch (t: Throwable) {
+                if (t is CancellationException) throw t
+                messageManager.showError("添加到分组失败，请重试")
+                onFailure(t)
+            }
         }
+    }
+
+    suspend fun addAlbumToGroup(groupId: Long, albumId: Long) {
+        if (groupId <= 0L || albumId <= 0L) return
+        groupRepository.addAlbumToGroup(groupId, albumId)
+        val group = groupRepository.getGroupById(groupId)
+        val name = group?.name.orEmpty()
+        messageManager.showSuccess("已添加到分组：$name")
     }
 }

--- a/app/src/main/java/com/asmr/player/ui/playlists/PlaylistPickerDialog.kt
+++ b/app/src/main/java/com/asmr/player/ui/playlists/PlaylistPickerDialog.kt
@@ -1,6 +1,7 @@
 package com.asmr.player.ui.playlists
 
 import android.net.Uri
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -27,11 +28,11 @@ import androidx.compose.material3.TextButton
 import androidx.compose.material3.windowsizeclass.WindowSizeClass
 import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
@@ -47,7 +48,6 @@ import com.asmr.player.playback.MediaItemFactory
 import com.asmr.player.ui.common.thinScrollbar
 import com.asmr.player.ui.theme.AsmrTheme
 import java.io.File
-import kotlinx.coroutines.launch
 
 @Composable
 fun PlaylistPickerScreen(
@@ -68,10 +68,12 @@ fun PlaylistPickerScreen(
     val playlists by viewModel.playlists.collectAsState()
     val userPlaylists = remember(playlists) { playlists.filter { it.category == "user" } }
     val colorScheme = AsmrTheme.colorScheme
-    val scope = rememberCoroutineScope()
     val listState = rememberLazyListState()
+    val screenActive = remember { mutableStateOf(true) }
     var createName by rememberSaveable { mutableStateOf("") }
+    var addingPlaylistId by rememberSaveable { mutableStateOf<Long?>(null) }
     val canCreate = remember(createName) { createName.trim().isNotBlank() }
+    val isAdding = addingPlaylistId != null
 
     val pickerItems = remember(mediaId, uri, title, artist, artworkUri, albumId, trackId, rjCode, items) {
         items ?: listOf(
@@ -86,6 +88,12 @@ fun PlaylistPickerScreen(
                 rjCode = rjCode
             )
         )
+    }
+
+    BackHandler(enabled = isAdding) {}
+
+    DisposableEffect(Unit) {
+        onDispose { screenActive.value = false }
     }
 
     val isCompact = windowSizeClass.widthSizeClass == WindowWidthSizeClass.Compact
@@ -130,7 +138,8 @@ fun PlaylistPickerScreen(
                         horizontalArrangement = Arrangement.End
                     ) {
                         TextButton(
-                            onClick = onBack,
+                            onClick = { if (!isAdding) onBack() },
+                            enabled = !isAdding,
                             colors = ButtonDefaults.textButtonColors(contentColor = colorScheme.primary)
                         ) {
                             Text("关闭")
@@ -143,6 +152,7 @@ fun PlaylistPickerScreen(
                         value = createName,
                         onValueChange = { createName = it },
                         modifier = Modifier.weight(1f),
+                        enabled = !isAdding,
                         singleLine = true,
                         placeholder = { Text("新建列表名称") }
                     )
@@ -154,7 +164,7 @@ fun PlaylistPickerScreen(
                             viewModel.createPlaylist(trimmed)
                             createName = ""
                         },
-                        enabled = canCreate,
+                        enabled = canCreate && !isAdding,
                         colors = ButtonDefaults.textButtonColors(contentColor = colorScheme.primary)
                     ) {
                         Text("创建")
@@ -183,11 +193,23 @@ fun PlaylistPickerScreen(
                                 .fillMaxWidth()
                                 .clip(RoundedCornerShape(16.dp))
                                 .background(colorScheme.surface.copy(alpha = 0.5f))
-                                .clickable {
-                                    scope.launch {
-                                        viewModel.addItemsToPlaylist(playlist.id, pickerItems)
-                                    }
-                                    onBack()
+                                .clickable(enabled = !isAdding) {
+                                    addingPlaylistId = playlist.id
+                                    viewModel.addItemsToPlaylistInBackground(
+                                        playlistId = playlist.id,
+                                        items = pickerItems,
+                                        onComplete = {
+                                            if (screenActive.value) {
+                                                addingPlaylistId = null
+                                                onBack()
+                                            }
+                                        },
+                                        onFailure = {
+                                            if (screenActive.value) {
+                                                addingPlaylistId = null
+                                            }
+                                        }
+                                    )
                                 }
                                 .padding(horizontal = 16.dp, vertical = 12.dp)
                         ) {

--- a/app/src/main/java/com/asmr/player/ui/playlists/PlaylistsViewModel.kt
+++ b/app/src/main/java/com/asmr/player/ui/playlists/PlaylistsViewModel.kt
@@ -10,6 +10,7 @@ import com.asmr.player.data.repository.PlaylistRepository
 import com.asmr.player.data.repository.RenamePlaylistResult
 import com.asmr.player.util.MessageManager
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.stateIn
@@ -64,6 +65,35 @@ class PlaylistsViewModel @Inject constructor(
 
     suspend fun addItemToPlaylist(playlistId: Long, item: MediaItem): Boolean {
         return addItemsToPlaylist(playlistId, listOf(item)).addedCount > 0
+    }
+
+    fun addItemsToFavoritesInBackground(items: List<MediaItem>) {
+        viewModelScope.launch {
+            try {
+                addItemsToFavorites(items)
+            } catch (t: Throwable) {
+                if (t is CancellationException) throw t
+                messageManager.showError("添加到收藏失败，请重试")
+            }
+        }
+    }
+
+    fun addItemsToPlaylistInBackground(
+        playlistId: Long,
+        items: List<MediaItem>,
+        onComplete: () -> Unit = {},
+        onFailure: (Throwable) -> Unit = {}
+    ) {
+        viewModelScope.launch {
+            try {
+                addItemsToPlaylist(playlistId, items)
+                onComplete()
+            } catch (t: Throwable) {
+                if (t is CancellationException) throw t
+                messageManager.showError("添加到列表失败，请重试")
+                onFailure(t)
+            }
+        }
     }
 
     suspend fun addItemsToFavorites(items: List<MediaItem>): PlaylistAddSummary {


### PR DESCRIPTION
## Summary
- keep playlist/group pickers open until add operations finish, preventing Compose-scope cancellation before DB writes complete
- run playlist, favorites, and group add operations through ViewModel background jobs
- serialize playlist/group add writes in repositories to make rapid repeated adds stable

## Verification
- .\gradlew.bat :app:assembleDebug
- installed debug APK on physical device and retested playlist add flow