### PR TITLE
Fix reorder drag item surface

### DIFF
--- a/app/src/main/java/com/asmr/player/ui/common/reorderable/ReorderableItem.kt
+++ b/app/src/main/java/com/asmr/player/ui/common/reorderable/ReorderableItem.kt
@@ -15,6 +15,7 @@ fun LazyItemScope.ReorderableItem(
     reorderableState: ReorderableState<*>,
     key: Any?,
     modifier: Modifier = Modifier,
+    draggingDecorationModifier: Modifier = Modifier,
     index: Int? = null,
     orientationLocked: Boolean = true,
     content: @Composable BoxScope.(isDragging: Boolean) -> Unit
@@ -22,6 +23,7 @@ fun LazyItemScope.ReorderableItem(
     state = reorderableState,
     key = key,
     modifier = modifier,
+    draggingDecorationModifier = draggingDecorationModifier,
     defaultDraggingModifier = Modifier.animateItemPlacement(),
     orientationLocked = orientationLocked,
     index = index,
@@ -33,6 +35,7 @@ fun ReorderableItem(
     state: ReorderableState<*>,
     key: Any?,
     modifier: Modifier = Modifier,
+    draggingDecorationModifier: Modifier = Modifier,
     defaultDraggingModifier: Modifier = Modifier,
     orientationLocked: Boolean = true,
     index: Int? = null,
@@ -43,6 +46,12 @@ fun ReorderableItem(
     } else {
         key == state.draggingItemKey
     }
+    val isDragCancelling = !isDragging && if (index != null) {
+        index == state.dragCancelledAnimation.position?.index
+    } else {
+        key == state.dragCancelledAnimation.position?.key
+    }
+    val active = isDragging || isDragCancelling
     val draggingModifier = if (isDragging) {
         Modifier
             .zIndex(1f)
@@ -51,12 +60,7 @@ fun ReorderableItem(
                 translationY = if (!orientationLocked || state.isVerticalScroll) state.draggingItemTop else 0f
             }
     } else {
-        val cancel = if (index != null) {
-            index == state.dragCancelledAnimation.position?.index
-        } else {
-            key == state.dragCancelledAnimation.position?.key
-        }
-        if (cancel) {
+        if (isDragCancelling) {
             Modifier
                 .zIndex(1f)
                 .graphicsLayer {
@@ -67,7 +71,11 @@ fun ReorderableItem(
             defaultDraggingModifier
         }
     }
-    Box(modifier = modifier.then(draggingModifier)) {
-        content(isDragging)
+    Box(
+        modifier = modifier
+            .then(draggingModifier)
+            .then(if (active) draggingDecorationModifier else Modifier)
+    ) {
+        content(active)
     }
 }

--- a/app/src/main/java/com/asmr/player/ui/groups/AlbumGroupDetailScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/groups/AlbumGroupDetailScreen.kt
@@ -1,10 +1,10 @@
 package com.asmr.player.ui.groups
 
 import android.net.Uri
-import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
@@ -149,6 +149,9 @@ internal fun AlbumGroupDetailContent(
 ) {
     val colorScheme = AsmrTheme.colorScheme
     val isCompact = windowSizeClass.widthSizeClass == WindowWidthSizeClass.Compact
+    val draggedTrackShape = RoundedCornerShape(18.dp)
+    val draggedTrackContainerColor = dynamicPageContainerColor(colorScheme)
+    val draggedTrackElevation = if (colorScheme.isDark) 10.dp else 14.dp
     val listState = rememberLazyListState()
     val expandedAlbumIds = rememberSaveable { mutableStateOf(setOf<Long>()) }
     val localRows = remember { mutableStateListOf<GroupDetailListRow>() }
@@ -258,7 +261,12 @@ internal fun AlbumGroupDetailContent(
                             is GroupDetailTrackRow -> {
                                 ReorderableItem(
                                     reorderableState = reorderState,
-                                    key = row.track.mediaId
+                                    key = row.track.mediaId,
+                                    modifier = Modifier.fillMaxWidth(),
+                                    draggingDecorationModifier = Modifier
+                                        .shadow(draggedTrackElevation, draggedTrackShape, clip = false)
+                                        .clip(draggedTrackShape)
+                                        .background(draggedTrackContainerColor)
                                 ) { isDragging ->
                                     val albumTracks = localRows.tracksForAlbum(row.albumId)
                                     val startIndex = albumTracks.indexOfFirst { it.mediaId == row.track.mediaId }
@@ -271,13 +279,7 @@ internal fun AlbumGroupDetailContent(
                                         modifier = Modifier
                                             .fillMaxWidth()
                                             .testTag("$GROUP_DETAIL_TRACK_TAG_PREFIX:${row.track.mediaId}")
-                                            .detectReorderAfterLongPress(reorderState)
-                                            .clickable {
-                                                onPlayMediaItems(
-                                                    albumTracks.map { it.toMediaItem() },
-                                                    startIndex
-                                                )
-                                            },
+                                            .detectReorderAfterLongPress(reorderState),
                                         onPlay = {
                                             onPlayMediaItems(
                                                 albumTracks.map { it.toMediaItem() },
@@ -410,18 +412,15 @@ private fun GroupTrackRow(
     val colorScheme = AsmrTheme.colorScheme
     val materialColorScheme = MaterialTheme.colorScheme
     val dynamicContainerColor = dynamicPageContainerColor(colorScheme)
+    val rowInteractionSource = remember { MutableInteractionSource() }
     var expanded by remember { mutableStateOf(false) }
     val durationMs = remember(item.trackDuration) { (item.trackDuration * 1000.0).roundToLong().coerceAtLeast(0L) }
     val subtitle = remember(durationMs) { Formatting.formatTrackTime(durationMs) }
-    val elevation by animateDpAsState(
-        targetValue = if (isDragging) 18.dp else 0.dp,
-        label = "groupTrackElevation"
-    )
 
     Box(
-        modifier = modifier.shadow(elevation, RoundedCornerShape(18.dp))
+        modifier = modifier
     ) {
-        if (showTopDivider) {
+        if (showTopDivider && !isDragging) {
             HorizontalDivider(
                 modifier = Modifier
                     .fillMaxWidth()
@@ -432,7 +431,15 @@ private fun GroupTrackRow(
             )
         }
         Row(
-            modifier = Modifier.padding(horizontal = 16.dp, vertical = 10.dp),
+            modifier = Modifier
+                .fillMaxWidth()
+                .clickable(
+                    enabled = !isDragging,
+                    interactionSource = rowInteractionSource,
+                    indication = null,
+                    onClick = onPlay
+                )
+                .padding(horizontal = 16.dp, vertical = 10.dp),
             verticalAlignment = Alignment.CenterVertically
         ) {
             AsmrAsyncImage(

--- a/app/src/main/java/com/asmr/player/ui/playlists/PlaylistDetailScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/playlists/PlaylistDetailScreen.kt
@@ -1,9 +1,9 @@
 package com.asmr.player.ui.playlists
 
-import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
@@ -145,6 +145,9 @@ internal fun PlaylistDetailContent(
     val playItems = localItems.map { item -> item.toPlaybackEntity() }
     val isCompact = windowSizeClass.widthSizeClass == WindowWidthSizeClass.Compact
     val colorScheme = AsmrTheme.colorScheme
+    val draggedItemShape = RoundedCornerShape(18.dp)
+    val draggedItemContainerColor = dynamicPageContainerColor(colorScheme)
+    val draggedItemElevation = if (colorScheme.isDark) 10.dp else 14.dp
     val isFavorites = title == PlaylistRepository.PLAYLIST_FAVORITES
     val emptyHeadline = if (isFavorites) {
         "收藏的内容会在这里出现"
@@ -200,7 +203,12 @@ internal fun PlaylistDetailContent(
                     itemsIndexed(localItems, key = { _, item -> item.mediaId }) { index, item ->
                         ReorderableItem(
                             reorderableState = reorderState,
-                            key = item.mediaId
+                            key = item.mediaId,
+                            modifier = Modifier.fillMaxWidth(),
+                            draggingDecorationModifier = Modifier
+                                .shadow(draggedItemElevation, draggedItemShape, clip = false)
+                                .clip(draggedItemShape)
+                                .background(draggedItemContainerColor)
                         ) { isDragging ->
                             PlaylistItemRow(
                                 item = item,
@@ -210,8 +218,7 @@ internal fun PlaylistDetailContent(
                                 modifier = Modifier
                                     .fillMaxWidth()
                                     .testTag("$PLAYLIST_DETAIL_ITEM_TAG_PREFIX:${item.mediaId}")
-                                    .detectReorderAfterLongPress(reorderState)
-                                    .clickable { onPlayAll(playItems, item.toPlaybackEntity()) },
+                                    .detectReorderAfterLongPress(reorderState),
                                 onPlay = { onPlayAll(playItems, item.toPlaybackEntity()) },
                                 onMoveToTop = { onMoveItemToTop(item.mediaId) },
                                 onMoveToBottom = { onMoveItemToBottom(item.mediaId) },
@@ -269,16 +276,13 @@ private fun PlaylistItemRow(
     val colorScheme = AsmrTheme.colorScheme
     val materialColorScheme = MaterialTheme.colorScheme
     val dynamicContainerColor = dynamicPageContainerColor(colorScheme)
+    val rowInteractionSource = remember { MutableInteractionSource() }
     var expanded by remember { mutableStateOf(false) }
-    val elevation by animateDpAsState(
-        targetValue = if (isDragging) 18.dp else 0.dp,
-        label = "playlistItemElevation"
-    )
 
     Box(
-        modifier = modifier.shadow(elevation, RoundedCornerShape(18.dp))
+        modifier = modifier
     ) {
-        if (showTopDivider) {
+        if (showTopDivider && !isDragging) {
             HorizontalDivider(
                 modifier = Modifier
                     .fillMaxWidth()
@@ -289,7 +293,15 @@ private fun PlaylistItemRow(
             )
         }
         Row(
-            modifier = Modifier.padding(horizontal = 16.dp, vertical = 10.dp),
+            modifier = Modifier
+                .fillMaxWidth()
+                .clickable(
+                    enabled = !isDragging,
+                    interactionSource = rowInteractionSource,
+                    indication = null,
+                    onClick = onPlay
+                )
+                .padding(horizontal = 16.dp, vertical = 10.dp),
             verticalAlignment = Alignment.CenterVertically
         ) {
             AsmrAsyncImage(


### PR DESCRIPTION
## Summary
- move drag-active decoration to the shared ReorderableItem wrapper so the whole lifted lazy item keeps a stable rounded surface
- keep drag/cancel visual state active through the return animation to avoid transient transparent blocks
- remove row-level press/ripple and internal shadow styling from playlist and group reorder rows while preserving click and reorder behavior

## Verification
- ./gradlew.bat :app:compileDebugKotlin