### PR TITLE
fix: improve app message bubbles

### DIFF
--- a/app/src/main/java/com/asmr/player/MainActivity.kt
+++ b/app/src/main/java/com/asmr/player/MainActivity.kt
@@ -324,16 +324,63 @@ class MainActivity : ComponentActivity() {
             var messageSeq by remember { mutableLongStateOf(0L) }
 
             LaunchedEffect(Unit) {
-                val maxVisible = 8
+                val maxVisible = 5
+                val maxRetained = maxVisible + 1
+                val exitAnimationMs = 220L
+
+                fun hideMessage(id: Long) {
+                    val index = visibleMessages.indexOfFirst { it.id == id }
+                    if (index >= 0) {
+                        visibleMessages[index] = visibleMessages[index].copy(isVisible = false)
+                    }
+                }
+
+                fun removeImmediately(id: Long) {
+                    dismissJobs.remove(id)?.cancel()
+                    visibleMessages.removeAll { it.id == id }
+                }
+
+                fun removeAfterExit(id: Long, cancelExistingJob: Boolean = true) {
+                    hideMessage(id)
+                    if (cancelExistingJob) {
+                        dismissJobs.remove(id)?.cancel()
+                    } else {
+                        dismissJobs.remove(id)
+                    }
+                    dismissJobs[id] = launch {
+                        delay(exitAnimationMs)
+                        visibleMessages.removeAll { it.id == id }
+                        dismissJobs.remove(id)
+                    }
+                }
+
+                fun trimRetainedMessages() {
+                    while (visibleMessages.size >= maxRetained) {
+                        val removed = visibleMessages.lastOrNull { !it.isVisible }
+                            ?: visibleMessages.lastOrNull()
+                            ?: break
+                        removeImmediately(removed.id)
+                    }
+                }
+
+                fun prepareForIncomingMessage() {
+                    trimRetainedMessages()
+                    if (visibleMessages.count { it.isVisible } >= maxVisible) {
+                        val removed = visibleMessages.lastOrNull { it.isVisible } ?: return
+                        removeAfterExit(removed.id)
+                    }
+                    trimRetainedMessages()
+                }
 
                 messageManager.messages.collect { appMessage ->
                     val now = System.currentTimeMillis()
                     if ((now - appMessage.createdAtMs) > 10_000L) return@collect
                     val normalized = appMessage.message.trim()
                     if (normalized.isBlank()) return@collect
-                    val displayMs = appMessage.durationMs.coerceIn(1500L, 4500L)
+                    val displayMs = appMessage.durationMs.coerceIn(1200L, 3600L)
 
                     val id = ++messageSeq
+                    prepareForIncomingMessage()
                     visibleMessages.add(
                         0,
                         VisibleAppMessage(
@@ -348,13 +395,7 @@ class MainActivity : ComponentActivity() {
                     )
                     dismissJobs[id] = launch {
                         delay(displayMs)
-                        visibleMessages.removeAll { it.id == id }
-                        dismissJobs.remove(id)
-                    }
-
-                    while (visibleMessages.size > maxVisible) {
-                        val removed = visibleMessages.removeLast()
-                        dismissJobs.remove(removed.id)?.cancel()
+                        removeAfterExit(id, cancelExistingJob = false)
                     }
                 }
             }

--- a/app/src/main/java/com/asmr/player/main/MainContainer.kt
+++ b/app/src/main/java/com/asmr/player/main/MainContainer.kt
@@ -1650,8 +1650,6 @@ fun MainContainer(
                     }
                 }
             }
-
-            NonTouchableAppMessageOverlay(messages = visibleMessages)
         }
 
         }
@@ -1902,6 +1900,8 @@ fun MainContainer(
                 }
             }
         }
+
+        NonTouchableAppMessageOverlay(messages = visibleMessages)
     }
 }
 

--- a/app/src/main/java/com/asmr/player/ui/common/AppMessageOverlay.kt
+++ b/app/src/main/java/com/asmr/player/ui/common/AppMessageOverlay.kt
@@ -1,10 +1,23 @@
 package com.asmr.player.ui.common
 
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.FastOutLinearInEasing
+import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.animation.core.MutableTransitionState
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.expandVertically
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.scaleIn
+import androidx.compose.animation.scaleOut
+import androidx.compose.animation.slideInVertically
+import androidx.compose.animation.slideOutVertically
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.key
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
@@ -17,7 +30,8 @@ data class VisibleAppMessage(
     val message: String,
     val type: MessageType,
     val count: Int = 1,
-    val durationMs: Long = 3000L
+    val durationMs: Long = 2000L,
+    val isVisible: Boolean = true
 )
 
 @Composable
@@ -26,19 +40,49 @@ fun AppMessageOverlay(
     modifier: Modifier = Modifier
 ) {
     Column(
-        modifier = modifier.widthIn(max = 360.dp),
+        modifier = modifier
+            .widthIn(max = 360.dp),
         verticalArrangement = Arrangement.spacedBy(8.dp),
         horizontalAlignment = Alignment.Start
     ) {
         messages.asReversed().forEach { msg ->
-            Box {
-                AppSnackbar(
-                    messageId = msg.renderId,
-                    message = msg.message,
-                    type = msg.type,
-                    count = msg.count,
-                    durationMs = msg.durationMs
-                )
+            key(msg.id) {
+                val visibleState = remember { MutableTransitionState(false) }
+                visibleState.targetState = msg.isVisible
+
+                AnimatedVisibility(
+                    visibleState = visibleState,
+                    enter = fadeIn(animationSpec = tween(durationMillis = 180)) +
+                        slideInVertically(
+                            animationSpec = tween(durationMillis = 220, easing = FastOutSlowInEasing),
+                            initialOffsetY = { it / 3 }
+                        ) +
+                        scaleIn(
+                            animationSpec = tween(durationMillis = 220, easing = FastOutSlowInEasing),
+                            initialScale = 0.96f
+                        ) +
+                        expandVertically(
+                            animationSpec = tween(durationMillis = 220, easing = FastOutSlowInEasing),
+                            expandFrom = Alignment.Bottom
+                        ),
+                    exit = fadeOut(animationSpec = tween(durationMillis = 160)) +
+                        slideOutVertically(
+                            animationSpec = tween(durationMillis = 180, easing = FastOutLinearInEasing),
+                            targetOffsetY = { -it / 4 }
+                        ) +
+                        scaleOut(
+                            animationSpec = tween(durationMillis = 180, easing = FastOutLinearInEasing),
+                            targetScale = 0.96f
+                        )
+                ) {
+                    AppSnackbar(
+                        messageId = msg.renderId,
+                        message = msg.message,
+                        type = msg.type,
+                        count = msg.count,
+                        durationMs = msg.durationMs
+                    )
+                }
             }
         }
     }

--- a/app/src/main/java/com/asmr/player/ui/common/AppSnackbar.kt
+++ b/app/src/main/java/com/asmr/player/ui/common/AppSnackbar.kt
@@ -177,7 +177,7 @@ fun AppSnackbarHost(
                 message = message,
                 type = type,
                 count = 1,
-                durationMs = 3_000L
+                durationMs = 2_000L
             )
         }
     )

--- a/app/src/main/java/com/asmr/player/ui/player/playerviewmodel.kt
+++ b/app/src/main/java/com/asmr/player/ui/player/playerviewmodel.kt
@@ -341,8 +341,10 @@ class PlayerViewModel @Inject constructor(
         val enabled = slicePlaybackController.sliceModeEnabled.value
         if (!enabled) {
             slicePlaybackController.setSliceModeEnabled(true)
+            messageManager.showInfo("仅播放切片已开启")
         } else {
             slicePlaybackController.setSliceModeEnabled(false)
+            messageManager.showInfo("仅播放切片已关闭")
         }
     }
 

--- a/app/src/main/java/com/asmr/player/util/MessageManager.kt
+++ b/app/src/main/java/com/asmr/player/util/MessageManager.kt
@@ -18,7 +18,7 @@ data class AppMessage(
     val id: Long,
     val message: String,
     val type: MessageType = MessageType.Info,
-    val durationMs: Long = 3000,
+    val durationMs: Long = 2000,
     val createdAtMs: Long
 ) {
     fun formatForSnackbar(): String = "[${type.name.uppercase()}]$message"
@@ -34,7 +34,7 @@ class MessageManager @Inject constructor() {
     )
     val messages = _messages.asSharedFlow()
 
-    fun showMessage(message: String, type: MessageType = MessageType.Info, durationMs: Long = 3000) {
+    fun showMessage(message: String, type: MessageType = MessageType.Info, durationMs: Long = 2000) {
         val normalizedMessage = when (type) {
             MessageType.Error -> AppErrorMessageFormatter.sanitize(message)
             else -> message.trim()


### PR DESCRIPTION
## Summary
- limit stacked app message bubbles to five and evict the oldest bubble when the stack overflows
- preserve per-bubble countdown progress while adding enter/exit motion and smoother insertion behavior
- keep message bubbles above NowPlaying and add feedback when toggling slice-only playback
- reduce default message duration to 2 seconds

## Verification
- ./gradlew.bat :app:compileDebugKotlin