### PR TITLE
fix: improve DLsite Play image preview loading

### DIFF
--- a/app/src/main/java/com/asmr/player/benchmark/BenchmarkHarnessActivity.kt
+++ b/app/src/main/java/com/asmr/player/benchmark/BenchmarkHarnessActivity.kt
@@ -154,7 +154,7 @@ private fun BenchmarkScenarioScreen(
         BenchmarkScenario.SearchNetwork -> {
             SearchScreen(
                 windowSizeClass = windowSizeClass,
-                onAlbumClick = {}
+                onAlbumClick = { _, _ -> }
             )
         }
 

--- a/app/src/main/java/com/asmr/player/data/remote/api/AsmrOneApi.kt
+++ b/app/src/main/java/com/asmr/player/data/remote/api/AsmrOneApi.kt
@@ -85,5 +85,9 @@ data class AsmrOneTrackNodeResponse(
     @SerializedName(value = "streamUrl", alternate = ["mediaStreamUrl", "stream_url"])
     val streamUrl: String? = null,
     @SerializedName(value = "mediaDownloadUrl", alternate = ["mediaUrl", "media_url", "downloadUrl", "download_url", "url"])
-    val mediaDownloadUrl: String? = null
+    val mediaDownloadUrl: String? = null,
+    val dlsitePlayImageCrypt: Boolean = false,
+    val dlsitePlayImageWidth: Int? = null,
+    val dlsitePlayImageHeight: Int? = null,
+    val dlsitePlayOptimizedName: String? = null
 )

--- a/app/src/main/java/com/asmr/player/data/remote/dlsite/DlsitePlayImageSupport.kt
+++ b/app/src/main/java/com/asmr/player/data/remote/dlsite/DlsitePlayImageSupport.kt
@@ -1,0 +1,140 @@
+package com.asmr.player.data.remote.dlsite
+
+import android.graphics.Bitmap
+import android.graphics.Canvas
+import android.graphics.Paint
+import android.graphics.Rect
+import kotlin.math.ceil
+import kotlin.math.floor
+
+internal const val DLSITE_PLAY_PREVIEW_CACHE_VERSION = 2
+
+internal fun parseDlsitePlayCryptFlag(value: Any?): Boolean {
+    return when (value) {
+        is Boolean -> value
+        is Number -> value.toInt() != 0
+        is String -> {
+            val normalized = value.trim().lowercase()
+            when {
+                normalized.isBlank() -> false
+                normalized == "true" || normalized == "yes" || normalized == "y" || normalized == "on" -> true
+                normalized == "false" || normalized == "no" || normalized == "n" || normalized == "off" -> false
+                else -> normalized.toIntOrNull()?.let { it != 0 } ?: false
+            }
+        }
+        else -> false
+    }
+}
+
+internal fun parseDlsitePlayImageSeed(optimizedName: String?): Int? {
+    val normalized = optimizedName?.trim().orEmpty()
+    if (normalized.length < 12) return null
+    return normalized.substring(5, 12).toIntOrNull(16)
+}
+
+internal fun descrambleDlsitePlayBitmap(src: Bitmap, seed: Int, width: Int, height: Int): Bitmap {
+    val tileSize = 128
+    val tilesW = ceil(width / tileSize.toDouble()).toInt().coerceAtLeast(1)
+    val tilesH = ceil(height / tileSize.toDouble()).toInt().coerceAtLeast(1)
+    val tileCount = tilesW * tilesH
+    val order = dlsitePlayMtShuffledTiles(seed, tileCount)
+    val reverse = IntArray(tileCount)
+    order.forEachIndexed { index, value ->
+        if (value in reverse.indices) reverse[value] = index
+    }
+
+    val out = Bitmap.createBitmap(src.width, src.height, Bitmap.Config.ARGB_8888)
+    val canvas = Canvas(out)
+    val paint = Paint(Paint.FILTER_BITMAP_FLAG)
+    for (i in 0 until tileCount) {
+        val srcIndex = reverse[i]
+        val srcX = (srcIndex % tilesW) * tileSize
+        val srcY = (srcIndex / tilesW) * tileSize
+        val dstX = (i % tilesW) * tileSize
+        val dstY = (i / tilesW) * tileSize
+        val srcW = minOf(tileSize, src.width - srcX)
+        val srcH = minOf(tileSize, src.height - srcY)
+        if (srcW <= 0 || srcH <= 0) continue
+        canvas.drawBitmap(
+            src,
+            Rect(srcX, srcY, srcX + srcW, srcY + srcH),
+            Rect(dstX, dstY, dstX + srcW, dstY + srcH),
+            paint
+        )
+    }
+
+    val croppedWidth = width.coerceAtMost(out.width)
+    val croppedHeight = height.coerceAtMost(out.height)
+    if (croppedWidth == out.width && croppedHeight == out.height) return out
+    val cropped = Bitmap.createBitmap(out, 0, 0, croppedWidth, croppedHeight)
+    if (cropped !== out) out.recycle()
+    return cropped
+}
+
+private fun dlsitePlayMtShuffledTiles(seed: Int, length: Int): List<Int> {
+    val random = DlsitePlayMtRandom(seed)
+    val values = MutableList(length) { it }
+    for (n in length - 1 downTo 0) {
+        val index = floor(random.nextDouble() * (n + 1)).toInt()
+        val tmp = values[n]
+        values[n] = values[index]
+        values[index] = tmp
+    }
+    return values
+}
+
+private class DlsitePlayMtRandom(seed: Int) {
+    private val mt = IntArray(624)
+    private var index = 624
+
+    init {
+        mt[0] = seed
+        for (i in 1 until 624) {
+            val prev = mt[i - 1]
+            mt[i] = (1812433253L * (prev xor (prev ushr 30)) + i).toInt()
+        }
+    }
+
+    fun nextDouble(): Double {
+        val a = nextInt32() ushr 5
+        val b = peekInt32() ushr 6
+        return (a * 67108864.0 + b) / 9007199254740992.0
+    }
+
+    private fun nextInt32(): Int {
+        if (index >= 624) twist()
+        val value = temper(mt[index])
+        index += 1
+        return value
+    }
+
+    private fun peekInt32(): Int {
+        if (index < 624) return temper(mt[index])
+
+        val saved = mt.copyOf()
+        val savedIndex = index
+        twist()
+        val value = temper(mt[index])
+        saved.copyInto(mt)
+        index = savedIndex
+        return value
+    }
+
+    private fun temper(value: Int): Int {
+        var y = value
+        y = y xor (y ushr 11)
+        y = y xor ((y shl 7) and -1658038656)
+        y = y xor ((y shl 15) and -272236544)
+        y = y xor (y ushr 18)
+        return y
+    }
+
+    private fun twist() {
+        for (i in 0 until 624) {
+            val y = (mt[i] and Int.MIN_VALUE) or (mt[(i + 1) % 624] and Int.MAX_VALUE)
+            mt[i] = mt[(i + 397) % 624] xor (y ushr 1)
+            if ((y and 1) != 0) mt[i] = mt[i] xor -1727483681
+        }
+        index = 0
+    }
+}

--- a/app/src/main/java/com/asmr/player/data/remote/dlsite/DlsitePlayLibraryClient.kt
+++ b/app/src/main/java/com/asmr/player/data/remote/dlsite/DlsitePlayLibraryClient.kt
@@ -29,6 +29,8 @@ class DlsitePlayLibraryClient @Inject constructor(
     private var cachedAlbums: List<Album> = emptyList()
     private var cachedTs: Long = 0L
 
+    fun hasStoredCredentials(): Boolean = authStore.isPlayLoggedIn()
+
     suspend fun searchPurchased(keyword: String, page: Int, pageSize: Int): PurchasedSearchPage {
         return withContext(Dispatchers.IO) {
             val all = ensureLibraryCached()

--- a/app/src/main/java/com/asmr/player/data/remote/dlsite/DlsitePlayWorkClient.kt
+++ b/app/src/main/java/com/asmr/player/data/remote/dlsite/DlsitePlayWorkClient.kt
@@ -87,6 +87,7 @@ class DlsitePlayWorkClient @Inject constructor(
         val q = buildQuery(mapOf("v" to rev) + params)
         val audioUrlByHash = LinkedHashMap<String, String>()
         val videoUrlByHash = LinkedHashMap<String, String>()
+        val optimizedUrlByHash = LinkedHashMap<String, String>()
         val durationByHash = LinkedHashMap<String, Double?>()
         val audioLeaves = mutableListOf<DlsitePlayLeaf>()
         val videoLeaves = mutableListOf<DlsitePlayLeaf>()
@@ -94,16 +95,20 @@ class DlsitePlayWorkClient @Inject constructor(
         if (playfile != null) {
             playfile.forEach { (k, v) ->
                 val origHash = k?.toString().orEmpty().trim()
+                if (origHash.isBlank()) return@forEach
                 val meta = v as? Map<*, *> ?: return@forEach
                 val type = (meta["type"] as? String).orEmpty()
+                val opt = optimizedBlock(meta, type)
+                val optName = (opt?.get("name") as? String).orEmpty().trim()
+                val optimizedUrl = if (optName.isNotBlank()) "${baseUrl}optimized/$optName?$q" else null
+                if (optimizedUrl != null) {
+                    optimizedUrlByHash[origHash] = optimizedUrl
+                }
                 when (type) {
                     "audio" -> {
-                        val audio = meta["audio"] as? Map<*, *> ?: return@forEach
-                        val opt = audio["optimized"] as? Map<*, *> ?: return@forEach
-                        val optName = (opt["name"] as? String).orEmpty().trim()
-                        if (optName.isBlank()) return@forEach
+                        if (opt == null || optimizedUrl == null) return@forEach
 
-                        val streamUrl = "${baseUrl}optimized/$optName?$q"
+                        val streamUrl = optimizedUrl
                         val display = fileToDisplay[origHash].orEmpty().ifBlank { origHash }
                         val (folder, filename) = splitFolder(display)
                         val subtitles = buildSubtitles(
@@ -114,7 +119,7 @@ class DlsitePlayWorkClient @Inject constructor(
                             dirToFiles = dirToFiles,
                             vttOpt = vttOpt
                         )
-                        val duration = (opt["duration"] as? Number)?.toDouble()
+                        val duration = parseDuration(opt["duration"])
                         audioUrlByHash[origHash] = streamUrl
                         durationByHash[origHash] = duration
                         audioLeaves.add(
@@ -127,12 +132,9 @@ class DlsitePlayWorkClient @Inject constructor(
                         )
                     }
                     "video", "movie" -> {
-                        val video = (meta["video"] as? Map<*, *>) ?: (meta["movie"] as? Map<*, *>)
-                        val opt = video?.get("optimized") as? Map<*, *> ?: return@forEach
-                        val optName = (opt["name"] as? String).orEmpty().trim()
-                        if (optName.isBlank()) return@forEach
+                        if (opt == null || optimizedUrl == null) return@forEach
 
-                        val streamUrl = "${baseUrl}optimized/$optName?$q"
+                        val streamUrl = optimizedUrl
                         val display = fileToDisplay[origHash].orEmpty().ifBlank { origHash }
                         val (folder, filename) = splitFolder(display)
                         val subtitles = buildSubtitles(
@@ -143,7 +145,7 @@ class DlsitePlayWorkClient @Inject constructor(
                             dirToFiles = dirToFiles,
                             vttOpt = vttOpt
                         )
-                        val duration = (opt["duration"] as? Number)?.toDouble()
+                        val duration = parseDuration(opt["duration"])
                         videoUrlByHash[origHash] = streamUrl
                         durationByHash[origHash] = duration
                         videoLeaves.add(
@@ -180,12 +182,38 @@ class DlsitePlayWorkClient @Inject constructor(
                 DlsiteFileKind.Audio -> audioUrlByHash[hn]
                 DlsiteFileKind.Subtitle -> subtitleUrlByHash[hn]
                 DlsiteFileKind.Video -> videoUrlByHash[hn]
+                DlsiteFileKind.Image,
+                DlsiteFileKind.Text,
+                DlsiteFileKind.Pdf -> optimizedUrlByHash[hn]
                 else -> null
+            }
+            if (url.isNullOrBlank() && kind != DlsiteFileKind.Pdf) return@mapNotNull null
+            val imageMeta = if (kind == DlsiteFileKind.Image) {
+                val meta = playfile?.get(hn) as? Map<*, *>
+                val opt = meta?.let { optimizedBlock(it, "image") }
+                val optimizedName = (opt?.get("name") as? String).orEmpty().trim()
+                if (opt != null && optimizedName.isNotBlank()) {
+                    val rawCrypt = opt["crypt"]
+                    val crypt = parseDlsitePlayCryptFlag(rawCrypt)
+                    val width = parseInt(opt["width"])
+                    val height = parseInt(opt["height"])
+                    DlsitePlayImageMeta(
+                        crypt = crypt,
+                        width = width,
+                        height = height,
+                        optimizedName = optimizedName
+                    )
+                } else {
+                    null
+                }
+            } else {
+                null
             }
             DlsitePlayFileEntry(
                 displayPath = display,
                 url = url,
-                duration = durationByHash[hn]
+                duration = durationByHash[hn],
+                imageMeta = imageMeta
             )
         }
 
@@ -268,7 +296,8 @@ class DlsitePlayWorkClient @Inject constructor(
             val title: String,
             val children: LinkedHashMap<String, Node> = linkedMapOf(),
             var url: String? = null,
-            var duration: Double? = null
+            var duration: Double? = null,
+            var imageMeta: DlsitePlayImageMeta? = null
         )
 
         val root = Node(title = "")
@@ -285,17 +314,23 @@ class DlsitePlayWorkClient @Inject constructor(
             val node = getOrCreateChild(cur, fileName)
             node.url = file.url
             node.duration = file.duration
+            node.imageMeta = file.imageMeta
         }
 
         fun toResponse(node: Node): AsmrOneTrackNodeResponse {
             val kids = node.children.values.map { toResponse(it) }
-            return AsmrOneTrackNodeResponse(
+            val resp = AsmrOneTrackNodeResponse(
                 title = node.title,
                 children = kids.takeIf { it.isNotEmpty() },
                 duration = node.duration,
                 streamUrl = node.url,
-                mediaDownloadUrl = node.url
+                mediaDownloadUrl = node.url,
+                dlsitePlayImageCrypt = node.imageMeta?.crypt == true,
+                dlsitePlayImageWidth = node.imageMeta?.width,
+                dlsitePlayImageHeight = node.imageMeta?.height,
+                dlsitePlayOptimizedName = node.imageMeta?.optimizedName
             )
+            return resp
         }
 
         return root.children.values.map { toResponse(it) }
@@ -337,6 +372,36 @@ class DlsitePlayWorkClient @Inject constructor(
         return if (idx >= 0) trimmed.substring(0, idx) to trimmed.substring(idx + 1) else "" to trimmed
     }
 
+    private fun typedFileBlock(meta: Map<*, *>, type: String): Map<*, *>? {
+        val keys = when (type) {
+            "movie" -> listOf("movie", "video")
+            else -> listOf(type)
+        }
+        return keys.asSequence()
+            .mapNotNull { key -> meta[key] as? Map<*, *> }
+            .firstOrNull()
+    }
+
+    private fun optimizedBlock(meta: Map<*, *>, type: String): Map<*, *>? {
+        return typedFileBlock(meta, type)?.get("optimized") as? Map<*, *>
+    }
+
+    private fun parseDuration(value: Any?): Double? {
+        return when (value) {
+            is Number -> value.toDouble()
+            is String -> value.toDoubleOrNull()
+            else -> null
+        }
+    }
+
+    private fun parseInt(value: Any?): Int? {
+        return when (value) {
+            is Number -> value.toInt()
+            is String -> value.toIntOrNull()
+            else -> null
+        }
+    }
+
     private fun buildQuery(params: Map<String, String>): String {
         return params.entries.joinToString("&") { (k, v) ->
             "${URLEncoder.encode(k, Charsets.UTF_8.name())}=${URLEncoder.encode(v, Charsets.UTF_8.name())}"
@@ -353,7 +418,15 @@ class DlsitePlayWorkClient @Inject constructor(
     private data class DlsitePlayFileEntry(
         val displayPath: String,
         val url: String?,
-        val duration: Double?
+        val duration: Double?,
+        val imageMeta: DlsitePlayImageMeta? = null
+    )
+
+    private data class DlsitePlayImageMeta(
+        val crypt: Boolean,
+        val width: Int?,
+        val height: Int?,
+        val optimizedName: String
     )
 
     private enum class DlsiteFileKind { Audio, Subtitle, Image, Video, Text, Pdf, Other }
@@ -362,10 +435,10 @@ class DlsitePlayWorkClient @Inject constructor(
         val ext = fileName.substringAfterLast('.', "").lowercase()
         return when (ext) {
             "mp3", "wav", "flac", "m4a", "ogg", "aac", "opus" -> DlsiteFileKind.Audio
-            "vtt", "lrc", "srt" -> DlsiteFileKind.Subtitle
+            "vtt", "lrc", "srt", "ass", "ssa" -> DlsiteFileKind.Subtitle
             "jpg", "jpeg", "png", "webp", "gif" -> DlsiteFileKind.Image
             "mp4", "mkv", "webm" -> DlsiteFileKind.Video
-            "txt", "md", "nfo" -> DlsiteFileKind.Text
+            "txt", "md", "nfo", "csv", "tsv", "json", "xml", "html", "htm", "log", "ini", "cue", "ks", "yaml", "yml", "rtf" -> DlsiteFileKind.Text
             "pdf" -> DlsiteFileKind.Pdf
             else -> DlsiteFileKind.Other
         }

--- a/app/src/main/java/com/asmr/player/main/MainContainer.kt
+++ b/app/src/main/java/com/asmr/player/main/MainContainer.kt
@@ -442,11 +442,11 @@ fun MainContainer(
         }
     }
 
-    fun openAlbumDetailFromSearch(albumId: Long?, rj: String?) {
+    fun openAlbumDetailFromSearch(albumId: Long?, rj: String?, preferDlsitePlay: Boolean = false) {
         val seq = ++pendingDetailNavigationSeq
         pendingDetailNavigation = true
         cancelPendingDetailNavigation = false
-        navigator.openAlbumDetail(albumId = albumId, rj = rj)
+        navigator.openAlbumDetail(albumId = albumId, rj = rj, preferDlsitePlay = preferDlsitePlay)
         scope.launch {
             delay(700)
             if (pendingDetailNavigationSeq == seq) {
@@ -1132,10 +1132,11 @@ fun MainContainer(
                                         Routes.Search -> {
                                             SearchScreen(
                                                 windowSizeClass = windowSizeClass,
-                                                onAlbumClick = { album ->
+                                                onAlbumClick = { album, fromPurchasedOnly ->
                                                     openAlbumDetailFromSearch(
                                                         albumId = album.id,
-                                                        rj = album.rjCode.ifBlank { album.workId }
+                                                        rj = album.rjCode.ifBlank { album.workId },
+                                                        preferDlsitePlay = fromPurchasedOnly
                                                     )
                                                 },
                                                 viewModel = searchViewModel
@@ -1229,15 +1230,19 @@ fun MainContainer(
                                 composable("search") {
                     Box(modifier = Modifier.fillMaxSize())
                 }
-                                composable(
-                    route = "album_detail_rj/{rj}",
-                    arguments = listOf(navArgument("rj") { defaultValue = "" })
+                composable(
+                    route = Routes.AlbumDetailByRjPattern,
+                    arguments = listOf(
+                        navArgument("rj") { defaultValue = "" },
+                        navArgument("initialTab") { type = NavType.StringType; nullable = true; defaultValue = null }
+                    )
                 ) { backStackEntry ->
                     val rj = backStackEntry.arguments?.getString("rj").orEmpty()
                     val refreshToken by backStackEntry.savedStateHandle.getStateFlow("refreshToken", 0L).collectAsState()
                     AlbumDetailScreen(
                         windowSizeClass = windowSizeClass,
                         rjCode = rj,
+                        initialTab = backStackEntry.arguments?.getString("initialTab").toAlbumDetailInitialTab(),
                         refreshToken = refreshToken,
                         onConsumeRefreshToken = { backStackEntry.savedStateHandle["refreshToken"] = 0L },
                         onPlayTracks = { album, tracks, startTrack ->
@@ -1288,10 +1293,11 @@ fun MainContainer(
                     )
                 }
                 composable(
-                    route = "album_detail/{albumId}?rjCode={rjCode}",
+                    route = Routes.AlbumDetailByIdPattern,
                     arguments = listOf(
                         navArgument("albumId") { type = NavType.LongType },
-                        navArgument("rjCode") { type = NavType.StringType; nullable = true; defaultValue = null }
+                        navArgument("rjCode") { type = NavType.StringType; nullable = true; defaultValue = null },
+                        navArgument("initialTab") { type = NavType.StringType; nullable = true; defaultValue = null }
                     )
                 ) { backStackEntry ->
                     val albumId = backStackEntry.arguments?.getLong("albumId") ?: 0L
@@ -1301,6 +1307,7 @@ fun MainContainer(
                         windowSizeClass = windowSizeClass,
                         albumId = albumId,
                         rjCode = rjCode,
+                        initialTab = backStackEntry.arguments?.getString("initialTab").toAlbumDetailInitialTab(),
                         refreshToken = refreshToken,
                         onConsumeRefreshToken = { backStackEntry.savedStateHandle["refreshToken"] = 0L },
                         onPlayTracks = { album, tracks, startTrack ->

--- a/app/src/main/java/com/asmr/player/main/MainNavigationSupport.kt
+++ b/app/src/main/java/com/asmr/player/main/MainNavigationSupport.kt
@@ -198,6 +198,15 @@ internal fun encodeRouteArg(value: String): String = URLEncoder.encode(value, "U
 internal fun decodeRouteArg(value: String): String = runCatching { URLDecoder.decode(value, "UTF-8") }
     .getOrDefault(value)
 
+internal fun String?.toAlbumDetailInitialTab(): Int? {
+    return when (this?.trim()) {
+        "local" -> 0
+        "dl" -> 1
+        "dlsitePlay" -> 2
+        else -> null
+    }
+}
+
 internal fun computePrimaryNavSelectionProgresses(
     pagerRoutes: List<String>,
     currentPage: Int,

--- a/app/src/main/java/com/asmr/player/ui/common/ImagePreviewDialog.kt
+++ b/app/src/main/java/com/asmr/player/ui/common/ImagePreviewDialog.kt
@@ -43,6 +43,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableStateMapOf
+import androidx.compose.runtime.produceState
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
@@ -92,6 +93,12 @@ internal val DefaultImagePreviewLayoutSpec = ImagePreviewLayoutSpec()
 internal data class ImagePreviewItem(
     val key: String,
     val title: String,
+    val imageModel: Any? = null,
+    val openPathOrUrl: String,
+    val prepareImage: (suspend () -> ImagePreviewPreparedItem?)? = null
+)
+
+internal data class ImagePreviewPreparedItem(
     val imageModel: Any,
     val openPathOrUrl: String
 )
@@ -135,13 +142,14 @@ internal fun ImagePreviewDialog(
         pageCount = { items.size }
     )
     val pageTransforms = remember(items) { mutableStateMapOf<String, ImagePreviewTransformState>() }
+    val resolvedItems = remember(items) { mutableStateMapOf<String, ImagePreviewPreparedItem>() }
     val currentItem = items.getOrElse(pagerState.currentPage) { items.first() }
     val currentTransform = pageTransforms.getOrPut(currentItem.key) { ImagePreviewTransformState() }
     val canNavigate = items.size > 1
     val allowPaging = currentTransform.isAtRest
 
     fun openCurrentWithOtherApp() {
-        val path = currentItem.openPathOrUrl.trim()
+        val path = (resolvedItems[currentItem.key]?.openPathOrUrl ?: currentItem.openPathOrUrl).trim()
         if (path.isBlank()) {
             messageManager.showError("无法打开：路径为空")
             return
@@ -265,14 +273,19 @@ internal fun ImagePreviewDialog(
                                 .fillMaxSize()
                                 .clipToBounds()
                                 .testTag(IMAGE_PREVIEW_PAGER_TAG),
-                            userScrollEnabled = canNavigate && allowPaging
+                            beyondBoundsPageCount = 0,
+                            userScrollEnabled = canNavigate && allowPaging,
+                            key = { index -> items[index].key }
                         ) { page ->
                             val item = items[page]
                             val transformState = pageTransforms.getOrPut(item.key) { ImagePreviewTransformState() }
-                            pageContent(
+                            ImagePreviewPageHost(
                                 item = item,
+                                cachedPrepared = resolvedItems[item.key],
+                                onPrepared = { prepared -> resolvedItems[item.key] = prepared },
                                 state = transformState,
-                                onStateChange = { pageTransforms[item.key] = it }
+                                onStateChange = { pageTransforms[item.key] = it },
+                                pageContent = pageContent
                             )
                         }
 
@@ -338,6 +351,51 @@ internal data class ImagePreviewTransformState(
         get() = scale <= 1.01f && kotlin.math.abs(offset.x) < 0.5f && kotlin.math.abs(offset.y) < 0.5f
 }
 
+@Composable
+private fun ImagePreviewPageHost(
+    item: ImagePreviewItem,
+    cachedPrepared: ImagePreviewPreparedItem?,
+    onPrepared: (ImagePreviewPreparedItem) -> Unit,
+    state: ImagePreviewTransformState,
+    onStateChange: (ImagePreviewTransformState) -> Unit,
+    pageContent: @Composable (
+        item: ImagePreviewItem,
+        state: ImagePreviewTransformState,
+        onStateChange: (ImagePreviewTransformState) -> Unit
+    ) -> Unit
+) {
+    val prepared by produceState(
+        initialValue = cachedPrepared ?: item.imageModel?.let { model ->
+            ImagePreviewPreparedItem(imageModel = model, openPathOrUrl = item.openPathOrUrl)
+        },
+        key1 = item.key,
+        key2 = cachedPrepared
+    ) {
+        if (value != null) return@produceState
+        value = item.prepareImage?.invoke()
+    }
+
+    LaunchedEffect(item.key, prepared) {
+        prepared?.let(onPrepared)
+    }
+
+    val displayItem = remember(item, prepared) {
+        prepared?.let { resolved ->
+            item.copy(
+                imageModel = resolved.imageModel,
+                openPathOrUrl = resolved.openPathOrUrl,
+                prepareImage = null
+            )
+        } ?: item.copy(prepareImage = null)
+    }
+
+    pageContent(
+        item = displayItem,
+        state = state,
+        onStateChange = onStateChange
+    )
+}
+
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
 private fun ImagePreviewPage(
@@ -366,6 +424,16 @@ private fun ImagePreviewPage(
             .clipToBounds(),
         contentAlignment = Alignment.Center
     ) {
+        if (item.imageModel == null) {
+            Box(
+                modifier = Modifier.fillMaxSize(),
+                contentAlignment = Alignment.Center
+            ) {
+                AsmrShimmerPlaceholder(modifier = Modifier.fillMaxSize(), cornerRadius = 0)
+            }
+            return
+        }
+
         AsmrAsyncImage(
             model = item.imageModel,
             contentDescription = null,

--- a/app/src/main/java/com/asmr/player/ui/library/AlbumDetailScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/AlbumDetailScreen.kt
@@ -201,6 +201,7 @@ fun AlbumDetailScreen(
     onPlayVideo: (String, String, String, String) -> Unit = { _, _, _, _ -> },
     onOpenDlsiteLogin: () -> Unit = {},
     onOpenAlbumByRj: (String) -> Unit = {},
+    initialTab: Int? = null,
     viewModel: AlbumDetailViewModel = hiltViewModel()
 ) {
     val uiState by viewModel.uiState.collectAsState()
@@ -212,8 +213,11 @@ fun AlbumDetailScreen(
         if (rjPart.isNotBlank()) "album:$rjPart" else "albumId:$idPart"
     }
     val introSessionKey = remember(screenKey) { "intro:${UUID.randomUUID()}" }
-    var selectedTab by rememberSaveable(screenKey) {
-        mutableIntStateOf(if (albumId != null && albumId > 0) 0 else 1)
+    val initialSelectedTab = remember(albumId, initialTab) {
+        initialTab?.coerceIn(0, 2) ?: if (albumId != null && albumId > 0) 0 else 1
+    }
+    var selectedTab by rememberSaveable(screenKey, initialSelectedTab) {
+        mutableIntStateOf(initialSelectedTab)
     }
     var lastChromeResetTab by rememberSaveable(screenKey) {
         mutableIntStateOf(selectedTab)
@@ -399,7 +403,10 @@ fun AlbumDetailScreen(
                                 viewModel.ensureDlsiteLoaded()
                                 viewModel.ensureAsmrOneLoaded()
                             }
-                            2 -> viewModel.ensureDlsitePlayLoaded()
+                            2 -> {
+                                viewModel.ensureDlsiteLoaded()
+                                viewModel.ensureDlsitePlayLoaded()
+                            }
                         }
                     }
 
@@ -587,6 +594,7 @@ fun AlbumDetailScreen(
                                         },
                                         onPreviewImages = { request -> imagePreviewRequest = request },
                                         onPreviewFile = { onlinePreviewFile = it },
+                                        prepareImagePreview = viewModel::prepareDlsitePlayImagePreview,
                                         treeStateKey = "tree:dlsitePlay:${model.baseRjCode.ifBlank { model.rjCode }.trim().uppercase()}",
                                         initialCurrentPath = viewModel.getTreeCurrentPath("tree:dlsitePlay:${model.baseRjCode.ifBlank { model.rjCode }.trim().uppercase()}"),
                                         topContentPadding = tabContentTopPadding,

--- a/app/src/main/java/com/asmr/player/ui/library/AlbumDetailViewModel.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/AlbumDetailViewModel.kt
@@ -22,13 +22,18 @@ import com.asmr.player.data.remote.api.AsmrOneTrackNodeResponse
 import com.asmr.player.data.remote.crawler.AsmrOneCrawler
 import com.asmr.player.data.remote.dlsite.DlsiteCloudSyncCandidate
 import com.asmr.player.data.remote.dlsite.DlsiteCloudSyncResolveResult
+import com.asmr.player.data.remote.dlsite.DLSITE_PLAY_PREVIEW_CACHE_VERSION
 import com.asmr.player.data.remote.dlsite.DlsitePlayWorkClient
 import com.asmr.player.data.remote.dlsite.DlsitePlayTreeResult
 import com.asmr.player.data.remote.dlsite.DlsiteLanguageEdition
 import com.asmr.player.data.remote.dlsite.DlsiteProductInfoClient
+import com.asmr.player.data.remote.dlsite.descrambleDlsitePlayBitmap
+import com.asmr.player.data.remote.dlsite.parseDlsitePlayImageSeed
 import com.asmr.player.data.remote.dlsite.resolveCloudSyncWorkId
 import com.asmr.player.data.remote.dlsite.resolveDlsiteCloudSync
 import com.asmr.player.data.remote.dlsite.resolveSelectedDlsiteCloudSync
+import com.asmr.player.data.remote.auth.DlsiteAuthStore
+import com.asmr.player.data.remote.auth.buildDlsiteCookieHeader
 import com.asmr.player.data.remote.download.DownloadManager
 import com.asmr.player.data.remote.scraper.DLSiteScraper
 import com.asmr.player.data.remote.scraper.DlsiteRecommendedWork
@@ -69,9 +74,6 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
-import android.graphics.Canvas
-import android.graphics.Paint
-import android.graphics.Rect
 import android.os.SystemClock
 import androidx.work.ExistingWorkPolicy
 import androidx.work.OneTimeWorkRequestBuilder
@@ -257,6 +259,62 @@ class AlbumDetailViewModel @Inject constructor(
         val u = url.trim()
         if (u.isBlank()) return null
         return lyricsLoader.fetchTextForPreview(u)
+    }
+
+    suspend fun prepareDlsitePlayImagePreview(
+        url: String,
+        optimizedName: String?,
+        crypt: Boolean,
+        width: Int?,
+        height: Int?
+    ): String? = withContext(Dispatchers.IO) {
+        val normalizedUrl = url.trim()
+        if (normalizedUrl.isBlank()) return@withContext null
+        if (!crypt) return@withContext normalizedUrl
+        val imageWidth = width ?: return@withContext null
+        val imageHeight = height ?: return@withContext null
+        if (imageWidth <= 0 || imageHeight <= 0) return@withContext null
+        val name = optimizedName?.trim().orEmpty().ifBlank {
+            normalizedUrl.substringBefore('?').substringAfterLast('/')
+        }
+        val seed = parseDlsitePlayImageSeed(name) ?: return@withContext null
+
+        val previewDir = File(context.cacheDir, "dlsite_play_preview").apply { if (!exists()) mkdirs() }
+        val previewKey = listOf(
+            DLSITE_PLAY_PREVIEW_CACHE_VERSION.toString(),
+            normalizedUrl,
+            name,
+            imageWidth.toString(),
+            imageHeight.toString(),
+            seed.toString()
+        ).joinToString("|")
+        val previewFile = File(previewDir, "${previewKey.hashCode()}_descrambled.png")
+        if (previewFile.exists() && previewFile.length() > 0L) return@withContext previewFile.absolutePath
+
+        val requestBuilder = Request.Builder()
+            .url(normalizedUrl)
+            .header("Accept", "image/*,*/*;q=0.8")
+            .header("Referer", "https://play.dlsite.com/")
+            .header("User-Agent", NetworkHeaders.USER_AGENT)
+            .header("Accept-Language", NetworkHeaders.ACCEPT_LANGUAGE)
+            .get()
+        val cookie = buildDlsiteCookieHeader(DlsiteAuthStore(context).getPlayCookie())
+        if (cookie.isNotBlank()) requestBuilder.header("Cookie", cookie)
+
+        val bytes = runCatching {
+            imageOkHttpClient.newCall(requestBuilder.build()).execute().use { resp ->
+                if (!resp.isSuccessful) return@use null
+                resp.body?.bytes()
+            }
+        }.getOrNull() ?: return@withContext null
+        val scrambled = BitmapFactory.decodeByteArray(bytes, 0, bytes.size) ?: return@withContext null
+        val descrambled = descrambleDlsitePlayBitmap(scrambled, seed, imageWidth, imageHeight)
+        FileOutputStream(previewFile).use { out ->
+            descrambled.compress(Bitmap.CompressFormat.PNG, 100, out)
+        }
+        if (descrambled !== scrambled && !descrambled.isRecycled) descrambled.recycle()
+        if (!scrambled.isRecycled) scrambled.recycle()
+        previewFile.absolutePath
     }
 
     fun getListScrollPosition(stateKey: String): Pair<Int, Int> {
@@ -2188,7 +2246,6 @@ class AlbumDetailViewModel @Inject constructor(
             fail("db_update_${e.javaClass.simpleName}")
         }
     }
-
 
     private data class OnlineSaveLeaf(
         val relativePath: String,

--- a/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailDialogs.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailDialogs.kt
@@ -696,8 +696,21 @@ internal fun FilePreviewDialog(
         mutableIntStateOf(initialCandidates.indexOf(absolutePath).takeIf { it >= 0 } ?: 0)
     }
     val currentPath = initialCandidates.getOrElse(currentIndex) { absolutePath }
-    val currentName = remember(currentPath) { currentPath.substringAfterLast('/').substringAfterLast('\\') }
-    val currentType = remember(currentName) { treeFileTypeForName(currentName) }
+    val currentName = remember(currentPath, absolutePath, title) {
+        if (currentPath == absolutePath && title.isNotBlank()) {
+            title
+        } else {
+            currentPath.substringAfterLast('/').substringAfterLast('\\')
+        }
+    }
+    val currentType = remember(currentPath, absolutePath, currentName, fileType) {
+        val inferred = treeFileTypeForName(currentName)
+        when {
+            currentPath == absolutePath && fileType != TreeFileType.Other -> fileType
+            inferred != TreeFileType.Other -> inferred
+            else -> fileType
+        }
+    }
     val canNavigate = initialCandidates.size > 1
     var fullscreen by remember { mutableStateOf(false) }
     val canFullscreen = currentType == TreeFileType.Video

--- a/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailDirectorySupport.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailDirectorySupport.kt
@@ -200,8 +200,8 @@ internal fun treeFileTypeForName(fileName: String): TreeFileType {
         "mp3", "wav", "flac", "m4a", "ogg", "aac", "opus" -> TreeFileType.Audio
         "mp4", "mkv", "webm", "mov", "m4v" -> TreeFileType.Video
         "jpg", "jpeg", "png", "webp", "gif" -> TreeFileType.Image
-        "lrc", "srt", "vtt" -> TreeFileType.Subtitle
-        "txt", "md", "nfo" -> TreeFileType.Text
+        "lrc", "srt", "vtt", "ass", "ssa" -> TreeFileType.Subtitle
+        "txt", "md", "nfo", "csv", "tsv", "json", "xml", "html", "htm", "log", "ini", "cue", "ks", "yaml", "yml", "rtf" -> TreeFileType.Text
         "pdf" -> TreeFileType.Pdf
         else -> TreeFileType.Other
     }
@@ -296,7 +296,11 @@ internal data class DirectoryFileItem(
     val thumbnailModel: Any? = null,
     val playlistTarget: PlaylistAddTarget? = null,
     val subtitleSources: List<RemoteSubtitleSource> = emptyList(),
-    val showSubtitleStamp: Boolean = false
+    val showSubtitleStamp: Boolean = false,
+    val dlsitePlayImageCrypt: Boolean = false,
+    val dlsitePlayImageWidth: Int? = null,
+    val dlsitePlayImageHeight: Int? = null,
+    val dlsitePlayOptimizedName: String? = null
 )
 
 internal data class DirectoryBrowserResult(
@@ -323,7 +327,7 @@ internal fun buildDirectoryImagePreviewRequest(
     if (imageFiles.isEmpty()) return null
     val items = imageFiles.mapNotNull(toPreviewItem)
     if (items.isEmpty()) return null
-    val initialIndex = imageFiles.indexOfFirst { it.path == clickedPath }
+    val initialIndex = items.indexOfFirst { it.key == clickedPath }
     if (initialIndex < 0) return null
     return ImagePreviewRequest(items = items, initialIndex = initialIndex)
 }
@@ -507,7 +511,11 @@ internal class RemoteTreeNode(
     var url: String = "",
     var durationSeconds: Double? = null,
     var subtitleSources: List<RemoteSubtitleSource> = emptyList(),
-    var playlistTarget: PlaylistAddTarget? = null
+    var playlistTarget: PlaylistAddTarget? = null,
+    var dlsitePlayImageCrypt: Boolean = false,
+    var dlsitePlayImageWidth: Int? = null,
+    var dlsitePlayImageHeight: Int? = null,
+    var dlsitePlayOptimizedName: String? = null
 )
 
 internal data class RemoteTreeIndex(
@@ -541,7 +549,11 @@ internal fun buildRemoteTreeIndex(
         val safeTitle: String,
         val url: String,
         val duration: Double?,
-        val fileType: TreeFileType
+        val fileType: TreeFileType,
+        val dlsitePlayImageCrypt: Boolean,
+        val dlsitePlayImageWidth: Int?,
+        val dlsitePlayImageHeight: Int?,
+        val dlsitePlayOptimizedName: String?
     ) {
         val ext: String = rawTitle.substringAfterLast('.', "").lowercase()
         val baseName: String = rawTitle.substringBeforeLast('.')
@@ -597,7 +609,11 @@ internal fun buildRemoteTreeIndex(
                     safeTitle = safeTitle,
                     url = url,
                     duration = node.duration,
-                    fileType = treeFileTypeForNode(rawTitle, url)
+                    fileType = treeFileTypeForNode(rawTitle, url),
+                    dlsitePlayImageCrypt = node.dlsitePlayImageCrypt,
+                    dlsitePlayImageWidth = node.dlsitePlayImageWidth,
+                    dlsitePlayImageHeight = node.dlsitePlayImageHeight,
+                    dlsitePlayOptimizedName = node.dlsitePlayOptimizedName
                 )
             } else {
                 null
@@ -632,6 +648,10 @@ internal fun buildRemoteTreeIndex(
             child.durationSeconds = leaf.duration
             child.subtitleSources = subtitleSources
             child.playlistTarget = playlistTarget
+            child.dlsitePlayImageCrypt = leaf.dlsitePlayImageCrypt
+            child.dlsitePlayImageWidth = leaf.dlsitePlayImageWidth
+            child.dlsitePlayImageHeight = leaf.dlsitePlayImageHeight
+            child.dlsitePlayOptimizedName = leaf.dlsitePlayOptimizedName
         }
 
         nodes.forEach { node ->
@@ -684,7 +704,11 @@ internal fun buildRemoteDirectoryBrowser(
                 url = child.url,
                 playlistTarget = child.playlistTarget,
                 subtitleSources = child.subtitleSources,
-                showSubtitleStamp = child.subtitleSources.isNotEmpty()
+                showSubtitleStamp = child.subtitleSources.isNotEmpty(),
+                dlsitePlayImageCrypt = child.dlsitePlayImageCrypt,
+                dlsitePlayImageWidth = child.dlsitePlayImageWidth,
+                dlsitePlayImageHeight = child.dlsitePlayImageHeight,
+                dlsitePlayOptimizedName = child.dlsitePlayOptimizedName
             )
         }
         .toList()

--- a/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailDlsiteTabs.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailDlsiteTabs.kt
@@ -125,6 +125,7 @@ import com.asmr.player.ui.common.AsmrShimmerPlaceholder
 import com.asmr.player.ui.common.CvChipsFlow
 import com.asmr.player.ui.common.EaraLogoLoadingIndicator
 import com.asmr.player.ui.common.ImagePreviewItem
+import com.asmr.player.ui.common.ImagePreviewPreparedItem
 import com.asmr.player.ui.common.ImagePreviewRequest
 import com.asmr.player.ui.common.collapsibleHeaderUiState
 import com.asmr.player.ui.common.rememberCollapsibleHeaderState
@@ -642,8 +643,13 @@ internal fun AlbumDlsiteInfoBreadcrumbTabV2(
                                                 ImagePreviewItem(
                                                     key = imageFile.path,
                                                     title = imageFile.title,
-                                                    imageModel = imageUrl,
-                                                    openPathOrUrl = imageUrl
+                                                    openPathOrUrl = imageUrl,
+                                                    prepareImage = {
+                                                        ImagePreviewPreparedItem(
+                                                            imageModel = imageUrl,
+                                                            openPathOrUrl = imageUrl
+                                                        )
+                                                    }
                                                 )
                                             }
                                         )?.let(onPreviewImages) ?: onPreviewFile(
@@ -818,7 +824,8 @@ internal fun AlbumDlsitePlayBreadcrumbTabV2(
     onPersistCurrentPath: (String) -> Unit,
     initialScroll: Pair<Int, Int>,
     onPersistScroll: (Int, Int) -> Unit,
-    loadRemoteFileSize: suspend (String) -> Long?
+    loadRemoteFileSize: suspend (String) -> Long?,
+    prepareImagePreview: suspend (String, String?, Boolean, Int?, Int?) -> String?
 ) {
     val context = LocalContext.current
     val lifecycleOwner = LocalLifecycleOwner.current
@@ -990,7 +997,7 @@ internal fun AlbumDlsitePlayBreadcrumbTabV2(
                                     }
                                 }
                                 TreeFileType.Image -> {
-                                    buildDirectoryImagePreviewRequest(
+                                    val request = buildDirectoryImagePreviewRequest(
                                         files = browser.files,
                                         clickedPath = file.path,
                                         toPreviewItem = { imageFile ->
@@ -998,20 +1005,37 @@ internal fun AlbumDlsitePlayBreadcrumbTabV2(
                                             ImagePreviewItem(
                                                 key = imageFile.path,
                                                 title = imageFile.title,
-                                                imageModel = imageUrl,
-                                                openPathOrUrl = imageUrl
+                                                openPathOrUrl = imageUrl,
+                                                prepareImage = {
+                                                    val prepared = prepareImagePreview(
+                                                        imageUrl,
+                                                        imageFile.dlsitePlayOptimizedName,
+                                                        imageFile.dlsitePlayImageCrypt,
+                                                        imageFile.dlsitePlayImageWidth,
+                                                        imageFile.dlsitePlayImageHeight
+                                                    ) ?: imageUrl
+                                                    ImagePreviewPreparedItem(
+                                                        imageModel = prepared,
+                                                        openPathOrUrl = prepared
+                                                    )
+                                                }
                                             )
                                         }
-                                    )?.let(onPreviewImages) ?: onPreviewFile(
-                                        AsmrTreeUiEntry.File(
-                                            path = file.path,
-                                            title = file.title,
-                                            depth = 0,
-                                            fileType = file.fileType,
-                                            isPlayable = false,
-                                            url = file.url
-                                        )
                                     )
+                                    if (request != null) {
+                                        onPreviewImages(request)
+                                    } else {
+                                        onPreviewFile(
+                                            AsmrTreeUiEntry.File(
+                                                path = file.path,
+                                                title = file.title,
+                                                depth = 0,
+                                                fileType = file.fileType,
+                                                isPlayable = false,
+                                                url = file.url
+                                            )
+                                        )
+                                    }
                                 }
                                 else -> onPreviewFile(
                                     AsmrTreeUiEntry.File(

--- a/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailLocalTab.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailLocalTab.kt
@@ -336,8 +336,13 @@ internal fun AlbumLocalBreadcrumbTabV2(
                                                         ImagePreviewItem(
                                                             key = imageFile.path,
                                                             title = imageFile.title,
-                                                            imageModel = path,
-                                                            openPathOrUrl = path
+                                                            openPathOrUrl = path,
+                                                            prepareImage = {
+                                                                com.asmr.player.ui.common.ImagePreviewPreparedItem(
+                                                                    imageModel = path,
+                                                                    openPathOrUrl = path
+                                                                )
+                                                            }
                                                         )
                                                     }
                                                 }

--- a/app/src/main/java/com/asmr/player/ui/nav/AppNavigator.kt
+++ b/app/src/main/java/com/asmr/player/ui/nav/AppNavigator.kt
@@ -8,28 +8,39 @@ object Routes {
     const val Search = "search"
     const val NowPlaying = "now_playing"
 
-    const val AlbumDetailByIdPattern = "album_detail/{albumId}?rjCode={rjCode}"
+    const val AlbumDetailByIdPattern = "album_detail/{albumId}?rjCode={rjCode}&initialTab={initialTab}"
     const val AlbumDetailOnlineByRjPattern = "album_detail_online/{rj}"
 
-    const val AlbumDetailByRjPattern = "album_detail_rj/{rj}"
-    fun albumDetailByRj(rj: String): String {
+    const val AlbumDetailByRjPattern = "album_detail_rj/{rj}?initialTab={initialTab}"
+    fun albumDetailByRj(rj: String, initialTab: String? = null): String {
         val encoded = URLEncoder.encode(rj, "UTF-8")
-        return "album_detail_rj/$encoded"
+        return buildString {
+            append("album_detail_rj/")
+            append(encoded)
+            if (!initialTab.isNullOrBlank()) {
+                append("?initialTab=")
+                append(URLEncoder.encode(initialTab, "UTF-8"))
+            }
+        }
     }
 }
 
 class AppNavigator(
     private val navController: NavHostController
 ) {
-    fun openAlbumDetail(albumId: Long?, rj: String?) {
+    fun openAlbumDetail(albumId: Long?, rj: String?, preferDlsitePlay: Boolean = false) {
         val normalizedRj = rj?.trim().orEmpty()
         if (normalizedRj.isNotBlank()) {
-            openAlbumDetailByRj(normalizedRj)
+            openAlbumDetailByRj(normalizedRj, preferDlsitePlay)
             return
         }
         val id = albumId ?: 0L
         if (id <= 0L) return
-        val route = "album_detail/$id"
+        val route = buildString {
+            append("album_detail/")
+            append(id)
+            if (preferDlsitePlay) append("?initialTab=dlsitePlay")
+        }
         val refreshToken = System.currentTimeMillis()
         val currentRoute = navController.currentBackStackEntry?.destination?.route
         val popToRoute = when {
@@ -49,10 +60,13 @@ class AppNavigator(
             ?: navController.currentBackStackEntry?.savedStateHandle?.set("refreshToken", refreshToken)
     }
 
-    fun openAlbumDetailByRj(rj: String) {
+    fun openAlbumDetailByRj(rj: String, preferDlsitePlay: Boolean = false) {
         val normalized = rj.trim().uppercase()
         if (normalized.isBlank()) return
-        val route = Routes.albumDetailByRj(normalized)
+        val route = Routes.albumDetailByRj(
+            normalized,
+            initialTab = if (preferDlsitePlay) "dlsitePlay" else null
+        )
         val refreshToken = System.currentTimeMillis()
         val currentRoute = navController.currentBackStackEntry?.destination?.route
         val popToRoute = when {

--- a/app/src/main/java/com/asmr/player/ui/search/SearchScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/search/SearchScreen.kt
@@ -123,7 +123,7 @@ private fun stableAlbumKey(album: Album): String {
 @Composable
 fun SearchScreen(
     windowSizeClass: WindowSizeClass,
-    onAlbumClick: (Album) -> Unit,
+    onAlbumClick: (Album, Boolean) -> Unit,
     viewModel: SearchViewModel = hiltViewModel()
 ) {
     var keyword by rememberSaveable { mutableStateOf("") }
@@ -304,7 +304,8 @@ fun SearchScreen(
                                 workId = album.workId,
                                 rjCode = album.rjCode,
                                 description = album.description
-                            )
+                            ),
+                            false
                         )
                     },
                     modifier = Modifier.fillMaxHeight()
@@ -388,7 +389,7 @@ fun SearchScreen(
                                         ) { album ->
                                             AlbumItem(
                                                 album = album,
-                                                onClick = { onAlbumClick(album) },
+                                                onClick = { onAlbumClick(album, state.purchasedOnly) },
                                                 emptyCoverUseShimmer = true
                                             )
                                         }
@@ -418,7 +419,7 @@ fun SearchScreen(
                                             val album = state.results[index]
                                             AlbumGridItem(
                                                 album = album,
-                                                onClick = { onAlbumClick(album) },
+                                                onClick = { onAlbumClick(album, state.purchasedOnly) },
                                                 emptyCoverUseShimmer = true
                                             )
                                         }
@@ -520,12 +521,14 @@ fun SearchScreen(
                         onMeasured = { size: IntSize -> chromeState.updateHeight(size.height.toFloat()) },
                         onSearchSubmit = ::submitSearch,
                         onPurchasedOnlySelected = {
-                            purchasedOnly = true
-                            viewModel.updateSearchOptions(
+                            val accepted = viewModel.updateSearchOptions(
                                 order = selectedOrder,
                                 purchasedOnly = true,
                                 locale = selectedLocale
                             )
+                            if (accepted) {
+                                purchasedOnly = true
+                            }
                         },
                         onOrderSelected = { order ->
                             selectedOrderName = order.name

--- a/app/src/main/java/com/asmr/player/ui/search/SearchViewModel.kt
+++ b/app/src/main/java/com/asmr/player/ui/search/SearchViewModel.kt
@@ -142,14 +142,19 @@ class SearchViewModel @Inject constructor(
         order: SearchSortOption = currentOrder,
         purchasedOnly: Boolean = this.purchasedOnly,
         locale: String? = currentLocale
-    ) {
-        val current = _uiState.value as? SearchUiState.Success ?: return
-        if (current.isBusy) return
-        if (currentOrder == order && this.purchasedOnly == purchasedOnly && currentLocale == locale) return
+    ): Boolean {
+        val current = _uiState.value as? SearchUiState.Success ?: return false
+        if (current.isBusy) return false
+        if (purchasedOnly && !dlsitePlayLibraryClient.hasStoredCredentials()) {
+            messageManager.showWarning("请先登录 DLsite 后再使用\"仅已购\"搜索")
+            return false
+        }
+        if (currentOrder == order && this.purchasedOnly == purchasedOnly && currentLocale == locale) return true
         currentOrder = order
         this.purchasedOnly = purchasedOnly
         currentLocale = locale
         requestPage(current.keyword, 1, SearchPendingRequestKind.Search)
+        return true
     }
 
     fun nextPage() {

--- a/app/src/test/java/com/asmr/player/data/remote/dlsite/DlsitePlayImageSupportTest.kt
+++ b/app/src/test/java/com/asmr/player/data/remote/dlsite/DlsitePlayImageSupportTest.kt
@@ -1,0 +1,60 @@
+package com.asmr.player.data.remote.dlsite
+
+import android.graphics.Bitmap
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class DlsitePlayImageSupportTest {
+
+    @Test
+    fun parseDlsitePlayCryptFlag_supportsBooleanNumberAndStringValues() {
+        assertTrue(parseDlsitePlayCryptFlag(true))
+        assertTrue(parseDlsitePlayCryptFlag(1))
+        assertTrue(parseDlsitePlayCryptFlag("1"))
+        assertTrue(parseDlsitePlayCryptFlag("true"))
+        assertTrue(parseDlsitePlayCryptFlag(" yes "))
+
+        assertFalse(parseDlsitePlayCryptFlag(false))
+        assertFalse(parseDlsitePlayCryptFlag(0))
+        assertFalse(parseDlsitePlayCryptFlag("0"))
+        assertFalse(parseDlsitePlayCryptFlag("false"))
+        assertFalse(parseDlsitePlayCryptFlag(""))
+        assertFalse(parseDlsitePlayCryptFlag(null))
+    }
+
+    @Test
+    fun parseDlsitePlayImageSeed_returnsExpectedHexSlice() {
+        assertEquals(0, parseDlsitePlayImageSeed("000000000000.png"))
+        assertEquals(0xabc1234, parseDlsitePlayImageSeed("00000abc1234.jpg"))
+        assertNull(parseDlsitePlayImageSeed("short"))
+        assertNull(parseDlsitePlayImageSeed("00000zzzzzzz.jpg"))
+    }
+
+    @Test
+    fun descrambleDlsitePlayBitmap_matchesReferenceTileOrderAndCropsPadding() {
+        val scrambled = Bitmap.createBitmap(256, 256, Bitmap.Config.ARGB_8888).apply {
+            eraseColor(0xFF000000.toInt())
+            setPixels(IntArray(128 * 128) { 0xFFFF0000.toInt() }, 0, 128, 0, 128, 128, 128)
+            setPixels(IntArray(128 * 128) { 0xFF00FF00.toInt() }, 0, 128, 128, 0, 128, 128)
+            setPixels(IntArray(128 * 128) { 0xFF0000FF.toInt() }, 0, 128, 128, 128, 128, 128)
+        }
+
+        val descrambled = descrambleDlsitePlayBitmap(scrambled, seed = 0, width = 200, height = 160)
+
+        assertEquals(200, descrambled.width)
+        assertEquals(160, descrambled.height)
+        assertEquals(0xFF000000.toInt(), descrambled.getPixel(0, 0))
+        assertEquals(0xFF0000FF.toInt(), descrambled.getPixel(0, 129))
+        assertEquals(0xFFFF0000.toInt(), descrambled.getPixel(129, 0))
+        assertEquals(0xFF00FF00.toInt(), descrambled.getPixel(129, 129))
+
+        descrambled.recycle()
+        scrambled.recycle()
+    }
+}

--- a/app/src/test/java/com/asmr/player/ui/common/ImagePreviewDialogTest.kt
+++ b/app/src/test/java/com/asmr/player/ui/common/ImagePreviewDialogTest.kt
@@ -3,6 +3,10 @@ package com.asmr.player.ui.common
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.semantics.SemanticsProperties
 import androidx.compose.ui.test.SemanticsMatcher
@@ -12,6 +16,7 @@ import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.waitUntil
 import com.asmr.player.ui.theme.AsmrPlayerTheme
 import com.asmr.player.util.MessageManager
 import org.junit.Assert.assertEquals
@@ -116,12 +121,55 @@ class ImagePreviewDialogTest {
         composeRule.onAllNodesWithTag(IMAGE_PREVIEW_NEXT_TAG).assertCountEquals(0)
     }
 
+    @Test
+    fun lazyPrepareImage_onlyResolvesVisitedPages() {
+        var prepareCount by mutableIntStateOf(0)
+
+        composeRule.setContent {
+            AsmrPlayerTheme {
+                ImagePreviewDialog(
+                    request = ImagePreviewRequest(
+                        items = listOf(
+                            sampleLazyItem("a") { prepareCount++ },
+                            sampleLazyItem("b") { prepareCount++ }
+                        ),
+                        initialIndex = 0
+                    ),
+                    messageManager = MessageManager(),
+                    onDismiss = {},
+                    pageContent = { _, _, _ ->
+                        Box(modifier = androidx.compose.ui.Modifier.fillMaxSize())
+                    }
+                )
+            }
+        }
+
+        composeRule.waitUntil(timeoutMillis = 5_000) { prepareCount == 1 }
+        composeRule.onNodeWithTag(IMAGE_PREVIEW_NEXT_TAG).performClick()
+        composeRule.waitUntil(timeoutMillis = 5_000) { prepareCount == 2 }
+    }
+
     private fun sampleItem(key: String): ImagePreviewItem {
         return ImagePreviewItem(
             key = key,
             title = "Image $key",
             imageModel = "mock://$key",
             openPathOrUrl = "https://example.com/$key.jpg"
+        )
+    }
+
+    private fun sampleLazyItem(key: String, onPrepare: () -> Unit): ImagePreviewItem {
+        return ImagePreviewItem(
+            key = key,
+            title = "Image $key",
+            openPathOrUrl = "https://example.com/$key.jpg",
+            prepareImage = {
+                onPrepare()
+                ImagePreviewPreparedItem(
+                    imageModel = "mock://$key",
+                    openPathOrUrl = "https://example.com/$key.jpg"
+                )
+            }
         )
     }
 }


### PR DESCRIPTION
## Summary
- fix DLsite Play directory image preview descrambling and metadata handling
- change directory image preview loading to lazy per-page preparation instead of preparing every image up front
- keep local, DL, and DL Play directory image preview behavior aligned to reduce memory and network pressure

## Testing
- ./gradlew :app:compileDebugKotlin
- ./gradlew :app:assembleDebug