### PR TITLE
fix: redesign image preview dialog

### DIFF
--- a/app/src/main/java/com/asmr/player/ui/common/ImagePreviewDialog.kt
+++ b/app/src/main/java/com/asmr/player/ui/common/ImagePreviewDialog.kt
@@ -1,0 +1,475 @@
+package com.asmr.player.ui.common
+
+import android.content.Intent
+import android.net.Uri
+import android.webkit.MimeTypeMap
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.gestures.detectTransformGestures
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.pager.HorizontalPager
+import androidx.compose.foundation.pager.rememberPagerState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.OpenInNew
+import androidx.compose.material.icons.filled.ChevronLeft
+import androidx.compose.material.icons.filled.ChevronRight
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.ImageNotSupported
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableStateMapOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.draw.clipToBounds
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
+import androidx.core.content.FileProvider
+import com.asmr.player.ui.theme.AsmrTheme
+import com.asmr.player.util.MessageManager
+import java.io.File
+import kotlinx.coroutines.launch
+
+internal const val IMAGE_PREVIEW_DIALOG_TAG = "image_preview_dialog"
+internal const val IMAGE_PREVIEW_CLOSE_TAG = "image_preview_close"
+internal const val IMAGE_PREVIEW_OUTSIDE_TAG = "image_preview_outside"
+internal const val IMAGE_PREVIEW_PAGER_TAG = "image_preview_pager"
+internal const val IMAGE_PREVIEW_COUNT_TAG = "image_preview_count"
+internal const val IMAGE_PREVIEW_PREV_TAG = "image_preview_prev"
+internal const val IMAGE_PREVIEW_NEXT_TAG = "image_preview_next"
+internal const val IMAGE_PREVIEW_OPEN_EXTERNAL_TAG = "image_preview_open_external"
+
+internal data class ImagePreviewLayoutSpec(
+    val widthFraction: Float = 0.92f,
+    val maxWidthDp: Int = 760,
+    val heightFraction: Float = 0.66f,
+    val minHeightDp: Int = 260,
+    val maxHeightDp: Int = 680,
+    val imageViewportPaddingDp: Int = 6,
+    val toolbarVerticalPaddingDp: Int = 8,
+    val footerVerticalPaddingDp: Int = 8
+)
+
+internal val DefaultImagePreviewLayoutSpec = ImagePreviewLayoutSpec()
+
+internal data class ImagePreviewItem(
+    val key: String,
+    val title: String,
+    val imageModel: Any,
+    val openPathOrUrl: String
+)
+
+internal data class ImagePreviewRequest(
+    val items: List<ImagePreviewItem>,
+    val initialIndex: Int = 0
+)
+
+internal fun ImagePreviewRequest.normalized(): ImagePreviewRequest? {
+    val normalizedItems = items.filter { item ->
+        item.key.isNotBlank() && item.openPathOrUrl.isNotBlank()
+    }
+    if (normalizedItems.isEmpty()) return null
+    val index = initialIndex.coerceIn(0, normalizedItems.lastIndex)
+    return copy(items = normalizedItems, initialIndex = index)
+}
+
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+internal fun ImagePreviewDialog(
+    request: ImagePreviewRequest,
+    messageManager: MessageManager,
+    onDismiss: () -> Unit,
+    pageContent: @Composable ((
+        item: ImagePreviewItem,
+        state: ImagePreviewTransformState,
+        onStateChange: (ImagePreviewTransformState) -> Unit
+    ) -> Unit) = { item, state, onStateChange ->
+        ImagePreviewPage(item = item, state = state, onStateChange = onStateChange)
+    }
+) {
+    val normalizedRequest = remember(request) { request.normalized() } ?: return
+    val items = normalizedRequest.items
+    val context = LocalContext.current
+    val colorScheme = AsmrTheme.colorScheme
+    val layoutSpec = DefaultImagePreviewLayoutSpec
+    val scope = rememberCoroutineScope()
+    val pagerState = rememberPagerState(
+        initialPage = normalizedRequest.initialIndex,
+        pageCount = { items.size }
+    )
+    val pageTransforms = remember(items) { mutableStateMapOf<String, ImagePreviewTransformState>() }
+    val currentItem = items.getOrElse(pagerState.currentPage) { items.first() }
+    val currentTransform = pageTransforms.getOrPut(currentItem.key) { ImagePreviewTransformState() }
+    val canNavigate = items.size > 1
+    val allowPaging = currentTransform.isAtRest
+
+    fun openCurrentWithOtherApp() {
+        val path = currentItem.openPathOrUrl.trim()
+        if (path.isBlank()) {
+            messageManager.showError("无法打开：路径为空")
+            return
+        }
+
+        runCatching {
+            val uri = when {
+                path.startsWith("content://", ignoreCase = true) -> Uri.parse(path)
+                path.startsWith("http://", ignoreCase = true) || path.startsWith("https://", ignoreCase = true) -> Uri.parse(path)
+                else -> {
+                    val file = File(path)
+                    if (!file.exists()) throw java.io.FileNotFoundException(path)
+                    FileProvider.getUriForFile(
+                        context,
+                        "${context.packageName}.fileprovider",
+                        file
+                    )
+                }
+            }
+            val mimeType = runCatching { context.contentResolver.getType(uri) }.getOrNull()
+                ?: path.substringAfterLast('.', "").lowercase().takeIf { it.isNotBlank() }?.let { ext ->
+                    MimeTypeMap.getSingleton().getMimeTypeFromExtension(ext)
+                }
+                ?: "image/*"
+            val intent = Intent(Intent.ACTION_VIEW).apply {
+                setDataAndType(uri, mimeType)
+                addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+            }
+            context.startActivity(Intent.createChooser(intent, "打开图片"))
+        }.onFailure { throwable ->
+            when (throwable) {
+                is android.content.ActivityNotFoundException -> messageManager.showInfo("未找到可打开的应用")
+                is java.io.FileNotFoundException -> messageManager.showError("文件不存在")
+                else -> messageManager.showError("无法打开该图片")
+            }
+        }
+    }
+
+    LaunchedEffect(pagerState.currentPage) {
+        pageTransforms[currentItem.key] = ImagePreviewTransformState()
+        pageTransforms.keys.toList().forEach { key ->
+            if (key != currentItem.key) {
+                pageTransforms[key] = ImagePreviewTransformState()
+            }
+        }
+    }
+
+    Dialog(
+        onDismissRequest = onDismiss,
+        properties = DialogProperties(usePlatformDefaultWidth = false)
+    ) {
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .testTag(IMAGE_PREVIEW_OUTSIDE_TAG)
+                .background(Color.Black.copy(alpha = 0.74f))
+                .clickable(onClick = onDismiss),
+            contentAlignment = Alignment.Center
+        ) {
+            Card(
+                modifier = Modifier
+                    .fillMaxWidth(layoutSpec.widthFraction)
+                    .widthIn(max = layoutSpec.maxWidthDp.dp)
+                    .fillMaxHeight(layoutSpec.heightFraction)
+                    .heightIn(min = layoutSpec.minHeightDp.dp, max = layoutSpec.maxHeightDp.dp)
+                    .testTag(IMAGE_PREVIEW_DIALOG_TAG),
+                shape = RoundedCornerShape(24.dp),
+                colors = CardDefaults.cardColors(containerColor = colorScheme.surface)
+            ) {
+                Column(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .clickable(
+                            indication = null,
+                            interactionSource = remember { MutableInteractionSource() },
+                            onClick = {}
+                        )
+                ) {
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 12.dp, vertical = layoutSpec.toolbarVerticalPaddingDp.dp),
+                        horizontalArrangement = Arrangement.spacedBy(8.dp),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Text(
+                            text = currentItem.title.ifBlank { currentItem.openPathOrUrl.substringAfterLast('/').substringAfterLast('\\') },
+                            modifier = Modifier.weight(1f),
+                            style = MaterialTheme.typography.titleMedium,
+                            color = colorScheme.textPrimary,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis
+                        )
+                        IconButton(
+                            onClick = ::openCurrentWithOtherApp,
+                            modifier = Modifier.testTag(IMAGE_PREVIEW_OPEN_EXTERNAL_TAG)
+                        ) {
+                            Icon(Icons.AutoMirrored.Filled.OpenInNew, contentDescription = "打开")
+                        }
+                        IconButton(
+                            onClick = onDismiss,
+                            modifier = Modifier.testTag(IMAGE_PREVIEW_CLOSE_TAG)
+                        ) {
+                            Icon(Icons.Default.Close, contentDescription = "关闭")
+                        }
+                    }
+
+                    HorizontalDivider(color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.08f))
+
+                    Box(
+                        modifier = Modifier
+                            .weight(1f)
+                            .fillMaxWidth()
+                            .clipToBounds()
+                            .background(Color(0xFF13161A)),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        HorizontalPager(
+                            state = pagerState,
+                            modifier = Modifier
+                                .fillMaxSize()
+                                .clipToBounds()
+                                .testTag(IMAGE_PREVIEW_PAGER_TAG),
+                            userScrollEnabled = canNavigate && allowPaging
+                        ) { page ->
+                            val item = items[page]
+                            val transformState = pageTransforms.getOrPut(item.key) { ImagePreviewTransformState() }
+                            pageContent(
+                                item = item,
+                                state = transformState,
+                                onStateChange = { pageTransforms[item.key] = it }
+                            )
+                        }
+
+                        if (canNavigate && allowPaging) {
+                            PreviewNavButton(
+                                modifier = Modifier
+                                    .align(Alignment.CenterStart)
+                                    .padding(start = 12.dp)
+                                    .testTag(IMAGE_PREVIEW_PREV_TAG),
+                                onClick = {
+                                    if (pagerState.currentPage > 0) {
+                                        pageTransforms[currentItem.key] = ImagePreviewTransformState()
+                                        scope.launch {
+                                            pagerState.animateScrollToPage(pagerState.currentPage - 1)
+                                        }
+                                    }
+                                },
+                                icon = Icons.Default.ChevronLeft,
+                                enabled = pagerState.currentPage > 0
+                            )
+                            PreviewNavButton(
+                                modifier = Modifier
+                                    .align(Alignment.CenterEnd)
+                                    .padding(end = 12.dp)
+                                    .testTag(IMAGE_PREVIEW_NEXT_TAG),
+                                onClick = {
+                                    if (pagerState.currentPage < items.lastIndex) {
+                                        pageTransforms[currentItem.key] = ImagePreviewTransformState()
+                                        scope.launch {
+                                            pagerState.animateScrollToPage(pagerState.currentPage + 1)
+                                        }
+                                    }
+                                },
+                                icon = Icons.Default.ChevronRight,
+                                enabled = pagerState.currentPage < items.lastIndex
+                            )
+                        }
+                    }
+
+                    if (canNavigate) {
+                        HorizontalDivider(color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.08f))
+                        Text(
+                            text = "${pagerState.currentPage + 1} / ${items.size}",
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(horizontal = 16.dp, vertical = layoutSpec.footerVerticalPaddingDp.dp)
+                                .testTag(IMAGE_PREVIEW_COUNT_TAG),
+                            style = MaterialTheme.typography.labelLarge,
+                            color = colorScheme.textSecondary
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+internal data class ImagePreviewTransformState(
+    val scale: Float = 1f,
+    val offset: Offset = Offset.Zero
+) {
+    val isAtRest: Boolean
+        get() = scale <= 1.01f && kotlin.math.abs(offset.x) < 0.5f && kotlin.math.abs(offset.y) < 0.5f
+}
+
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+private fun ImagePreviewPage(
+    item: ImagePreviewItem,
+    state: ImagePreviewTransformState,
+    onStateChange: (ImagePreviewTransformState) -> Unit
+) {
+    var scale by rememberSaveable(item.key) { mutableFloatStateOf(1f) }
+    var offsetX by rememberSaveable(item.key) { mutableFloatStateOf(0f) }
+    var offsetY by rememberSaveable(item.key) { mutableFloatStateOf(0f) }
+
+    LaunchedEffect(item.key, state) {
+        scale = state.scale
+        offsetX = state.offset.x
+        offsetY = state.offset.y
+    }
+
+    fun publish(newScale: Float, newOffset: Offset) {
+        onStateChange(ImagePreviewTransformState(scale = newScale, offset = newOffset))
+    }
+
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(DefaultImagePreviewLayoutSpec.imageViewportPaddingDp.dp)
+            .clipToBounds(),
+        contentAlignment = Alignment.Center
+    ) {
+        AsmrAsyncImage(
+            model = item.imageModel,
+            contentDescription = null,
+            contentScale = ContentScale.Fit,
+            modifier = Modifier
+                .fillMaxSize()
+                .pointerInput(item.key) {
+                    detectTapGestures(
+                        onDoubleTap = {
+                            val nextScale = if (scale > 1f) 1f else 2f
+                            val nextOffset = Offset.Zero
+                            scale = nextScale
+                            offsetX = nextOffset.x
+                            offsetY = nextOffset.y
+                            publish(nextScale, nextOffset)
+                        }
+                    )
+                }
+                .pointerInput(item.key) {
+                    detectTransformGestures { _, pan, zoom, _ ->
+                        val nextScale = (scale * zoom).coerceIn(1f, 5f)
+                        val nextOffset = if (nextScale > 1f) {
+                            Offset(offsetX + pan.x, offsetY + pan.y)
+                        } else {
+                            Offset.Zero
+                        }
+                        scale = nextScale
+                        offsetX = nextOffset.x
+                        offsetY = nextOffset.y
+                        publish(nextScale, nextOffset)
+                    }
+                }
+                .graphicsLayer(
+                    scaleX = scale,
+                    scaleY = scale,
+                    translationX = offsetX,
+                    translationY = offsetY
+                ),
+            placeholderCornerRadius = 0,
+            placeholder = { modifier ->
+                PreviewImageFallback(
+                    modifier = modifier,
+                    title = item.title,
+                    failed = true
+                )
+            },
+            loading = { modifier ->
+                Box(
+                    modifier = modifier.fillMaxSize(),
+                    contentAlignment = Alignment.Center
+                ) {
+                    AsmrShimmerPlaceholder(modifier = Modifier.fillMaxSize(), cornerRadius = 0)
+                }
+            }
+        )
+    }
+}
+
+@Composable
+private fun PreviewImageFallback(
+    modifier: Modifier,
+    title: String,
+    failed: Boolean
+) {
+    val colorScheme = AsmrTheme.colorScheme
+    Surface(
+        modifier = modifier.fillMaxSize(),
+        color = Color.Transparent
+    ) {
+        Column(
+            modifier = Modifier.fillMaxSize(),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center
+        ) {
+            Icon(
+                imageVector = Icons.Default.ImageNotSupported,
+                contentDescription = null,
+                tint = colorScheme.textTertiary,
+                modifier = Modifier.size(40.dp)
+            )
+            Text(
+                text = if (failed) "图片加载失败" else title,
+                color = colorScheme.textSecondary,
+                style = MaterialTheme.typography.bodyMedium,
+                modifier = Modifier.padding(top = 10.dp)
+            )
+        }
+    }
+}
+
+@Composable
+private fun PreviewNavButton(
+    modifier: Modifier,
+    onClick: () -> Unit,
+    icon: androidx.compose.ui.graphics.vector.ImageVector,
+    enabled: Boolean
+) {
+    Surface(
+        modifier = modifier,
+        shape = CircleShape,
+        color = Color.Black.copy(alpha = if (enabled) 0.48f else 0.24f)
+    ) {
+        IconButton(onClick = onClick, enabled = enabled) {
+            Icon(icon, contentDescription = null, tint = Color.White)
+        }
+    }
+}

--- a/app/src/main/java/com/asmr/player/ui/library/AlbumDetailScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/AlbumDetailScreen.kt
@@ -126,6 +126,8 @@ import com.asmr.player.ui.common.AsmrAsyncImage
 import com.asmr.player.ui.common.AsmrShimmerPlaceholder
 import com.asmr.player.ui.common.CvChipsFlow
 import com.asmr.player.ui.common.EaraLogoLoadingIndicator
+import com.asmr.player.ui.common.ImagePreviewDialog
+import com.asmr.player.ui.common.ImagePreviewRequest
 import com.asmr.player.ui.common.collapsibleHeaderUiState
 import com.asmr.player.ui.common.rememberCollapsibleHeaderState
 import com.asmr.player.ui.playlists.PlaylistPickerScreen
@@ -297,6 +299,7 @@ fun AlbumDetailScreen(
                     )
                     var localPreviewFile by remember { mutableStateOf<LocalTreeUiEntry.File?>(null) }
                     var onlinePreviewFile by remember { mutableStateOf<AsmrTreeUiEntry.File?>(null) }
+                    var imagePreviewRequest by remember { mutableStateOf<ImagePreviewRequest?>(null) }
                     val tabChromeState = rememberCollapsibleHeaderState()
                     val animatedTabChromeOffsetPx by animateFloatAsState(
                         targetValue = tabChromeState.offsetPx,
@@ -484,6 +487,7 @@ fun AlbumDetailScreen(
                                                 onSetCoverFromImage = { pathOrUri ->
                                                     viewModel.setLocalCoverPath(pathOrUri)
                                                 },
+                                                onPreviewImages = { request -> imagePreviewRequest = request },
                                                 onPreviewFile = { localPreviewFile = it },
                                                 animateIntro = shouldPlayInitialAnimations
                                             )
@@ -542,6 +546,7 @@ fun AlbumDetailScreen(
                                                 target.rjCode
                                             )
                                         },
+                                        onPreviewImages = { request -> imagePreviewRequest = request },
                                         onPreviewFile = { onlinePreviewFile = it },
                                         treeStateKey = "tree:asmrOne:${model.rjCode.trim().uppercase()}",
                                         initialCurrentPath = viewModel.getTreeCurrentPath("tree:asmrOne:${model.rjCode.trim().uppercase()}"),
@@ -580,6 +585,7 @@ fun AlbumDetailScreen(
                                         onDownloadOne = { relPath ->
                                             viewModel.downloadDlsitePlaySelected(setOf(relPath))
                                         },
+                                        onPreviewImages = { request -> imagePreviewRequest = request },
                                         onPreviewFile = { onlinePreviewFile = it },
                                         treeStateKey = "tree:dlsitePlay:${model.baseRjCode.ifBlank { model.rjCode }.trim().uppercase()}",
                                         initialCurrentPath = viewModel.getTreeCurrentPath("tree:dlsitePlay:${model.baseRjCode.ifBlank { model.rjCode }.trim().uppercase()}"),
@@ -701,6 +707,14 @@ fun AlbumDetailScreen(
                         messageManager = viewModel.messageManager,
                         loadOnlineText = viewModel::loadOnlineTextPreview,
                         onDismiss = { onlinePreviewFile = null }
+                    )
+                }
+
+                imagePreviewRequest?.let { request ->
+                    ImagePreviewDialog(
+                        request = request,
+                        messageManager = viewModel.messageManager,
+                        onDismiss = { imagePreviewRequest = null }
                     )
                 }
 

--- a/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailDialogs.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailDialogs.kt
@@ -675,13 +675,12 @@ internal fun FilePreviewDialog(
             if (absolutePath.startsWith("http", ignoreCase = true) || absolutePath.startsWith("content://")) {
                 return@withContext listOf(absolutePath)
             }
-            if (fileType != TreeFileType.Image && fileType != TreeFileType.Video) {
+            if (fileType != TreeFileType.Video) {
                 return@withContext listOf(absolutePath)
             }
             val current = File(absolutePath)
             val parent = current.parentFile ?: return@withContext listOf(absolutePath)
             val exts = when (fileType) {
-                TreeFileType.Image -> setOf("jpg", "jpeg", "png", "webp", "gif", "bmp", "heic", "heif")
                 TreeFileType.Video -> setOf("mp4", "mkv", "webm", "mov", "m4v")
                 else -> emptySet()
             }
@@ -794,7 +793,7 @@ internal fun FilePreviewDialog(
                 .then(
                     if (fullscreen && currentType == TreeFileType.Video) {
                         Modifier.fillMaxSize()
-                    } else if (computedSize != null && (currentType == TreeFileType.Image || currentType == TreeFileType.Video)) {
+                    } else if (computedSize != null && currentType == TreeFileType.Video) {
                         Modifier.width(computedSize.first).height(computedSize.second)
                     } else {
                         Modifier.fillMaxWidth(0.95f).fillMaxHeight(0.85f)
@@ -848,34 +847,6 @@ internal fun FilePreviewDialog(
                     contentAlignment = Alignment.Center
                 ) {
                     when (currentType) {
-                        TreeFileType.Image -> {
-                            var scale by remember { mutableStateOf(1f) }
-                            var offset by remember { mutableStateOf(androidx.compose.ui.geometry.Offset.Zero) }
-                            AsmrAsyncImage(
-                                model = currentPath,
-                                contentDescription = null,
-                                contentScale = ContentScale.Fit,
-                                modifier = Modifier
-                                    .fillMaxSize()
-                                    .pointerInput(Unit) {
-                                        detectTransformGestures { _, pan, zoom, _ ->
-                                            scale = (scale * zoom).coerceIn(1f, 5f)
-                                            if (scale > 1f) {
-                                                offset += pan
-                                            } else {
-                                                offset = androidx.compose.ui.geometry.Offset.Zero
-                                            }
-                                        }
-                                    }
-                                    .graphicsLayer(
-                                        scaleX = scale,
-                                        scaleY = scale,
-                                        translationX = offset.x,
-                                        translationY = offset.y
-                                    ),
-                                placeholderCornerRadius = 0,
-                            )
-                        }
                         TreeFileType.Video -> {
                             InlineVideoPlayer(
                                 url = currentPath,

--- a/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailDirectorySupport.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailDirectorySupport.kt
@@ -124,6 +124,8 @@ import com.asmr.player.ui.common.AsmrAsyncImage
 import com.asmr.player.ui.common.AsmrShimmerPlaceholder
 import com.asmr.player.ui.common.CvChipsFlow
 import com.asmr.player.ui.common.EaraLogoLoadingIndicator
+import com.asmr.player.ui.common.ImagePreviewItem
+import com.asmr.player.ui.common.ImagePreviewRequest
 import com.asmr.player.ui.common.collapsibleHeaderUiState
 import com.asmr.player.ui.common.rememberCollapsibleHeaderState
 import com.asmr.player.ui.playlists.PlaylistPickerScreen
@@ -306,6 +308,32 @@ internal data class DirectoryBrowserResult(
                 else -> null
             }
         }
+}
+
+internal fun buildDirectoryImagePreviewRequest(
+    files: List<DirectoryFileItem>,
+    clickedPath: String,
+    toPreviewItem: (DirectoryFileItem) -> ImagePreviewItem?
+): ImagePreviewRequest? {
+    val imageFiles = files.filter { it.fileType == TreeFileType.Image }
+    if (imageFiles.isEmpty()) return null
+    val items = imageFiles.mapNotNull(toPreviewItem)
+    if (items.isEmpty()) return null
+    val initialIndex = imageFiles.indexOfFirst { it.path == clickedPath }
+    if (initialIndex < 0) return null
+    return ImagePreviewRequest(items = items, initialIndex = initialIndex)
+}
+
+internal fun buildGalleryImagePreviewRequest(
+    galleryUrls: List<String>,
+    clickedUrl: String,
+    toPreviewItem: (String) -> ImagePreviewItem?
+): ImagePreviewRequest? {
+    val items = galleryUrls.mapNotNull(toPreviewItem)
+    if (items.isEmpty()) return null
+    val initialIndex = galleryUrls.indexOfFirst { it == clickedUrl }
+    if (initialIndex < 0) return null
+    return ImagePreviewRequest(items = items, initialIndex = initialIndex)
 }
 
 internal fun buildBreadcrumbSegments(currentPath: String): List<DirectoryBreadcrumbSegment> {

--- a/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailDlsiteTabs.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailDlsiteTabs.kt
@@ -124,6 +124,8 @@ import com.asmr.player.ui.common.AsmrAsyncImage
 import com.asmr.player.ui.common.AsmrShimmerPlaceholder
 import com.asmr.player.ui.common.CvChipsFlow
 import com.asmr.player.ui.common.EaraLogoLoadingIndicator
+import com.asmr.player.ui.common.ImagePreviewItem
+import com.asmr.player.ui.common.ImagePreviewRequest
 import com.asmr.player.ui.common.collapsibleHeaderUiState
 import com.asmr.player.ui.common.rememberCollapsibleHeaderState
 import com.asmr.player.ui.playlists.PlaylistPickerScreen
@@ -381,6 +383,7 @@ internal fun AlbumDlsiteInfoBreadcrumbTabV2(
     onDownloadOne: (String) -> Unit,
     onAddToPlaylistOne: (String) -> Unit,
     onAddToPlaylist: (Track) -> Unit,
+    onPreviewImages: (ImagePreviewRequest) -> Unit,
     onPreviewFile: (AsmrTreeUiEntry.File) -> Unit,
     treeStateKey: String,
     initialCurrentPath: String,
@@ -395,7 +398,6 @@ internal fun AlbumDlsiteInfoBreadcrumbTabV2(
     loadRemoteFileSize: suspend (String) -> Long?
 ) {
     val scope = rememberCoroutineScope()
-    var previewUrl by remember { mutableStateOf<String?>(null) }
     val videoTracks = remember(trialTracks) { trialTracks.filter { isVideoPreviewUrl(it.path) } }
     val audioTracks = remember(trialTracks) { trialTracks.filterNot { isVideoPreviewUrl(it.path) } }
     val asmrLeafTracks = remember(asmrOneTree) { flattenAsmrOneTracksForUi(asmrOneTree) }
@@ -516,7 +518,26 @@ internal fun AlbumDlsiteInfoBreadcrumbTabV2(
                             if (headers.isEmpty()) url else CacheImageModel(data = url, headers = headers, keyTag = "dlsite")
                         }
                         Card(
-                            modifier = Modifier.size(width = 140.dp, height = 100.dp).clickable { previewUrl = url },
+                            modifier = Modifier.size(width = 140.dp, height = 100.dp).clickable {
+                                buildGalleryImagePreviewRequest(
+                                    galleryUrls = galleryUrls,
+                                    clickedUrl = url,
+                                    toPreviewItem = { galleryUrl ->
+                                        val headers = DlsiteAntiHotlink.headersForImageUrl(galleryUrl)
+                                        val model = if (headers.isEmpty()) {
+                                            galleryUrl
+                                        } else {
+                                            CacheImageModel(data = galleryUrl, headers = headers, keyTag = "dlsite")
+                                        }
+                                        ImagePreviewItem(
+                                            key = galleryUrl,
+                                            title = galleryUrl.substringBefore('?').substringAfterLast('/').ifBlank { "Gallery" },
+                                            imageModel = model,
+                                            openPathOrUrl = galleryUrl
+                                        )
+                                    }
+                                )?.let(onPreviewImages)
+                            },
                             shape = RoundedCornerShape(12.dp)
                         ) {
                             AsmrAsyncImage(
@@ -610,6 +631,30 @@ internal fun AlbumDlsiteInfoBreadcrumbTabV2(
                                                 )
                                             )
                                         }
+                                    }
+                                    TreeFileType.Image -> {
+                                        buildDirectoryImagePreviewRequest(
+                                            files = browser.files,
+                                            clickedPath = file.path,
+                                            toPreviewItem = { imageFile ->
+                                                val imageUrl = imageFile.url.takeIf { it.isNotBlank() } ?: return@buildDirectoryImagePreviewRequest null
+                                                ImagePreviewItem(
+                                                    key = imageFile.path,
+                                                    title = imageFile.title,
+                                                    imageModel = imageUrl,
+                                                    openPathOrUrl = imageUrl
+                                                )
+                                            }
+                                        )?.let(onPreviewImages) ?: onPreviewFile(
+                                            AsmrTreeUiEntry.File(
+                                                path = file.path,
+                                                title = file.title,
+                                                depth = 0,
+                                                fileType = file.fileType,
+                                                isPlayable = false,
+                                                url = file.url
+                                            )
+                                        )
                                     }
                                     else -> onPreviewFile(
                                         AsmrTreeUiEntry.File(
@@ -742,50 +787,6 @@ internal fun AlbumDlsiteInfoBreadcrumbTabV2(
             }
         }
     }
-
-    if (previewUrl != null) {
-        Dialog(onDismissRequest = { previewUrl = null }) {
-            Box(
-                modifier = Modifier.fillMaxSize().clickable { previewUrl = null },
-                contentAlignment = Alignment.Center
-            ) {
-                var scale by remember { mutableStateOf(1f) }
-                var offset by remember { mutableStateOf(androidx.compose.ui.geometry.Offset.Zero) }
-                Card(
-                    modifier = Modifier
-                        .fillMaxWidth(0.95f)
-                        .wrapContentHeight()
-                        .pointerInput(Unit) {
-                            detectTransformGestures { _, pan, zoom, _ ->
-                                scale = (scale * zoom).coerceIn(1f, 5f)
-                                if (scale > 1f) offset += pan else offset = androidx.compose.ui.geometry.Offset.Zero
-                            }
-                        }
-                        .graphicsLayer(
-                            scaleX = scale,
-                            scaleY = scale,
-                            translationX = offset.x,
-                            translationY = offset.y
-                        ),
-                    shape = RoundedCornerShape(16.dp),
-                    elevation = CardDefaults.cardElevation(defaultElevation = 8.dp)
-                ) {
-                    val url = previewUrl.orEmpty()
-                    val model = remember(url) {
-                        val headers = DlsiteAntiHotlink.headersForImageUrl(url)
-                        if (headers.isEmpty()) url else CacheImageModel(data = url, headers = headers, keyTag = "dlsite")
-                    }
-                    AsmrAsyncImage(
-                        model = model,
-                        contentDescription = null,
-                        contentScale = ContentScale.Fit,
-                        modifier = Modifier.fillMaxWidth().padding(8.dp),
-                        placeholderCornerRadius = 16
-                    )
-                }
-            }
-        }
-    }
 }
 
 
@@ -806,6 +807,7 @@ internal fun AlbumDlsitePlayBreadcrumbTabV2(
     onAddMediaItemsToFavorites: (List<MediaItem>) -> Unit,
     onOpenBatchPlaylistPicker: (List<MediaItem>) -> Unit,
     onDownloadOne: (String) -> Unit,
+    onPreviewImages: (ImagePreviewRequest) -> Unit,
     onPreviewFile: (AsmrTreeUiEntry.File) -> Unit,
     treeStateKey: String,
     initialCurrentPath: String,
@@ -984,6 +986,30 @@ internal fun AlbumDlsitePlayBreadcrumbTabV2(
                                             )
                                         }
                                     }
+                                }
+                                TreeFileType.Image -> {
+                                    buildDirectoryImagePreviewRequest(
+                                        files = browser.files,
+                                        clickedPath = file.path,
+                                        toPreviewItem = { imageFile ->
+                                            val imageUrl = imageFile.url.takeIf { it.isNotBlank() } ?: return@buildDirectoryImagePreviewRequest null
+                                            ImagePreviewItem(
+                                                key = imageFile.path,
+                                                title = imageFile.title,
+                                                imageModel = imageUrl,
+                                                openPathOrUrl = imageUrl
+                                            )
+                                        }
+                                    )?.let(onPreviewImages) ?: onPreviewFile(
+                                        AsmrTreeUiEntry.File(
+                                            path = file.path,
+                                            title = file.title,
+                                            depth = 0,
+                                            fileType = file.fileType,
+                                            isPlayable = false,
+                                            url = file.url
+                                        )
+                                    )
                                 }
                                 else -> onPreviewFile(
                                     AsmrTreeUiEntry.File(

--- a/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailLocalTab.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailLocalTab.kt
@@ -123,6 +123,8 @@ import com.asmr.player.ui.common.AsmrAsyncImage
 import com.asmr.player.ui.common.AsmrShimmerPlaceholder
 import com.asmr.player.ui.common.CvChipsFlow
 import com.asmr.player.ui.common.EaraLogoLoadingIndicator
+import com.asmr.player.ui.common.ImagePreviewItem
+import com.asmr.player.ui.common.ImagePreviewRequest
 import com.asmr.player.ui.common.collapsibleHeaderUiState
 import com.asmr.player.ui.common.rememberCollapsibleHeaderState
 import com.asmr.player.ui.playlists.PlaylistPickerScreen
@@ -160,6 +162,7 @@ internal fun AlbumLocalBreadcrumbTabV2(
     onManageTrackTags: (Track) -> Unit,
     onRemoveTrack: (Track) -> Unit,
     onSetCoverFromImage: (String) -> Unit,
+    onPreviewImages: (ImagePreviewRequest) -> Unit,
     onPreviewFile: (LocalTreeUiEntry.File) -> Unit,
 ) {
     val queueTracks = remember(album.id, album.tracks) { album.tracks.sortedBy { it.path } }
@@ -323,16 +326,42 @@ internal fun AlbumLocalBreadcrumbTabV2(
                                     if (prepared != null) {
                                         onPlayMediaItems(prepared.items, prepared.startIndex)
                                     } else {
-                                        onPreviewFile(
-                                            LocalTreeUiEntry.File(
-                                                path = file.path,
-                                                title = file.title,
-                                                depth = 0,
-                                                absolutePath = file.absolutePath,
-                                                fileType = file.fileType,
-                                                track = file.track
+                                        if (file.fileType == TreeFileType.Image) {
+                                            buildDirectoryImagePreviewRequest(
+                                                files = browserValue.files,
+                                                clickedPath = file.path,
+                                                toPreviewItem = { imageFile ->
+                                                    imageFile.absolutePath.takeIf { it.isNotBlank() }?.let { path ->
+                                                        ImagePreviewItem(
+                                                            key = imageFile.path,
+                                                            title = imageFile.title,
+                                                            imageModel = path,
+                                                            openPathOrUrl = path
+                                                        )
+                                                    }
+                                                }
+                                            )?.let(onPreviewImages) ?: onPreviewFile(
+                                                LocalTreeUiEntry.File(
+                                                    path = file.path,
+                                                    title = file.title,
+                                                    depth = 0,
+                                                    absolutePath = file.absolutePath,
+                                                    fileType = file.fileType,
+                                                    track = file.track
+                                                )
                                             )
-                                        )
+                                        } else {
+                                            onPreviewFile(
+                                                LocalTreeUiEntry.File(
+                                                    path = file.path,
+                                                    title = file.title,
+                                                    depth = 0,
+                                                    absolutePath = file.absolutePath,
+                                                    fileType = file.fileType,
+                                                    track = file.track
+                                                )
+                                            )
+                                        }
                                     }
                                 }
                             },

--- a/app/src/test/java/com/asmr/player/ui/common/ImagePreviewDialogTest.kt
+++ b/app/src/test/java/com/asmr/player/ui/common/ImagePreviewDialogTest.kt
@@ -1,0 +1,127 @@
+package com.asmr.player.ui.common
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.test.SemanticsMatcher
+import androidx.compose.ui.test.assert
+import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onAllNodesWithTag
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import com.asmr.player.ui.theme.AsmrPlayerTheme
+import com.asmr.player.util.MessageManager
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+
+class ImagePreviewDialogTest {
+
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    @Test
+    fun singleImage_hidesNavigationAndClosesFromButtonsAndOverlay() {
+        var dismissCount = 0
+
+        composeRule.setContent {
+            AsmrPlayerTheme {
+                ImagePreviewDialog(
+                    request = ImagePreviewRequest(
+                        items = listOf(sampleItem("a"))
+                    ),
+                    messageManager = MessageManager(),
+                    onDismiss = { dismissCount++ },
+                    pageContent = { _, _, _ ->
+                        Box(modifier = androidx.compose.ui.Modifier.fillMaxSize())
+                    }
+                )
+            }
+        }
+
+        composeRule.onAllNodesWithTag(IMAGE_PREVIEW_COUNT_TAG).assertCountEquals(0)
+        composeRule.onAllNodesWithTag(IMAGE_PREVIEW_PREV_TAG).assertCountEquals(0)
+        composeRule.onAllNodesWithTag(IMAGE_PREVIEW_NEXT_TAG).assertCountEquals(0)
+
+        composeRule.onNodeWithTag(IMAGE_PREVIEW_CLOSE_TAG).performClick()
+        composeRule.onNodeWithTag(IMAGE_PREVIEW_OUTSIDE_TAG).performClick()
+
+        assertEquals(2, dismissCount)
+    }
+
+    @Test
+    fun multiImage_showsCountAndNavigationButtons() {
+        composeRule.setContent {
+            AsmrPlayerTheme {
+                ImagePreviewDialog(
+                    request = ImagePreviewRequest(
+                        items = listOf(sampleItem("a"), sampleItem("b")),
+                        initialIndex = 0
+                    ),
+                    messageManager = MessageManager(),
+                    onDismiss = {},
+                    pageContent = { _, _, _ ->
+                        Box(modifier = androidx.compose.ui.Modifier.fillMaxSize())
+                    }
+                )
+            }
+        }
+
+        composeRule.onNodeWithTag(IMAGE_PREVIEW_COUNT_TAG).assert(
+            SemanticsMatcher.expectValue(SemanticsProperties.TestTag, IMAGE_PREVIEW_COUNT_TAG)
+        )
+        composeRule.onNodeWithTag(IMAGE_PREVIEW_PREV_TAG).assert(
+            SemanticsMatcher.expectValue(SemanticsProperties.TestTag, IMAGE_PREVIEW_PREV_TAG)
+        )
+        composeRule.onNodeWithTag(IMAGE_PREVIEW_NEXT_TAG).assert(
+            SemanticsMatcher.expectValue(SemanticsProperties.TestTag, IMAGE_PREVIEW_NEXT_TAG)
+        )
+    }
+
+    @Test
+    fun layoutSpec_matchesPlannedBounds() {
+        assertEquals(0.92f, DefaultImagePreviewLayoutSpec.widthFraction)
+        assertEquals(760, DefaultImagePreviewLayoutSpec.maxWidthDp)
+        assertEquals(0.66f, DefaultImagePreviewLayoutSpec.heightFraction)
+        assertEquals(260, DefaultImagePreviewLayoutSpec.minHeightDp)
+        assertEquals(680, DefaultImagePreviewLayoutSpec.maxHeightDp)
+    }
+
+    @Test
+    fun zoomedState_hidesNavigationButtons() {
+        composeRule.setContent {
+            AsmrPlayerTheme {
+                ImagePreviewDialog(
+                    request = ImagePreviewRequest(
+                        items = listOf(sampleItem("a"), sampleItem("b")),
+                        initialIndex = 0
+                    ),
+                    messageManager = MessageManager(),
+                    onDismiss = {},
+                    pageContent = { item, _, onStateChange ->
+                        LaunchedEffect(item.key) {
+                            onStateChange(ImagePreviewTransformState(scale = 2f, offset = Offset(24f, 0f)))
+                        }
+                        Box(modifier = androidx.compose.ui.Modifier.fillMaxSize())
+                    }
+                )
+            }
+        }
+
+        composeRule.waitForIdle()
+        composeRule.onAllNodesWithTag(IMAGE_PREVIEW_PREV_TAG).assertCountEquals(0)
+        composeRule.onAllNodesWithTag(IMAGE_PREVIEW_NEXT_TAG).assertCountEquals(0)
+    }
+
+    private fun sampleItem(key: String): ImagePreviewItem {
+        return ImagePreviewItem(
+            key = key,
+            title = "Image $key",
+            imageModel = "mock://$key",
+            openPathOrUrl = "https://example.com/$key.jpg"
+        )
+    }
+}

--- a/app/src/test/java/com/asmr/player/ui/library/ImagePreviewSupportTest.kt
+++ b/app/src/test/java/com/asmr/player/ui/library/ImagePreviewSupportTest.kt
@@ -1,0 +1,99 @@
+package com.asmr.player.ui.library
+
+import com.asmr.player.ui.common.ImagePreviewItem
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class ImagePreviewSupportTest {
+
+    @Test
+    fun buildDirectoryImagePreviewRequest_collectsOnlyCurrentDirectoryImagesInOrder() {
+        val files = listOf(
+            directoryFile(path = "disc1/cover.jpg", title = "cover", type = TreeFileType.Image, absolutePath = "/album/disc1/cover.jpg"),
+            directoryFile(path = "disc1/track1.mp3", title = "track1", type = TreeFileType.Audio, absolutePath = "/album/disc1/track1.mp3"),
+            directoryFile(path = "disc1/page02.png", title = "page02", type = TreeFileType.Image, absolutePath = "/album/disc1/page02.png")
+        )
+
+        val result = buildDirectoryImagePreviewRequest(
+            files = files,
+            clickedPath = "disc1/page02.png",
+            toPreviewItem = { file ->
+                ImagePreviewItem(
+                    key = file.path,
+                    title = file.title,
+                    imageModel = file.absolutePath,
+                    openPathOrUrl = file.absolutePath
+                )
+            }
+        )
+
+        requireNotNull(result)
+        assertEquals(listOf("disc1/cover.jpg", "disc1/page02.png"), result.items.map { it.key })
+        assertEquals(1, result.initialIndex)
+    }
+
+    @Test
+    fun buildDirectoryImagePreviewRequest_returnsNullWhenClickedFileIsNotInImageSet() {
+        val files = listOf(
+            directoryFile(path = "disc1/cover.jpg", title = "cover", type = TreeFileType.Image, absolutePath = "/album/disc1/cover.jpg")
+        )
+
+        val result = buildDirectoryImagePreviewRequest(
+            files = files,
+            clickedPath = "disc1/missing.png",
+            toPreviewItem = { file ->
+                ImagePreviewItem(
+                    key = file.path,
+                    title = file.title,
+                    imageModel = file.absolutePath,
+                    openPathOrUrl = file.absolutePath
+                )
+            }
+        )
+
+        assertNull(result)
+    }
+
+    @Test
+    fun buildGalleryImagePreviewRequest_preservesGalleryOrderAndSelectedIndex() {
+        val urls = listOf(
+            "https://img.example/1.jpg",
+            "https://img.example/2.jpg",
+            "https://img.example/3.jpg"
+        )
+
+        val result = buildGalleryImagePreviewRequest(
+            galleryUrls = urls,
+            clickedUrl = "https://img.example/2.jpg",
+            toPreviewItem = { url ->
+                ImagePreviewItem(
+                    key = url,
+                    title = url.substringAfterLast('/'),
+                    imageModel = url,
+                    openPathOrUrl = url
+                )
+            }
+        )
+
+        requireNotNull(result)
+        assertEquals(urls, result.items.map { it.key })
+        assertEquals(1, result.initialIndex)
+    }
+
+    private fun directoryFile(
+        path: String,
+        title: String,
+        type: TreeFileType,
+        absolutePath: String
+    ): DirectoryFileItem {
+        return DirectoryFileItem(
+            path = path,
+            title = title,
+            fileType = type,
+            isPlayable = false,
+            absolutePath = absolutePath,
+            url = absolutePath
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- unify album detail image preview into a shared dialog for local tree, remote tree, and DL Gallery
- reduce dialog height and padding so previews no longer feel wrapped by an oversized container
- clip zoomed images to the viewport so they do not overlap the dialog header or footer
## Verification
- ./gradlew :app:compileDebugKotlin --console=plain
- ## Notes
- added unit/compose tests for preview request construction and shared dialog behavior
- debug unit test task still has unrelated baseline failures in existing test sources, so verification here uses compileDebugKotlin