### PR TITLE
fix: polish album list and metadata presentation

### DIFF
--- a/app/src/main/java/com/asmr/player/ui/groups/AlbumGroupDetailScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/groups/AlbumGroupDetailScreen.kt
@@ -203,23 +203,6 @@ internal fun AlbumGroupDetailContent(
                     .fillMaxWidth()
             }
         ) {
-            if (tracks.isNotEmpty()) {
-                Row(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(16.dp),
-                    verticalAlignment = Alignment.CenterVertically
-                ) {
-                    Text(
-                        text = title,
-                        style = MaterialTheme.typography.titleLarge,
-                        maxLines = 1,
-                        overflow = TextOverflow.Ellipsis,
-                        color = colorScheme.textPrimary
-                    )
-                }
-            }
-
             if (tracks.isEmpty()) {
                 EaraBrandedEmptyState(
                     sectionTitle = title.ifBlank { "我的分组" },
@@ -443,7 +426,7 @@ private fun GroupTrackRow(
             showClickIndication = false,
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(horizontal = 16.dp, vertical = 10.dp),
+                .padding(horizontal = 12.dp, vertical = 2.dp),
             leadingContent = {
                 AsmrAsyncImage(
                     model = coverModel?.toString().orEmpty(),
@@ -451,7 +434,7 @@ private fun GroupTrackRow(
                     contentScale = ContentScale.Crop,
                     placeholderCornerRadius = 6,
                     modifier = Modifier
-                        .size(40.dp)
+                        .size(48.dp)
                         .clip(RoundedCornerShape(6.dp))
                 )
             },

--- a/app/src/main/java/com/asmr/player/ui/library/AlbumDetailScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/AlbumDetailScreen.kt
@@ -1031,6 +1031,7 @@ private fun AlbumHeader(
                                 circle = circle,
                                 rjOnClick = { copy("RJ", rj) },
                                 circleOnClick = { copy("社团", circle) },
+                                appearance = AlbumMetaAppearance.OnImage,
                             )
                         }
                     }

--- a/app/src/main/java/com/asmr/player/ui/library/AlbumDetailScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/AlbumDetailScreen.kt
@@ -125,7 +125,6 @@ import com.asmr.player.ui.common.SubtitleStamp
 import com.asmr.player.ui.common.DiscPlaceholder
 import com.asmr.player.ui.common.AsmrAsyncImage
 import com.asmr.player.ui.common.AsmrShimmerPlaceholder
-import com.asmr.player.ui.common.CvChipsFlow
 import com.asmr.player.ui.common.EaraLogoLoadingIndicator
 import com.asmr.player.ui.common.ImagePreviewDialog
 import com.asmr.player.ui.common.ImagePreviewRequest
@@ -1027,33 +1026,12 @@ private fun AlbumHeader(
                             delayMillis = 40,
                             enabled = animateIntro
                         ) {
-                    Row(
-                        horizontalArrangement = Arrangement.spacedBy(10.dp),
-                        verticalAlignment = Alignment.CenterVertically
-                    ) {
-                        if (rj.isNotBlank()) {
-                            Text(
-                                text = rj,
-                                style = MaterialTheme.typography.labelSmall,
-                                fontWeight = FontWeight.Bold,
-                                color = colorScheme.primary,
-                                modifier = Modifier
-                                    .clickable { copy("RJ", rj) }
-                                    .background(Color.White.copy(alpha = 0.9f), RoundedCornerShape(4.dp))
-                                    .padding(horizontal = 6.dp, vertical = 2.dp)
+                            AlbumPrimaryMetaRow(
+                                rjCode = rj,
+                                circle = circle,
+                                rjOnClick = { copy("RJ", rj) },
+                                circleOnClick = { copy("社团", circle) },
                             )
-                        }
-                        if (circle.isNotBlank()) {
-                            Text(
-                                text = circle,
-                                modifier = Modifier.clickable { copy("社团", circle) },
-                                style = MaterialTheme.typography.labelMedium,
-                                color = Color.White.copy(alpha = 0.9f),
-                                maxLines = 1,
-                                overflow = TextOverflow.Ellipsis
-                            )
-                        }
-                    }
                         }
                     }
                 }
@@ -1066,7 +1044,7 @@ private fun AlbumHeader(
                         delayMillis = 80,
                         enabled = animateIntro
                     ) {
-                        CvChipsFlow(
+                        AlbumCvChipsFlow(
                             cvText = album.cv,
                             horizontalArrangement = Arrangement.spacedBy(8.dp),
                             verticalArrangement = Arrangement.spacedBy(6.dp),
@@ -1120,22 +1098,12 @@ private fun AlbumHeader(
                         delayMillis = 120,
                         enabled = animateIntro
                     ) {
-                    FlowRow(
-                        horizontalArrangement = Arrangement.spacedBy(8.dp),
-                        verticalArrangement = Arrangement.spacedBy(6.dp)
-                    ) {
-                        album.tags.forEach { tag ->
-                            Text(
-                                text = tag,
-                                style = MaterialTheme.typography.labelSmall,
-                                color = colorScheme.primary,
-                                modifier = Modifier
-                                    .background(colorScheme.primary.copy(alpha = 0.1f), RoundedCornerShape(6.dp))
-                                    .padding(horizontal = 8.dp, vertical = 4.dp)
-                                    .clickable { copy("标签", tag) }
-                            )
-                        }
-                    }
+                        AlbumTagsFlow(
+                            tags = album.tags,
+                            horizontalArrangement = Arrangement.spacedBy(8.dp),
+                            verticalArrangement = Arrangement.spacedBy(6.dp),
+                            onTagClick = { tag -> copy("标签", tag) },
+                        )
                     }
                 }
 

--- a/app/src/main/java/com/asmr/player/ui/library/AlbumItem.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/AlbumItem.kt
@@ -312,9 +312,8 @@ fun AlbumGridItem(
                 overflow = TextOverflow.Clip
             )
             
-            val rj = album.rjCode.ifBlank { album.workId }
             AlbumPrimaryMetaRow(
-                rjCode = rj,
+                rjCode = "",
                 circle = album.circle,
                 modifier = Modifier.fillMaxWidth(),
             )

--- a/app/src/main/java/com/asmr/player/ui/library/AlbumItem.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/AlbumItem.kt
@@ -17,46 +17,27 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.Card
-import androidx.compose.material3.CardDefaults
-import androidx.compose.material3.ElevatedCard
 import androidx.compose.foundation.background
-import androidx.compose.foundation.border
-import androidx.compose.foundation.horizontalScroll
-import androidx.compose.foundation.rememberScrollState
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.compositeOver
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
-import androidx.compose.material3.SuggestionChip
-import androidx.compose.material3.SuggestionChipDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalConfiguration
-import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.text.SpanStyle
-import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
-import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
 import com.asmr.player.domain.model.Album
 import com.asmr.player.cache.CacheImageModel
 import com.asmr.player.ui.common.AsmrAsyncImage
- import com.asmr.player.ui.common.CoverContentRow
-import com.asmr.player.ui.common.CvChipsFlow
-import com.asmr.player.ui.common.CvChipsSingleLine
+import com.asmr.player.ui.common.CoverContentRow
 import com.asmr.player.ui.common.AsmrShimmerPlaceholder
-import com.asmr.player.ui.common.rememberDominantColor
 import com.asmr.player.util.DlsiteAntiHotlink
 
 import com.asmr.player.ui.theme.AsmrTheme
@@ -155,32 +136,15 @@ fun AlbumItem(
                         overflow = TextOverflow.Ellipsis
                     )
                 
-                    Row(verticalAlignment = Alignment.CenterVertically) {
-                        if (rj.isNotBlank()) {
-                            Text(
-                                text = rj,
-                                style = MaterialTheme.typography.labelSmall,
-                                color = colorScheme.primary,
-                                modifier = Modifier
-                                    .background(colorScheme.primaryContainer, RoundedCornerShape(4.dp))
-                                    .padding(horizontal = 4.dp, vertical = 2.dp)
-                            )
-                            Spacer(modifier = Modifier.width(8.dp))
-                        }
-                        if (album.circle.isNotBlank()) {
-                            Text(
-                                text = album.circle,
-                                style = MaterialTheme.typography.bodySmall,
-                                color = colorScheme.primary.copy(alpha = 0.8f),
-                                maxLines = 1,
-                                overflow = TextOverflow.Ellipsis
-                            )
-                        }
-                    }
+                    AlbumPrimaryMetaRow(
+                        rjCode = rj,
+                        circle = album.circle,
+                        modifier = Modifier.fillMaxWidth(),
+                    )
 
                     if (album.cv.isNotBlank()) {
                         Spacer(modifier = Modifier.height(4.dp))
-                        CvChipsSingleLine(
+                        AlbumCvChipsSingleLine(
                             cvText = album.cv,
                             modifier = Modifier.fillMaxWidth(),
                         )
@@ -225,28 +189,10 @@ fun AlbumItem(
                     }
 
                     if (album.tags.isNotEmpty()) {
-                        val scrollState = rememberScrollState()
-                        Row(
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .clipToBounds()
-                                .horizontalScroll(scrollState),
-                            horizontalArrangement = Arrangement.spacedBy(4.dp)
-                        ) {
-                            album.tags.forEach { tag ->
-                                Text(
-                                    text = tag,
-                                    style = MaterialTheme.typography.labelSmall,
-                                    color = colorScheme.primary.copy(alpha = 0.7f),
-                                    maxLines = 1,
-                                    overflow = TextOverflow.Ellipsis,
-                                    modifier = Modifier
-                                        .widthIn(max = 200.dp)
-                                        .background(colorScheme.primary.copy(alpha = 0.08f), RoundedCornerShape(4.dp))
-                                        .padding(horizontal = 4.dp, vertical = 1.dp)
-                                )
-                            }
-                        }
+                        AlbumTagsSingleLine(
+                            tags = album.tags,
+                            modifier = Modifier.fillMaxWidth(),
+                        )
                     }
                 }
             },
@@ -366,17 +312,14 @@ fun AlbumGridItem(
                 overflow = TextOverflow.Clip
             )
             
-            if (album.circle.isNotBlank()) {
-                Text(
-                    text = album.circle,
-                    style = MaterialTheme.typography.labelSmall,
-                    color = colorScheme.primary.copy(alpha = 0.8f),
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis
-                )
-            }
+            val rj = album.rjCode.ifBlank { album.workId }
+            AlbumPrimaryMetaRow(
+                rjCode = rj,
+                circle = album.circle,
+                modifier = Modifier.fillMaxWidth(),
+            )
 
-            CvChipsFlow(cvText = album.cv)
+            AlbumCvChipsFlow(cvText = album.cv)
 
             val statsText = remember(album.ratingValue, album.ratingCount, album.priceJpy) {
                 buildString {
@@ -403,22 +346,10 @@ fun AlbumGridItem(
             }
 
             if (album.tags.isNotEmpty()) {
-                FlowRow(
+                AlbumTagsFlow(
+                    tags = album.tags,
                     modifier = Modifier.padding(top = 2.dp),
-                    horizontalArrangement = Arrangement.spacedBy(4.dp),
-                    verticalArrangement = Arrangement.spacedBy(4.dp)
-                ) {
-                    album.tags.forEach { tag ->
-                        Text(
-                            text = tag,
-                            style = MaterialTheme.typography.labelSmall,
-                            color = colorScheme.primary.copy(alpha = 0.7f),
-                            modifier = Modifier
-                                .background(colorScheme.primary.copy(alpha = 0.08f), RoundedCornerShape(4.dp))
-                                .padding(horizontal = 4.dp, vertical = 1.dp)
-                        )
-                    }
-                }
+                )
             }
         }
     }

--- a/app/src/main/java/com/asmr/player/ui/library/AlbumItem.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/AlbumItem.kt
@@ -61,6 +61,10 @@ import com.asmr.player.util.DlsiteAntiHotlink
 
 import com.asmr.player.ui.theme.AsmrTheme
 
+internal val AlbumListItemCornerRadius = 6.dp
+internal val AlbumGridItemCornerRadius = 6.dp
+internal val AlbumGridItemSpacing = 6.dp
+
 @Composable
 @OptIn(ExperimentalFoundationApi::class)
 fun AlbumItem(
@@ -71,8 +75,15 @@ fun AlbumItem(
     emptyCoverUseShimmer: Boolean = false
 ) {
     val colorScheme = AsmrTheme.colorScheme
-    val shape = remember { RoundedCornerShape(16.dp) }
-    val coverShape = remember { RoundedCornerShape(topStart = 16.dp, bottomStart = 16.dp, topEnd = 0.dp, bottomEnd = 0.dp) }
+    val shape = remember { RoundedCornerShape(AlbumListItemCornerRadius) }
+    val coverShape = remember {
+        RoundedCornerShape(
+            topStart = AlbumListItemCornerRadius,
+            bottomStart = AlbumListItemCornerRadius,
+            topEnd = 0.dp,
+            bottomEnd = 0.dp
+        )
+    }
     val data = album.coverThumbPath.takeIf { it.isNotBlank() && it.contains("_v2") }
         .orEmpty()
         .ifBlank { album.coverPath }
@@ -138,7 +149,7 @@ fun AlbumItem(
                     val rj = album.rjCode.ifBlank { album.workId }
                     Text(
                         text = album.title,
-                        style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.Bold),
+                        style = MaterialTheme.typography.titleSmall.copy(fontWeight = FontWeight.Bold),
                         color = colorScheme.textPrimary,
                         maxLines = 1,
                         overflow = TextOverflow.Ellipsis
@@ -261,8 +272,15 @@ fun AlbumGridItem(
     emptyCoverUseShimmer: Boolean = false
 ) {
     val colorScheme = AsmrTheme.colorScheme
-    val shape = remember { RoundedCornerShape(20.dp) }
-    val coverShape = remember { RoundedCornerShape(topStart = 20.dp, topEnd = 20.dp, bottomStart = 0.dp, bottomEnd = 0.dp) }
+    val shape = remember { RoundedCornerShape(AlbumGridItemCornerRadius) }
+    val coverShape = remember {
+        RoundedCornerShape(
+            topStart = AlbumGridItemCornerRadius,
+            topEnd = AlbumGridItemCornerRadius,
+            bottomStart = 0.dp,
+            bottomEnd = 0.dp
+        )
+    }
     val data = album.coverThumbPath.takeIf { it.isNotBlank() && it.contains("_v2") }
         .orEmpty()
         .ifBlank { album.coverPath }

--- a/app/src/main/java/com/asmr/player/ui/library/AlbumMetaChips.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/AlbumMetaChips.kt
@@ -35,6 +35,11 @@ private data class AlbumMetaPalette(
     val border: Color,
 )
 
+internal enum class AlbumMetaAppearance {
+    Default,
+    OnImage,
+}
+
 private fun parseAlbumCvNames(cvText: String): List<String> {
     return cvText
         .split(',', '，', '、', '/', '\n', ';', '；', '|')
@@ -57,6 +62,7 @@ internal fun AlbumPrimaryMetaRow(
     modifier: Modifier = Modifier,
     rjOnClick: (() -> Unit)? = null,
     circleOnClick: (() -> Unit)? = null,
+    appearance: AlbumMetaAppearance = AlbumMetaAppearance.Default,
 ) {
     val normalizedRj = remember(rjCode) { rjCode.trim() }
     val normalizedCircle = remember(circle) { circle.trim() }
@@ -75,6 +81,7 @@ internal fun AlbumPrimaryMetaRow(
                 tone = AlbumMetaTone.Rj,
                 shape = AlbumMetaDenseTagShape,
                 onClick = rjOnClick,
+                appearance = appearance,
             )
         }
         if (normalizedCircle.isNotBlank()) {
@@ -83,6 +90,7 @@ internal fun AlbumPrimaryMetaRow(
                 tone = AlbumMetaTone.Circle,
                 shape = AlbumMetaPillShape,
                 onClick = circleOnClick,
+                appearance = appearance,
             )
         }
     }
@@ -237,9 +245,10 @@ private fun AlbumMetaBadge(
     maxWidth: androidx.compose.ui.unit.Dp? = null,
     onClick: (() -> Unit)? = null,
     textWeight: FontWeight? = null,
+    appearance: AlbumMetaAppearance = AlbumMetaAppearance.Default,
 ) {
     val colorScheme = AsmrTheme.colorScheme
-    val palette = albumMetaPalette(tone, colorScheme)
+    val palette = albumMetaPalette(tone, colorScheme, appearance)
     val styledModifier = modifier
         .then(if (maxWidth != null) Modifier.widthIn(max = maxWidth) else Modifier)
         .background(palette.container, shape)
@@ -265,12 +274,43 @@ private fun AlbumMetaBadge(
 private fun albumMetaPalette(
     tone: AlbumMetaTone,
     colorScheme: com.asmr.player.ui.theme.AsmrColorScheme,
+    appearance: AlbumMetaAppearance,
 ): AlbumMetaPalette {
+    if (appearance == AlbumMetaAppearance.OnImage) {
+        return when (tone) {
+            AlbumMetaTone.Rj -> AlbumMetaPalette(
+                container = Color.White.copy(alpha = 0.22f),
+                content = Color.White,
+                border = Color.White.copy(alpha = 0.28f),
+            )
+            AlbumMetaTone.Circle -> AlbumMetaPalette(
+                container = Color.White.copy(alpha = 0.12f),
+                content = Color.White.copy(alpha = 0.96f),
+                border = Color.White.copy(alpha = 0.18f),
+            )
+            AlbumMetaTone.CvLabel -> AlbumMetaPalette(
+                container = Color.White.copy(alpha = 0.18f),
+                content = Color.White,
+                border = Color.White.copy(alpha = 0.24f),
+            )
+            AlbumMetaTone.CvValue -> AlbumMetaPalette(
+                container = Color.White.copy(alpha = 0.1f),
+                content = Color.White.copy(alpha = 0.96f),
+                border = Color.White.copy(alpha = 0.16f),
+            )
+            AlbumMetaTone.Tag -> AlbumMetaPalette(
+                container = Color.Black.copy(alpha = 0.26f),
+                content = Color.White.copy(alpha = 0.92f),
+                border = Color.White.copy(alpha = 0.12f),
+            )
+        }
+    }
+
     return when (tone) {
         AlbumMetaTone.Rj -> AlbumMetaPalette(
-            container = colorScheme.primary.copy(alpha = if (colorScheme.isDark) 0.16f else 0.1f),
+            container = colorScheme.primary.copy(alpha = if (colorScheme.isDark) 0.38f else 0.28f),
             content = colorScheme.primary,
-            border = colorScheme.primary.copy(alpha = 0.18f),
+            border = colorScheme.primary.copy(alpha = 0.36f),
         )
         AlbumMetaTone.Circle -> AlbumMetaPalette(
             container = colorScheme.primary.copy(alpha = if (colorScheme.isDark) 0.1f else 0.06f),

--- a/app/src/main/java/com/asmr/player/ui/library/AlbumMetaChips.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/AlbumMetaChips.kt
@@ -1,0 +1,296 @@
+package com.asmr.player.ui.library
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clipToBounds
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import com.asmr.player.ui.theme.AsmrTheme
+
+private val AlbumMetaPillShape = RoundedCornerShape(999.dp)
+private val AlbumMetaTagShape = RoundedCornerShape(7.dp)
+private val AlbumMetaDenseTagShape = RoundedCornerShape(6.dp)
+
+private data class AlbumMetaPalette(
+    val container: Color,
+    val content: Color,
+    val border: Color,
+)
+
+private fun parseAlbumCvNames(cvText: String): List<String> {
+    return cvText
+        .split(',', '，', '、', '/', '\n', ';', '；', '|')
+        .map { it.trim() }
+        .filter { it.isNotBlank() }
+        .distinct()
+}
+
+private fun normalizeAlbumTags(tags: List<String>): List<String> {
+    return tags
+        .map { it.trim() }
+        .filter { it.isNotBlank() }
+        .distinct()
+}
+
+@Composable
+internal fun AlbumPrimaryMetaRow(
+    rjCode: String,
+    circle: String,
+    modifier: Modifier = Modifier,
+    rjOnClick: (() -> Unit)? = null,
+    circleOnClick: (() -> Unit)? = null,
+) {
+    val normalizedRj = remember(rjCode) { rjCode.trim() }
+    val normalizedCircle = remember(circle) { circle.trim() }
+    if (normalizedRj.isBlank() && normalizedCircle.isBlank()) return
+
+    Row(
+        modifier = modifier
+            .clipToBounds()
+            .horizontalScroll(rememberScrollState()),
+        horizontalArrangement = Arrangement.spacedBy(4.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        if (normalizedRj.isNotBlank()) {
+            AlbumMetaBadge(
+                text = normalizedRj,
+                tone = AlbumMetaTone.Rj,
+                shape = AlbumMetaDenseTagShape,
+                onClick = rjOnClick,
+            )
+        }
+        if (normalizedCircle.isNotBlank()) {
+            AlbumMetaBadge(
+                text = normalizedCircle,
+                tone = AlbumMetaTone.Circle,
+                shape = AlbumMetaPillShape,
+                onClick = circleOnClick,
+            )
+        }
+    }
+}
+
+@Composable
+internal fun AlbumCvChipsSingleLine(
+    cvText: String,
+    modifier: Modifier = Modifier,
+    showLabel: Boolean = true,
+    onCvClick: ((String) -> Unit)? = null,
+) {
+    val cvs = remember(cvText) { parseAlbumCvNames(cvText) }
+    if (cvs.isEmpty()) return
+
+    Row(
+        modifier = modifier
+            .clipToBounds()
+            .horizontalScroll(rememberScrollState()),
+        horizontalArrangement = Arrangement.spacedBy(4.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        if (showLabel) {
+            AlbumMetaBadge(
+                text = "CV",
+                tone = AlbumMetaTone.CvLabel,
+                shape = AlbumMetaPillShape,
+                textWeight = FontWeight.SemiBold,
+            )
+        }
+        cvs.forEach { cv ->
+            AlbumMetaBadge(
+                text = cv,
+                tone = AlbumMetaTone.CvValue,
+                shape = AlbumMetaPillShape,
+                maxWidth = 200.dp,
+                onClick = { onCvClick?.invoke(cv) },
+            )
+        }
+    }
+}
+
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+internal fun AlbumCvChipsFlow(
+    cvText: String,
+    modifier: Modifier = Modifier,
+    horizontalArrangement: Arrangement.Horizontal = Arrangement.spacedBy(4.dp),
+    verticalArrangement: Arrangement.Vertical = Arrangement.spacedBy(4.dp),
+    showLabel: Boolean = true,
+    onCvClick: ((String) -> Unit)? = null,
+) {
+    val cvs = remember(cvText) { parseAlbumCvNames(cvText) }
+    if (cvs.isEmpty()) return
+
+    FlowRow(
+        modifier = modifier,
+        horizontalArrangement = horizontalArrangement,
+        verticalArrangement = verticalArrangement,
+    ) {
+        if (showLabel) {
+            AlbumMetaBadge(
+                text = "CV",
+                tone = AlbumMetaTone.CvLabel,
+                shape = AlbumMetaPillShape,
+                textWeight = FontWeight.SemiBold,
+            )
+        }
+        cvs.forEach { cv ->
+            AlbumMetaBadge(
+                text = cv,
+                tone = AlbumMetaTone.CvValue,
+                shape = AlbumMetaPillShape,
+                maxWidth = 200.dp,
+                onClick = { onCvClick?.invoke(cv) },
+            )
+        }
+    }
+}
+
+@Composable
+internal fun AlbumTagsSingleLine(
+    tags: List<String>,
+    modifier: Modifier = Modifier,
+    onTagClick: ((String) -> Unit)? = null,
+) {
+    val normalizedTags = remember(tags) { normalizeAlbumTags(tags) }
+    if (normalizedTags.isEmpty()) return
+
+    Row(
+        modifier = modifier
+            .clipToBounds()
+            .horizontalScroll(rememberScrollState()),
+        horizontalArrangement = Arrangement.spacedBy(4.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        normalizedTags.forEach { tag ->
+            AlbumMetaBadge(
+                text = if (tag.startsWith("#")) tag else "#$tag",
+                tone = AlbumMetaTone.Tag,
+                shape = AlbumMetaTagShape,
+                maxWidth = 220.dp,
+                onClick = { onTagClick?.invoke(tag) },
+            )
+        }
+    }
+}
+
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+internal fun AlbumTagsFlow(
+    tags: List<String>,
+    modifier: Modifier = Modifier,
+    horizontalArrangement: Arrangement.Horizontal = Arrangement.spacedBy(4.dp),
+    verticalArrangement: Arrangement.Vertical = Arrangement.spacedBy(4.dp),
+    onTagClick: ((String) -> Unit)? = null,
+) {
+    val normalizedTags = remember(tags) { normalizeAlbumTags(tags) }
+    if (normalizedTags.isEmpty()) return
+
+    FlowRow(
+        modifier = modifier,
+        horizontalArrangement = horizontalArrangement,
+        verticalArrangement = verticalArrangement,
+    ) {
+        normalizedTags.forEach { tag ->
+            AlbumMetaBadge(
+                text = if (tag.startsWith("#")) tag else "#$tag",
+                tone = AlbumMetaTone.Tag,
+                shape = AlbumMetaTagShape,
+                maxWidth = 220.dp,
+                onClick = { onTagClick?.invoke(tag) },
+            )
+        }
+    }
+}
+
+private enum class AlbumMetaTone {
+    Rj,
+    Circle,
+    CvLabel,
+    CvValue,
+    Tag,
+}
+
+@Composable
+private fun AlbumMetaBadge(
+    text: String,
+    tone: AlbumMetaTone,
+    shape: RoundedCornerShape,
+    modifier: Modifier = Modifier,
+    maxWidth: androidx.compose.ui.unit.Dp? = null,
+    onClick: (() -> Unit)? = null,
+    textWeight: FontWeight? = null,
+) {
+    val colorScheme = AsmrTheme.colorScheme
+    val palette = albumMetaPalette(tone, colorScheme)
+    val styledModifier = modifier
+        .then(if (maxWidth != null) Modifier.widthIn(max = maxWidth) else Modifier)
+        .background(palette.container, shape)
+        .border(0.5.dp, palette.border, shape)
+        .padding(
+            horizontal = 7.dp,
+            vertical = 2.dp,
+        )
+        .let { if (onClick != null) it.clickable(onClick = onClick) else it }
+
+    Text(
+        text = text,
+        style = MaterialTheme.typography.labelSmall,
+        fontWeight = textWeight,
+        color = palette.content,
+        maxLines = 1,
+        overflow = TextOverflow.Ellipsis,
+        modifier = styledModifier,
+    )
+}
+
+@Composable
+private fun albumMetaPalette(
+    tone: AlbumMetaTone,
+    colorScheme: com.asmr.player.ui.theme.AsmrColorScheme,
+): AlbumMetaPalette {
+    return when (tone) {
+        AlbumMetaTone.Rj -> AlbumMetaPalette(
+            container = colorScheme.primary.copy(alpha = if (colorScheme.isDark) 0.16f else 0.1f),
+            content = colorScheme.primary,
+            border = colorScheme.primary.copy(alpha = 0.18f),
+        )
+        AlbumMetaTone.Circle -> AlbumMetaPalette(
+            container = colorScheme.primary.copy(alpha = if (colorScheme.isDark) 0.1f else 0.06f),
+            content = colorScheme.primary,
+            border = colorScheme.primary.copy(alpha = 0.14f),
+        )
+        AlbumMetaTone.CvLabel -> AlbumMetaPalette(
+            container = colorScheme.primary.copy(alpha = if (colorScheme.isDark) 0.16f else 0.1f),
+            content = colorScheme.primary,
+            border = colorScheme.primary.copy(alpha = 0.18f),
+        )
+        AlbumMetaTone.CvValue -> AlbumMetaPalette(
+            container = colorScheme.primary.copy(alpha = if (colorScheme.isDark) 0.1f else 0.06f),
+            content = colorScheme.primary,
+            border = colorScheme.primary.copy(alpha = 0.14f),
+        )
+        AlbumMetaTone.Tag -> AlbumMetaPalette(
+            container = colorScheme.surfaceVariant.copy(alpha = if (colorScheme.isDark) 0.75f else 0.92f),
+            content = colorScheme.textSecondary,
+            border = colorScheme.onSurfaceVariant.copy(alpha = if (colorScheme.isDark) 0.32f else 0.18f),
+        )
+    }
+}

--- a/app/src/main/java/com/asmr/player/ui/library/LibraryScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/LibraryScreen.kt
@@ -1295,9 +1295,8 @@ private fun AlbumGridItem(
                 overflow = TextOverflow.Clip
             )
             
-            val rj = album.rjCode.ifBlank { album.workId }
             AlbumPrimaryMetaRow(
-                rjCode = rj,
+                rjCode = "",
                 circle = album.circle,
                 modifier = Modifier.fillMaxWidth(),
             )

--- a/app/src/main/java/com/asmr/player/ui/library/LibraryScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/LibraryScreen.kt
@@ -14,6 +14,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -47,14 +48,11 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.ElevatedCard
 import androidx.compose.foundation.layout.fillMaxHeight
-import androidx.compose.foundation.layout.widthIn
 import com.asmr.player.util.Formatting
 import com.asmr.player.ui.common.SubtitleStamp
 import com.asmr.player.ui.common.DiscPlaceholder
 import com.asmr.player.ui.common.LocalBottomOverlayPadding
 import com.asmr.player.ui.common.CoverContentRow
-import com.asmr.player.ui.common.CvChipsFlow
-import com.asmr.player.ui.common.CvChipsSingleLine
 import com.asmr.player.ui.common.AudioItemMenuAction
 import com.asmr.player.ui.common.AudioItemRow
 import com.asmr.player.ui.common.EaraBrandedEmptyState
@@ -116,12 +114,8 @@ import com.asmr.player.ui.library.LibraryUiState
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
-import androidx.compose.foundation.horizontalScroll
-import androidx.compose.foundation.rememberScrollState
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.layout.size
 import androidx.compose.ui.text.font.FontWeight
@@ -1301,17 +1295,14 @@ private fun AlbumGridItem(
                 overflow = TextOverflow.Clip
             )
             
-            if (album.circle.isNotBlank()) {
-                Text(
-                    text = album.circle,
-                    style = MaterialTheme.typography.labelSmall,
-                    color = colorScheme.primary.copy(alpha = 0.8f),
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis
-                )
-            }
+            val rj = album.rjCode.ifBlank { album.workId }
+            AlbumPrimaryMetaRow(
+                rjCode = rj,
+                circle = album.circle,
+                modifier = Modifier.fillMaxWidth(),
+            )
 
-            CvChipsFlow(cvText = album.cv)
+            AlbumCvChipsFlow(cvText = album.cv)
 
             val statsText = buildString {
                 val rv = album.ratingValue
@@ -1336,22 +1327,10 @@ private fun AlbumGridItem(
             }
 
             if (album.tags.isNotEmpty()) {
-                FlowRow(
+                AlbumTagsFlow(
+                    tags = album.tags,
                     modifier = Modifier.padding(top = 2.dp),
-                    horizontalArrangement = Arrangement.spacedBy(4.dp),
-                    verticalArrangement = Arrangement.spacedBy(4.dp)
-                ) {
-                    album.tags.forEach { tag ->
-                        Text(
-                            text = tag,
-                            style = MaterialTheme.typography.labelSmall,
-                            color = colorScheme.primary.copy(alpha = 0.7f),
-                            modifier = Modifier
-                                .background(colorScheme.primary.copy(alpha = 0.08f), RoundedCornerShape(4.dp))
-                                .padding(horizontal = 4.dp, vertical = 1.dp)
-                        )
-                    }
-                }
+                )
             }
         }
     }
@@ -1483,31 +1462,14 @@ private fun AlbumItem(
                     )
 
                     val rj = album.rjCode.ifBlank { album.workId }
-                    Row(verticalAlignment = Alignment.CenterVertically) {
-                        if (rj.isNotBlank()) {
-                            Text(
-                                text = rj,
-                                style = MaterialTheme.typography.labelSmall,
-                                color = colorScheme.primary,
-                                modifier = Modifier
-                                    .background(colorScheme.primaryContainer, RoundedCornerShape(4.dp))
-                                    .padding(horizontal = 4.dp, vertical = 2.dp)
-                            )
-                            Spacer(modifier = Modifier.width(8.dp))
-                        }
-                        if (album.circle.isNotBlank()) {
-                            Text(
-                                text = album.circle,
-                                style = MaterialTheme.typography.bodySmall,
-                                color = colorScheme.primary.copy(alpha = 0.8f),
-                                maxLines = 1,
-                                overflow = TextOverflow.Ellipsis
-                            )
-                        }
-                    }
+                    AlbumPrimaryMetaRow(
+                        rjCode = rj,
+                        circle = album.circle,
+                        modifier = Modifier.fillMaxWidth(),
+                    )
 
                     if (album.cv.isNotBlank()) {
-                        CvChipsSingleLine(
+                        AlbumCvChipsSingleLine(
                             cvText = album.cv,
                             modifier = Modifier.fillMaxWidth(),
                         )
@@ -1524,27 +1486,10 @@ private fun AlbumItem(
                     }
 
                     if (album.tags.isNotEmpty()) {
-                        Row(
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .clipToBounds()
-                                .horizontalScroll(rememberScrollState()),
-                            horizontalArrangement = Arrangement.spacedBy(4.dp)
-                        ) {
-                            album.tags.forEach { tag ->
-                                Text(
-                                    text = tag,
-                                    style = MaterialTheme.typography.labelSmall,
-                                    color = colorScheme.primary.copy(alpha = 0.7f),
-                                    maxLines = 1,
-                                    overflow = TextOverflow.Ellipsis,
-                                    modifier = Modifier
-                                        .widthIn(max = 200.dp)
-                                        .background(colorScheme.primary.copy(alpha = 0.08f), RoundedCornerShape(4.dp))
-                                        .padding(horizontal = 4.dp, vertical = 1.dp)
-                                )
-                            }
-                        }
+                        AlbumTagsSingleLine(
+                            tags = album.tags,
+                            modifier = Modifier.fillMaxWidth(),
+                        )
                     }
                 }
             },

--- a/app/src/main/java/com/asmr/player/ui/library/LibraryScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/LibraryScreen.kt
@@ -670,8 +670,8 @@ fun LibraryScreen(
                                             .thinScrollbar(gridState),
                                         contentPadding = PaddingValues(top = topPadding, start = 16.dp, end = 16.dp, bottom = 16.dp)
                                             .withAddedBottomPadding(LocalBottomOverlayPadding.current),
-                                        verticalItemSpacing = 16.dp,
-                                        horizontalArrangement = Arrangement.spacedBy(16.dp)
+                                        verticalItemSpacing = AlbumGridItemSpacing,
+                                        horizontalArrangement = Arrangement.spacedBy(AlbumGridItemSpacing)
                                     ) {
                                         staggeredItems(
                                             pagedAlbumIndices,
@@ -1165,24 +1165,24 @@ private fun TrackListRow(
         modifier = Modifier.fillMaxWidth(),
         actions = listOf(
             AudioItemMenuAction(
-                label = "娣诲姞鍒版挱鏀鹃槦鍒?",
+                label = "添加到播放队列",
                 onClick = onAddToQueue,
                 icon = Icons.AutoMirrored.Filled.QueueMusic
             ),
             AudioItemMenuAction(
-                label = "娣诲姞鍒版挱鏀惧垪琛?",
+                label = "添加到播放列表",
                 onClick = onAddToPlaylist,
                 icon = Icons.AutoMirrored.Filled.PlaylistAdd,
                 showDividerBefore = true
             ),
             AudioItemMenuAction(
-                label = "鏍囩绠＄悊",
+                label = "标签管理",
                 onClick = onManageTags,
                 icon = Icons.AutoMirrored.Filled.Label,
                 showDividerBefore = true
             ),
             AudioItemMenuAction(
-                label = "浠庝笓杈戠Щ闄?",
+                label = "从专辑移除",
                 onClick = onRemove,
                 icon = Icons.Default.Delete,
                 showDividerBefore = true
@@ -1200,11 +1200,18 @@ private fun AlbumGridItem(
     onLongClick: () -> Unit
 ) {
     val colorScheme = AsmrTheme.colorScheme
-    val coverShape = remember { RoundedCornerShape(topStart = 20.dp, topEnd = 20.dp, bottomStart = 0.dp, bottomEnd = 0.dp) }
+    val coverShape = remember {
+        RoundedCornerShape(
+            topStart = AlbumGridItemCornerRadius,
+            topEnd = AlbumGridItemCornerRadius,
+            bottomStart = 0.dp,
+            bottomEnd = 0.dp
+        )
+    }
     Column(
         modifier = Modifier
             .fillMaxWidth()
-            .clip(RoundedCornerShape(20.dp))
+            .clip(RoundedCornerShape(AlbumGridItemCornerRadius))
             .background(colorScheme.surface.copy(alpha = 0.3f))
             .combinedClickable(
                 onClick = onClick,
@@ -1359,7 +1366,14 @@ private fun AlbumItem(
     onLongClick: () -> Unit
 ) {
     val colorScheme = AsmrTheme.colorScheme
-    val coverShape = remember { RoundedCornerShape(topStart = 16.dp, bottomStart = 16.dp, topEnd = 0.dp, bottomEnd = 0.dp) }
+    val coverShape = remember {
+        RoundedCornerShape(
+            topStart = AlbumListItemCornerRadius,
+            bottomStart = AlbumListItemCornerRadius,
+            topEnd = 0.dp,
+            bottomEnd = 0.dp
+        )
+    }
     val screenWidthDp = LocalConfiguration.current.screenWidthDp
     val listItemHeight = (screenWidthDp.dp * 0.24f).coerceIn(112.dp, 140.dp)
     val coverSize = listItemHeight
@@ -1368,7 +1382,7 @@ private fun AlbumItem(
         modifier = Modifier
             .fillMaxWidth()
             .padding(horizontal = 16.dp, vertical = 4.dp)
-            .clip(RoundedCornerShape(16.dp))
+            .clip(RoundedCornerShape(AlbumListItemCornerRadius))
             .background(colorScheme.surface.copy(alpha = 0.5f))
             .combinedClickable(
                 onClick = onClick,
@@ -1462,7 +1476,7 @@ private fun AlbumItem(
                 ) {
                     Text(
                         text = album.title,
-                        style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.Bold),
+                        style = MaterialTheme.typography.titleSmall.copy(fontWeight = FontWeight.Bold),
                         color = colorScheme.textPrimary,
                         maxLines = 1,
                         overflow = TextOverflow.Ellipsis

--- a/app/src/main/java/com/asmr/player/ui/player/playerviewmodel.kt
+++ b/app/src/main/java/com/asmr/player/ui/player/playerviewmodel.kt
@@ -649,11 +649,11 @@ class PlayerViewModel @Inject constructor(
         startPositionMs: Long
     ): Boolean {
         if (playerConnection.getControllerOrNull() == null) {
-            messageManager.showError("鎾斁鍣ㄦ湭杩炴帴")
+            messageManager.showError("播放器未连接")
             return false
         }
         if (startTrack.path.contains(".m3u8", ignoreCase = true)) {
-            messageManager.showError("褰撳墠涓嶆敮鎸?m3u8 娴佸獟浣擄紝璇峰厛涓嬭浇闊抽鏂囦欢")
+            messageManager.showError("当前不支持 m3u8 流媒体，请先下载音频文件")
             return false
         }
         val (items, index) = withContext(Dispatchers.Default) {
@@ -662,7 +662,7 @@ class PlayerViewModel @Inject constructor(
             preparedItems to preparedIndex
         }
         if (playerConnection.getControllerOrNull() == null) {
-            messageManager.showError("鎾斁鍣ㄦ湭杩炴帴")
+            messageManager.showError("播放器未连接")
             return false
         }
         playerConnection.setQueue(

--- a/app/src/main/java/com/asmr/player/ui/playlists/PlaylistDetailScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/playlists/PlaylistDetailScreen.kt
@@ -305,7 +305,7 @@ private fun PlaylistItemRow(
             showClickIndication = false,
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(horizontal = 16.dp, vertical = 10.dp),
+                .padding(horizontal = 16.dp, vertical = 2.dp),
             leadingContent = {
                 AsmrAsyncImage(
                     model = item.artworkUri,
@@ -313,7 +313,7 @@ private fun PlaylistItemRow(
                     contentScale = ContentScale.Crop,
                     placeholderCornerRadius = 6,
                     modifier = Modifier
-                        .size(40.dp)
+                        .size(48.dp)
                         .clip(RoundedCornerShape(6.dp))
                 )
             },

--- a/app/src/main/java/com/asmr/player/ui/search/SearchScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/search/SearchScreen.kt
@@ -92,6 +92,7 @@ import com.asmr.player.ui.common.rememberCollapsibleHeaderState
 import com.asmr.player.ui.common.thinScrollbar
 import com.asmr.player.ui.common.withAddedBottomPadding
 import com.asmr.player.ui.library.AlbumGridItem
+import com.asmr.player.ui.library.AlbumGridItemSpacing
 import com.asmr.player.ui.library.AlbumItem
 import com.asmr.player.ui.sidepanel.LandscapeRightPanelHost
 import com.asmr.player.ui.sidepanel.RecentAlbumsPanel
@@ -408,8 +409,8 @@ fun SearchScreen(
                                             end = 16.dp,
                                             bottom = 16.dp
                                         ).withAddedBottomPadding(LocalBottomOverlayPadding.current),
-                                        horizontalArrangement = Arrangement.spacedBy(16.dp),
-                                        verticalItemSpacing = 16.dp
+                                        horizontalArrangement = Arrangement.spacedBy(AlbumGridItemSpacing),
+                                        verticalItemSpacing = AlbumGridItemSpacing
                                     ) {
                                         items(
                                             state.results.size,

--- a/app/src/test/java/com/asmr/player/ui/groups/AlbumGroupDetailScreenTest.kt
+++ b/app/src/test/java/com/asmr/player/ui/groups/AlbumGroupDetailScreenTest.kt
@@ -128,7 +128,7 @@ class AlbumGroupDetailScreenTest {
             AsmrPlayerTheme {
                 AlbumGroupDetailContent(
                     windowSizeClass = testWindowSizeClass(),
-                    title = "鎴戠殑鍒嗙粍",
+                    title = "我的分组",
                     tracks = sampleTracks(),
                     onPlayMediaItems = { _: List<MediaItem>, _: Int -> },
                     onRemoveTrack = {},


### PR DESCRIPTION
## Summary
- tighten album list and album card layout across library and search views
- compact collection/group track rows and remove duplicated group detail title
- unify album metadata styling for RJ, circle, CV, and tags across list, card, and detail views
- refine detail header metadata contrast and avoid duplicate RJ display in album cards
- fix visible Chinese garbled strings in album-related menus and playback errors

## Verification
- ./gradlew :app:compileDebugKotlin
