### PR TITLE
fix: block manual lyrics binding for online audio

### DIFF
--- a/app/src/main/java/com/asmr/player/ui/player/NowPlayingScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/player/NowPlayingScreen.kt
@@ -194,6 +194,7 @@ internal fun NowPlayingScreen(
     val canBindManualLyrics = lyricsTargetContextFromMediaItem(item) != null
     val colorScheme = AsmrTheme.colorScheme
     val uriText = item?.localConfiguration?.uri?.toString().orEmpty()
+    val isOnlineMedia = remember(uriText, item?.mediaId) { item.isOnlineMedia() }
     val artworkModel = remember(metadata?.artworkUri) {
         sanitizeBackdropArtworkModel(metadata?.artworkUri)
     }
@@ -288,8 +289,14 @@ internal fun NowPlayingScreen(
             lyricsViewModel.refreshCurrentLyrics()
         }
     }
-    val openLyricsPicker: (() -> Unit)? = if (canBindManualLyrics) {
-        { lyricsPicker.launch(lyricsPickerMimeTypes) }
+    val openManualLyricsAction: (() -> Unit)? = if (canBindManualLyrics) {
+        {
+            if (isOnlineMedia) {
+                viewModel.showOnlineManualLyricsUnsupported()
+            } else {
+                lyricsPicker.launch(lyricsPickerMimeTypes)
+            }
+        }
     } else {
         null
     }
@@ -461,7 +468,7 @@ internal fun NowPlayingScreen(
                 onNavigateUp = handleNavigateUp,
                 onShowSleepTimer = onShowSleepTimer,
                 onShowQueue = onShowQueue,
-                onManualBindLyrics = if (surfaceMode == NowPlayingSurfaceMode.LYRICS) openLyricsPicker else null,
+                onManualBindLyrics = if (surfaceMode == NowPlayingSurfaceMode.LYRICS) openManualLyricsAction else null,
                 navigationEnabled = !pendingRouteExit,
                 modifier = Modifier
                     .fillMaxWidth()
@@ -1162,7 +1169,7 @@ internal fun NowPlayingScreen(
                     lyricColors = lyricColors,
                     lyricsPageSettings = lyricsPageSettings,
                     onSeekTo = { viewModel.seekTo(it) },
-                    onAddLyrics = openLyricsPicker,
+                    onAddLyrics = openManualLyricsAction,
                     modifier = Modifier
                         .fillMaxSize()
                         .then(routeTransition.nowPlayingMotionModifier(currentMotionLayout, NowPlayingMotionSlot.COVER))

--- a/app/src/main/java/com/asmr/player/ui/player/PlayerMediaItemSupport.kt
+++ b/app/src/main/java/com/asmr/player/ui/player/PlayerMediaItemSupport.kt
@@ -1,0 +1,13 @@
+package com.asmr.player.ui.player
+
+import androidx.media3.common.MediaItem
+
+internal fun MediaItem?.isOnlineMedia(): Boolean {
+    val item = this ?: return false
+    val uri = item.localConfiguration?.uri?.toString().orEmpty().trim()
+    val mediaId = item.mediaId.trim()
+    return uri.startsWith("http://", ignoreCase = true) ||
+        uri.startsWith("https://", ignoreCase = true) ||
+        mediaId.startsWith("http://", ignoreCase = true) ||
+        mediaId.startsWith("https://", ignoreCase = true)
+}

--- a/app/src/main/java/com/asmr/player/ui/player/nowplaying/NowPlayingControls.kt
+++ b/app/src/main/java/com/asmr/player/ui/player/nowplaying/NowPlayingControls.kt
@@ -187,13 +187,7 @@ internal fun PlaybackControls(
                     )
                 }
 
-                val isOnlineMedia = playback.currentMediaItem?.let { current ->
-                    val uri = current.localConfiguration?.uri?.toString().orEmpty()
-                    uri.startsWith("http://", ignoreCase = true) ||
-                        uri.startsWith("https://", ignoreCase = true) ||
-                        current.mediaId.startsWith("http://", ignoreCase = true) ||
-                        current.mediaId.startsWith("https://", ignoreCase = true)
-                } == true
+                val isOnlineMedia = playback.currentMediaItem.isOnlineMedia()
                 IconButton(
                     onClick = {
                         if (isOnlineMedia) viewModel.showOnlineTagManageUnsupported() else onManageTags()

--- a/app/src/main/java/com/asmr/player/ui/player/playerviewmodel.kt
+++ b/app/src/main/java/com/asmr/player/ui/player/playerviewmodel.kt
@@ -58,6 +58,8 @@ import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
 
+private const val ONLINE_MANUAL_LYRICS_MESSAGE = "在线音频如需替换歌词，请先下载音频到本地"
+
 @HiltViewModel
 @OptIn(FlowPreview::class)
 class PlayerViewModel @Inject constructor(
@@ -272,8 +274,16 @@ class PlayerViewModel @Inject constructor(
         messageManager.showInfo("在线音频暂不支持标签管理")
     }
 
+    fun showOnlineManualLyricsUnsupported() {
+        messageManager.showInfo(ONLINE_MANUAL_LYRICS_MESSAGE)
+    }
+
     fun bindManualLyrics(uri: String, onSuccess: () -> Unit = {}) {
         val item = playback.value.currentMediaItem ?: return
+        if (item.isOnlineMedia()) {
+            showOnlineManualLyricsUnsupported()
+            return
+        }
         val target = lyricsTargetContextFromMediaItem(item) ?: return
         val trimmed = uri.trim()
         if (trimmed.isBlank()) return


### PR DESCRIPTION
## Summary
- block manual lyrics binding for online audio in the now playing lyrics entry points
- show the message 在线音频如需替换歌词，请先下载音频到本地 instead of opening the picker
- reuse a shared online-media check and keep a ViewModel guard as fallback

## Verification
- ./gradlew :app:compileDebugKotlin