### PR TITLE
fix: polish album list and track list UI for v1.0.5

### DIFF
--- a/app/src/main/java/com/asmr/player/data/local/db/AppDatabaseMigrations.kt
+++ b/app/src/main/java/com/asmr/player/data/local/db/AppDatabaseMigrations.kt
@@ -373,4 +373,12 @@ object AppDatabaseMigrations {
             db.execSQL("ALTER TABLE playlist_items ADD COLUMN `isVideo` INTEGER NOT NULL DEFAULT 0")
         }
     }
+
+    val MIGRATION_21_22: Migration = object : Migration(21, 22) {
+        override fun migrate(db: SupportSQLiteDatabase) {
+            db.execSQL("ALTER TABLE albums ADD COLUMN `audioTrackCount` INTEGER NOT NULL DEFAULT 0")
+            db.execSQL("ALTER TABLE albums ADD COLUMN `audioTotalDuration` REAL NOT NULL DEFAULT 0")
+            db.execSQL("ALTER TABLE albums ADD COLUMN `audioTotalSizeBytes` INTEGER NOT NULL DEFAULT 0")
+        }
+    }
 }

--- a/app/src/main/java/com/asmr/player/data/local/db/AppDatabaseProvider.kt
+++ b/app/src/main/java/com/asmr/player/data/local/db/AppDatabaseProvider.kt
@@ -36,7 +36,8 @@ object AppDatabaseProvider {
                 AppDatabaseMigrations.MIGRATION_17_18,
                 AppDatabaseMigrations.MIGRATION_18_19,
                 AppDatabaseMigrations.MIGRATION_19_20,
-                AppDatabaseMigrations.MIGRATION_20_21
+                AppDatabaseMigrations.MIGRATION_20_21,
+                AppDatabaseMigrations.MIGRATION_21_22
             )
             // Never wipe the local database during app upgrades.
             // If a migration is missing, fail loudly so user data can still be recovered.

--- a/app/src/main/java/com/asmr/player/data/local/db/appdatabase.kt
+++ b/app/src/main/java/com/asmr/player/data/local/db/appdatabase.kt
@@ -65,7 +65,7 @@ import com.asmr.player.data.local.db.entities.TrackPlaybackProgressEntity
         TrackSliceEntity::class,
         TrackPlaybackProgressEntity::class
     ],
-    version = 21,
+    version = 22,
     exportSchema = false
 )
 abstract class AppDatabase : RoomDatabase() {

--- a/app/src/main/java/com/asmr/player/data/local/db/dao/LibraryTrackAlbumHeaderRow.kt
+++ b/app/src/main/java/com/asmr/player/data/local/db/dao/LibraryTrackAlbumHeaderRow.kt
@@ -8,5 +8,7 @@ data class LibraryTrackAlbumHeaderRow(
     val coverUrl: String,
     val coverPath: String,
     val workId: String,
-    val rjCode: String
+    val rjCode: String,
+    val trackCount: Int,
+    val totalDuration: Double
 )

--- a/app/src/main/java/com/asmr/player/data/local/db/dao/LibraryTrackAlbumHeaderRow.kt
+++ b/app/src/main/java/com/asmr/player/data/local/db/dao/LibraryTrackAlbumHeaderRow.kt
@@ -10,5 +10,6 @@ data class LibraryTrackAlbumHeaderRow(
     val workId: String,
     val rjCode: String,
     val trackCount: Int,
-    val totalDuration: Double
+    val totalDuration: Double,
+    val totalSizeBytes: Long
 )

--- a/app/src/main/java/com/asmr/player/data/local/db/entities/albumentity.kt
+++ b/app/src/main/java/com/asmr/player/data/local/db/entities/albumentity.kt
@@ -18,5 +18,8 @@ data class AlbumEntity(
     val coverThumbPath: String = "",
     val workId: String = "",
     val rjCode: String = "",
-    val description: String = ""
+    val description: String = "",
+    val audioTrackCount: Int = 0,
+    val audioTotalDuration: Double = 0.0,
+    val audioTotalSizeBytes: Long = 0L
 )

--- a/app/src/main/java/com/asmr/player/domain/model/Album.kt
+++ b/app/src/main/java/com/asmr/player/domain/model/Album.kt
@@ -21,6 +21,9 @@ data class Album(
     val priceJpy: Int = 0,
     val hasAsmrOne: Boolean = false,
     val description: String = "",
+    val audioTrackCount: Int = 0,
+    val audioTotalDuration: Double = 0.0,
+    val audioTotalSizeBytes: Long = 0L,
     val tracks: List<Track> = emptyList()
 ) {
     fun getAllLocalPaths(): List<String> {

--- a/app/src/main/java/com/asmr/player/main/MainContainer.kt
+++ b/app/src/main/java/com/asmr/player/main/MainContainer.kt
@@ -335,6 +335,13 @@ fun MainContainer(
     var bottomChromeOverflowExpanded by remember { mutableStateOf(false) }
     var bottomChromeOverflowProtectedBounds by remember { mutableStateOf<List<Rect>>(emptyList()) }
     var pendingPrimaryNavigationRoute by remember { mutableStateOf<String?>(null) }
+    var libraryScrollToTopSignal by remember { mutableLongStateOf(0L) }
+    var searchScrollToTopSignal by remember { mutableLongStateOf(0L) }
+    var favoritesScrollToTopSignal by remember { mutableLongStateOf(0L) }
+    var playlistsScrollToTopSignal by remember { mutableLongStateOf(0L) }
+    var groupsScrollToTopSignal by remember { mutableLongStateOf(0L) }
+    var downloadsScrollToTopSignal by remember { mutableLongStateOf(0L) }
+    var settingsScrollToTopSignal by remember { mutableLongStateOf(0L) }
     val appVolumeWarningSessionState = rememberAppVolumeWarningSessionState()
     val audioOutputRouteKind = rememberCurrentAudioOutputRouteKind()
     
@@ -435,6 +442,18 @@ fun MainContainer(
         } else {
             pendingPrimaryNavigationRoute = null
             navController.navigateSingleTop(route, popUpToRoute = Routes.Library)
+        }
+    }
+
+    fun triggerPrimaryRouteScrollToTop(route: String) {
+        when (route) {
+            Routes.Library -> libraryScrollToTopSignal += 1L
+            Routes.Search -> searchScrollToTopSignal += 1L
+            "playlist_system/favorites" -> favoritesScrollToTopSignal += 1L
+            "playlists" -> playlistsScrollToTopSignal += 1L
+            "groups" -> groupsScrollToTopSignal += 1L
+            "downloads" -> downloadsScrollToTopSignal += 1L
+            "settings" -> settingsScrollToTopSignal += 1L
         }
     }
 
@@ -1103,6 +1122,7 @@ fun MainContainer(
                                         Routes.Library -> {
                                             LibraryScreen(
                                                 windowSizeClass = windowSizeClass,
+                                                scrollToTopSignal = libraryScrollToTopSignal,
                                                 onAlbumClick = { album ->
                                                     navigator.openAlbumDetail(
                                                         albumId = album.id,
@@ -1130,6 +1150,7 @@ fun MainContainer(
                                         Routes.Search -> {
                                             SearchScreen(
                                                 windowSizeClass = windowSizeClass,
+                                                scrollToTopSignal = searchScrollToTopSignal,
                                                 onAlbumClick = { album, fromPurchasedOnly ->
                                                     openAlbumDetailFromSearch(
                                                         albumId = album.id,
@@ -1144,6 +1165,7 @@ fun MainContainer(
                                         "playlist_system/favorites" -> {
                                             SystemPlaylistScreen(
                                                 windowSizeClass = windowSizeClass,
+                                                scrollToTopSignal = favoritesScrollToTopSignal,
                                                 onPlayAll = { items, startItem ->
                                                     playerViewModel.playPlaylistItems(items, startItem)
                                                     openNowPlaying()
@@ -1155,6 +1177,7 @@ fun MainContainer(
                                         "playlists" -> {
                                             PlaylistsScreen(
                                                 windowSizeClass = windowSizeClass,
+                                                scrollToTopSignal = playlistsScrollToTopSignal,
                                                 onPlaylistClick = { playlist ->
                                                     val encoded = URLEncoder.encode(playlist.name, "UTF-8")
                                                     navController.navigateSingleTop("playlist/${playlist.id}/$encoded")
@@ -1166,6 +1189,7 @@ fun MainContainer(
                                         "groups" -> {
                                             com.asmr.player.ui.groups.AlbumGroupsScreen(
                                                 windowSizeClass = windowSizeClass,
+                                                scrollToTopSignal = groupsScrollToTopSignal,
                                                 onGroupClick = { group ->
                                                     val encoded = encodeRouteArg(group.name)
                                                     navController.navigateSingleTop("group/${group.id}/$encoded")
@@ -1177,6 +1201,7 @@ fun MainContainer(
                                         "downloads" -> {
                                             DownloadsScreen(
                                                 windowSizeClass = windowSizeClass,
+                                                scrollToTopSignal = downloadsScrollToTopSignal,
                                                 viewModel = downloadsViewModel
                                             )
                                         }
@@ -1186,6 +1211,7 @@ fun MainContainer(
                                                 windowSizeClass = windowSizeClass,
                                                 viewModel = settingsViewModel,
                                                 libraryViewModel = libraryViewModel,
+                                                scrollToTopSignal = settingsScrollToTopSignal,
                                                 onHorizontalControlInteractionChanged = { active ->
                                                     primaryPagerScrollLocked = active
                                                 }
@@ -1590,6 +1616,10 @@ fun MainContainer(
                         },
                         onOpenQueue = onShowQueue,
                         onNavigate = { route ->
+                            if (route == activePrimaryRoute) {
+                                triggerPrimaryRouteScrollToTop(route)
+                                return@BottomChrome
+                            }
                             val projectedPagerRoutes = if (route in bottomNavRoutes && route !in fixedBottomNavRoutes) {
                                 resolvePrimaryPagerRoutes(
                                     navItems = bottomNavItems,

--- a/app/src/main/java/com/asmr/player/main/MainContainer.kt
+++ b/app/src/main/java/com/asmr/player/main/MainContainer.kt
@@ -960,6 +960,9 @@ fun MainContainer(
                                                             ) {
                                                             DropdownMenuItem(
                                                                 text = { Text("专辑列表") },
+                                                                leadingIcon = {
+                                                                    Icon(Icons.Default.ViewList, contentDescription = null)
+                                                                },
                                                                 onClick = {
                                                                     viewMenuExpanded = false
                                                                     libraryViewModel.setLibraryViewMode(0)
@@ -972,6 +975,9 @@ fun MainContainer(
                                                             )
                                                             DropdownMenuItem(
                                                                 text = { Text("专辑卡片") },
+                                                                leadingIcon = {
+                                                                    Icon(Icons.Default.GridView, contentDescription = null)
+                                                                },
                                                                 onClick = {
                                                                     viewMenuExpanded = false
                                                                     libraryViewModel.setLibraryViewMode(1)
@@ -984,6 +990,9 @@ fun MainContainer(
                                                             )
                                                             DropdownMenuItem(
                                                                 text = { Text("音轨列表") },
+                                                                leadingIcon = {
+                                                                    Icon(Icons.Default.Audiotrack, contentDescription = null)
+                                                                },
                                                                 onClick = {
                                                                     viewMenuExpanded = false
                                                                     libraryViewModel.setLibraryViewMode(2)

--- a/app/src/main/java/com/asmr/player/ui/common/AudioItemRow.kt
+++ b/app/src/main/java/com/asmr/player/ui/common/AudioItemRow.kt
@@ -52,6 +52,7 @@ internal val AudioItemTrailingSpacing = 4.dp
 internal val AudioItemSubtitleStampSpacing = 4.dp
 internal val AudioItemMenuButtonSize = 36.dp
 internal val AudioItemMenuIconSize = 18.dp
+internal val AudioItemTrailingEndPadding = 2.dp
 
 @Composable
 internal fun AudioItemRow(
@@ -153,6 +154,7 @@ internal fun AudioItemRow(
 
             var expanded by remember { mutableStateOf(false) }
             Row(
+                modifier = Modifier.padding(end = AudioItemTrailingEndPadding),
                 verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.spacedBy(AudioItemTrailingSpacing)
             ) {

--- a/app/src/main/java/com/asmr/player/ui/common/AudioItemRow.kt
+++ b/app/src/main/java/com/asmr/player/ui/common/AudioItemRow.kt
@@ -7,7 +7,9 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material3.DropdownMenu
@@ -46,6 +48,11 @@ internal data class AudioItemMenuAction(
     val showDividerBefore: Boolean = false
 )
 
+internal val AudioItemTrailingSpacing = 4.dp
+internal val AudioItemSubtitleStampSpacing = 4.dp
+internal val AudioItemMenuButtonSize = 36.dp
+internal val AudioItemMenuIconSize = 18.dp
+
 @Composable
 internal fun AudioItemRow(
     title: String,
@@ -54,7 +61,7 @@ internal fun AudioItemRow(
     modifier: Modifier = Modifier,
     leadingContent: (@Composable (() -> Unit))? = null,
     showSubtitleStamp: Boolean = false,
-    subtitleStampModifier: Modifier = Modifier.padding(end = 8.dp),
+    subtitleStampModifier: Modifier = Modifier,
     subtitleStampTestTag: String? = null,
     menuButtonTestTag: String? = null,
     actions: List<AudioItemMenuAction> = emptyList(),
@@ -145,7 +152,10 @@ internal fun AudioItemRow(
             if (!showTrailing) return@ListItem
 
             var expanded by remember { mutableStateOf(false) }
-            Row(verticalAlignment = Alignment.CenterVertically) {
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(AudioItemTrailingSpacing)
+            ) {
                 if (showSubtitleStamp) {
                     val stampModifier = if (subtitleStampTestTag != null) {
                         subtitleStampModifier.testTag(subtitleStampTestTag)
@@ -162,15 +172,18 @@ internal fun AudioItemRow(
                         IconButton(
                             onClick = { expanded = true },
                             modifier = if (menuButtonTestTag != null) {
-                                Modifier.testTag(menuButtonTestTag)
-                            } else {
                                 Modifier
+                                    .size(AudioItemMenuButtonSize)
+                                    .testTag(menuButtonTestTag)
+                            } else {
+                                Modifier.size(AudioItemMenuButtonSize)
                             }
                         ) {
                             Icon(
                                 imageVector = Icons.Default.MoreVert,
                                 contentDescription = null,
-                                tint = colorScheme.onSurfaceVariant
+                                tint = colorScheme.onSurfaceVariant,
+                                modifier = Modifier.size(AudioItemMenuIconSize)
                             )
                         }
                         MaterialTheme(

--- a/app/src/main/java/com/asmr/player/ui/common/AudioItemRow.kt
+++ b/app/src/main/java/com/asmr/player/ui/common/AudioItemRow.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material.icons.Icons
@@ -52,7 +53,7 @@ internal val AudioItemTrailingSpacing = 4.dp
 internal val AudioItemSubtitleStampSpacing = 4.dp
 internal val AudioItemMenuButtonSize = 36.dp
 internal val AudioItemMenuIconSize = 18.dp
-internal val AudioItemTrailingEndPadding = 2.dp
+internal val AudioItemTrailingRightOffset = 6.dp
 
 @Composable
 internal fun AudioItemRow(
@@ -154,7 +155,7 @@ internal fun AudioItemRow(
 
             var expanded by remember { mutableStateOf(false) }
             Row(
-                modifier = Modifier.padding(end = AudioItemTrailingEndPadding),
+                modifier = Modifier.offset(x = AudioItemTrailingRightOffset),
                 verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.spacedBy(AudioItemTrailingSpacing)
             ) {

--- a/app/src/main/java/com/asmr/player/ui/downloads/DownloadsScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/downloads/DownloadsScreen.kt
@@ -45,6 +45,7 @@ import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -65,11 +66,12 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import com.asmr.player.ui.common.thinScrollbar
 import java.io.File
 
-private val DownloadsPageHorizontalPadding = 12.dp
+private val DownloadsPageHorizontalPadding = 8.dp
 
 @Composable
 fun DownloadsScreen(
     windowSizeClass: WindowSizeClass,
+    scrollToTopSignal: Long = 0L,
     viewModel: DownloadsViewModel = hiltViewModel()
 ) {
     val tasks by viewModel.tasks.collectAsState()
@@ -81,6 +83,10 @@ fun DownloadsScreen(
         File(context.getExternalFilesDir(null), "albums").absolutePath
     }
     val listState = rememberLazyListState()
+    LaunchedEffect(scrollToTopSignal) {
+        if (scrollToTopSignal == 0L) return@LaunchedEffect
+        runCatching { listState.animateScrollToItem(0) }
+    }
 
     // 屏幕尺寸判断
     val isCompact = windowSizeClass.widthSizeClass == WindowWidthSizeClass.Compact

--- a/app/src/main/java/com/asmr/player/ui/downloads/DownloadsScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/downloads/DownloadsScreen.kt
@@ -65,6 +65,8 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import com.asmr.player.ui.common.thinScrollbar
 import java.io.File
 
+private val DownloadsPageHorizontalPadding = 12.dp
+
 @Composable
 fun DownloadsScreen(
     windowSizeClass: WindowSizeClass,
@@ -92,14 +94,14 @@ fun DownloadsScreen(
             modifier = if (isCompact) {
                 Modifier
                     .fillMaxSize()
-                    .padding(horizontal = 16.dp, vertical = 10.dp)
+                    .padding(horizontal = DownloadsPageHorizontalPadding, vertical = 10.dp)
             } else {
                 // 仅用于平板适配：限制内容区域最大宽度并填充可用空间
                 Modifier
                     .fillMaxHeight()
-                    .widthIn(max = 720.dp)
+                    .widthIn(max = 760.dp)
                     .fillMaxWidth()
-                    .padding(horizontal = 16.dp, vertical = 10.dp)
+                    .padding(horizontal = DownloadsPageHorizontalPadding, vertical = 10.dp)
             },
             verticalArrangement = Arrangement.spacedBy(10.dp)
         ) {

--- a/app/src/main/java/com/asmr/player/ui/groups/AlbumGroupDetailScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/groups/AlbumGroupDetailScreen.kt
@@ -82,7 +82,7 @@ import com.asmr.player.ui.common.reorderable.reorderable
 import com.asmr.player.ui.theme.AsmrTheme
 import com.asmr.player.ui.theme.dynamicPageContainerColor
 
-private val GroupDetailHorizontalPadding = 12.dp
+private val GroupDetailHorizontalPadding = 8.dp
 
 internal const val GROUP_DETAIL_SECTION_HEADER_TAG_PREFIX = "groupDetailSectionHeader"
 internal const val GROUP_DETAIL_TRACK_TAG_PREFIX = "groupDetailTrack"
@@ -123,6 +123,7 @@ fun AlbumGroupDetailScreen(
     groupId: Long,
     title: String,
     onPlayMediaItems: (List<MediaItem>, Int) -> Unit,
+    scrollToTopSignal: Long = 0L,
     viewModel: AlbumGroupDetailViewModel = hiltViewModel()
 ) {
     LaunchedEffect(groupId) {
@@ -138,7 +139,8 @@ fun AlbumGroupDetailScreen(
         onRemoveAlbum = viewModel::removeAlbum,
         onMoveTrackToTop = viewModel::moveTrackToTop,
         onMoveTrackToBottom = viewModel::moveTrackToBottom,
-        onSaveAlbumTrackOrder = viewModel::saveAlbumTrackOrder
+        onSaveAlbumTrackOrder = viewModel::saveAlbumTrackOrder,
+        scrollToTopSignal = scrollToTopSignal,
     )
 }
 
@@ -152,7 +154,8 @@ internal fun AlbumGroupDetailContent(
     onRemoveAlbum: (Long) -> Unit,
     onMoveTrackToTop: (Long, String) -> Unit,
     onMoveTrackToBottom: (Long, String) -> Unit,
-    onSaveAlbumTrackOrder: (Long, List<String>) -> Unit
+    onSaveAlbumTrackOrder: (Long, List<String>) -> Unit,
+    scrollToTopSignal: Long = 0L,
 ) {
     val colorScheme = AsmrTheme.colorScheme
     val isCompact = windowSizeClass.widthSizeClass == WindowWidthSizeClass.Compact
@@ -187,6 +190,10 @@ internal fun AlbumGroupDetailContent(
         if (reorderState.draggingItemIndex == null) {
             localRows.sync(buildGroupDetailRows(tracks, expandedAlbumIds.value))
         }
+    }
+    LaunchedEffect(scrollToTopSignal) {
+        if (scrollToTopSignal == 0L) return@LaunchedEffect
+        runCatching { listState.animateScrollToItem(0) }
     }
 
     Box(

--- a/app/src/main/java/com/asmr/player/ui/groups/AlbumGroupDetailScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/groups/AlbumGroupDetailScreen.kt
@@ -4,6 +4,7 @@ import android.net.Uri
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -56,6 +57,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.core.net.toUri
@@ -69,6 +71,7 @@ import com.asmr.player.ui.common.AudioItemRow
 import com.asmr.player.ui.common.EaraBrandedEmptyState
 import com.asmr.player.ui.common.LocalBottomOverlayPadding
 import com.asmr.player.ui.common.StableWindowInsets
+import com.asmr.player.ui.common.queryTrackFileSize
 import com.asmr.player.ui.common.rememberAudioMeta
 import com.asmr.player.ui.common.rememberAudioMetaText
 import com.asmr.player.ui.common.SubtitleStamp
@@ -81,8 +84,15 @@ import com.asmr.player.ui.common.reorderable.rememberReorderableLazyListState
 import com.asmr.player.ui.common.reorderable.reorderable
 import com.asmr.player.ui.theme.AsmrTheme
 import com.asmr.player.ui.theme.dynamicPageContainerColor
+import com.asmr.player.util.Formatting
+import androidx.compose.ui.platform.LocalContext
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 
 private val GroupDetailHorizontalPadding = 8.dp
+private val GroupAlbumHeaderCornerRadius = 10.dp
+private val GroupActionButtonSize = 34.dp
+private val GroupActionIconSize = 18.dp
 
 internal const val GROUP_DETAIL_SECTION_HEADER_TAG_PREFIX = "groupDetailSectionHeader"
 internal const val GROUP_DETAIL_TRACK_TAG_PREFIX = "groupDetailTrack"
@@ -104,6 +114,7 @@ private data class GroupDetailHeaderRow(
     val albumTitle: String,
     val rjCode: String,
     val coverModel: String,
+    val tracks: List<AlbumGroupTrackRow>,
     val expanded: Boolean
 ) : GroupDetailListRow {
     override val key: String = "header:$albumId"
@@ -241,6 +252,7 @@ internal fun AlbumGroupDetailContent(
                                     albumTitle = row.albumTitle,
                                     rjCode = row.rjCode,
                                     coverModel = row.coverModel,
+                                    tracks = row.tracks,
                                     expanded = row.expanded,
                                     onToggle = {
                                         expandedAlbumIds.value = if (row.expanded) {
@@ -342,16 +354,33 @@ private fun AlbumSectionHeader(
     albumTitle: String,
     rjCode: String,
     coverModel: Any?,
+    tracks: List<AlbumGroupTrackRow>,
     expanded: Boolean,
     onToggle: () -> Unit,
     onRemoveAlbum: () -> Unit
 ) {
     val colorScheme = AsmrTheme.colorScheme
+    val context = LocalContext.current
+    val totalSizeBytes by androidx.compose.runtime.produceState<Long?>(initialValue = null, tracks) {
+        value = withContext(Dispatchers.IO) {
+            tracks.sumOf { row -> queryTrackFileSize(context, row.trackPath) ?: 0L }
+                .takeIf { it > 0L }
+        }
+    }
+    val footerSegments = remember(rjCode, tracks, totalSizeBytes) {
+        buildList {
+            if (rjCode.isNotBlank()) add(rjCode)
+            add("${tracks.size} 音频")
+            Formatting.formatTrackSeconds(tracks.sumOf { it.trackDuration }).takeIf { it.isNotBlank() }?.let(::add)
+            totalSizeBytes?.let(Formatting::formatFileSize)?.let(::add)
+        }
+    }
     Row(
         modifier = Modifier
             .fillMaxWidth()
             .testTag("$GROUP_DETAIL_SECTION_HEADER_TAG_PREFIX:$albumId")
-            .background(colorScheme.surface)
+            .clip(RoundedCornerShape(GroupAlbumHeaderCornerRadius))
+            .background(colorScheme.surface.copy(alpha = 0.5f))
             .clickable { onToggle() }
             .padding(horizontal = GroupDetailHorizontalPadding, vertical = 10.dp),
         verticalAlignment = Alignment.CenterVertically
@@ -366,29 +395,28 @@ private fun AlbumSectionHeader(
                 .clip(RoundedCornerShape(8.dp))
         )
         Spacer(modifier = Modifier.width(10.dp))
-        Column(modifier = Modifier.weight(1f)) {
+        Column(modifier = Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(4.dp)) {
             Text(
                 text = albumTitle.ifBlank { rjCode.ifBlank { "专辑" } },
-                style = MaterialTheme.typography.titleMedium,
+                style = MaterialTheme.typography.titleSmall.copy(fontWeight = FontWeight.Bold),
                 color = colorScheme.textPrimary,
                 maxLines = 2,
                 overflow = TextOverflow.Ellipsis
             )
-            if (rjCode.isNotBlank()) {
-                Text(
-                    text = if (expanded) "$rjCode · 已展开" else "$rjCode · 已折叠",
-                    style = MaterialTheme.typography.labelSmall,
-                    color = colorScheme.textTertiary,
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis
-                )
-            }
+            Text(
+                text = footerSegments.joinToString(" · "),
+                style = MaterialTheme.typography.labelSmall,
+                color = colorScheme.textTertiary,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
+            )
         }
-        IconButton(onClick = onRemoveAlbum) {
+        IconButton(onClick = onRemoveAlbum, modifier = Modifier.size(GroupActionButtonSize)) {
             Icon(
                 imageVector = Icons.Default.Delete,
                 contentDescription = null,
-                tint = colorScheme.danger.copy(alpha = 0.7f)
+                tint = colorScheme.danger.copy(alpha = 0.7f),
+                modifier = Modifier.size(GroupActionIconSize)
             )
         }
     }
@@ -494,6 +522,7 @@ private fun buildGroupDetailRows(
             albumTitle = sectionTitle,
             rjCode = first.albumRjCode.orEmpty(),
             coverModel = coverModel,
+            tracks = list,
             expanded = expanded
         )
         if (expanded) {

--- a/app/src/main/java/com/asmr/player/ui/groups/AlbumGroupDetailScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/groups/AlbumGroupDetailScreen.kt
@@ -82,6 +82,8 @@ import com.asmr.player.ui.common.reorderable.reorderable
 import com.asmr.player.ui.theme.AsmrTheme
 import com.asmr.player.ui.theme.dynamicPageContainerColor
 
+private val GroupDetailHorizontalPadding = 12.dp
+
 internal const val GROUP_DETAIL_SECTION_HEADER_TAG_PREFIX = "groupDetailSectionHeader"
 internal const val GROUP_DETAIL_TRACK_TAG_PREFIX = "groupDetailTrack"
 internal const val GROUP_DETAIL_TRACK_MENU_BUTTON_TAG_PREFIX = "groupDetailTrackMenu"
@@ -199,7 +201,7 @@ internal fun AlbumGroupDetailContent(
             } else {
                 Modifier
                     .fillMaxHeight()
-                    .widthIn(max = 720.dp)
+                    .widthIn(max = 760.dp)
                     .fillMaxWidth()
             }
         ) {
@@ -344,7 +346,7 @@ private fun AlbumSectionHeader(
             .testTag("$GROUP_DETAIL_SECTION_HEADER_TAG_PREFIX:$albumId")
             .background(colorScheme.surface)
             .clickable { onToggle() }
-            .padding(horizontal = 16.dp, vertical = 10.dp),
+            .padding(horizontal = GroupDetailHorizontalPadding, vertical = 10.dp),
         verticalAlignment = Alignment.CenterVertically
     ) {
         AsmrAsyncImage(
@@ -404,7 +406,7 @@ private fun GroupTrackRow(
             HorizontalDivider(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(horizontal = 16.dp)
+                    .padding(horizontal = GroupDetailHorizontalPadding)
                     .align(Alignment.TopCenter),
                 thickness = 0.5.dp,
                 color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.2f)
@@ -426,7 +428,7 @@ private fun GroupTrackRow(
             showClickIndication = false,
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(horizontal = 12.dp, vertical = 2.dp),
+                .padding(horizontal = GroupDetailHorizontalPadding, vertical = 2.dp),
             leadingContent = {
                 AsmrAsyncImage(
                     model = coverModel?.toString().orEmpty(),

--- a/app/src/main/java/com/asmr/player/ui/groups/AlbumGroupDetailScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/groups/AlbumGroupDetailScreen.kt
@@ -47,6 +47,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.produceState
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
@@ -64,6 +65,7 @@ import androidx.core.net.toUri
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.media3.common.MediaItem
 import androidx.media3.common.MediaMetadata
+import com.asmr.player.data.local.db.AppDatabaseProvider
 import com.asmr.player.data.local.db.dao.AlbumGroupTrackRow
 import com.asmr.player.ui.common.AsmrAsyncImage
 import com.asmr.player.ui.common.AudioItemMenuAction
@@ -361,6 +363,11 @@ private fun AlbumSectionHeader(
 ) {
     val colorScheme = AsmrTheme.colorScheme
     val context = LocalContext.current
+    val persistedAlbum by produceState<com.asmr.player.data.local.db.entities.AlbumEntity?>(initialValue = null, albumId) {
+        value = withContext(Dispatchers.IO) {
+            AppDatabaseProvider.get(context).albumDao().getAlbumById(albumId)
+        }
+    }
     val totalSizeBytes by androidx.compose.runtime.produceState<Long?>(initialValue = null, tracks) {
         value = withContext(Dispatchers.IO) {
             tracks.sumOf { row -> queryTrackFileSize(context, row.trackPath) ?: 0L }

--- a/app/src/main/java/com/asmr/player/ui/groups/AlbumGroupsScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/groups/AlbumGroupsScreen.kt
@@ -64,6 +64,8 @@ import com.asmr.player.ui.common.withAddedBottomPadding
 import com.asmr.player.ui.theme.AsmrTheme
 
 private val AlbumGroupsPageHorizontalPadding = 8.dp
+private val AlbumGroupRowActionButtonSize = 34.dp
+private val AlbumGroupRowActionIconSize = 18.dp
 
 @Composable
 fun AlbumGroupsScreen(
@@ -207,11 +209,21 @@ private fun AlbumGroupRow(
                     color = colorScheme.textTertiary
                 )
             }
-            IconButton(onClick = { showRename = true }) {
-                Icon(Icons.Default.Edit, contentDescription = null, tint = colorScheme.textSecondary)
+            IconButton(onClick = { showRename = true }, modifier = Modifier.size(AlbumGroupRowActionButtonSize)) {
+                Icon(
+                    Icons.Default.Edit,
+                    contentDescription = null,
+                    tint = colorScheme.textSecondary,
+                    modifier = Modifier.size(AlbumGroupRowActionIconSize)
+                )
             }
-            IconButton(onClick = { showDeleteConfirm = true }) {
-                Icon(Icons.Default.Delete, contentDescription = null, tint = colorScheme.danger.copy(alpha = 0.7f))
+            IconButton(onClick = { showDeleteConfirm = true }, modifier = Modifier.size(AlbumGroupRowActionButtonSize)) {
+                Icon(
+                    Icons.Default.Delete,
+                    contentDescription = null,
+                    tint = colorScheme.danger.copy(alpha = 0.7f),
+                    modifier = Modifier.size(AlbumGroupRowActionIconSize)
+                )
             }
         }
     }

--- a/app/src/main/java/com/asmr/player/ui/groups/AlbumGroupsScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/groups/AlbumGroupsScreen.kt
@@ -38,6 +38,7 @@ import androidx.compose.material3.TextButton
 import androidx.compose.material3.windowsizeclass.WindowSizeClass
 import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -62,12 +63,13 @@ import com.asmr.player.ui.common.thinScrollbar
 import com.asmr.player.ui.common.withAddedBottomPadding
 import com.asmr.player.ui.theme.AsmrTheme
 
-private val AlbumGroupsPageHorizontalPadding = 12.dp
+private val AlbumGroupsPageHorizontalPadding = 8.dp
 
 @Composable
 fun AlbumGroupsScreen(
     windowSizeClass: WindowSizeClass,
     onGroupClick: (AlbumGroupEntity) -> Unit,
+    scrollToTopSignal: Long = 0L,
     viewModel: AlbumGroupsViewModel = hiltViewModel()
 ) {
     val groups by viewModel.groups.collectAsState()
@@ -81,6 +83,10 @@ fun AlbumGroupsScreen(
         containerColor = Color.Transparent,
         contentColor = colorScheme.onBackground
     ) { padding ->
+        LaunchedEffect(scrollToTopSignal) {
+            if (scrollToTopSignal == 0L) return@LaunchedEffect
+            runCatching { listState.animateScrollToItem(0) }
+        }
         Box(
             modifier = Modifier
                 .fillMaxSize()

--- a/app/src/main/java/com/asmr/player/ui/groups/AlbumGroupsScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/groups/AlbumGroupsScreen.kt
@@ -62,6 +62,8 @@ import com.asmr.player.ui.common.thinScrollbar
 import com.asmr.player.ui.common.withAddedBottomPadding
 import com.asmr.player.ui.theme.AsmrTheme
 
+private val AlbumGroupsPageHorizontalPadding = 12.dp
+
 @Composable
 fun AlbumGroupsScreen(
     windowSizeClass: WindowSizeClass,
@@ -90,7 +92,7 @@ fun AlbumGroupsScreen(
             } else {
                 Modifier
                     .fillMaxHeight()
-                    .widthIn(max = 720.dp)
+                    .widthIn(max = 760.dp)
                     .fillMaxWidth()
             }
             Box(modifier = contentModifier) {
@@ -107,7 +109,7 @@ fun AlbumGroupsScreen(
                     LazyColumn(
                         state = listState,
                         modifier = Modifier.fillMaxSize().thinScrollbar(listState),
-                        contentPadding = PaddingValues(horizontal = 16.dp, vertical = 8.dp)
+                        contentPadding = PaddingValues(horizontal = AlbumGroupsPageHorizontalPadding, vertical = 8.dp)
                             .withAddedBottomPadding(LocalBottomOverlayPadding.current + 72.dp),
                         verticalArrangement = Arrangement.spacedBy(12.dp)
                     ) {
@@ -135,7 +137,7 @@ fun AlbumGroupsScreen(
                     contentColor = colorScheme.primary,
                     modifier = Modifier
                         .align(Alignment.BottomEnd)
-                        .padding(end = 16.dp, bottom = LocalBottomOverlayPadding.current + 16.dp)
+                        .padding(end = AlbumGroupsPageHorizontalPadding, bottom = LocalBottomOverlayPadding.current + 16.dp)
                 ) {
                     Icon(Icons.Default.Add, contentDescription = null)
                 }

--- a/app/src/main/java/com/asmr/player/ui/library/AlbumDetailScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/AlbumDetailScreen.kt
@@ -57,14 +57,12 @@ import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.layout.onSizeChanged
-import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.stateDescription
 import androidx.compose.ui.state.ToggleableState
-import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.IntOffset
@@ -916,8 +914,8 @@ private fun AlbumHeader(
     messageManager: MessageManager
 ) {
     val context = LocalContext.current
-    val clipboard = LocalClipboardManager.current
     val colorScheme = AsmrTheme.colorScheme
+    val copyMeta = rememberAlbumMetaCopyAction(messageManager)
     val data = album.coverPath.ifEmpty { album.coverUrl }
     val imageModel = remember(data) {
         val headers = if (data.startsWith("http", ignoreCase = true)) DlsiteAntiHotlink.headersForImageUrl(data) else emptyMap()
@@ -938,12 +936,6 @@ private fun AlbumHeader(
         }
         delay(700)
         headerIntroPlayed = true
-    }
-    fun copy(label: String, value: String) {
-        val v = value.trim()
-        if (v.isBlank()) return
-        clipboard.setText(AnnotatedString(v))
-        messageManager.showSuccess("$label 已复制")
     }
 
     val headerContainerModifier = Modifier
@@ -1012,7 +1004,7 @@ private fun AlbumHeader(
                     ) {
                     Text(
                         text = album.title,
-                        modifier = Modifier.clickable { copy("标题", album.title) },
+                        modifier = Modifier.clickable { copyMeta("标题", album.title) },
                         style = MaterialTheme.typography.titleLarge.copy(fontWeight = FontWeight.Bold),
                         color = Color.White,
                         maxLines = 2,
@@ -1029,8 +1021,8 @@ private fun AlbumHeader(
                             AlbumPrimaryMetaRow(
                                 rjCode = rj,
                                 circle = circle,
-                                rjOnClick = { copy("RJ", rj) },
-                                circleOnClick = { copy("社团", circle) },
+                                rjOnClick = { copyMeta("RJ", rj) },
+                                circleOnClick = { copyMeta("社团", circle) },
                                 appearance = AlbumMetaAppearance.OnImage,
                             )
                         }
@@ -1049,7 +1041,7 @@ private fun AlbumHeader(
                             cvText = album.cv,
                             horizontalArrangement = Arrangement.spacedBy(8.dp),
                             verticalArrangement = Arrangement.spacedBy(6.dp),
-                            onCvClick = { cv -> copy("CV", cv) },
+                            onCvClick = { cv -> copyMeta("CV", cv) },
                         )
                     }
                 }
@@ -1103,7 +1095,7 @@ private fun AlbumHeader(
                             tags = album.tags,
                             horizontalArrangement = Arrangement.spacedBy(8.dp),
                             verticalArrangement = Arrangement.spacedBy(6.dp),
-                            onTagClick = { tag -> copy("标签", tag) },
+                            onTagClick = { tag -> copyMeta("标签", tag) },
                         )
                     }
                 }

--- a/app/src/main/java/com/asmr/player/ui/library/AlbumDetailScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/AlbumDetailScreen.kt
@@ -163,6 +163,7 @@ internal data class PreparedMediaPlayback(
 private val AlbumDetailTabContentGap = 12.dp
 private val AlbumDetailTabCollapseOvershoot = 10.dp
 private const val AlbumDetailInitialIntroDurationMs = 1200L
+private val AlbumDetailHorizontalPadding = 8.dp
 
 private val DlsiteElasticResizeSpring = spring<IntSize>(
     dampingRatio = Spring.DampingRatioLowBouncy,
@@ -257,7 +258,7 @@ fun AlbumDetailScreen(
                 // 仅用于平板适配：限制内容区域最大宽度并填充可用空间
                 Modifier
                     .fillMaxHeight()
-                    .widthIn(max = 720.dp)
+                    .widthIn(max = 800.dp)
                     .fillMaxWidth()
             }
         ) {
@@ -769,7 +770,7 @@ private fun AlbumDetailTabChrome(
     BoxWithConstraints(
         modifier = modifier
             .fillMaxWidth()
-            .padding(horizontal = 16.dp, vertical = 8.dp)
+            .padding(horizontal = AlbumDetailHorizontalPadding, vertical = 8.dp)
             .onSizeChanged(onMeasured)
             .graphicsLayer {
                 translationY = animatedOffsetPx -
@@ -940,7 +941,7 @@ private fun AlbumHeader(
 
     val headerContainerModifier = Modifier
         .fillMaxWidth()
-        .padding(16.dp)
+        .padding(horizontal = AlbumDetailHorizontalPadding, vertical = 12.dp)
         .clip(RoundedCornerShape(24.dp))
         .background(colorScheme.surface.copy(alpha = 0.5f))
 
@@ -993,7 +994,7 @@ private fun AlbumHeader(
                 Column(
                     modifier = Modifier
                         .align(Alignment.BottomStart)
-                        .padding(16.dp),
+                        .padding(12.dp),
                     verticalArrangement = Arrangement.spacedBy(6.dp)
                 ) {
                     AlbumHeaderInfoReveal(
@@ -1030,7 +1031,7 @@ private fun AlbumHeader(
                 }
             }
 
-            Column(modifier = Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(12.dp)) {
+            Column(modifier = Modifier.padding(12.dp), verticalArrangement = Arrangement.spacedBy(12.dp)) {
                 if (album.cv.isNotBlank()) {
                     AlbumHeaderInfoReveal(
                         revealKey = "$headerAnimationScopeKey:cv",

--- a/app/src/main/java/com/asmr/player/ui/library/AlbumDetailViewModel.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/AlbumDetailViewModel.kt
@@ -43,6 +43,7 @@ import com.asmr.player.data.lyrics.LyricsLoader
 import com.asmr.player.data.lyrics.deriveLyricsRelativePathNoExt
 import com.asmr.player.domain.model.Album
 import com.asmr.player.domain.model.Track
+import com.asmr.player.ui.common.queryTrackFileSize
 import com.asmr.player.util.OnlineLyricsStore
 import com.asmr.player.util.RemoteSubtitleSource
 import com.asmr.player.util.SubtitleMatchSupport
@@ -104,6 +105,39 @@ class AlbumDetailViewModel @Inject constructor(
     val messageManager: MessageManager,
     @ApplicationContext private val context: Context
 ) : ViewModel() {
+
+    private data class AlbumAudioAggregate(
+        val trackCount: Int,
+        val totalDuration: Double,
+        val totalSizeBytes: Long,
+    )
+
+    private suspend fun computeAlbumAudioAggregate(
+        tracks: List<TrackEntity>,
+    ): AlbumAudioAggregate {
+        val totalSizeBytes = withContext(Dispatchers.IO) {
+            tracks.sumOf { track -> queryTrackFileSize(context, track.path) ?: 0L }
+        }
+        return AlbumAudioAggregate(
+            trackCount = tracks.size,
+            totalDuration = tracks.sumOf { it.duration },
+            totalSizeBytes = totalSizeBytes,
+        )
+    }
+
+    private suspend fun refreshAlbumAudioAggregate(albumId: Long) {
+        if (albumId <= 0L) return
+        val entity = albumDao.getAlbumById(albumId) ?: return
+        val tracks = trackDao.getTracksForAlbumOnce(albumId)
+        val aggregate = computeAlbumAudioAggregate(tracks)
+        albumDao.updateAlbum(
+            entity.copy(
+                audioTrackCount = aggregate.trackCount,
+                audioTotalDuration = aggregate.totalDuration,
+                audioTotalSizeBytes = aggregate.totalSizeBytes,
+            )
+        )
+    }
 
     private val _uiState = MutableStateFlow<AlbumDetailUiState>(AlbumDetailUiState.Loading)
     val uiState = _uiState.asStateFlow()
@@ -2040,11 +2074,15 @@ class AlbumDetailViewModel @Inject constructor(
                         if (sources.isNotEmpty()) {
                             runCatching { database.remoteSubtitleSourceDao().insertAll(sources) }
                         }
-                    }
                 }
+            }
 
-                SaveOnlineToLibraryResult(
-                    selectedCount = selected.size,
+            if (albumIdResult > 0L) {
+                refreshAlbumAudioAggregate(albumIdResult)
+            }
+
+            SaveOnlineToLibraryResult(
+                selectedCount = selected.size,
                     insertedCount = insertedCount,
                     albumId = albumIdResult,
                     coverUrl = coverUrlResult,

--- a/app/src/main/java/com/asmr/player/ui/library/AlbumItem.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/AlbumItem.kt
@@ -2,6 +2,7 @@ package com.asmr.player.ui.library
 
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -53,7 +54,11 @@ fun AlbumItem(
     onClick: () -> Unit,
     onLongClick: (() -> Unit)? = null,
     modifier: Modifier = Modifier,
-    emptyCoverUseShimmer: Boolean = false
+    emptyCoverUseShimmer: Boolean = false,
+    onRjClick: ((String) -> Unit)? = null,
+    onCircleClick: ((String) -> Unit)? = null,
+    onCvClick: ((String) -> Unit)? = null,
+    onTagClick: ((String) -> Unit)? = null,
 ) {
     val colorScheme = AsmrTheme.colorScheme
     val shape = remember { RoundedCornerShape(AlbumListItemCornerRadius) }
@@ -140,6 +145,8 @@ fun AlbumItem(
                         rjCode = rj,
                         circle = album.circle,
                         modifier = Modifier.fillMaxWidth(),
+                        rjOnClick = onRjClick?.let { click -> { click(rj) } },
+                        circleOnClick = onCircleClick?.let { click -> { click(album.circle) } },
                     )
 
                     if (album.cv.isNotBlank()) {
@@ -147,6 +154,7 @@ fun AlbumItem(
                         AlbumCvChipsSingleLine(
                             cvText = album.cv,
                             modifier = Modifier.fillMaxWidth(),
+                            onCvClick = onCvClick,
                         )
                     }
 
@@ -192,6 +200,7 @@ fun AlbumItem(
                         AlbumTagsSingleLine(
                             tags = album.tags,
                             modifier = Modifier.fillMaxWidth(),
+                            onTagClick = onTagClick,
                         )
                     }
                 }
@@ -215,7 +224,11 @@ fun AlbumGridItem(
     onClick: () -> Unit,
     onLongClick: (() -> Unit)? = null,
     modifier: Modifier = Modifier,
-    emptyCoverUseShimmer: Boolean = false
+    emptyCoverUseShimmer: Boolean = false,
+    onRjClick: ((String) -> Unit)? = null,
+    onCircleClick: ((String) -> Unit)? = null,
+    onCvClick: ((String) -> Unit)? = null,
+    onTagClick: ((String) -> Unit)? = null,
 ) {
     val colorScheme = AsmrTheme.colorScheme
     val shape = remember { RoundedCornerShape(AlbumGridItemCornerRadius) }
@@ -275,6 +288,13 @@ fun AlbumGridItem(
                         .align(Alignment.TopStart)
                         .padding(8.dp)
                         .background(Color.Black.copy(alpha = 0.5f), RoundedCornerShape(4.dp))
+                        .let { base ->
+                            if (onRjClick != null) {
+                                base.clickable { onRjClick(rj) }
+                            } else {
+                                base
+                            }
+                        }
                         .padding(horizontal = 4.dp, vertical = 2.dp)
                 )
             }
@@ -316,9 +336,13 @@ fun AlbumGridItem(
                 rjCode = "",
                 circle = album.circle,
                 modifier = Modifier.fillMaxWidth(),
+                circleOnClick = onCircleClick?.let { click -> { click(album.circle) } },
             )
 
-            AlbumCvChipsFlow(cvText = album.cv)
+            AlbumCvChipsFlow(
+                cvText = album.cv,
+                onCvClick = onCvClick,
+            )
 
             val statsText = remember(album.ratingValue, album.ratingCount, album.priceJpy) {
                 buildString {
@@ -348,6 +372,7 @@ fun AlbumGridItem(
                 AlbumTagsFlow(
                     tags = album.tags,
                     modifier = Modifier.padding(top = 2.dp),
+                    onTagClick = onTagClick,
                 )
             }
         }

--- a/app/src/main/java/com/asmr/player/ui/library/AlbumItem.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/AlbumItem.kt
@@ -46,6 +46,7 @@ import com.asmr.player.ui.theme.AsmrTheme
 internal val AlbumListItemCornerRadius = 6.dp
 internal val AlbumGridItemCornerRadius = 6.dp
 internal val AlbumGridItemSpacing = 6.dp
+private val AlbumItemHorizontalPadding = 12.dp
 
 @Composable
 @OptIn(ExperimentalFoundationApi::class)
@@ -85,7 +86,7 @@ fun AlbumItem(
     Box(
         modifier = modifier
             .fillMaxWidth()
-            .padding(horizontal = 16.dp, vertical = 4.dp)
+            .padding(horizontal = AlbumItemHorizontalPadding, vertical = 4.dp)
             .clip(shape)
             .background(colorScheme.surface.copy(alpha = 0.5f))
             .combinedClickable(

--- a/app/src/main/java/com/asmr/player/ui/library/AlbumItem.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/AlbumItem.kt
@@ -46,7 +46,8 @@ import com.asmr.player.ui.theme.AsmrTheme
 internal val AlbumListItemCornerRadius = 6.dp
 internal val AlbumGridItemCornerRadius = 6.dp
 internal val AlbumGridItemSpacing = 6.dp
-private val AlbumItemHorizontalPadding = 12.dp
+private val AlbumItemHorizontalPadding = 8.dp
+private val AlbumItemVerticalPadding = 2.dp
 
 @Composable
 @OptIn(ExperimentalFoundationApi::class)
@@ -86,7 +87,7 @@ fun AlbumItem(
     Box(
         modifier = modifier
             .fillMaxWidth()
-            .padding(horizontal = AlbumItemHorizontalPadding, vertical = 4.dp)
+            .padding(horizontal = AlbumItemHorizontalPadding, vertical = AlbumItemVerticalPadding)
             .clip(shape)
             .background(colorScheme.surface.copy(alpha = 0.5f))
             .combinedClickable(

--- a/app/src/main/java/com/asmr/player/ui/library/AlbumMetaChips.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/AlbumMetaChips.kt
@@ -16,14 +16,17 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
+import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.asmr.player.ui.theme.AsmrTheme
+import com.asmr.player.util.MessageManager
 
 private val AlbumMetaPillShape = RoundedCornerShape(999.dp)
 private val AlbumMetaTagShape = RoundedCornerShape(7.dp)
@@ -38,6 +41,24 @@ private data class AlbumMetaPalette(
 internal enum class AlbumMetaAppearance {
     Default,
     OnImage,
+}
+
+@Composable
+internal fun rememberAlbumMetaCopyAction(
+    messageManager: MessageManager,
+): (String, String) -> Unit {
+    val clipboard = LocalClipboardManager.current
+    return remember(clipboard, messageManager) {
+        { label: String, value: String ->
+            val normalizedValue = value.trim()
+            if (normalizedValue.isBlank()) {
+                Unit
+            } else {
+                clipboard.setText(AnnotatedString(normalizedValue))
+                messageManager.showSuccess("$label 已复制")
+            }
+        }
+    }
 }
 
 private fun parseAlbumCvNames(cvText: String): List<String> {

--- a/app/src/main/java/com/asmr/player/ui/library/LibraryScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/LibraryScreen.kt
@@ -169,6 +169,7 @@ internal const val LIBRARY_SORT_BUTTON_TAG = "library_sort_button"
 internal const val LIBRARY_FILTER_BUTTON_TAG = "library_filter_button"
 private val LibraryChromeContentGap = 20.dp
 private val LibraryChromeCollapseOvershoot = 12.dp
+private val LibraryPageHorizontalPadding = 12.dp
 
 private fun Album.withUserTags(userTags: List<String>): Album {
     if (userTags.isEmpty()) return this
@@ -371,7 +372,7 @@ fun LibraryScreen(
                     } else {
                         Modifier
                             .fillMaxHeight()
-                            .widthIn(max = 720.dp)
+                            .widthIn(max = 760.dp)
                             .fillMaxWidth()
                     }
                 ) {
@@ -522,7 +523,7 @@ fun LibraryScreen(
                                                     Box(
                                                         modifier = Modifier
                                                             .fillMaxWidth()
-                                                            .padding(horizontal = 16.dp, vertical = 10.dp)
+                                                            .padding(horizontal = LibraryPageHorizontalPadding, vertical = 10.dp)
                                                     ) {
                                                         Spacer(modifier = Modifier.height(50.dp))
                                                     }
@@ -538,7 +539,7 @@ fun LibraryScreen(
                                                 Column {
                                                     if (headerIndex > 0) {
                                                         HorizontalDivider(
-                                                            modifier = Modifier.padding(horizontal = 16.dp),
+                                                            modifier = Modifier.padding(horizontal = LibraryPageHorizontalPadding),
                                                             thickness = 0.5.dp,
                                                             color = colorScheme.onSurfaceVariant.copy(alpha = 0.2f)
                                                         )
@@ -645,7 +646,7 @@ fun LibraryScreen(
                                                         )
                                                         if (index < rows.size - 1) {
                                                             HorizontalDivider(
-                                                                modifier = Modifier.padding(horizontal = 16.dp),
+                                                                modifier = Modifier.padding(horizontal = LibraryPageHorizontalPadding),
                                                                 thickness = 0.5.dp,
                                                                 color = colorScheme.onSurfaceVariant.copy(alpha = 0.2f)
                                                             )
@@ -663,7 +664,7 @@ fun LibraryScreen(
                                             .fillMaxSize()
                                             .nestedScroll(chromeState.nestedScrollConnection)
                                             .thinScrollbar(gridState),
-                                        contentPadding = PaddingValues(top = topPadding, start = 16.dp, end = 16.dp, bottom = 16.dp)
+                                        contentPadding = PaddingValues(top = topPadding, start = LibraryPageHorizontalPadding, end = LibraryPageHorizontalPadding, bottom = 16.dp)
                                             .withAddedBottomPadding(LocalBottomOverlayPadding.current),
                                         verticalItemSpacing = AlbumGridItemSpacing,
                                         horizontalArrangement = Arrangement.spacedBy(AlbumGridItemSpacing)
@@ -980,7 +981,7 @@ internal fun LibraryChrome(
     Row(
         modifier = modifier
             .fillMaxWidth()
-            .padding(horizontal = 16.dp, vertical = 8.dp)
+            .padding(horizontal = LibraryPageHorizontalPadding, vertical = 8.dp)
             .onSizeChanged(onMeasured)
             .graphicsLayer {
                 translationY = chromeOffsetPx - (collapseFraction.coerceIn(0f, 1f) * collapseOvershootPx)
@@ -1116,7 +1117,7 @@ private fun TrackAlbumHeader(
             .fillMaxWidth()
             .background(colorScheme.surface.copy(alpha = 0.5f))
             .clickable { onToggle() }
-            .padding(horizontal = 16.dp, vertical = 10.dp),
+            .padding(horizontal = LibraryPageHorizontalPadding, vertical = 10.dp),
         verticalAlignment = Alignment.CenterVertically
     ) {
         AsmrAsyncImage(
@@ -1388,7 +1389,7 @@ private fun AlbumItem(
     Box(
         modifier = Modifier
             .fillMaxWidth()
-            .padding(horizontal = 16.dp, vertical = 4.dp)
+            .padding(horizontal = LibraryPageHorizontalPadding, vertical = 4.dp)
             .clip(RoundedCornerShape(AlbumListItemCornerRadius))
             .background(colorScheme.surface.copy(alpha = 0.5f))
             .combinedClickable(

--- a/app/src/main/java/com/asmr/player/ui/library/LibraryScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/LibraryScreen.kt
@@ -173,6 +173,7 @@ private val LibraryChromeContentGap = 20.dp
 private val LibraryChromeCollapseOvershoot = 12.dp
 private val LibraryPageHorizontalPadding = 8.dp
 private val LibraryTrackListHeaderCornerRadius = 10.dp
+private val LibraryAlbumItemVerticalPadding = 2.dp
 
 private fun Album.withUserTags(userTags: List<String>): Album {
     if (userTags.isEmpty()) return this
@@ -1432,7 +1433,7 @@ private fun AlbumItem(
     Box(
         modifier = Modifier
             .fillMaxWidth()
-            .padding(horizontal = LibraryPageHorizontalPadding, vertical = 4.dp)
+            .padding(horizontal = LibraryPageHorizontalPadding, vertical = LibraryAlbumItemVerticalPadding)
             .clip(RoundedCornerShape(AlbumListItemCornerRadius))
             .background(colorScheme.surface.copy(alpha = 0.5f))
             .combinedClickable(

--- a/app/src/main/java/com/asmr/player/ui/library/LibraryScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/LibraryScreen.kt
@@ -238,6 +238,7 @@ fun LibraryScreen(
     val userTagsByAlbumId by viewModel.userTagsByAlbumId.collectAsState()
     val userTagsByTrackId by viewModel.userTagsByTrackId.collectAsState()
     val isGlobalSyncRunning by viewModel.isGlobalSyncRunning.collectAsState()
+    val copyMeta = rememberAlbumMetaCopyAction(viewModel.messageManager)
     val playerViewModel: PlayerViewModel = hiltViewModel()
     val scope = rememberCoroutineScope()
     var searchText by rememberSaveable { mutableStateOf(querySpec.textQuery.orEmpty()) }
@@ -680,7 +681,11 @@ fun LibraryScreen(
                                                 onLongClick = {
                                                     actionAlbum = mergedAlbum
                                                     showAlbumActions = true
-                                                }
+                                                },
+                                                onRjClick = { copyMeta("RJ", it) },
+                                                onCircleClick = { copyMeta("社团", it) },
+                                                onCvClick = { copyMeta("CV", it) },
+                                                onTagClick = { copyMeta("标签", it) },
                                             )
                                         }
                                     }
@@ -735,7 +740,11 @@ fun LibraryScreen(
                                                 onLongClick = {
                                                     actionAlbum = mergedAlbum
                                                     showAlbumActions = true
-                                                }
+                                                },
+                                                onRjClick = { copyMeta("RJ", it) },
+                                                onCircleClick = { copyMeta("社团", it) },
+                                                onCvClick = { copyMeta("CV", it) },
+                                                onTagClick = { copyMeta("标签", it) },
                                             )
                                         }
                                     }
@@ -1105,7 +1114,7 @@ private fun TrackAlbumHeader(
     Row(
         modifier = Modifier
             .fillMaxWidth()
-            .background(colorScheme.surface)
+            .background(colorScheme.surface.copy(alpha = 0.5f))
             .clickable { onToggle() }
             .padding(horizontal = 16.dp, vertical = 10.dp),
         verticalAlignment = Alignment.CenterVertically
@@ -1191,7 +1200,11 @@ private fun AlbumGridItem(
     album: Album,
     syncStatus: SyncStatus,
     onClick: () -> Unit,
-    onLongClick: () -> Unit
+    onLongClick: () -> Unit,
+    onRjClick: ((String) -> Unit)? = null,
+    onCircleClick: ((String) -> Unit)? = null,
+    onCvClick: ((String) -> Unit)? = null,
+    onTagClick: ((String) -> Unit)? = null,
 ) {
     val colorScheme = AsmrTheme.colorScheme
     val coverShape = remember {
@@ -1279,6 +1292,13 @@ private fun AlbumGridItem(
                         .align(Alignment.TopStart)
                         .padding(8.dp)
                         .background(Color.Black.copy(alpha = 0.5f), RoundedCornerShape(4.dp))
+                        .let { base ->
+                            if (onRjClick != null) {
+                                base.clickable { onRjClick(rj) }
+                            } else {
+                                base
+                            }
+                        }
                         .padding(horizontal = 4.dp, vertical = 2.dp)
                 )
             }
@@ -1299,9 +1319,13 @@ private fun AlbumGridItem(
                 rjCode = "",
                 circle = album.circle,
                 modifier = Modifier.fillMaxWidth(),
+                circleOnClick = onCircleClick?.let { click -> { click(album.circle) } },
             )
 
-            AlbumCvChipsFlow(cvText = album.cv)
+            AlbumCvChipsFlow(
+                cvText = album.cv,
+                onCvClick = onCvClick,
+            )
 
             val statsText = buildString {
                 val rv = album.ratingValue
@@ -1329,6 +1353,7 @@ private fun AlbumGridItem(
                 AlbumTagsFlow(
                     tags = album.tags,
                     modifier = Modifier.padding(top = 2.dp),
+                    onTagClick = onTagClick,
                 )
             }
         }
@@ -1341,7 +1366,11 @@ private fun AlbumItem(
     album: Album,
     syncStatus: SyncStatus,
     onClick: () -> Unit,
-    onLongClick: () -> Unit
+    onLongClick: () -> Unit,
+    onRjClick: ((String) -> Unit)? = null,
+    onCircleClick: ((String) -> Unit)? = null,
+    onCvClick: ((String) -> Unit)? = null,
+    onTagClick: ((String) -> Unit)? = null,
 ) {
     val colorScheme = AsmrTheme.colorScheme
     val coverShape = remember {
@@ -1465,12 +1494,15 @@ private fun AlbumItem(
                         rjCode = rj,
                         circle = album.circle,
                         modifier = Modifier.fillMaxWidth(),
+                        rjOnClick = onRjClick?.let { click -> { click(rj) } },
+                        circleOnClick = onCircleClick?.let { click -> { click(album.circle) } },
                     )
 
                     if (album.cv.isNotBlank()) {
                         AlbumCvChipsSingleLine(
                             cvText = album.cv,
                             modifier = Modifier.fillMaxWidth(),
+                            onCvClick = onCvClick,
                         )
                     }
 
@@ -1488,6 +1520,7 @@ private fun AlbumItem(
                         AlbumTagsSingleLine(
                             tags = album.tags,
                             modifier = Modifier.fillMaxWidth(),
+                            onTagClick = onTagClick,
                         )
                     }
                 }

--- a/app/src/main/java/com/asmr/player/ui/library/LibraryScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/LibraryScreen.kt
@@ -7,6 +7,7 @@ import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -105,6 +106,7 @@ import androidx.compose.ui.unit.Constraints
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.platform.LocalContext
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.asmr.player.domain.model.Album
 import com.asmr.player.domain.model.Track
@@ -169,7 +171,8 @@ internal const val LIBRARY_SORT_BUTTON_TAG = "library_sort_button"
 internal const val LIBRARY_FILTER_BUTTON_TAG = "library_filter_button"
 private val LibraryChromeContentGap = 20.dp
 private val LibraryChromeCollapseOvershoot = 12.dp
-private val LibraryPageHorizontalPadding = 12.dp
+private val LibraryPageHorizontalPadding = 8.dp
+private val LibraryTrackListHeaderCornerRadius = 10.dp
 
 private fun Album.withUserTags(userTags: List<String>): Album {
     if (userTags.isEmpty()) return this
@@ -227,6 +230,7 @@ fun LibraryScreen(
     onOpenPlaylistPicker: (MediaItem) -> Unit = {},
     onOpenGroupPicker: (albumId: Long) -> Unit = { _ -> },
     onOpenFilterScreen: () -> Unit = {},
+    scrollToTopSignal: Long = 0L,
     viewModel: LibraryViewModel = hiltViewModel()
 ) {
     val colorScheme = AsmrTheme.colorScheme
@@ -319,6 +323,14 @@ fun LibraryScreen(
         ) {
             chromeState.expand()
         }
+    }
+    LaunchedEffect(scrollToTopSignal) {
+        if (scrollToTopSignal == 0L) return@LaunchedEffect
+        when (mode) {
+            1 -> runCatching { gridState.animateScrollToItem(0) }
+            else -> runCatching { listState.animateScrollToItem(0) }
+        }
+        chromeState.expand()
     }
 
     Scaffold(
@@ -547,6 +559,9 @@ fun LibraryScreen(
                                                     TrackAlbumHeader(
                                                         albumTitle = header.albumTitle,
                                                         rjCode = header.rjCode.ifBlank { header.workId },
+                                                        trackCount = header.trackCount,
+                                                        totalDurationSeconds = header.totalDuration,
+                                                        totalSizeBytes = rememberAlbumTrackListTotalSizeBytes(rows),
                                                         coverModel = header.coverPath.takeIf { it.isNotBlank() }.takeIf { it != "null" }
                                                             ?: header.coverUrl.takeIf { it.isNotBlank() },
                                                         onToggle = {
@@ -1108,6 +1123,9 @@ private sealed class TagAssignTarget {
 private fun TrackAlbumHeader(
     albumTitle: String,
     rjCode: String,
+    trackCount: Int,
+    totalDurationSeconds: Double,
+    totalSizeBytes: Long?,
     coverModel: Any?,
     onToggle: () -> Unit
 ) {
@@ -1115,6 +1133,7 @@ private fun TrackAlbumHeader(
     Row(
         modifier = Modifier
             .fillMaxWidth()
+            .clip(RoundedCornerShape(LibraryTrackListHeaderCornerRadius))
             .background(colorScheme.surface.copy(alpha = 0.5f))
             .clickable { onToggle() }
             .padding(horizontal = LibraryPageHorizontalPadding, vertical = 10.dp),
@@ -1130,22 +1149,46 @@ private fun TrackAlbumHeader(
                 .clip(RoundedCornerShape(8.dp)),
         )
         Spacer(modifier = Modifier.width(10.dp))
-        Text(
-            text = albumTitle.ifBlank { rjCode.ifBlank { "专辑" } },
-            style = MaterialTheme.typography.titleMedium,
-            color = colorScheme.textPrimary,
-            maxLines = 2,
-            overflow = TextOverflow.Ellipsis,
-            modifier = Modifier.weight(1f)
-        )
-        if (rjCode.isNotBlank()) {
+        Column(modifier = Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(4.dp)) {
             Text(
-                text = rjCode,
-                style = MaterialTheme.typography.labelSmall,
-                color = colorScheme.textTertiary
+                text = albumTitle.ifBlank { rjCode.ifBlank { "专辑" } },
+                style = MaterialTheme.typography.titleSmall.copy(fontWeight = FontWeight.Bold),
+                color = colorScheme.textPrimary,
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis
             )
+
+            val footerSegments = buildList {
+                if (rjCode.isNotBlank()) add(rjCode)
+                add("$trackCount 音频")
+                Formatting.formatTrackSeconds(totalDurationSeconds).takeIf { it.isNotBlank() }?.let(::add)
+                totalSizeBytes?.takeIf { it > 0L }?.let(Formatting::formatFileSize)?.let(::add)
+            }
+            if (footerSegments.isNotEmpty()) {
+                Text(
+                    text = footerSegments.joinToString(" 路 "),
+                    style = MaterialTheme.typography.labelSmall,
+                    color = colorScheme.textTertiary,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
+            }
         }
     }
+}
+
+@Composable
+private fun rememberAlbumTrackListTotalSizeBytes(rows: List<com.asmr.player.data.local.db.dao.LibraryTrackRow>): Long? {
+    val context = LocalContext.current
+    val paths = remember(rows) { rows.map { it.trackPath } }
+    return androidx.compose.runtime.produceState<Long?>(initialValue = null, paths) {
+        value = withContext(Dispatchers.IO) {
+            val total = rows.sumOf { row ->
+                com.asmr.player.ui.common.queryTrackFileSize(context, row.trackPath) ?: 0L
+            }
+            total.takeIf { it > 0L }
+        }
+    }.value
 }
 
 @Composable

--- a/app/src/main/java/com/asmr/player/ui/library/LibraryScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/LibraryScreen.kt
@@ -1166,7 +1166,7 @@ private fun TrackAlbumHeader(
             }
             if (footerSegments.isNotEmpty()) {
                 Text(
-                    text = footerSegments.joinToString(" 路 "),
+                    text = footerSegments.joinToString(" · "),
                     style = MaterialTheme.typography.labelSmall,
                     color = colorScheme.textTertiary,
                     maxLines = 1,

--- a/app/src/main/java/com/asmr/player/ui/library/LibraryScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/LibraryScreen.kt
@@ -562,7 +562,8 @@ fun LibraryScreen(
                                                         rjCode = header.rjCode.ifBlank { header.workId },
                                                         trackCount = header.trackCount,
                                                         totalDurationSeconds = header.totalDuration,
-                                                        totalSizeBytes = rememberAlbumTrackListTotalSizeBytes(rows),
+                                                        totalSizeBytes = header.totalSizeBytes.takeIf { it > 0L }
+                                                            ?: rememberAlbumTrackListTotalSizeBytes(rows),
                                                         coverModel = header.coverPath.takeIf { it.isNotBlank() }.takeIf { it != "null" }
                                                             ?: header.coverUrl.takeIf { it.isNotBlank() },
                                                         onToggle = {

--- a/app/src/main/java/com/asmr/player/ui/library/LibraryTrackQuery.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/LibraryTrackQuery.kt
@@ -278,7 +278,9 @@ object LibraryTrackQueryBuilder {
                 a.coverUrl AS coverUrl,
                 CASE WHEN a.coverThumbPath IS NOT NULL AND a.coverThumbPath != '' AND a.coverThumbPath LIKE '%_v2%' THEN a.coverThumbPath ELSE a.coverPath END AS coverPath,
                 a.workId AS workId,
-                a.rjCode AS rjCode
+                a.rjCode AS rjCode,
+                COUNT(t.id) AS trackCount,
+                COALESCE(SUM(t.duration), 0) AS totalDuration
             FROM tracks t
             JOIN albums a ON a.id = t.albumId
             """.trimIndent()
@@ -360,6 +362,8 @@ object LibraryTrackQueryBuilder {
             sql.append(" WHERE ")
             sql.append(where.joinToString(" AND "))
         }
+
+        sql.append(" GROUP BY a.id, a.title, a.circle, a.cv, a.coverUrl, coverPath, a.workId, a.rjCode")
 
         sql.append(" ORDER BY ")
         sql.append(

--- a/app/src/main/java/com/asmr/player/ui/library/LibraryTrackQuery.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/LibraryTrackQuery.kt
@@ -279,8 +279,9 @@ object LibraryTrackQueryBuilder {
                 CASE WHEN a.coverThumbPath IS NOT NULL AND a.coverThumbPath != '' AND a.coverThumbPath LIKE '%_v2%' THEN a.coverThumbPath ELSE a.coverPath END AS coverPath,
                 a.workId AS workId,
                 a.rjCode AS rjCode,
-                COUNT(t.id) AS trackCount,
-                COALESCE(SUM(t.duration), 0) AS totalDuration
+                COALESCE(NULLIF(a.audioTrackCount, 0), COUNT(t.id)) AS trackCount,
+                COALESCE(NULLIF(a.audioTotalDuration, 0), SUM(t.duration), 0) AS totalDuration,
+                COALESCE(a.audioTotalSizeBytes, 0) AS totalSizeBytes
             FROM tracks t
             JOIN albums a ON a.id = t.albumId
             """.trimIndent()

--- a/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailDirectorySupport.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailDirectorySupport.kt
@@ -123,6 +123,8 @@ import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.zIndex
 import com.asmr.player.ui.common.rememberDominantColor
 import com.asmr.player.ui.common.SubtitleStamp
+import com.asmr.player.ui.common.AudioItemMenuButtonSize
+import com.asmr.player.ui.common.AudioItemSubtitleStampSpacing
 import com.asmr.player.ui.common.DiscPlaceholder
 import com.asmr.player.ui.common.AsmrAsyncImage
 import com.asmr.player.ui.common.AsmrShimmerPlaceholder
@@ -3069,7 +3071,7 @@ internal fun DirectoryFileRow(
                 {
                     Row(verticalAlignment = Alignment.CenterVertically) {
                         if (file.showSubtitleStamp) {
-                            SubtitleStamp(modifier = Modifier.padding(end = 8.dp))
+                            SubtitleStamp(modifier = Modifier.padding(end = AudioItemSubtitleStampSpacing))
                         }
                         if (selectionMode && onSelectedChange != null) {
                             Checkbox(
@@ -3094,7 +3096,7 @@ internal fun DirectoryFileRow(
                             Box {
                                 IconButton(
                                     onClick = { showMenuExpanded = true },
-                                    modifier = Modifier.size(32.dp)
+                                    modifier = Modifier.size(AudioItemMenuButtonSize)
                                 ) {
                                     Icon(
                                         imageVector = Icons.Default.MoreVert,
@@ -3330,7 +3332,7 @@ internal fun TreeFileRow(
                 {
                     Row(verticalAlignment = Alignment.CenterVertically) {
                         if (showSubtitleStamp) {
-                            SubtitleStamp(modifier = Modifier.padding(end = 8.dp))
+                            SubtitleStamp(modifier = Modifier.padding(end = AudioItemSubtitleStampSpacing))
                         }
                         if (onSetAsCover != null) {
                             IconButton(
@@ -3350,7 +3352,7 @@ internal fun TreeFileRow(
                             Box {
                                 IconButton(
                                     onClick = { showMenuExpanded = true },
-                                    modifier = Modifier.size(32.dp)
+                                    modifier = Modifier.size(AudioItemMenuButtonSize)
                                 ) {
                                     Icon(
                                         imageVector = Icons.Default.MoreVert,

--- a/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailSharedSections.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailSharedSections.kt
@@ -118,6 +118,8 @@ import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.zIndex
 import com.asmr.player.ui.common.rememberDominantColor
 import com.asmr.player.ui.common.SubtitleStamp
+import com.asmr.player.ui.common.AudioItemMenuButtonSize
+import com.asmr.player.ui.common.AudioItemSubtitleStampSpacing
 import com.asmr.player.ui.common.DiscPlaceholder
 import com.asmr.player.ui.common.AsmrAsyncImage
 import com.asmr.player.ui.common.AsmrShimmerPlaceholder
@@ -511,10 +513,10 @@ internal fun TrackItem(
         },
         trailingContent = {
             if (showSubtitleStamp) {
-                SubtitleStamp(modifier = Modifier.padding(end = 8.dp))
+                SubtitleStamp(modifier = Modifier.padding(end = AudioItemSubtitleStampSpacing))
             }
             if (onAddToPlaylist != null) {
-                IconButton(onClick = onAddToPlaylist) {
+                IconButton(onClick = onAddToPlaylist, modifier = Modifier.size(AudioItemMenuButtonSize)) {
                     Icon(Icons.AutoMirrored.Filled.PlaylistAdd, contentDescription = null, tint = colorScheme.onSurfaceVariant)
                 }
             }

--- a/app/src/main/java/com/asmr/player/ui/library/libraryviewmodel.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/libraryviewmodel.kt
@@ -130,7 +130,7 @@ class LibraryViewModel @Inject constructor(
     private val settingsRepository: SettingsRepository,
     private val syncCoordinator: SyncCoordinator,
     @Named("image") private val imageOkHttpClient: OkHttpClient,
-    private val messageManager: MessageManager,
+    val messageManager: MessageManager,
     private val playerConnection: PlayerConnection,
     @ApplicationContext private val context: Context
 ) : ViewModel() {

--- a/app/src/main/java/com/asmr/player/ui/library/libraryviewmodel.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/libraryviewmodel.kt
@@ -48,6 +48,7 @@ import com.asmr.player.data.settings.SettingsRepository
 import com.asmr.player.domain.model.Album
 import com.asmr.player.domain.model.Track
 import com.asmr.player.playback.PlayerConnection
+import com.asmr.player.ui.common.queryTrackFileSize
 import com.asmr.player.util.GlobalSyncState
 import com.asmr.player.util.ScanRootsStore
 import com.asmr.player.util.SubtitleEntry
@@ -305,7 +306,45 @@ class LibraryViewModel @Inject constructor(
             coverThumbPath = coverThumbPath,
             workId = workId,
             rjCode = rjCode.ifBlank { workId },
+            audioTrackCount = audioTrackCount,
+            audioTotalDuration = audioTotalDuration,
+            audioTotalSizeBytes = audioTotalSizeBytes,
             description = description
+        )
+    }
+
+    private data class AlbumAudioAggregate(
+        val trackCount: Int,
+        val totalDuration: Double,
+        val totalSizeBytes: Long,
+    )
+
+    private suspend fun computeAlbumAudioAggregate(
+        trackSpecs: List<TrackEntity>,
+    ): AlbumAudioAggregate {
+        val totalSizeBytes = withContext(Dispatchers.IO) {
+            trackSpecs.sumOf { track ->
+                queryTrackFileSize(context, track.path) ?: 0L
+            }
+        }
+        return AlbumAudioAggregate(
+            trackCount = trackSpecs.size,
+            totalDuration = trackSpecs.sumOf { it.duration },
+            totalSizeBytes = totalSizeBytes,
+        )
+    }
+
+    private suspend fun refreshAlbumAudioAggregate(albumId: Long) {
+        if (albumId <= 0L) return
+        val entity = albumDao.getAlbumById(albumId) ?: return
+        val tracks = trackDao.getTracksForAlbumOnce(albumId)
+        val aggregate = computeAlbumAudioAggregate(tracks)
+        albumDao.updateAlbum(
+            entity.copy(
+                audioTrackCount = aggregate.trackCount,
+                audioTotalDuration = aggregate.totalDuration,
+                audioTotalSizeBytes = aggregate.totalSizeBytes,
+            )
         )
     }
 
@@ -1587,6 +1626,8 @@ class LibraryViewModel @Inject constructor(
                 runCatching { database.localTreeCacheDao().deleteByAlbum(track.albumId) }
             }
 
+            refreshAlbumAudioAggregate(track.albumId)
+
             if (deletedFile) {
                 messageManager.showSuccess("已删除文件并移除")
             } else {
@@ -1751,6 +1792,11 @@ class LibraryViewModel @Inject constructor(
                 localPath = null,
                 downloadPath = albumDir.absolutePath
             )
+            val aggregateTracks = albumDir.walkTopDown()
+                .filter { it.isFile && setOf("mp3", "flac", "wav", "m4a", "ogg", "aac", "opus").contains(it.extension.lowercase()) }
+                .map { file -> TrackEntity(albumId = 0L, title = file.nameWithoutExtension, path = file.absolutePath, duration = 0.0, group = "") }
+                .toList()
+            val aggregate = computeAlbumAudioAggregate(aggregateTracks)
             val entity = AlbumEntity(
                 id = existing?.id ?: 0L,
                 title = existing?.title?.takeIf { it.isNotBlank() && it != title } ?: title,
@@ -1765,7 +1811,10 @@ class LibraryViewModel @Inject constructor(
                 coverThumbPath = existing?.coverThumbPath ?: "",
                 workId = existing?.workId?.takeIf { it.isNotBlank() } ?: rj,
                 rjCode = existing?.rjCode?.takeIf { it.isNotBlank() } ?: rj,
-                description = existing?.description ?: ""
+                description = existing?.description ?: "",
+                audioTrackCount = aggregate.trackCount,
+                audioTotalDuration = aggregate.totalDuration,
+                audioTotalSizeBytes = aggregate.totalSizeBytes,
             )
             val albumId = albumDao.insertAlbum(entity)
             upsertAlbumFtsIndex(albumId, entity.copy(id = albumId))
@@ -1996,6 +2045,8 @@ class LibraryViewModel @Inject constructor(
             playerConnection.requestLyricsReload()
         }
 
+        refreshAlbumAudioAggregate(albumId)
+
         upsertLocalTreeCache(
             albumId = albumId,
             albumPaths = listOf(albumDir.absolutePath),
@@ -2199,6 +2250,8 @@ class LibraryViewModel @Inject constructor(
                         }
                     }
                 }
+
+                refreshAlbumAudioAggregate(insertedAlbumId)
 
                 val leaves = all.asSequence()
                     .mapNotNull { node ->
@@ -2561,6 +2614,7 @@ class LibraryViewModel @Inject constructor(
         if (wroteAnySubtitles) {
             playerConnection.requestLyricsReload()
         }
+        refreshAlbumAudioAggregate(albumId)
         if (persistedPaths.isNotEmpty() && cacheLeaves.isNotEmpty()) {
             upsertLocalTreeCache(
                 albumId = albumId,

--- a/app/src/main/java/com/asmr/player/ui/playlists/PlaylistDetailScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/playlists/PlaylistDetailScreen.kt
@@ -77,6 +77,8 @@ import com.asmr.player.ui.common.reorderable.reorderable
 import com.asmr.player.ui.theme.AsmrTheme
 import com.asmr.player.ui.theme.dynamicPageContainerColor
 
+private val PlaylistDetailHorizontalPadding = 12.dp
+
 internal const val PLAYLIST_DETAIL_ITEM_TAG_PREFIX = "playlistDetailItem"
 internal const val PLAYLIST_DETAIL_ITEM_MENU_BUTTON_TAG_PREFIX = "playlistDetailItemMenu"
 internal const val PLAYLIST_DETAIL_MOVE_TOP_MENU_ITEM_TAG = "playlistDetailMoveTopMenuItem"
@@ -181,7 +183,7 @@ internal fun PlaylistDetailContent(
             } else {
                 Modifier
                     .fillMaxHeight()
-                    .widthIn(max = 720.dp)
+                    .widthIn(max = 760.dp)
                     .fillMaxWidth()
             }
             if (localItems.isEmpty()) {
@@ -284,7 +286,7 @@ private fun PlaylistItemRow(
             HorizontalDivider(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(horizontal = 16.dp)
+                    .padding(horizontal = PlaylistDetailHorizontalPadding)
                     .align(Alignment.TopCenter),
                 thickness = 0.5.dp,
                 color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.2f)
@@ -305,7 +307,7 @@ private fun PlaylistItemRow(
             showClickIndication = false,
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(horizontal = 16.dp, vertical = 2.dp),
+                .padding(horizontal = PlaylistDetailHorizontalPadding, vertical = 2.dp),
             leadingContent = {
                 AsmrAsyncImage(
                     model = item.artworkUri,

--- a/app/src/main/java/com/asmr/player/ui/playlists/PlaylistDetailScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/playlists/PlaylistDetailScreen.kt
@@ -77,7 +77,7 @@ import com.asmr.player.ui.common.reorderable.reorderable
 import com.asmr.player.ui.theme.AsmrTheme
 import com.asmr.player.ui.theme.dynamicPageContainerColor
 
-private val PlaylistDetailHorizontalPadding = 12.dp
+private val PlaylistDetailHorizontalPadding = 8.dp
 
 internal const val PLAYLIST_DETAIL_ITEM_TAG_PREFIX = "playlistDetailItem"
 internal const val PLAYLIST_DETAIL_ITEM_MENU_BUTTON_TAG_PREFIX = "playlistDetailItemMenu"
@@ -94,6 +94,7 @@ fun PlaylistDetailScreen(
     playlistId: Long,
     title: String,
     onPlayAll: (List<PlaylistItemEntity>, PlaylistItemEntity) -> Unit,
+    scrollToTopSignal: Long = 0L,
     viewModel: PlaylistDetailViewModel = hiltViewModel()
 ) {
     LaunchedEffect(playlistId) {
@@ -108,7 +109,8 @@ fun PlaylistDetailScreen(
         onRemoveItem = viewModel::removeItem,
         onMoveItemToTop = viewModel::moveItemToTop,
         onMoveItemToBottom = viewModel::moveItemToBottom,
-        onSaveManualOrder = viewModel::saveManualOrder
+        onSaveManualOrder = viewModel::saveManualOrder,
+        scrollToTopSignal = scrollToTopSignal,
     )
 }
 
@@ -121,7 +123,8 @@ internal fun PlaylistDetailContent(
     onRemoveItem: (String) -> Unit,
     onMoveItemToTop: (String) -> Unit,
     onMoveItemToBottom: (String) -> Unit,
-    onSaveManualOrder: (List<String>) -> Unit
+    onSaveManualOrder: (List<String>) -> Unit,
+    scrollToTopSignal: Long = 0L,
 ) {
     val listState = rememberLazyListState()
     val localItems = remember { mutableStateListOf<PlaylistItemWithSubtitles>() }
@@ -146,6 +149,10 @@ internal fun PlaylistDetailContent(
         if (reorderState.draggingItemIndex == null) {
             localItems.sync(items)
         }
+    }
+    LaunchedEffect(scrollToTopSignal) {
+        if (scrollToTopSignal == 0L) return@LaunchedEffect
+        runCatching { listState.animateScrollToItem(0) }
     }
 
     val playItems = localItems.map { item -> item.toPlaybackEntity() }

--- a/app/src/main/java/com/asmr/player/ui/playlists/PlaylistsScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/playlists/PlaylistsScreen.kt
@@ -28,6 +28,7 @@ import androidx.compose.material3.*
 import androidx.compose.material3.windowsizeclass.WindowSizeClass
 import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -58,12 +59,13 @@ import com.asmr.player.ui.common.EaraBrandedEmptyState
 import com.asmr.player.ui.common.thinScrollbar
 import com.asmr.player.ui.common.withAddedBottomPadding
 
-private val PlaylistsPageHorizontalPadding = 12.dp
+private val PlaylistsPageHorizontalPadding = 8.dp
 
 @Composable
 fun PlaylistsScreen(
     windowSizeClass: WindowSizeClass,
     onPlaylistClick: (PlaylistEntity) -> Unit,
+    scrollToTopSignal: Long = 0L,
     viewModel: PlaylistsViewModel = hiltViewModel()
 ) {
     val playlists by viewModel.playlists.collectAsState()
@@ -80,6 +82,10 @@ fun PlaylistsScreen(
         containerColor = Color.Transparent,
         contentColor = colorScheme.onBackground
     ) { padding ->
+        LaunchedEffect(scrollToTopSignal) {
+            if (scrollToTopSignal == 0L) return@LaunchedEffect
+            runCatching { listState.animateScrollToItem(0) }
+        }
         Box(
             modifier = Modifier
                 .fillMaxSize()

--- a/app/src/main/java/com/asmr/player/ui/playlists/PlaylistsScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/playlists/PlaylistsScreen.kt
@@ -60,6 +60,8 @@ import com.asmr.player.ui.common.thinScrollbar
 import com.asmr.player.ui.common.withAddedBottomPadding
 
 private val PlaylistsPageHorizontalPadding = 8.dp
+private val PlaylistRowActionButtonSize = 34.dp
+private val PlaylistRowActionIconSize = 18.dp
 
 @Composable
 fun PlaylistsScreen(
@@ -208,22 +210,26 @@ private fun PlaylistRow(
             }
             IconButton(
                 onClick = { showRename = true },
-                enabled = playlist.category != "system"
+                enabled = playlist.category != "system",
+                modifier = Modifier.size(PlaylistRowActionButtonSize)
             ) {
                 Icon(
                     Icons.Default.Edit,
                     contentDescription = null,
-                    tint = if (playlist.category != "system") colorScheme.textSecondary else colorScheme.textTertiary
+                    tint = if (playlist.category != "system") colorScheme.textSecondary else colorScheme.textTertiary,
+                    modifier = Modifier.size(PlaylistRowActionIconSize)
                 )
             }
             IconButton(
                 onClick = { showDeleteConfirm = true },
-                enabled = playlist.category != "system"
+                enabled = playlist.category != "system",
+                modifier = Modifier.size(PlaylistRowActionButtonSize)
             ) {
                 Icon(
                     Icons.Default.Delete, 
                     contentDescription = null, 
-                    tint = if (playlist.category != "system") colorScheme.danger.copy(alpha = 0.7f) else colorScheme.textTertiary
+                    tint = if (playlist.category != "system") colorScheme.danger.copy(alpha = 0.7f) else colorScheme.textTertiary,
+                    modifier = Modifier.size(PlaylistRowActionIconSize)
                 )
             }
         }

--- a/app/src/main/java/com/asmr/player/ui/playlists/PlaylistsScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/playlists/PlaylistsScreen.kt
@@ -58,6 +58,8 @@ import com.asmr.player.ui.common.EaraBrandedEmptyState
 import com.asmr.player.ui.common.thinScrollbar
 import com.asmr.player.ui.common.withAddedBottomPadding
 
+private val PlaylistsPageHorizontalPadding = 12.dp
+
 @Composable
 fun PlaylistsScreen(
     windowSizeClass: WindowSizeClass,
@@ -89,7 +91,7 @@ fun PlaylistsScreen(
             } else {
                 Modifier
                     .fillMaxHeight()
-                    .widthIn(max = 720.dp)
+                    .widthIn(max = 760.dp)
                     .fillMaxWidth()
             }
             Box(modifier = contentModifier) {
@@ -106,7 +108,7 @@ fun PlaylistsScreen(
                     LazyColumn(
                         state = listState,
                         modifier = Modifier.fillMaxSize().thinScrollbar(listState),
-                        contentPadding = PaddingValues(horizontal = 16.dp, vertical = 8.dp)
+                        contentPadding = PaddingValues(horizontal = PlaylistsPageHorizontalPadding, vertical = 8.dp)
                             .withAddedBottomPadding(LocalBottomOverlayPadding.current + 72.dp),
                         verticalArrangement = Arrangement.spacedBy(12.dp)
                     ) {
@@ -135,7 +137,7 @@ fun PlaylistsScreen(
                     contentColor = colorScheme.primary,
                     modifier = Modifier
                         .align(Alignment.BottomEnd)
-                        .padding(end = 16.dp, bottom = LocalBottomOverlayPadding.current + 16.dp)
+                        .padding(end = PlaylistsPageHorizontalPadding, bottom = LocalBottomOverlayPadding.current + 16.dp)
                 ) {
                     Icon(Icons.Default.Add, contentDescription = null)
                 }

--- a/app/src/main/java/com/asmr/player/ui/playlists/SystemPlaylistScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/playlists/SystemPlaylistScreen.kt
@@ -18,6 +18,7 @@ import com.asmr.player.ui.theme.AsmrTheme
 fun SystemPlaylistScreen(
     windowSizeClass: WindowSizeClass,
     onPlayAll: (List<PlaylistItemEntity>, PlaylistItemEntity) -> Unit,
+    scrollToTopSignal: Long = 0L,
     viewModel: PlaylistsViewModel = hiltViewModel()
 ) {
     val playlists by viewModel.playlists.collectAsState()
@@ -35,6 +36,7 @@ fun SystemPlaylistScreen(
         windowSizeClass = windowSizeClass,
         playlistId = playlist.id,
         title = playlist.name,
-        onPlayAll = onPlayAll
+        onPlayAll = onPlayAll,
+        scrollToTopSignal = scrollToTopSignal,
     )
 }

--- a/app/src/main/java/com/asmr/player/ui/search/SearchScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/search/SearchScreen.kt
@@ -113,6 +113,7 @@ internal const val SEARCH_CHROME_TAG = "search_chrome"
 private val SearchChromeContentGap = 16.dp
 private const val SearchPullRefreshContentShiftRatio = 1f
 private val SearchPullRefreshIndicatorSize = 40.dp
+private val SearchPageHorizontalPadding = 12.dp
 
 private fun stableAlbumKey(album: Album): String {
     val id = album.rjCode.ifBlank { album.workId }.trim()
@@ -326,7 +327,7 @@ fun SearchScreen(
                     } else {
                         Modifier
                             .fillMaxHeight()
-                            .widthIn(max = 720.dp)
+                            .widthIn(max = 760.dp)
                             .fillMaxWidth()
                     }
                 ) {
@@ -411,8 +412,8 @@ fun SearchScreen(
                                             .thinScrollbar(gridState),
                                         contentPadding = PaddingValues(
                                             top = topPadding,
-                                            start = 16.dp,
-                                            end = 16.dp,
+                                            start = SearchPageHorizontalPadding,
+                                            end = SearchPageHorizontalPadding,
                                             bottom = 16.dp
                                         ).withAddedBottomPadding(LocalBottomOverlayPadding.current),
                                         horizontalArrangement = Arrangement.spacedBy(AlbumGridItemSpacing),
@@ -722,7 +723,7 @@ internal fun SearchToolbar(
     Row(
         modifier = Modifier
             .fillMaxWidth()
-            .padding(horizontal = 16.dp, vertical = 8.dp),
+            .padding(horizontal = SearchPageHorizontalPadding, vertical = 8.dp),
         verticalAlignment = Alignment.CenterVertically
     ) {
         CustomSearchBar(
@@ -906,7 +907,7 @@ internal fun SearchPaginationHeader(
     Box(
         modifier = Modifier
             .fillMaxWidth()
-            .padding(horizontal = 16.dp, vertical = 2.dp)
+            .padding(horizontal = SearchPageHorizontalPadding, vertical = 2.dp)
     ) {
         Row(
             modifier = Modifier

--- a/app/src/main/java/com/asmr/player/ui/search/SearchScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/search/SearchScreen.kt
@@ -113,7 +113,7 @@ internal const val SEARCH_CHROME_TAG = "search_chrome"
 private val SearchChromeContentGap = 16.dp
 private const val SearchPullRefreshContentShiftRatio = 1f
 private val SearchPullRefreshIndicatorSize = 40.dp
-private val SearchPageHorizontalPadding = 12.dp
+private val SearchPageHorizontalPadding = 8.dp
 
 private fun stableAlbumKey(album: Album): String {
     val id = album.rjCode.ifBlank { album.workId }.trim()
@@ -127,6 +127,7 @@ private fun stableAlbumKey(album: Album): String {
 fun SearchScreen(
     windowSizeClass: WindowSizeClass,
     onAlbumClick: (Album, Boolean) -> Unit,
+    scrollToTopSignal: Long = 0L,
     viewModel: SearchViewModel = hiltViewModel()
 ) {
     var keyword by rememberSaveable { mutableStateOf("") }
@@ -278,6 +279,14 @@ fun SearchScreen(
         if (viewMode != 0 && gridState.firstVisibleItemIndex == 0 && gridState.firstVisibleItemScrollOffset == 0) {
             chromeState.expand()
         }
+    }
+    LaunchedEffect(scrollToTopSignal) {
+        if (scrollToTopSignal == 0L) return@LaunchedEffect
+        when (viewMode) {
+            0 -> runCatching { listState.animateScrollToItem(0) }
+            else -> runCatching { gridState.animateScrollToItem(0) }
+        }
+        chromeState.expand()
     }
 
     Scaffold(

--- a/app/src/main/java/com/asmr/player/ui/search/SearchScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/search/SearchScreen.kt
@@ -94,6 +94,7 @@ import com.asmr.player.ui.common.withAddedBottomPadding
 import com.asmr.player.ui.library.AlbumGridItem
 import com.asmr.player.ui.library.AlbumGridItemSpacing
 import com.asmr.player.ui.library.AlbumItem
+import com.asmr.player.ui.library.rememberAlbumMetaCopyAction
 import com.asmr.player.ui.sidepanel.LandscapeRightPanelHost
 import com.asmr.player.ui.sidepanel.RecentAlbumsPanel
 import com.asmr.player.ui.theme.AsmrTheme
@@ -141,6 +142,7 @@ fun SearchScreen(
     val listState = rememberSaveable(currentPageKey, saver = LazyListState.Saver) { LazyListState(0, 0) }
     val gridState = rememberSaveable(currentPageKey, saver = LazyStaggeredGridState.Saver) { LazyStaggeredGridState() }
     val colorScheme = AsmrTheme.colorScheme
+    val copyMeta = rememberAlbumMetaCopyAction(viewModel.messageManager)
     val scope = rememberCoroutineScope()
     val keyboardController = LocalSoftwareKeyboardController.current
     val isCompact = windowSizeClass.widthSizeClass == WindowWidthSizeClass.Compact
@@ -391,7 +393,11 @@ fun SearchScreen(
                                             AlbumItem(
                                                 album = album,
                                                 onClick = { onAlbumClick(album, state.purchasedOnly) },
-                                                emptyCoverUseShimmer = true
+                                                emptyCoverUseShimmer = true,
+                                                onRjClick = { copyMeta("RJ", it) },
+                                                onCircleClick = { copyMeta("社团", it) },
+                                                onCvClick = { copyMeta("CV", it) },
+                                                onTagClick = { copyMeta("标签", it) },
                                             )
                                         }
                                     }
@@ -421,7 +427,11 @@ fun SearchScreen(
                                             AlbumGridItem(
                                                 album = album,
                                                 onClick = { onAlbumClick(album, state.purchasedOnly) },
-                                                emptyCoverUseShimmer = true
+                                                emptyCoverUseShimmer = true,
+                                                onRjClick = { copyMeta("RJ", it) },
+                                                onCircleClick = { copyMeta("社团", it) },
+                                                onCvClick = { copyMeta("CV", it) },
+                                                onTagClick = { copyMeta("标签", it) },
                                             )
                                         }
                                     }

--- a/app/src/main/java/com/asmr/player/ui/search/SearchScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/search/SearchScreen.kt
@@ -336,7 +336,7 @@ fun SearchScreen(
                     } else {
                         Modifier
                             .fillMaxHeight()
-                            .widthIn(max = 760.dp)
+                            .widthIn(max = 800.dp)
                             .fillMaxWidth()
                     }
                 ) {

--- a/app/src/main/java/com/asmr/player/ui/search/SearchViewModel.kt
+++ b/app/src/main/java/com/asmr/player/ui/search/SearchViewModel.kt
@@ -59,7 +59,7 @@ class SearchViewModel @Inject constructor(
     private val asmrOneCrawler: AsmrOneCrawler,
     private val settingsRepository: SettingsRepository,
     private val searchCacheStore: SearchCacheStore,
-    private val messageManager: MessageManager
+    val messageManager: MessageManager
 ) : ViewModel() {
     private val pageSize = 30
     private var currentOrder: SearchSortOption = SearchSortOption.Trend

--- a/app/src/main/java/com/asmr/player/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/settings/SettingsScreen.kt
@@ -73,6 +73,8 @@ import com.asmr.player.ui.common.withAddedBottomPadding
 import java.io.File
 import kotlin.math.abs
 
+private val SettingsPageHorizontalPadding = 12.dp
+
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun SettingsScreen(
@@ -161,14 +163,14 @@ fun SettingsScreen(
             } else {
                 Modifier
                     .fillMaxHeight()
-                    .widthIn(max = 720.dp)
+                    .widthIn(max = 760.dp)
                     .fillMaxWidth()
             }
 
             LazyColumn(
                 state = listState,
                 modifier = contentModifier.thinScrollbar(listState),
-                contentPadding = PaddingValues(horizontal = 16.dp, vertical = 10.dp)
+                contentPadding = PaddingValues(horizontal = SettingsPageHorizontalPadding, vertical = 10.dp)
                     .withAddedBottomPadding(LocalBottomOverlayPadding.current),
                 verticalArrangement = Arrangement.spacedBy(16.dp)
             ) {

--- a/app/src/main/java/com/asmr/player/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/settings/SettingsScreen.kt
@@ -73,7 +73,7 @@ import com.asmr.player.ui.common.withAddedBottomPadding
 import java.io.File
 import kotlin.math.abs
 
-private val SettingsPageHorizontalPadding = 12.dp
+private val SettingsPageHorizontalPadding = 8.dp
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -81,6 +81,7 @@ fun SettingsScreen(
     windowSizeClass: WindowSizeClass,
     viewModel: SettingsViewModel = hiltViewModel(),
     libraryViewModel: LibraryViewModel = hiltViewModel(),
+    scrollToTopSignal: Long = 0L,
     onHorizontalControlInteractionChanged: (Boolean) -> Unit = {},
 ) {
     val floatingLyricsEnabled by viewModel.floatingLyricsEnabled.collectAsState()
@@ -152,6 +153,10 @@ fun SettingsScreen(
         containerColor = Color.Transparent,
         contentColor = colorScheme.onBackground
     ) { padding ->
+        LaunchedEffect(scrollToTopSignal) {
+            if (scrollToTopSignal == 0L) return@LaunchedEffect
+            runCatching { listState.animateScrollToItem(0) }
+        }
         Box(
             modifier = Modifier
                 .fillMaxSize()


### PR DESCRIPTION
## Summary
- polish local library and search album list spacing, chip copy interactions, and view mode menu
- add scroll-to-top on active bottom nav taps and refine track list/group/playlist item chrome
- persist album audio aggregates and use them in local library track-list headers with fallback behavior

## Testing
- ./gradlew :app:compileDebugKotlin