### PR TITLE
fix: unify playlist add flow and preserve lyrics context

### DIFF
--- a/app/src/main/java/com/asmr/player/benchmark/BenchmarkHarnessActivity.kt
+++ b/app/src/main/java/com/asmr/player/benchmark/BenchmarkHarnessActivity.kt
@@ -26,6 +26,7 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.asmr.player.data.repository.AlbumGroupRepository
 import com.asmr.player.data.repository.PlaylistRepository
+import com.asmr.player.playback.MediaItemFactory
 import com.asmr.player.ui.groups.AlbumGroupDetailContent
 import com.asmr.player.ui.groups.AlbumGroupPickerScreen
 import com.asmr.player.ui.groups.AlbumGroupsScreen
@@ -145,7 +146,7 @@ private fun BenchmarkScenarioScreen(
                 windowSizeClass = windowSizeClass,
                 onAlbumClick = {},
                 onPlayTracks = { _, _, _ -> },
-                onOpenPlaylistPicker = { _, _, _, _, _, _, _, _ -> },
+                onOpenPlaylistPicker = { _ -> },
                 onOpenGroupPicker = {},
                 onOpenFilterScreen = {}
             )
@@ -194,22 +195,6 @@ private fun BenchmarkScenarioScreen(
                 onMoveItemToTop = {},
                 onMoveItemToBottom = {},
                 onSaveManualOrder = {}
-            )
-        }
-
-        BenchmarkScenario.PlaylistPicker -> {
-            PlaylistPickerScreen(
-                windowSizeClass = windowSizeClass,
-                mediaId = seedSummary.sampleMediaId,
-                uri = seedSummary.sampleUri,
-                title = seedSummary.sampleTitle,
-                artist = seedSummary.sampleArtist,
-                artworkUri = seedSummary.sampleArtworkUri,
-                albumId = seedSummary.sampleAlbumId,
-                trackId = seedSummary.sampleTrackId,
-                rjCode = seedSummary.sampleRjCode,
-                embeddedInDialog = true,
-                onBack = {}
             )
         }
 

--- a/app/src/main/java/com/asmr/player/benchmark/BenchmarkScenario.kt
+++ b/app/src/main/java/com/asmr/player/benchmark/BenchmarkScenario.kt
@@ -11,7 +11,6 @@ enum class BenchmarkScenario(
     FavoritesDetail("favorites_detail"),
     PlaylistsList("playlists_list"),
     PlaylistDetail("playlist_detail"),
-    PlaylistPicker("playlist_picker"),
     GroupsList("groups_list"),
     GroupDetail("group_detail"),
     GroupPicker("group_picker"),

--- a/app/src/main/java/com/asmr/player/data/local/db/AppDatabaseMigrations.kt
+++ b/app/src/main/java/com/asmr/player/data/local/db/AppDatabaseMigrations.kt
@@ -359,4 +359,18 @@ object AppDatabaseMigrations {
             )
         }
     }
+
+    val MIGRATION_20_21: Migration = object : Migration(20, 21) {
+        override fun migrate(db: SupportSQLiteDatabase) {
+            db.execSQL("ALTER TABLE playlist_items ADD COLUMN `albumTitle` TEXT NOT NULL DEFAULT ''")
+            db.execSQL("ALTER TABLE playlist_items ADD COLUMN `albumId` INTEGER NOT NULL DEFAULT 0")
+            db.execSQL("ALTER TABLE playlist_items ADD COLUMN `trackId` INTEGER NOT NULL DEFAULT 0")
+            db.execSQL("ALTER TABLE playlist_items ADD COLUMN `rjCode` TEXT NOT NULL DEFAULT ''")
+            db.execSQL("ALTER TABLE playlist_items ADD COLUMN `albumWorkId` TEXT NOT NULL DEFAULT ''")
+            db.execSQL("ALTER TABLE playlist_items ADD COLUMN `trackGroup` TEXT NOT NULL DEFAULT ''")
+            db.execSQL("ALTER TABLE playlist_items ADD COLUMN `lyricsRelativePathNoExt` TEXT NOT NULL DEFAULT ''")
+            db.execSQL("ALTER TABLE playlist_items ADD COLUMN `mimeType` TEXT NOT NULL DEFAULT ''")
+            db.execSQL("ALTER TABLE playlist_items ADD COLUMN `isVideo` INTEGER NOT NULL DEFAULT 0")
+        }
+    }
 }

--- a/app/src/main/java/com/asmr/player/data/local/db/AppDatabaseProvider.kt
+++ b/app/src/main/java/com/asmr/player/data/local/db/AppDatabaseProvider.kt
@@ -35,7 +35,8 @@ object AppDatabaseProvider {
                 AppDatabaseMigrations.MIGRATION_16_17,
                 AppDatabaseMigrations.MIGRATION_17_18,
                 AppDatabaseMigrations.MIGRATION_18_19,
-                AppDatabaseMigrations.MIGRATION_19_20
+                AppDatabaseMigrations.MIGRATION_19_20,
+                AppDatabaseMigrations.MIGRATION_20_21
             )
             // Never wipe the local database during app upgrades.
             // If a migration is missing, fail loudly so user data can still be recovered.

--- a/app/src/main/java/com/asmr/player/data/local/db/appdatabase.kt
+++ b/app/src/main/java/com/asmr/player/data/local/db/appdatabase.kt
@@ -65,7 +65,7 @@ import com.asmr.player.data.local.db.entities.TrackPlaybackProgressEntity
         TrackSliceEntity::class,
         TrackPlaybackProgressEntity::class
     ],
-    version = 20,
+    version = 21,
     exportSchema = false
 )
 abstract class AppDatabase : RoomDatabase() {

--- a/app/src/main/java/com/asmr/player/data/local/db/dao/PlaylistItemDao.kt
+++ b/app/src/main/java/com/asmr/player/data/local/db/dao/PlaylistItemDao.kt
@@ -24,6 +24,7 @@ interface PlaylistItemDao {
             pi.mediaId,
             pi.title,
             pi.artist,
+            pi.albumTitle,
             pi.uri,
             COALESCE(
                 NULLIF(a.coverThumbPath, ''),
@@ -39,6 +40,14 @@ interface PlaylistItemDao {
                 NULLIF(a.coverThumbPath, ''),
                 ''
             ) AS playbackArtworkUri,
+            pi.albumId,
+            pi.trackId,
+            pi.rjCode,
+            pi.albumWorkId,
+            pi.trackGroup,
+            pi.lyricsRelativePathNoExt,
+            pi.mimeType,
+            pi.isVideo,
             pi.itemOrder,
             (
                 EXISTS(

--- a/app/src/main/java/com/asmr/player/data/local/db/entities/PlaylistItemEntity.kt
+++ b/app/src/main/java/com/asmr/player/data/local/db/entities/PlaylistItemEntity.kt
@@ -16,8 +16,17 @@ data class PlaylistItemEntity(
     val mediaId: String,
     val title: String,
     val artist: String = "",
+    val albumTitle: String = "",
     val uri: String,
     val artworkUri: String = "",
+    val albumId: Long = 0L,
+    val trackId: Long = 0L,
+    val rjCode: String = "",
+    val albumWorkId: String = "",
+    val trackGroup: String = "",
+    val lyricsRelativePathNoExt: String = "",
+    val mimeType: String = "",
+    val isVideo: Boolean = false,
     val itemOrder: Int = 0
 )
 

--- a/app/src/main/java/com/asmr/player/data/local/db/entities/PlaylistItemWithSubtitles.kt
+++ b/app/src/main/java/com/asmr/player/data/local/db/entities/PlaylistItemWithSubtitles.kt
@@ -5,9 +5,18 @@ data class PlaylistItemWithSubtitles(
     val mediaId: String,
     val title: String,
     val artist: String = "",
+    val albumTitle: String = "",
     val uri: String,
     val artworkUri: String = "",
     val playbackArtworkUri: String = "",
+    val albumId: Long = 0L,
+    val trackId: Long = 0L,
+    val rjCode: String = "",
+    val albumWorkId: String = "",
+    val trackGroup: String = "",
+    val lyricsRelativePathNoExt: String = "",
+    val mimeType: String = "",
+    val isVideo: Boolean = false,
     val itemOrder: Int = 0,
     val hasSubtitles: Boolean
 )

--- a/app/src/main/java/com/asmr/player/data/lyrics/LyricsLoader.kt
+++ b/app/src/main/java/com/asmr/player/data/lyrics/LyricsLoader.kt
@@ -70,7 +70,9 @@ class LyricsLoader @Inject constructor(
     private suspend fun load(target: LyricsTargetContext, fallbackTitle: String): LyricsResult {
         if (target.mediaId.isBlank()) return LyricsResult(title = "", lyrics = emptyList())
 
-        val track = trackDao.getTrackByPathOnce(target.mediaId)
+        val trackByPath = trackDao.getTrackByPathOnce(target.mediaId)
+        val trackById = target.trackId.takeIf { it > 0L }?.let { id -> trackDao.getTrackByIdOnce(id) }
+        val track = trackByPath ?: trackById
         val title = track?.title?.takeIf { it.isNotBlank() } ?: fallbackTitle.ifBlank { target.mediaId }
 
         val manualLyrics = loadManualLyrics(target)

--- a/app/src/main/java/com/asmr/player/data/repository/PlaylistMediaItemMapper.kt
+++ b/app/src/main/java/com/asmr/player/data/repository/PlaylistMediaItemMapper.kt
@@ -1,0 +1,88 @@
+package com.asmr.player.data.repository
+
+import android.net.Uri
+import androidx.core.net.toUri
+import androidx.media3.common.MediaItem
+import com.asmr.player.data.lyrics.EXTRA_ALBUM_WORK_ID
+import com.asmr.player.data.lyrics.EXTRA_LYRICS_RELATIVE_PATH_NO_EXT
+import com.asmr.player.data.lyrics.EXTRA_TRACK_GROUP
+import com.asmr.player.data.local.db.entities.PlaylistItemEntity
+import com.asmr.player.playback.MediaItemFactory
+import java.io.File
+
+object PlaylistMediaItemMapper {
+    fun fromMediaItem(
+        playlistId: Long,
+        item: MediaItem,
+        itemOrder: Int
+    ): PlaylistItemEntity {
+        val metadata = item.mediaMetadata
+        val extras = metadata.extras
+        val normalizedUri = repairPlayableUri(item.localConfiguration?.uri?.toString().orEmpty())
+        return PlaylistItemEntity(
+            playlistId = playlistId,
+            mediaId = item.mediaId.ifBlank { normalizedUri },
+            title = metadata.title?.toString().orEmpty(),
+            artist = metadata.artist?.toString().orEmpty(),
+            albumTitle = metadata.albumTitle?.toString().orEmpty(),
+            uri = normalizedUri,
+            artworkUri = metadata.artworkUri?.toString().orEmpty(),
+            albumId = extras?.getLong("album_id") ?: 0L,
+            trackId = extras?.getLong("track_id") ?: 0L,
+            rjCode = extras?.getString("rj_code").orEmpty(),
+            albumWorkId = extras?.getString(EXTRA_ALBUM_WORK_ID).orEmpty(),
+            trackGroup = extras?.getString(EXTRA_TRACK_GROUP).orEmpty(),
+            lyricsRelativePathNoExt = extras?.getString(EXTRA_LYRICS_RELATIVE_PATH_NO_EXT).orEmpty(),
+            mimeType = item.localConfiguration?.mimeType.orEmpty(),
+            isVideo = extras?.getBoolean("is_video") == true,
+            itemOrder = itemOrder
+        )
+    }
+
+    fun toMediaItemOrNull(item: PlaylistItemEntity): MediaItem? {
+        val normalizedUri = repairPlayableUri(item.uri)
+        if (normalizedUri.isBlank() || normalizedUri.equals("null", ignoreCase = true)) return null
+        return MediaItemFactory.fromDetails(
+            mediaId = repairMediaId(item.mediaId, normalizedUri),
+            uri = normalizedUri,
+            title = item.title,
+            artist = item.artist,
+            albumTitle = item.albumTitle,
+            artworkUri = item.artworkUri,
+            albumId = item.albumId,
+            trackId = item.trackId,
+            rjCode = item.rjCode,
+            albumWorkId = item.albumWorkId,
+            trackGroup = item.trackGroup,
+            lyricsRelativePathNoExt = item.lyricsRelativePathNoExt,
+            mimeType = item.mimeType.ifBlank { null },
+            isVideo = item.isVideo
+        )
+    }
+
+    fun repairPlayableUri(raw: String): String {
+        val trimmed = raw.trim()
+        if (!trimmed.startsWith("content://", ignoreCase = true)) return trimmed
+        return repairDocumentUri(trimmed)
+    }
+
+    private fun repairMediaId(raw: String, fallbackUri: String): String {
+        val trimmed = raw.trim().ifBlank { fallbackUri }
+        return if (trimmed.startsWith("content://", ignoreCase = true)) {
+            repairDocumentUri(trimmed)
+        } else {
+            trimmed
+        }
+    }
+
+    private fun repairDocumentUri(raw: String): String {
+        val uri = runCatching { Uri.parse(raw) }.getOrNull() ?: return raw
+        val segments = uri.pathSegments ?: return raw
+        val docIndex = segments.indexOf("document")
+        if (docIndex < 0 || segments.size <= docIndex + 2) return raw
+        val docId = segments.subList(docIndex + 1, segments.size).joinToString("/")
+        val encodedDocId = Uri.encode(docId)
+        val encodedPath = "/" + segments.take(docIndex + 1).joinToString("/") + "/" + encodedDocId
+        return uri.buildUpon().encodedPath(encodedPath).build().toString()
+    }
+}

--- a/app/src/main/java/com/asmr/player/data/repository/PlaylistRepository.kt
+++ b/app/src/main/java/com/asmr/player/data/repository/PlaylistRepository.kt
@@ -65,15 +65,13 @@ class PlaylistRepository @Inject constructor(
 
     suspend fun replacePlaylistWithMediaItems(playlistId: Long, items: List<MediaItem>) {
         val entities = items.mapIndexed { index, item ->
-            PlaylistItemEntity(
+            PlaylistMediaItemMapper.fromMediaItem(
                 playlistId = playlistId,
-                mediaId = item.mediaId.ifBlank { item.localConfiguration?.uri.toString() },
-                title = item.mediaMetadata.title?.toString().orEmpty(),
-                artist = item.mediaMetadata.artist?.toString().orEmpty(),
-                uri = item.localConfiguration?.uri.toString(),
-                artworkUri = resolvePlaylistItemArtwork(item),
+                item = item,
                 itemOrder = index
-            )
+            ).let { mapped ->
+                mapped.copy(artworkUri = resolvePlaylistItemArtwork(item, mapped.artworkUri))
+            }
         }
         playlistItemDao.replaceAll(playlistId, entities)
     }
@@ -124,15 +122,12 @@ class PlaylistRepository @Inject constructor(
                 skipped += 1
                 return@forEach
             }
-            toInsert += PlaylistItemEntity(
+            val mapped = PlaylistMediaItemMapper.fromMediaItem(
                 playlistId = playlistId,
-                mediaId = mediaId,
-                title = item.mediaMetadata.title?.toString().orEmpty(),
-                artist = item.mediaMetadata.artist?.toString().orEmpty(),
-                uri = item.localConfiguration?.uri.toString(),
-                artworkUri = resolvePlaylistItemArtwork(item),
+                item = item,
                 itemOrder = nextOrder++
             )
+            toInsert += mapped.copy(artworkUri = resolvePlaylistItemArtwork(item, mapped.artworkUri))
         }
 
         if (toInsert.isNotEmpty()) {
@@ -190,7 +185,7 @@ class PlaylistRepository @Inject constructor(
         )
     }
 
-    private suspend fun resolvePlaylistItemArtwork(item: MediaItem): String {
+    private suspend fun resolvePlaylistItemArtwork(item: MediaItem, fallbackArtwork: String = ""): String {
         val extras = item.mediaMetadata.extras
         android.util.Log.d("PlaylistRepository", "resolvePlaylistItemArtwork - START - mediaId: ${item.mediaId}, extras: $extras")
         val albumId = extras?.getLong("album_id") ?: 0L
@@ -204,7 +199,7 @@ class PlaylistRepository @Inject constructor(
             }
         }
 
-        val artwork = item.mediaMetadata.artworkUri?.toString().orEmpty().trim()
+        val artwork = fallbackArtwork.trim().ifBlank { item.mediaMetadata.artworkUri?.toString().orEmpty().trim() }
         android.util.Log.d("PlaylistRepository", "resolvePlaylistItemArtwork - artworkUri from metadata: '$artwork'")
         if (artwork.isNotBlank()) {
             android.util.Log.d("PlaylistRepository", "resolvePlaylistItemArtwork - returning artwork from metadata: '$artwork'")

--- a/app/src/main/java/com/asmr/player/main/MainContainer.kt
+++ b/app/src/main/java/com/asmr/player/main/MainContainer.kt
@@ -196,14 +196,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 
 internal data class PlaylistPickerRequest(
-    val mediaId: String,
-    val uri: String,
-    val title: String,
-    val artist: String,
-    val artworkUri: String,
-    val albumId: Long,
-    val trackId: Long,
-    val rjCode: String
+    val items: List<MediaItem>
 )
 
 internal data class BatchPlaylistPickerRequest(
@@ -1114,18 +1107,8 @@ fun MainContainer(
                                                         }
                                                     }
                                                 },
-                                                onOpenPlaylistPicker = { mediaId, uri, title, artist, artworkUri, albumId, trackId, rjCode ->
-                                                    navController.navigateSingleTop(
-                                                        "playlist_picker" +
-                                                            "?mediaId=${encodeRouteArg(mediaId)}" +
-                                                            "&uri=${encodeRouteArg(uri)}" +
-                                                            "&title=${encodeRouteArg(title)}" +
-                                                            "&artist=${encodeRouteArg(artist)}" +
-                                                            "&artworkUri=${encodeRouteArg(artworkUri)}" +
-                                                            "&albumId=$albumId" +
-                                                            "&trackId=$trackId" +
-                                                            "&rjCode=${encodeRouteArg(rjCode)}"
-                                                    )
+                                                onOpenPlaylistPicker = { item ->
+                                                    albumBatchPlaylistPickerRequest = BatchPlaylistPickerRequest(listOf(item))
                                                 },
                                                 onOpenGroupPicker = { albumId ->
                                                     navController.navigateSingleTop("group_picker?albumId=$albumId")
@@ -1152,7 +1135,6 @@ fun MainContainer(
                                         "playlist_system/favorites" -> {
                                             SystemPlaylistScreen(
                                                 windowSizeClass = windowSizeClass,
-                                                type = "favorites",
                                                 onPlayAll = { items, startItem ->
                                                     playerViewModel.playPlaylistItems(items, startItem)
                                                     openNowPlaying()
@@ -1271,21 +1253,8 @@ fun MainContainer(
                         onAddMediaItemsToFavorites = { items ->
                             playlistsViewModel.addItemsToFavoritesInBackground(items)
                         },
-                        onOpenPlaylistPicker = { mediaId, uri, title, artist, artworkUri, albumId, trackId, rjCode ->
-                            navController.navigateSingleTop(
-                                "playlist_picker" +
-                                    "?mediaId=${encodeRouteArg(mediaId)}" +
-                                    "&uri=${encodeRouteArg(uri)}" +
-                                    "&title=${encodeRouteArg(title)}" +
-                                    "&artist=${encodeRouteArg(artist)}" +
-                                    "&artworkUri=${encodeRouteArg(artworkUri)}" +
-                                    "&albumId=$albumId" +
-                                    "&trackId=$trackId" +
-                                    "&rjCode=${encodeRouteArg(rjCode)}"
-                            )
-                        },
-                        onOpenBatchPlaylistPicker = { items ->
-                            albumBatchPlaylistPickerRequest = BatchPlaylistPickerRequest(items)
+                        onOpenPlaylistPicker = { item ->
+                            albumBatchPlaylistPickerRequest = BatchPlaylistPickerRequest(listOf(item))
                         },
                         onOpenGroupPicker = { albumId ->
                             navController.navigateSingleTop("group_picker?albumId=$albumId")
@@ -1336,21 +1305,8 @@ fun MainContainer(
                         onAddMediaItemsToFavorites = { items ->
                             playlistsViewModel.addItemsToFavoritesInBackground(items)
                         },
-                        onOpenPlaylistPicker = { mediaId, uri, title, artist, artworkUri, albumId, trackId, rjCode ->
-                            navController.navigateSingleTop(
-                                "playlist_picker" +
-                                    "?mediaId=${encodeRouteArg(mediaId)}" +
-                                    "&uri=${encodeRouteArg(uri)}" +
-                                    "&title=${encodeRouteArg(title)}" +
-                                    "&artist=${encodeRouteArg(artist)}" +
-                                    "&artworkUri=${encodeRouteArg(artworkUri)}" +
-                                    "&albumId=$albumId" +
-                                    "&trackId=$trackId" +
-                                    "&rjCode=${encodeRouteArg(rjCode)}"
-                            )
-                        },
-                        onOpenBatchPlaylistPicker = { items ->
-                            albumBatchPlaylistPickerRequest = BatchPlaylistPickerRequest(items)
+                        onOpenPlaylistPicker = { item ->
+                            albumBatchPlaylistPickerRequest = BatchPlaylistPickerRequest(listOf(item))
                         },
                         onOpenGroupPicker = { albumId ->
                             navController.navigateSingleTop("group_picker?albumId=$albumId")
@@ -1388,18 +1344,8 @@ fun MainContainer(
                         onAddToQueue = { album, track ->
                             playerViewModel.addTrackToQueue(album, track)
                         },
-                        onOpenPlaylistPicker = { mediaId, uri, title, artist, artworkUri, albumId, trackId, rjCode ->
-                            navController.navigateSingleTop(
-                                "playlist_picker" +
-                                    "?mediaId=${encodeRouteArg(mediaId)}" +
-                                    "&uri=${encodeRouteArg(uri)}" +
-                                    "&title=${encodeRouteArg(title)}" +
-                                    "&artist=${encodeRouteArg(artist)}" +
-                                    "&artworkUri=${encodeRouteArg(artworkUri)}" +
-                                    "&albumId=$albumId" +
-                                    "&trackId=$trackId" +
-                                    "&rjCode=${encodeRouteArg(rjCode)}"
-                            )
+                        onOpenPlaylistPicker = { item ->
+                            albumBatchPlaylistPickerRequest = BatchPlaylistPickerRequest(listOf(item))
                         },
                         onOpenGroupPicker = { albumId ->
                             navController.navigateSingleTop("group_picker?albumId=$albumId")
@@ -1496,7 +1442,6 @@ fun MainContainer(
                     } else {
                         SystemPlaylistScreen(
                             windowSizeClass = windowSizeClass,
-                            type = type,
                             onPlayAll = { items, startItem ->
                                 playerViewModel.playPlaylistItems(items, startItem)
                                 openNowPlaying()
@@ -1504,41 +1449,6 @@ fun MainContainer(
                             viewModel = playlistsViewModel
                         )
                     }
-                }
-                composable(
-                    route = "playlist_picker?mediaId={mediaId}&uri={uri}&title={title}&artist={artist}&artworkUri={artworkUri}&albumId={albumId}&trackId={trackId}&rjCode={rjCode}",
-                    arguments = listOf(
-                        navArgument("mediaId") { defaultValue = "" },
-                        navArgument("uri") { defaultValue = "" },
-                        navArgument("title") { defaultValue = "" },
-                        navArgument("artist") { defaultValue = "" },
-                        navArgument("artworkUri") { defaultValue = "" },
-                        navArgument("albumId") { type = NavType.LongType },
-                        navArgument("trackId") { type = NavType.LongType },
-                        navArgument("rjCode") { defaultValue = "" }
-                    )
-                ) { backStackEntry ->
-                    val mediaId = decodeRouteArg(backStackEntry.arguments?.getString("mediaId").orEmpty())
-                    val uri = decodeRouteArg(backStackEntry.arguments?.getString("uri").orEmpty())
-                    val title = decodeRouteArg(backStackEntry.arguments?.getString("title").orEmpty())
-                    val artist = decodeRouteArg(backStackEntry.arguments?.getString("artist").orEmpty())
-                    val artworkUri = decodeRouteArg(backStackEntry.arguments?.getString("artworkUri").orEmpty())
-                    val albumId = backStackEntry.arguments?.getLong("albumId") ?: 0L
-                    val trackId = backStackEntry.arguments?.getLong("trackId") ?: 0L
-                    val rjCode = decodeRouteArg(backStackEntry.arguments?.getString("rjCode").orEmpty())
-                    PlaylistPickerScreen(
-                        windowSizeClass = windowSizeClass,
-                        mediaId = mediaId,
-                        uri = uri,
-                        title = title,
-                        artist = artist,
-                        artworkUri = artworkUri,
-                        albumId = albumId,
-                        trackId = trackId,
-                        rjCode = rjCode,
-                        onBack = { navController.popBackStack() },
-                        viewModel = playlistsViewModel
-                    )
                 }
                 composable("settings") {
                     Box(modifier = Modifier.fillMaxSize())
@@ -1743,17 +1653,8 @@ fun MainContainer(
                     },
                     onShowQueue = onShowQueue,
                     onShowSleepTimer = onShowSleepTimer,
-                    onOpenPlaylistPicker = { mediaId, uri, title, artist, artworkUri, albumId, trackId, rjCode ->
-                        nowPlayingPlaylistPickerRequest = PlaylistPickerRequest(
-                            mediaId = mediaId,
-                            uri = uri,
-                            title = title,
-                            artist = artist,
-                            artworkUri = artworkUri,
-                            albumId = albumId,
-                            trackId = trackId,
-                            rjCode = rjCode
-                        )
+                    onOpenPlaylistPicker = { item ->
+                        nowPlayingPlaylistPickerRequest = PlaylistPickerRequest(items = listOf(item))
                     },
                     viewModel = playerViewModel,
                     coverBackgroundEnabled = coverBackgroundEnabled,
@@ -1784,14 +1685,7 @@ fun MainContainer(
                             ) {
                                 PlaylistPickerScreen(
                                     windowSizeClass = windowSizeClass,
-                                    mediaId = request.mediaId,
-                                    uri = request.uri,
-                                    title = request.title,
-                                    artist = request.artist,
-                                    artworkUri = request.artworkUri,
-                                    albumId = request.albumId,
-                                    trackId = request.trackId,
-                                    rjCode = request.rjCode,
+                                    items = request.items,
                                     onBack = { nowPlayingPlaylistPickerRequest = null },
                                     embeddedInDialog = true,
                                     viewModel = playlistsViewModel

--- a/app/src/main/java/com/asmr/player/ui/library/AlbumDetailScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/AlbumDetailScreen.kt
@@ -196,8 +196,7 @@ fun AlbumDetailScreen(
     onAddToQueue: (Album, Track) -> Boolean = { _, _ -> false },
     onAddMediaItemsToQueue: (List<MediaItem>) -> Unit = {},
     onAddMediaItemsToFavorites: (List<MediaItem>) -> Unit = {},
-    onOpenPlaylistPicker: (mediaId: String, uri: String, title: String, artist: String, artworkUri: String, albumId: Long, trackId: Long, rjCode: String) -> Unit = { _, _, _, _, _, _, _, _ -> },
-    onOpenBatchPlaylistPicker: (List<MediaItem>) -> Unit = {},
+    onOpenPlaylistPicker: (MediaItem) -> Unit = {},
     onOpenGroupPicker: (albumId: Long) -> Unit = { _ -> },
     onPlayVideo: (String, String, String, String) -> Unit = { _, _, _, _ -> },
     onOpenDlsiteLogin: () -> Unit = {},
@@ -475,16 +474,7 @@ fun AlbumDetailScreen(
                                                 },
                                                 onAddToPlaylist = { track ->
                                                     val target = PlaylistAddTarget.fromTrack(local, track)
-                                                    onOpenPlaylistPicker(
-                                                        target.mediaId,
-                                                        target.uri,
-                                                        target.title,
-                                                        target.artist,
-                                                        target.artworkUri,
-                                                        target.albumId,
-                                                        target.trackId,
-                                                        target.rjCode
-                                                    )
+                                                    onOpenPlaylistPicker(target.toMediaItem())
                                                 },
                                                 onManageTrackTags = { track ->
                                                     tagManageTrack = track
@@ -530,29 +520,11 @@ fun AlbumDetailScreen(
                                         },
                                         onAddToPlaylistOne = { relPath ->
                                             val target = PlaylistAddTarget.fromAsmrOne(album, asmrOneTree, relPath) ?: return@AlbumDlsiteInfoBreadcrumbTabV2
-                                            onOpenPlaylistPicker(
-                                                target.mediaId,
-                                                target.uri,
-                                                target.title,
-                                                target.artist,
-                                                target.artworkUri,
-                                                target.albumId,
-                                                target.trackId,
-                                                target.rjCode
-                                            )
+                                            onOpenPlaylistPicker(target.toMediaItem())
                                         },
                                         onAddToPlaylist = { track ->
                                             val target = PlaylistAddTarget.fromTrack(album, track)
-                                            onOpenPlaylistPicker(
-                                                target.mediaId,
-                                                target.uri,
-                                                target.title,
-                                                target.artist,
-                                                target.artworkUri,
-                                                target.albumId,
-                                                target.trackId,
-                                                target.rjCode
-                                            )
+                                            onOpenPlaylistPicker(target.toMediaItem())
                                         },
                                         onPreviewImages = { request -> imagePreviewRequest = request },
                                         onPreviewFile = { onlinePreviewFile = it },

--- a/app/src/main/java/com/asmr/player/ui/library/LibraryScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/LibraryScreen.kt
@@ -105,6 +105,7 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.asmr.player.domain.model.Album
 import com.asmr.player.domain.model.Track
+import androidx.media3.common.MediaItem
 import com.asmr.player.ui.player.PlayerViewModel
 import com.asmr.player.ui.library.LibraryUiState
 
@@ -133,6 +134,8 @@ import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.staggeredgrid.rememberLazyStaggeredGridState
 import androidx.compose.material.icons.automirrored.filled.Label
+import androidx.compose.material.icons.automirrored.filled.PlaylistAdd
+import androidx.compose.material.icons.automirrored.filled.QueueMusic
 import androidx.compose.material.icons.filled.ErrorOutline
 import androidx.compose.material.icons.filled.Label
 import androidx.compose.material3.Card
@@ -159,6 +162,7 @@ import com.asmr.player.ui.common.ActionButton
 import com.asmr.player.ui.common.collapsibleHeaderUiState
 import com.asmr.player.ui.common.rememberCollapsibleHeaderState
 import com.asmr.player.ui.common.thinScrollbar
+import com.asmr.player.playback.MediaItemFactory
 
 internal const val LIBRARY_CHROME_TAG = "library_chrome"
 internal const val LIBRARY_SEARCH_INPUT_TAG = "library_search_input"
@@ -220,7 +224,7 @@ fun LibraryScreen(
     windowSizeClass: WindowSizeClass,
     onAlbumClick: (Album) -> Unit,
     onPlayTracks: (Album, List<Track>, Track) -> Unit,
-    onOpenPlaylistPicker: (mediaId: String, uri: String, title: String, artist: String, artworkUri: String, albumId: Long, trackId: Long, rjCode: String) -> Unit = { _, _, _, _, _, _, _, _ -> },
+    onOpenPlaylistPicker: (MediaItem) -> Unit = {},
     onOpenGroupPicker: (albumId: Long) -> Unit = { _ -> },
     onOpenFilterScreen: () -> Unit = {},
     viewModel: LibraryViewModel = hiltViewModel()
@@ -500,52 +504,7 @@ fun LibraryScreen(
                                             null
                                         }
                                     )
-                                } /* else if (false) {
-                                    val hasAnyQuery =
-                                        !querySpec.textQuery.isNullOrBlank() ||
-                                            querySpec.includeTagIds.isNotEmpty() ||
-                                            querySpec.excludeTagIds.isNotEmpty() ||
-                                            querySpec.circles.isNotEmpty() ||
-                                            querySpec.cvs.isNotEmpty() ||
-                                            querySpec.source != null
-
-                                    Box(modifier = Modifier.fillMaxSize()) {
-                                        Column(
-                                            modifier = Modifier
-                                                .fillMaxWidth()
-                                                .padding(horizontal = 24.dp)
-                                                .align(Alignment.Center),
-                                            horizontalAlignment = Alignment.CenterHorizontally,
-                                            verticalArrangement = Arrangement.spacedBy(16.dp)
-                                        ) {
-                                            if (hasAnyQuery) {
-                                                Text(
-                                                    "没有匹配结果",
-                                                    style = MaterialTheme.typography.bodyLarge,
-                                                    color = colorScheme.textSecondary
-                                                )
-                                                Button(
-                                                    onClick = {
-                                                        searchText = ""
-                                                        viewModel.setSearchQuery("")
-                                                        viewModel.clearFilters()
-                                                    }
-                                                ) { Text("重置筛选与搜索") }
-                                            } else {
-                                                Text(
-                                                    "还没有扫描到本地专辑",
-                                                    style = MaterialTheme.typography.bodyLarge,
-                                                    color = colorScheme.textSecondary
-                                                )
-                                                Text(
-                                                    "请到「设置」→「本地库」添加目录并执行同步/刷新",
-                                                    style = MaterialTheme.typography.bodySmall,
-                                                    color = colorScheme.textSecondary
-                                                )
-                                            }
-                                        }
-                                    }
-                                } */ else if (isTrackList) {
+                                } else if (isTrackList) {
                                     LazyColumn(
                                         state = listState,
                                         modifier = Modifier
@@ -589,7 +548,6 @@ fun LibraryScreen(
                                                         rjCode = header.rjCode.ifBlank { header.workId },
                                                         coverModel = header.coverPath.takeIf { it.isNotBlank() }.takeIf { it != "null" }
                                                             ?: header.coverUrl.takeIf { it.isNotBlank() },
-                                                        expanded = expanded,
                                                         onToggle = {
                                                             if (expanded) expandedAlbumIds.remove(albumId) else expandedAlbumIds.add(albumId)
                                                         }
@@ -662,26 +620,7 @@ fun LibraryScreen(
                                                                 playerViewModel.addTrackToQueue(album, track)
                                                             },
                                                             onAddToPlaylist = {
-                                                                val rj = album.rjCode.ifBlank { album.workId }
-                                                                val artist = when {
-                                                                    album.cv.isNotBlank() -> album.cv
-                                                                    album.circle.isNotBlank() -> album.circle
-                                                                    else -> rj
-                                                                }
-                                                                val artwork = album.coverPath.ifBlank { album.coverUrl }
-                                                                val displayTitle = track.title.ifBlank {
-                                                                    track.path.substringAfterLast('/').substringAfterLast('\\')
-                                                                }
-                                                                onOpenPlaylistPicker(
-                                                                    track.path,
-                                                                    track.path,
-                                                                    displayTitle,
-                                                                    artist.orEmpty(),
-                                                                    artwork,
-                                                                    album.id,
-                                                                    track.id,
-                                                                    rj
-                                                                )
+                                                                onOpenPlaylistPicker(MediaItemFactory.fromTrack(album, track))
                                                             },
                                                             onManageTags = {
                                                                 scope.launch {
@@ -1158,7 +1097,6 @@ private fun TrackAlbumHeader(
     albumTitle: String,
     rjCode: String,
     coverModel: Any?,
-    expanded: Boolean,
     onToggle: () -> Unit
 ) {
     val colorScheme = AsmrTheme.colorScheme
@@ -1221,6 +1159,17 @@ private fun TrackListRow(
                 style = MaterialTheme.typography.bodyLarge
             )
         },
+        supportingContent = {
+            if (subtitle.isNotBlank()) {
+                Text(
+                    text = subtitle,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = colorScheme.textTertiary
+                )
+            }
+        },
         trailingContent = {
             var expanded by remember { mutableStateOf(false) }
             Row(verticalAlignment = Alignment.CenterVertically) {
@@ -1247,6 +1196,9 @@ private fun TrackListRow(
                                 onClick = {
                                     expanded = false
                                     onAddToQueue()
+                                },
+                                leadingIcon = {
+                                    Icon(Icons.AutoMirrored.Filled.QueueMusic, contentDescription = null)
                                 }
                             )
                             HorizontalDivider(
@@ -1255,10 +1207,13 @@ private fun TrackListRow(
                                 color = materialColorScheme.outlineVariant.copy(alpha = 0.3f)
                             )
                             DropdownMenuItem(
-                                text = { Text("添加到歌单") },
+                                text = { Text("添加到播放列表") },
                                 onClick = {
                                     expanded = false
                                     onAddToPlaylist()
+                                },
+                                leadingIcon = {
+                                    Icon(Icons.AutoMirrored.Filled.PlaylistAdd, contentDescription = null)
                                 }
                             )
                             HorizontalDivider(
@@ -1271,6 +1226,9 @@ private fun TrackListRow(
                                 onClick = {
                                     expanded = false
                                     onManageTags()
+                                },
+                                leadingIcon = {
+                                    Icon(Icons.AutoMirrored.Filled.Label, contentDescription = null)
                                 }
                             )
                             HorizontalDivider(
@@ -1283,6 +1241,9 @@ private fun TrackListRow(
                                 onClick = {
                                     expanded = false
                                     onRemove()
+                                },
+                                leadingIcon = {
+                                    Icon(Icons.Default.Delete, contentDescription = null)
                                 }
                             )
                         }

--- a/app/src/main/java/com/asmr/player/ui/nav/BottomChrome.kt
+++ b/app/src/main/java/com/asmr/player/ui/nav/BottomChrome.kt
@@ -276,7 +276,6 @@ fun resolvePrimaryRoute(
         currentRoute?.startsWith("group_picker") == true -> "groups"
         currentRoute == "library_filter" -> Routes.Library
         currentRoute?.startsWith("album_detail") == true -> lastPrimaryRoute ?: Routes.Library
-        currentRoute?.startsWith("playlist_picker") == true -> lastPrimaryRoute ?: Routes.Library
         else -> lastPrimaryRoute ?: Routes.Library
     }
 }

--- a/app/src/main/java/com/asmr/player/ui/player/NowPlayingScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/player/NowPlayingScreen.kt
@@ -73,6 +73,7 @@ import androidx.compose.ui.viewinterop.AndroidView
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.media3.common.MediaItem
 import androidx.media3.common.Player
 import androidx.media3.common.VideoSize
 import androidx.media3.ui.PlayerView
@@ -169,7 +170,7 @@ internal fun NowPlayingScreen(
     onRouteExitStarted: (exitDurationMs: Int) -> Unit = {},
     onShowQueue: () -> Unit,
     onShowSleepTimer: () -> Unit,
-    onOpenPlaylistPicker: (mediaId: String, uri: String, title: String, artist: String, artworkUri: String, albumId: Long, trackId: Long, rjCode: String) -> Unit,
+    onOpenPlaylistPicker: (MediaItem) -> Unit,
     viewModel: PlayerViewModel,
     coverBackgroundEnabled: Boolean,
     coverBackgroundClarity: Float,
@@ -703,21 +704,7 @@ internal fun NowPlayingScreen(
                             viewModel = viewModel,
                             onShowPlaylistPicker = {
                                 val current = playback.currentMediaItem ?: return@PlaybackControls
-                                val md = current.mediaMetadata
-                                val extras = md.extras
-                                val albumId = extras?.getLong("album_id") ?: 0L
-                                val trackId = extras?.getLong("track_id") ?: 0L
-                                val rjCode = extras?.getString("rj_code").orEmpty()
-                                onOpenPlaylistPicker(
-                                    current.mediaId,
-                                    current.localConfiguration?.uri?.toString().orEmpty(),
-                                    md.title?.toString().orEmpty(),
-                                    md.artist?.toString().orEmpty(),
-                                    md.artworkUri?.toString().orEmpty(),
-                                    albumId,
-                                    trackId,
-                                    rjCode
-                                )
+                                onOpenPlaylistPicker(current)
                             },
                             onShowEqualizer = { showEqualizer = true },
                             onManageTags = {
@@ -928,21 +915,7 @@ internal fun NowPlayingScreen(
                             viewModel = viewModel,
                             onShowPlaylistPicker = {
                                 val current = playback.currentMediaItem ?: return@PlaybackControls
-                                val md = current.mediaMetadata
-                                val extras = md.extras
-                                val albumId = extras?.getLong("album_id") ?: 0L
-                                val trackId = extras?.getLong("track_id") ?: 0L
-                                val rjCode = extras?.getString("rj_code").orEmpty()
-                                onOpenPlaylistPicker(
-                                    current.mediaId,
-                                    current.localConfiguration?.uri?.toString().orEmpty(),
-                                    md.title?.toString().orEmpty(),
-                                    md.artist?.toString().orEmpty(),
-                                    md.artworkUri?.toString().orEmpty(),
-                                    albumId,
-                                    trackId,
-                                    rjCode
-                                )
+                                onOpenPlaylistPicker(current)
                             },
                             onShowEqualizer = { showEqualizer = true },
                             onManageTags = {
@@ -1147,21 +1120,7 @@ internal fun NowPlayingScreen(
                         viewModel = viewModel,
                         onShowPlaylistPicker = {
                             val current = playback.currentMediaItem ?: return@PlaybackControls
-                            val md = current.mediaMetadata
-                            val extras = md.extras
-                            val albumId = extras?.getLong("album_id") ?: 0L
-                            val trackId = extras?.getLong("track_id") ?: 0L
-                            val rjCode = extras?.getString("rj_code").orEmpty()
-                            onOpenPlaylistPicker(
-                                current.mediaId,
-                                current.localConfiguration?.uri?.toString().orEmpty(),
-                                md.title?.toString().orEmpty(),
-                                md.artist?.toString().orEmpty(),
-                                md.artworkUri?.toString().orEmpty(),
-                                albumId,
-                                trackId,
-                                rjCode
-                            )
+                            onOpenPlaylistPicker(current)
                         },
                         onShowEqualizer = { showEqualizer = true },
                         onManageTags = {

--- a/app/src/main/java/com/asmr/player/ui/player/playerviewmodel.kt
+++ b/app/src/main/java/com/asmr/player/ui/player/playerviewmodel.kt
@@ -38,6 +38,7 @@ import android.os.Bundle
 import java.io.File
 
 import com.asmr.player.data.repository.PlaylistRepository
+import com.asmr.player.data.repository.PlaylistMediaItemMapper
 import com.asmr.player.data.repository.TrackSliceRepository
 import com.asmr.player.data.repository.SliceOverlapException
 import com.asmr.player.data.settings.EqualizerSettings
@@ -764,40 +765,5 @@ class PlayerViewModel @Inject constructor(
 }
 
 private fun PlaylistItemEntity.toMediaItemOrNull(): MediaItem? {
-    val trimmed = uri.trim()
-    if (trimmed.isBlank() || trimmed.equals("null", ignoreCase = true)) return null
-    val metadata = MediaMetadata.Builder()
-        .setTitle(title)
-        .setArtist(artist)
-        .setArtworkUri(artworkUri.takeIf { it.isNotBlank() }?.toUri())
-        .build()
-
-    fun repairDocumentUri(raw: String): String {
-        val u = runCatching { Uri.parse(raw) }.getOrNull() ?: return raw
-        val segs = u.pathSegments ?: return raw
-        val docIndex = segs.indexOf("document")
-        if (docIndex < 0) return raw
-        if (segs.size <= docIndex + 2) return raw
-        val docId = segs.subList(docIndex + 1, segs.size).joinToString("/")
-        val encodedDocId = Uri.encode(docId)
-        val encodedPath = "/" + segs.take(docIndex + 1).joinToString("/") + "/" + encodedDocId
-        return u.buildUpon().encodedPath(encodedPath).build().toString()
-    }
-
-    val normalized = if (trimmed.startsWith("content://", ignoreCase = true)) repairDocumentUri(trimmed) else trimmed
-    val normalizedMediaId = mediaId.trim().let { mid ->
-        if (mid.startsWith("content://", ignoreCase = true)) repairDocumentUri(mid) else mid
-    }.ifBlank { normalized }
-    val parsedUri = when {
-        normalized.startsWith("http", ignoreCase = true) ||
-            normalized.startsWith("content://", ignoreCase = true) ||
-            normalized.startsWith("file://", ignoreCase = true) -> normalized.toUri()
-        trimmed.startsWith("/") -> Uri.fromFile(File(trimmed))
-        else -> return null
-    }
-    return MediaItem.Builder()
-        .setMediaId(normalizedMediaId)
-        .setUri(parsedUri)
-        .setMediaMetadata(metadata)
-        .build()
+    return PlaylistMediaItemMapper.toMediaItemOrNull(this)
 }

--- a/app/src/main/java/com/asmr/player/ui/playlists/PlaylistDetailScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/playlists/PlaylistDetailScreen.kt
@@ -403,8 +403,17 @@ private fun PlaylistItemWithSubtitles.toPlaybackEntity(): PlaylistItemEntity {
         mediaId = mediaId,
         title = title,
         artist = artist,
+        albumTitle = albumTitle,
         uri = uri,
         artworkUri = playbackArtworkUri.ifBlank { artworkUri },
+        albumId = albumId,
+        trackId = trackId,
+        rjCode = rjCode,
+        albumWorkId = albumWorkId,
+        trackGroup = trackGroup,
+        lyricsRelativePathNoExt = lyricsRelativePathNoExt,
+        mimeType = mimeType,
+        isVideo = isVideo,
         itemOrder = itemOrder
     )
 }

--- a/app/src/main/java/com/asmr/player/ui/playlists/PlaylistPickerDialog.kt
+++ b/app/src/main/java/com/asmr/player/ui/playlists/PlaylistPickerDialog.kt
@@ -44,23 +44,13 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.media3.common.MediaItem
-import com.asmr.player.playback.MediaItemFactory
 import com.asmr.player.ui.common.thinScrollbar
 import com.asmr.player.ui.theme.AsmrTheme
-import java.io.File
 
 @Composable
 fun PlaylistPickerScreen(
     windowSizeClass: WindowSizeClass,
-    mediaId: String = "",
-    uri: String = "",
-    title: String = "",
-    artist: String = "",
-    artworkUri: String = "",
-    albumId: Long = 0L,
-    trackId: Long = 0L,
-    rjCode: String = "",
-    items: List<MediaItem>? = null,
+    items: List<MediaItem>,
     onBack: () -> Unit,
     embeddedInDialog: Boolean = false,
     viewModel: PlaylistsViewModel = hiltViewModel()
@@ -75,21 +65,7 @@ fun PlaylistPickerScreen(
     val canCreate = remember(createName) { createName.trim().isNotBlank() }
     val isAdding = addingPlaylistId != null
 
-    val pickerItems = remember(mediaId, uri, title, artist, artworkUri, albumId, trackId, rjCode, items) {
-        items ?: listOf(
-            buildPlaylistAddMediaItem(
-                mediaId = mediaId,
-                uri = uri,
-                title = title,
-                artist = artist,
-                artworkUri = artworkUri,
-                albumId = albumId,
-                trackId = trackId,
-                rjCode = rjCode
-            )
-        )
-    }
-
+    val pickerItems = remember(items) { items }
     BackHandler(enabled = isAdding) {}
 
     DisposableEffect(Unit) {
@@ -227,60 +203,4 @@ fun PlaylistPickerScreen(
             }
         }
     }
-}
-
-private fun buildPlaylistAddMediaItem(
-    mediaId: String,
-    uri: String,
-    title: String,
-    artist: String,
-    artworkUri: String,
-    albumId: Long = 0L,
-    trackId: Long = 0L,
-    rjCode: String = ""
-): MediaItem {
-    return MediaItemFactory.fromDetails(
-        mediaId = mediaId,
-        uri = repairPlayableUriForPlaylist(uri),
-        title = title,
-        artist = artist,
-        artworkUri = artworkUri,
-        albumId = albumId,
-        trackId = trackId,
-        rjCode = rjCode
-    )
-}
-
-private fun repairPlayableUriForPlaylist(raw: String): String {
-    val trimmed = raw.trim()
-    if (!trimmed.startsWith("content://", ignoreCase = true)) return trimmed
-    return repairDocumentUri(trimmed)
-}
-
-private fun repairDocumentUri(raw: String): String {
-    val uri = runCatching { Uri.parse(raw) }.getOrNull() ?: return raw
-    val segments = uri.pathSegments ?: return raw
-    val docIndex = segments.indexOf("document")
-    if (docIndex < 0 || segments.size <= docIndex + 2) return raw
-    val docId = segments.subList(docIndex + 1, segments.size).joinToString("/")
-    val encodedDocId = Uri.encode(docId)
-    val encodedPath = "/" + segments.take(docIndex + 1).joinToString("/") + "/" + encodedDocId
-    return uri.buildUpon().encodedPath(encodedPath).build().toString()
-}
-
-@Suppress("unused")
-private fun toPlayableUriForPlaylist(raw: String): Uri {
-    val trimmed = raw.trim()
-    if (
-        trimmed.startsWith("content://", ignoreCase = true) ||
-            trimmed.startsWith("http://", ignoreCase = true) ||
-            trimmed.startsWith("https://", ignoreCase = true) ||
-            trimmed.startsWith("file://", ignoreCase = true)
-    ) {
-        return Uri.parse(repairPlayableUriForPlaylist(trimmed))
-    }
-    if (trimmed.startsWith("/")) {
-        return Uri.fromFile(File(trimmed))
-    }
-    return Uri.parse(trimmed)
 }

--- a/app/src/main/java/com/asmr/player/ui/playlists/SystemPlaylistScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/playlists/SystemPlaylistScreen.kt
@@ -17,7 +17,6 @@ import com.asmr.player.ui.theme.AsmrTheme
 @Composable
 fun SystemPlaylistScreen(
     windowSizeClass: WindowSizeClass,
-    type: String,
     onPlayAll: (List<PlaylistItemEntity>, PlaylistItemEntity) -> Unit,
     viewModel: PlaylistsViewModel = hiltViewModel()
 ) {

--- a/app/src/test/java/com/asmr/player/data/local/db/AppDatabaseMigrationsTest.kt
+++ b/app/src/test/java/com/asmr/player/data/local/db/AppDatabaseMigrationsTest.kt
@@ -1,0 +1,83 @@
+package com.asmr.player.data.local.db
+
+import androidx.room.Room
+import androidx.sqlite.db.framework.FrameworkSQLiteOpenHelperFactory
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import java.io.File
+
+@RunWith(RobolectricTestRunner::class)
+class AppDatabaseMigrationsTest {
+    @Test
+    fun migration20To21_addsPlaylistPlaybackContextColumns() {
+        val context = RuntimeEnvironment.getApplication()
+        val dbName = "migration-test-${System.nanoTime()}.db"
+        val dbFile = context.getDatabasePath(dbName)
+        dbFile.parentFile?.mkdirs()
+        if (dbFile.exists()) dbFile.delete()
+
+        val helper = FrameworkSQLiteOpenHelperFactory().create(
+            androidx.sqlite.db.SupportSQLiteOpenHelper.Configuration.builder(context)
+                .name(dbName)
+                .callback(object : androidx.sqlite.db.SupportSQLiteOpenHelper.Callback(20) {
+                    override fun onCreate(db: androidx.sqlite.db.SupportSQLiteDatabase) {
+                        db.execSQL(
+                            """
+                            CREATE TABLE IF NOT EXISTS `playlist_items` (
+                                `playlistId` INTEGER NOT NULL,
+                                `mediaId` TEXT NOT NULL,
+                                `title` TEXT NOT NULL,
+                                `artist` TEXT NOT NULL DEFAULT '',
+                                `uri` TEXT NOT NULL,
+                                `artworkUri` TEXT NOT NULL DEFAULT '',
+                                `itemOrder` INTEGER NOT NULL DEFAULT 0,
+                                PRIMARY KEY(`playlistId`, `mediaId`)
+                            )
+                            """.trimIndent()
+                        )
+                        db.execSQL(
+                            "INSERT INTO playlist_items(playlistId, mediaId, title, artist, uri, artworkUri, itemOrder) VALUES(1, 'a', 'Track A', 'Artist', 'file:///a.mp3', '', 0)"
+                        )
+                    }
+
+                    override fun onUpgrade(
+                        db: androidx.sqlite.db.SupportSQLiteDatabase,
+                        oldVersion: Int,
+                        newVersion: Int
+                    ) = Unit
+                })
+                .build()
+        )
+        helper.writableDatabase.close()
+        helper.close()
+
+        val migrated = Room.databaseBuilder(context, AppDatabase::class.java, dbName)
+            .addMigrations(AppDatabaseMigrations.MIGRATION_20_21)
+            .allowMainThreadQueries()
+            .build()
+
+        val cursor = migrated.openHelper.writableDatabase.query(
+            "SELECT albumTitle, albumId, trackId, rjCode, albumWorkId, trackGroup, lyricsRelativePathNoExt, mimeType, isVideo FROM playlist_items WHERE playlistId = 1 AND mediaId = 'a'"
+        )
+        cursor.use {
+            it.moveToFirst()
+            assertEquals("", it.getString(0))
+            assertEquals(0L, it.getLong(1))
+            assertEquals(0L, it.getLong(2))
+            assertEquals("", it.getString(3))
+            assertEquals("", it.getString(4))
+            assertEquals("", it.getString(5))
+            assertEquals("", it.getString(6))
+            assertEquals("", it.getString(7))
+            assertEquals(0, it.getInt(8))
+        }
+
+        migrated.close()
+        File(dbFile.absolutePath).delete()
+        File(dbFile.absolutePath + "-wal").delete()
+        File(dbFile.absolutePath + "-shm").delete()
+    }
+}

--- a/app/src/test/java/com/asmr/player/data/repository/PlaylistRepositoryOrderTest.kt
+++ b/app/src/test/java/com/asmr/player/data/repository/PlaylistRepositoryOrderTest.kt
@@ -2,13 +2,20 @@ package com.asmr.player.data.repository
 
 import androidx.media3.common.MediaItem
 import androidx.media3.common.MediaMetadata
+import android.os.Bundle
 import androidx.room.Room
 import com.asmr.player.data.local.db.AppDatabase
+import com.asmr.player.data.lyrics.EXTRA_ALBUM_WORK_ID
+import com.asmr.player.data.lyrics.EXTRA_LYRICS_RELATIVE_PATH_NO_EXT
+import com.asmr.player.data.lyrics.EXTRA_TRACK_GROUP
 import com.asmr.player.data.local.db.entities.PlaylistEntity
 import com.asmr.player.data.local.db.entities.PlaylistItemEntity
 import kotlinx.coroutines.runBlocking
 import org.junit.After
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -85,14 +92,62 @@ class PlaylistRepositoryOrderTest {
         assertEquals(listOf(0, 1, 2, 3), items.map { it.itemOrder })
     }
 
+    @Test
+    fun playlistMediaItem_roundTrip_preservesPlaybackContext() {
+        val item = mediaItem(
+            mediaId = "content://media/external/audio/document/primary:Album/01.mp3",
+            title = "Track A"
+        )
+
+        val entity = PlaylistMediaItemMapper.fromMediaItem(
+            playlistId = 3L,
+            item = item,
+            itemOrder = 7
+        )
+
+        assertEquals("Album Title", entity.albumTitle)
+        assertEquals(12L, entity.albumId)
+        assertEquals(34L, entity.trackId)
+        assertEquals("RJ123456", entity.rjCode)
+        assertEquals("WORK123", entity.albumWorkId)
+        assertEquals("Disc 1", entity.trackGroup)
+        assertEquals("Disc 1/01", entity.lyricsRelativePathNoExt)
+        assertEquals("audio/flac", entity.mimeType)
+        assertFalse(entity.isVideo)
+
+        val restored = PlaylistMediaItemMapper.toMediaItemOrNull(entity)
+        assertNotNull(restored)
+        val restoredItem = restored!!
+        val extras = restoredItem.mediaMetadata.extras
+        assertEquals(entity.mediaId, restoredItem.mediaId)
+        assertEquals(entity.albumTitle, restoredItem.mediaMetadata.albumTitle?.toString())
+        assertEquals(entity.mimeType, restoredItem.localConfiguration?.mimeType)
+        assertEquals(entity.albumId, extras?.getLong("album_id"))
+        assertEquals(entity.trackId, extras?.getLong("track_id"))
+        assertEquals(entity.rjCode, extras?.getString("rj_code"))
+        assertEquals(entity.albumWorkId, extras?.getString(EXTRA_ALBUM_WORK_ID))
+        assertEquals(entity.trackGroup, extras?.getString(EXTRA_TRACK_GROUP))
+        assertEquals(entity.lyricsRelativePathNoExt, extras?.getString(EXTRA_LYRICS_RELATIVE_PATH_NO_EXT))
+        assertTrue(restoredItem.localConfiguration?.uri.toString().contains("primary%3AAlbum%2F01.mp3"))
+    }
+
     private fun playlistItem(playlistId: Long, mediaId: String, order: Int): PlaylistItemEntity {
         return PlaylistItemEntity(
             playlistId = playlistId,
             mediaId = mediaId,
             title = mediaId.uppercase(),
             artist = "",
+            albumTitle = "",
             uri = "file:///$mediaId.mp3",
             artworkUri = "",
+            albumId = 0L,
+            trackId = 0L,
+            rjCode = "",
+            albumWorkId = "",
+            trackGroup = "",
+            lyricsRelativePathNoExt = "",
+            mimeType = "",
+            isVideo = false,
             itemOrder = order
         )
     }
@@ -101,9 +156,23 @@ class PlaylistRepositoryOrderTest {
         return MediaItem.Builder()
             .setMediaId(mediaId)
             .setUri("file:///$mediaId.mp3")
+            .setMimeType("audio/flac")
             .setMediaMetadata(
                 MediaMetadata.Builder()
                     .setTitle(title)
+                    .setArtist("Artist")
+                    .setAlbumTitle("Album Title")
+                    .setArtworkUri(android.net.Uri.parse("https://example.com/cover.jpg"))
+                    .setExtras(
+                        Bundle().apply {
+                            putLong("album_id", 12L)
+                            putLong("track_id", 34L)
+                            putString("rj_code", "RJ123456")
+                            putString(EXTRA_ALBUM_WORK_ID, "WORK123")
+                            putString(EXTRA_TRACK_GROUP, "Disc 1")
+                            putString(EXTRA_LYRICS_RELATIVE_PATH_NO_EXT, "Disc 1/01")
+                        }
+                    )
                     .build()
             )
             .build()

--- a/app/src/test/java/com/asmr/player/ui/playlists/PlaylistDetailScreenTest.kt
+++ b/app/src/test/java/com/asmr/player/ui/playlists/PlaylistDetailScreenTest.kt
@@ -128,9 +128,18 @@ class PlaylistDetailScreenTest {
             mediaId = mediaId,
             title = title,
             artist = "Artist",
+            albumTitle = "Album",
             uri = "file:///$mediaId.mp3",
             artworkUri = "",
             playbackArtworkUri = "",
+            albumId = 1L,
+            trackId = 2L,
+            rjCode = "RJ123456",
+            albumWorkId = "WORK123",
+            trackGroup = "Disc 1",
+            lyricsRelativePathNoExt = "Disc 1/$mediaId",
+            mimeType = "audio/mpeg",
+            isVideo = false,
             itemOrder = 0,
             hasSubtitles = false
         )


### PR DESCRIPTION
## Summary
- unify all add-to-playlist entry points onto the same MediaItem-based flow
- persist complete playlist item playback context so playlist replay keeps lyrics/subtitle matching data
- restore playlist replay to rebuild MediaItem with full extras and fix missing subtitles after adding from album tree / track list
- align the track-list overflow menu with icon + text actions and standardize wording to 添加到播放列表

## Validation
- compiled successfully with ./gradlew :app:compileDebugKotlin
- manually verified the regression path where tracks added from album tree / track list could lose subtitles in playlist playback