### PR TITLE
fix: polish album detail and downloads ui

### DIFF
--- a/app/src/main/java/com/asmr/player/data/remote/download/DownloadManager.kt
+++ b/app/src/main/java/com/asmr/player/data/remote/download/DownloadManager.kt
@@ -693,7 +693,6 @@ class DownloadWorker(context: Context, parameters: WorkerParameters) : Coroutine
                     else -> -1L
                 }
                 val buffer = ByteArray(DOWNLOAD_BUFFER_SIZE)
-                var lastProgressAt = 0L
                 var lastBytes = 0L
                 var lastTs = System.currentTimeMillis()
 
@@ -740,7 +739,7 @@ class DownloadWorker(context: Context, parameters: WorkerParameters) : Coroutine
                             pendingTrafficBytes += read.toLong()
 
                             val now = System.currentTimeMillis()
-                            val shouldUpdate = downloaded - lastProgressAt >= PROGRESS_UPDATE_BYTES || now - lastTs >= PROGRESS_UPDATE_INTERVAL_MS
+                            val shouldUpdate = now - lastTs >= PROGRESS_UPDATE_INTERVAL_MS
                             if (shouldUpdate) {
                                 flushTrafficStats()
                                 val dt = (now - lastTs).coerceAtLeast(1)
@@ -753,7 +752,6 @@ class DownloadWorker(context: Context, parameters: WorkerParameters) : Coroutine
                                     speed = speed,
                                     updatedAt = now
                                 )
-                                lastProgressAt = downloaded
                                 lastBytes = downloaded
                                 lastTs = now
                             }
@@ -831,7 +829,6 @@ class DownloadWorker(context: Context, parameters: WorkerParameters) : Coroutine
 
     companion object {
         private const val DOWNLOAD_BUFFER_SIZE = 64 * 1024
-        private const val PROGRESS_UPDATE_BYTES = 256 * 1024L
         private const val PROGRESS_UPDATE_INTERVAL_MS = 1_000L
 
         @Volatile

--- a/app/src/main/java/com/asmr/player/ui/downloads/DownloadsScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/downloads/DownloadsScreen.kt
@@ -4,15 +4,16 @@ import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -24,34 +25,40 @@ import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.InsertDriveFile
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
+import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Folder
-import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.Image
+import androidx.compose.material.icons.filled.KeyboardArrowDown
+import androidx.compose.material.icons.filled.Movie
+import androidx.compose.material.icons.filled.MusicNote
 import androidx.compose.material.icons.filled.Pause
 import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material.icons.filled.Refresh
-import androidx.compose.material.icons.filled.InsertDriveFile
-import androidx.compose.material.icons.filled.MusicNote
 import androidx.compose.material.icons.filled.Subtitles
-import androidx.compose.material.icons.filled.Image
-import androidx.compose.material.icons.filled.Movie
-import androidx.compose.material.icons.filled.KeyboardArrowDown
-import androidx.compose.material.icons.filled.KeyboardArrowRight
-import androidx.compose.material.icons.filled.CheckCircle
-import androidx.compose.material.icons.filled.Error
-import androidx.compose.material3.*
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.material3.windowsizeclass.WindowSizeClass
 import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.produceState
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.saveable.rememberSaveable
-import com.asmr.player.ui.common.LocalBottomOverlayPadding
-import com.asmr.player.ui.theme.AsmrTheme
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -63,8 +70,12 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
+import com.asmr.player.ui.common.LocalBottomOverlayPadding
 import com.asmr.player.ui.common.thinScrollbar
+import com.asmr.player.ui.theme.AsmrTheme
+import com.asmr.player.util.Formatting
 import java.io.File
+import kotlinx.coroutines.delay
 
 private val DownloadsPageHorizontalPadding = 8.dp
 
@@ -83,18 +94,17 @@ fun DownloadsScreen(
         File(context.getExternalFilesDir(null), "albums").absolutePath
     }
     val listState = rememberLazyListState()
+
     LaunchedEffect(scrollToTopSignal) {
         if (scrollToTopSignal == 0L) return@LaunchedEffect
         runCatching { listState.animateScrollToItem(0) }
     }
 
-    // 屏幕尺寸判断
     val isCompact = windowSizeClass.widthSizeClass == WindowWidthSizeClass.Compact
 
     Box(
-        modifier = Modifier
-            .fillMaxSize(),
-        contentAlignment = Alignment.TopCenter // 仅用于平板适配：居中显示内容
+        modifier = Modifier.fillMaxSize(),
+        contentAlignment = Alignment.TopCenter
     ) {
         Column(
             modifier = if (isCompact) {
@@ -102,7 +112,6 @@ fun DownloadsScreen(
                     .fillMaxSize()
                     .padding(horizontal = DownloadsPageHorizontalPadding, vertical = 10.dp)
             } else {
-                // 仅用于平板适配：限制内容区域最大宽度并填充可用空间
                 Modifier
                     .fillMaxHeight()
                     .widthIn(max = 760.dp)
@@ -118,6 +127,7 @@ fun DownloadsScreen(
                 singleLine = true,
                 modifier = Modifier.fillMaxWidth()
             )
+
             Text(
                 text = "下载目录：$downloadRoot",
                 style = MaterialTheme.typography.bodySmall,
@@ -141,14 +151,20 @@ fun DownloadsScreen(
             }
 
             if (shownTasks.isEmpty()) {
-                Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.Center) {
-                    Text(if (normalizedQuery.isBlank()) "暂无下载任务" else "未找到任务：$normalizedQuery", color = MaterialTheme.colorScheme.onSurfaceVariant)
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.Center
+                ) {
+                    Text(
+                        text = if (normalizedQuery.isBlank()) "暂无下载任务" else "未找到任务：$normalizedQuery",
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
                 }
             } else {
                 LazyColumn(
                     state = listState,
                     modifier = Modifier.thinScrollbar(listState),
-                    verticalArrangement = Arrangement.spacedBy(10.dp),
+                    verticalArrangement = Arrangement.spacedBy(6.dp),
                     contentPadding = PaddingValues(
                         top = 4.dp,
                         bottom = LocalBottomOverlayPadding.current + 6.dp
@@ -159,7 +175,11 @@ fun DownloadsScreen(
                             task = task,
                             expanded = expandedTasks.contains(task.taskId),
                             onToggleExpanded = {
-                                if (expandedTasks.contains(task.taskId)) expandedTasks.remove(task.taskId) else expandedTasks.add(task.taskId)
+                                if (expandedTasks.contains(task.taskId)) {
+                                    expandedTasks.remove(task.taskId)
+                                } else {
+                                    expandedTasks.add(task.taskId)
+                                }
                             },
                             onRequestDeleteTask = { pendingDelete = PendingDeleteAction.Task(task.taskId) },
                             onPauseItem = { viewModel.pauseItem(it) },
@@ -183,20 +203,22 @@ fun DownloadsScreen(
                         val task = tasks.firstOrNull { it.taskId == action.taskId } ?: return@remember null
                         ResolvedDeleteText(
                             title = "确认删除",
-                            message = "将物理删除“${task.title}”目录下的文件（不可恢复）。"
+                            message = "将物理删除“${task.title}”目录下的文件，且不可恢复。"
                         )
                     }
+
                     is PendingDeleteAction.Item -> {
                         val item = tasks.asSequence()
                             .flatMap { it.items.asSequence() }
                             .firstOrNull { it.workId == action.workId } ?: return@remember null
                         ResolvedDeleteText(
                             title = "确认删除",
-                            message = "将物理删除文件“${item.fileName}”（不可恢复）。"
+                            message = "将物理删除文件“${item.fileName}”，且不可恢复。"
                         )
                     }
                 }
             }
+
             if (resolved != null) {
                 AlertDialog(
                     onDismissRequest = { pendingDelete = null },
@@ -239,25 +261,6 @@ private data class ResolvedDeleteText(
 )
 
 @Composable
-private fun DeleteConfirmBanner(
-    title: String,
-    message: String,
-    onConfirm: () -> Unit,
-    onDismiss: () -> Unit
-) {
-    ElevatedCard(modifier = Modifier.fillMaxWidth()) {
-        Column(modifier = Modifier.padding(12.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
-            Text(title, style = MaterialTheme.typography.titleMedium)
-            Text(message, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
-            Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.End) {
-                TextButton(onClick = onDismiss) { Text("取消") }
-                TextButton(onClick = onConfirm) { Text("删除") }
-            }
-        }
-    }
-}
-
-@Composable
 private fun DownloadTaskCard(
     task: DownloadTaskUi,
     expanded: Boolean,
@@ -276,210 +279,203 @@ private fun DownloadTaskCard(
         flattenDownloadTreeForUi(task.items, folderExpanded.toSet())
     }
     val hasFailedItems = remember(task.items) { task.items.any { it.state == DownloadItemState.FAILED } }
-    val hasActiveItems = remember(task.items) { 
-        task.items.any { it.state == DownloadItemState.RUNNING || it.state == DownloadItemState.ENQUEUED } 
+    val hasActiveItems = remember(task.items) {
+        task.items.any { it.state == DownloadItemState.RUNNING || it.state == DownloadItemState.ENQUEUED }
     }
-    val hasPausedItems = remember(task.items) { 
-        task.items.any { it.state == DownloadItemState.PAUSED } 
+    val hasPausedItems = remember(task.items) { task.items.any { it.state == DownloadItemState.PAUSED } }
+    val hasUnknownTotalRunningItem = remember(task.items) {
+        task.items.any { it.state == DownloadItemState.RUNNING && it.total <= 0 }
     }
     val colors = AsmrTheme.colorScheme
 
-    Card(
-        modifier = Modifier.fillMaxWidth(),
-        shape = RoundedCornerShape(16.dp),
-        colors = CardDefaults.cardColors(
-            containerColor = colors.surfaceVariant
-        ),
-        elevation = CardDefaults.cardElevation(
-            defaultElevation = 4.dp
-        )
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(6.dp))
+            .background(colors.surface.copy(alpha = 0.5f))
     ) {
-        Column(modifier = Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(12.dp)) {
+        Column(
+            modifier = Modifier.padding(horizontal = 10.dp, vertical = 8.dp),
+            verticalArrangement = Arrangement.spacedBy(4.dp)
+        ) {
             Row(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .clip(RoundedCornerShape(8.dp))
-                    .clickable(onClick = onToggleExpanded)
-                    .padding(vertical = 4.dp),
-                verticalAlignment = Alignment.CenterVertically
+                    .clickable(
+                        indication = null,
+                        interactionSource = remember { MutableInteractionSource() },
+                        onClick = onToggleExpanded
+                    )
+                    .padding(vertical = 2.dp),
+                verticalAlignment = Alignment.Top
             ) {
-                Icon(
-                    imageVector = if (expanded) Icons.Default.KeyboardArrowDown else Icons.Default.KeyboardArrowRight,
-                    contentDescription = null,
-                    tint = colors.primary,
-                    modifier = Modifier.size(24.dp)
-                )
-                Spacer(modifier = Modifier.width(8.dp))
-                Column(modifier = Modifier.weight(1f)) {
-                    Text(
-                        text = task.title,
-                        style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.SemiBold),
-                        maxLines = 1,
-                        overflow = TextOverflow.Ellipsis,
-                        color = colors.textPrimary
-                    )
-                    Spacer(modifier = Modifier.height(2.dp))
-                    Text(
-                        text = task.subtitle.ifBlank { task.rootDir.substringAfterLast('\\').substringAfterLast('/') },
-                        style = MaterialTheme.typography.bodySmall,
-                        color = colors.textSecondary,
-                        maxLines = 1,
-                        overflow = TextOverflow.Ellipsis
-                    )
-                }
-                if (hasFailedItems) {
-                    IconButton(
-                        onClick = onRetryFailedInTask,
-                        modifier = Modifier.size(40.dp)
-                    ) {
-                        Icon(
-                            Icons.Default.Refresh,
-                            contentDescription = null,
-                            tint = colors.primary
-                        )
-                    }
-                }
-                if (hasActiveItems) {
-                    IconButton(
-                        onClick = onPauseTask,
-                        modifier = Modifier.size(40.dp)
-                    ) {
-                        Icon(
-                            Icons.Default.Pause,
-                            contentDescription = null,
-                            tint = colors.primary
-                        )
-                    }
-                } else if (hasPausedItems) {
-                    IconButton(
-                        onClick = onResumeTask,
-                        modifier = Modifier.size(40.dp)
-                    ) {
-                        Icon(
-                            Icons.Default.PlayArrow,
-                            contentDescription = null,
-                            tint = colors.primary
-                        )
-                    }
-                }
-                IconButton(
-                    onClick = onRequestDeleteTask,
-                    modifier = Modifier.size(40.dp)
+                Column(
+                    modifier = Modifier.weight(1f),
+                    verticalArrangement = Arrangement.spacedBy(3.dp)
                 ) {
-                    Icon(
-                        Icons.Default.Close,
-                        contentDescription = null,
-                        tint = colors.textSecondary
+                    val taskSummary by rememberTaskSummary(
+                        downloadedBytes = task.downloadedBytes,
+                        totalBytes = task.totalBytes,
+                        speed = task.speed,
+                        hasUnknownTotalRunning = hasUnknownTotalRunningItem,
+                        state = task.state
                     )
-                }
-            }
 
-            val hasUnknownTotalRunningItem = task.items.any {
-                it.state == DownloadItemState.RUNNING && it.total <= 0
-            }
-
-            when {
-                task.progressFraction != null -> {
-                    Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(8.dp)
+                    ) {
+                        Icon(
+                            imageVector = if (expanded) Icons.Default.KeyboardArrowDown else Icons.AutoMirrored.Filled.KeyboardArrowRight,
+                            contentDescription = null,
+                            tint = colors.primary,
+                            modifier = Modifier.size(22.dp)
+                        )
+                        Text(
+                            text = task.title,
+                            style = MaterialTheme.typography.titleSmall.copy(fontWeight = FontWeight.Bold),
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis,
+                            color = colors.textPrimary,
+                            modifier = Modifier.weight(1f)
+                        )
                         Row(
-                            modifier = Modifier.fillMaxWidth(),
-                            horizontalArrangement = Arrangement.SpaceBetween,
-                            verticalAlignment = Alignment.CenterVertically
+                            verticalAlignment = Alignment.CenterVertically,
+                            horizontalArrangement = Arrangement.spacedBy(2.dp)
                         ) {
-                            Text(
-                                text = "下载进度",
-                                style = MaterialTheme.typography.bodySmall,
-                                color = colors.textSecondary,
-                                fontSize = 12.sp
-                            )
-                            Text(
-                                text = "${(task.progressFraction * 100).toInt()}%",
-                                style = MaterialTheme.typography.bodySmall.copy(fontWeight = FontWeight.Medium),
-                                color = colors.primary,
-                                fontSize = 12.sp
-                            )
-                        }
-                        Box(
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .height(8.dp)
-                                .clip(RoundedCornerShape(4.dp))
-                                .background(colors.surfaceVariant)
-                        ) {
-                            val animatedProgress by animateFloatAsState(
-                                targetValue = task.progressFraction,
-                                animationSpec = tween(durationMillis = 300),
-                                label = "progress"
-                            )
-                            Box(
-                                modifier = Modifier
-                                    .fillMaxWidth(animatedProgress)
-                                    .fillMaxHeight()
-                                    .background(colors.primary)
-                            )
+                            taskSummary.takeIf { it.isNotBlank() }?.let { summary ->
+                                Text(
+                                    text = summary,
+                                    style = MaterialTheme.typography.labelSmall.copy(fontWeight = FontWeight.Medium),
+                                    color = colors.textSecondary,
+                                    maxLines = 1
+                                )
+                            }
+                            if (hasFailedItems) {
+                                IconButton(
+                                    onClick = onRetryFailedInTask,
+                                    modifier = Modifier.size(36.dp)
+                                ) {
+                                    Icon(
+                                        Icons.Default.Refresh,
+                                        contentDescription = null,
+                                        tint = colors.primary,
+                                        modifier = Modifier.size(18.dp)
+                                    )
+                                }
+                            }
+                            if (hasActiveItems) {
+                                IconButton(
+                                    onClick = onPauseTask,
+                                    modifier = Modifier.size(36.dp)
+                                ) {
+                                    Icon(
+                                        Icons.Default.Pause,
+                                        contentDescription = null,
+                                        tint = colors.primary,
+                                        modifier = Modifier.size(18.dp)
+                                    )
+                                }
+                            } else if (hasPausedItems) {
+                                IconButton(
+                                    onClick = onResumeTask,
+                                    modifier = Modifier.size(36.dp)
+                                ) {
+                                    Icon(
+                                        Icons.Default.PlayArrow,
+                                        contentDescription = null,
+                                        tint = colors.primary,
+                                        modifier = Modifier.size(18.dp)
+                                    )
+                                }
+                            }
                         }
                     }
-                }
-                hasUnknownTotalRunningItem -> {
-                    Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
-                        Text(
-                            text = "下载中...",
-                            style = MaterialTheme.typography.bodySmall,
-                            color = colors.textSecondary,
-                            fontSize = 12.sp
-                        )
-                        LinearProgressIndicator(
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .height(8.dp)
-                                .clip(RoundedCornerShape(4.dp)),
-                            color = colors.primary,
-                            trackColor = colors.surfaceVariant
-                        )
+
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.spacedBy(8.dp),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Box(modifier = Modifier.weight(1f)) {
+                            when {
+                                task.progressFraction != null -> {
+                                    CompactProgressBar(
+                                        progress = task.progressFraction,
+                                        trackColor = colors.surface.copy(alpha = 0.8f),
+                                        progressColor = colors.primary,
+                                        indeterminate = false
+                                    )
+                                }
+
+                                hasUnknownTotalRunningItem -> {
+                                    CompactProgressBar(
+                                        progress = null,
+                                        trackColor = colors.surface.copy(alpha = 0.8f),
+                                        progressColor = colors.primary,
+                                        indeterminate = true
+                                    )
+                                }
+                            }
+                        }
+
+                        IconButton(
+                            onClick = onRequestDeleteTask,
+                            modifier = Modifier.size(36.dp)
+                        ) {
+                            Icon(
+                                Icons.Default.Close,
+                                contentDescription = null,
+                                tint = colors.textSecondary,
+                                modifier = Modifier.size(18.dp)
+                            )
+                        }
                     }
                 }
             }
 
             if (expanded) {
-                Surface(
-                    modifier = Modifier.fillMaxWidth(),
-                    shape = RoundedCornerShape(12.dp),
-                    color = colors.surfaceVariant.copy(alpha = 0.3f)
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(top = 2.dp),
+                    verticalArrangement = Arrangement.spacedBy(2.dp)
                 ) {
-                    Column(
-                        modifier = Modifier.padding(8.dp),
-                        verticalArrangement = Arrangement.spacedBy(4.dp)
-                    ) {
-                        treeEntries.forEachIndexed { index, entry ->
-                            when (entry) {
-                                is DownloadTreeUiEntry.Folder -> {
-                                    DownloadFolderRow(
-                                        title = entry.title,
-                                        depth = entry.depth,
-                                        expanded = folderExpanded.contains(entry.path),
-                                        onToggle = {
-                                            if (folderExpanded.contains(entry.path)) folderExpanded.remove(entry.path) else folderExpanded.add(entry.path)
+                    treeEntries.forEachIndexed { index, entry ->
+                        when (entry) {
+                            is DownloadTreeUiEntry.Folder -> {
+                                DownloadFolderRow(
+                                    title = entry.title,
+                                    depth = entry.depth,
+                                    expanded = folderExpanded.contains(entry.path),
+                                    onToggle = {
+                                        if (folderExpanded.contains(entry.path)) {
+                                            folderExpanded.remove(entry.path)
+                                        } else {
+                                            folderExpanded.add(entry.path)
                                         }
-                                    )
-                                }
-                                is DownloadTreeUiEntry.File -> {
-                                    DownloadFileRow(
-                                        item = entry.item,
-                                        depth = entry.depth,
-                                        onPause = { onPauseItem(entry.item.workId) },
-                                        onResume = { onResumeItem(entry.item.workId) },
-                                        onRetry = { onRetryItem(entry.item.workId) },
-                                        onDelete = { onDeleteItem(entry.item.workId) }
-                                    )
-                                }
-                            }
-                            if (index < treeEntries.size - 1) {
-                                HorizontalDivider(
-                                    modifier = Modifier.padding(horizontal = 8.dp),
-                                    thickness = 0.5.dp,
-                                    color = colors.onSurfaceVariant.copy(alpha = 0.2f)
+                                    }
                                 )
                             }
+
+                            is DownloadTreeUiEntry.File -> {
+                                DownloadFileRow(
+                                    item = entry.item,
+                                    depth = entry.depth,
+                                    onPause = { onPauseItem(entry.item.workId) },
+                                    onResume = { onResumeItem(entry.item.workId) },
+                                    onRetry = { onRetryItem(entry.item.workId) },
+                                    onDelete = { onDeleteItem(entry.item.workId) }
+                                )
+                            }
+                        }
+                        if (index < treeEntries.size - 1) {
+                            HorizontalDivider(
+                                modifier = Modifier.padding(horizontal = 8.dp),
+                                thickness = 0.5.dp,
+                                color = colors.onSurfaceVariant.copy(alpha = 0.2f)
+                            )
                         }
                     }
                 }
@@ -519,34 +515,38 @@ private fun flattenDownloadTreeForUi(
     )
 
     val root = Node(name = "", path = "")
-    items.forEach { it ->
-        val rel = it.relativePath.replace('\\', '/').trim().trimStart('/')
-        val segments = rel.split('/').filter { seg -> seg.isNotBlank() }
+    items.forEach { item ->
+        val rel = item.relativePath.replace('\\', '/').trim().trimStart('/')
+        val segments = rel.split('/').filter { it.isNotBlank() }
         if (segments.isEmpty()) return@forEach
-        var cur = root
-        segments.forEachIndexed { idx, seg ->
-            val isLeaf = idx == segments.lastIndex
-            val nextPath = if (cur.path.isBlank()) seg else "${cur.path}/$seg"
-            val child = cur.children.getOrPut(seg) { Node(name = seg, path = nextPath) }
-            if (isLeaf) child.item = it
-            cur = child
+        var current = root
+        segments.forEachIndexed { index, segment ->
+            val isLeaf = index == segments.lastIndex
+            val nextPath = if (current.path.isBlank()) segment else "${current.path}/$segment"
+            val child = current.children.getOrPut(segment) { Node(name = segment, path = nextPath) }
+            if (isLeaf) child.item = item
+            current = child
         }
     }
 
-    fun nodeKey(n: Node): String = n.name.lowercase()
+    fun nodeKey(node: Node): String = node.name.lowercase()
+
     val out = mutableListOf<DownloadTreeUiEntry>()
     fun walk(node: Node, depth: Int) {
         val folders = node.children.values.filter { it.children.isNotEmpty() }.sortedBy(::nodeKey)
         val files = node.children.values.filter { it.children.isEmpty() && it.item != null }.sortedBy(::nodeKey)
-        folders.forEach { f ->
-            out.add(DownloadTreeUiEntry.Folder(path = f.path, title = f.name, depth = depth))
-            if (expanded.contains(f.path)) walk(f, depth + 1)
+
+        folders.forEach { folder ->
+            out.add(DownloadTreeUiEntry.Folder(path = folder.path, title = folder.name, depth = depth))
+            if (expanded.contains(folder.path)) walk(folder, depth + 1)
         }
-        files.forEach { f ->
-            val item = f.item ?: return@forEach
-            out.add(DownloadTreeUiEntry.File(path = f.path, title = f.name, depth = depth, item = item))
+
+        files.forEach { file ->
+            val item = file.item ?: return@forEach
+            out.add(DownloadTreeUiEntry.File(path = file.path, title = file.name, depth = depth, item = item))
         }
     }
+
     walk(root, 0)
     return out
 }
@@ -559,14 +559,18 @@ private fun DownloadFolderRow(
     onToggle: () -> Unit
 ) {
     val colors = AsmrTheme.colorScheme
-    
+
     Row(
         modifier = Modifier
             .fillMaxWidth()
             .padding(start = (depth * 16).dp)
             .clip(RoundedCornerShape(8.dp))
-            .clickable(onClick = onToggle)
-            .padding(horizontal = 12.dp, vertical = 10.dp),
+            .clickable(
+                indication = null,
+                interactionSource = remember { MutableInteractionSource() },
+                onClick = onToggle
+            )
+            .padding(horizontal = 10.dp, vertical = 6.dp),
         verticalAlignment = Alignment.CenterVertically
     ) {
         Icon(
@@ -585,7 +589,7 @@ private fun DownloadFolderRow(
             modifier = Modifier.weight(1f)
         )
         Icon(
-            imageVector = if (expanded) Icons.Default.KeyboardArrowDown else Icons.Default.KeyboardArrowRight,
+            imageVector = if (expanded) Icons.Default.KeyboardArrowDown else Icons.AutoMirrored.Filled.KeyboardArrowRight,
             contentDescription = null,
             tint = colors.textSecondary,
             modifier = Modifier.size(20.dp)
@@ -613,72 +617,51 @@ private fun DownloadFileRow(
         modifier = Modifier
             .fillMaxWidth()
             .clip(RoundedCornerShape(8.dp))
-            .background(
-                when (item.state) {
-                    DownloadItemState.SUCCEEDED -> colors.primary.copy(alpha = 0.05f)
-                    DownloadItemState.FAILED -> colors.danger.copy(alpha = 0.05f)
-                    else -> Color.Transparent
-                }
-            )
-            .padding(horizontal = 12.dp, vertical = 10.dp)
+            .padding(start = 10.dp + (depth * 12).dp, end = 10.dp, top = 6.dp, bottom = 6.dp),
+        verticalArrangement = Arrangement.spacedBy(4.dp)
     ) {
         Row(
             verticalAlignment = Alignment.CenterVertically,
-            modifier = Modifier.fillMaxWidth()
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(10.dp)
         ) {
             Box(
                 modifier = Modifier
-                    .size(36.dp)
-                    .clip(CircleShape)
-                    .background(colors.surfaceVariant),
+                    .size(32.dp)
+                    .clip(CircleShape),
                 contentAlignment = Alignment.Center
             ) {
                 Icon(
                     imageVector = pickFileIcon(item.fileName),
                     contentDescription = null,
                     tint = colors.primary,
-                    modifier = Modifier.size(18.dp)
+                    modifier = Modifier.size(16.dp)
                 )
             }
-            
-            Spacer(modifier = Modifier.width(12.dp))
-            
-            Column(modifier = Modifier.weight(1f)) {
+
+            Column(
+                modifier = Modifier.weight(1f),
+                verticalArrangement = Arrangement.spacedBy(4.dp)
+            ) {
                 Text(
                     text = item.fileName,
-                    style = MaterialTheme.typography.bodyMedium,
+                    style = MaterialTheme.typography.bodySmall.copy(fontWeight = FontWeight.Medium),
                     maxLines = 1,
                     overflow = TextOverflow.Ellipsis,
                     color = colors.textPrimary
                 )
-                Spacer(modifier = Modifier.height(4.dp))
+
                 Row(
-                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    horizontalArrangement = Arrangement.spacedBy(6.dp),
                     verticalAlignment = Alignment.CenterVertically
                 ) {
-                    // 状态标签
                     Box(
                         modifier = Modifier
                             .clip(RoundedCornerShape(4.dp))
-                            .background(
-                                when (item.state) {
-                                    DownloadItemState.SUCCEEDED -> colors.primary.copy(alpha = 0.15f)
-                                    DownloadItemState.FAILED -> colors.danger.copy(alpha = 0.15f)
-                                    DownloadItemState.RUNNING -> colors.primary.copy(alpha = 0.15f)
-                                    else -> colors.surfaceVariant
-                                }
-                            )
                             .padding(horizontal = 6.dp, vertical = 2.dp)
                     ) {
                         Text(
-                            text = when (item.state) {
-                                DownloadItemState.SUCCEEDED -> "已完成"
-                                DownloadItemState.FAILED -> "失败"
-                                DownloadItemState.RUNNING -> "下载中"
-                                DownloadItemState.PAUSED -> "已暂停"
-                                DownloadItemState.CANCELLED -> "已取消"
-                                DownloadItemState.ENQUEUED -> "等待中"
-                            },
+                            text = downloadItemStateLabel(item.state),
                             style = MaterialTheme.typography.labelSmall,
                             color = when (item.state) {
                                 DownloadItemState.SUCCEEDED -> colors.primary
@@ -689,7 +672,7 @@ private fun DownloadFileRow(
                             fontSize = 11.sp
                         )
                     }
-                    
+
                     if (percent != null) {
                         Text(
                             text = "$percent%",
@@ -698,112 +681,250 @@ private fun DownloadFileRow(
                             fontSize = 11.sp
                         )
                     }
+
+                    formatSpeed(item.speed).takeIf { it.isNotBlank() }?.let { speed ->
+                        Text(
+                            text = speed,
+                            style = MaterialTheme.typography.labelSmall,
+                            color = colors.textTertiary,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis
+                        )
+                    }
+                }
+
+                when {
+                    percent != null && item.state != DownloadItemState.SUCCEEDED -> {
+                        CompactProgressBar(
+                            progress = percent / 100f,
+                            trackColor = colors.surface.copy(alpha = 0.8f),
+                            progressColor = colors.primary,
+                            indeterminate = false
+                        )
+                    }
+
+                    item.state == DownloadItemState.SUCCEEDED -> {
+                        CompactProgressBar(
+                            progress = 1f,
+                            trackColor = colors.primary.copy(alpha = 0.2f),
+                            progressColor = colors.primary.copy(alpha = 0.45f),
+                            indeterminate = false
+                        )
+                    }
+
+                    item.total <= 0 && item.state == DownloadItemState.RUNNING -> {
+                        CompactProgressBar(
+                            progress = null,
+                            trackColor = colors.surface.copy(alpha = 0.8f),
+                            progressColor = colors.primary,
+                            indeterminate = true
+                        )
+                    }
                 }
             }
-            
-            Row(horizontalArrangement = Arrangement.spacedBy(4.dp)) {
+
+            Row(horizontalArrangement = Arrangement.spacedBy(2.dp)) {
                 when (item.state) {
                     DownloadItemState.RUNNING, DownloadItemState.ENQUEUED -> {
                         IconButton(
                             onClick = onPause,
-                            modifier = Modifier.size(36.dp)
+                            modifier = Modifier.size(32.dp)
                         ) {
                             Icon(
                                 Icons.Default.Pause,
                                 contentDescription = null,
                                 tint = colors.primary,
-                                modifier = Modifier.size(18.dp)
+                                modifier = Modifier.size(16.dp)
                             )
                         }
                     }
+
                     DownloadItemState.PAUSED, DownloadItemState.CANCELLED -> {
                         IconButton(
                             onClick = onResume,
-                            modifier = Modifier.size(36.dp)
+                            modifier = Modifier.size(32.dp)
                         ) {
                             Icon(
                                 Icons.Default.PlayArrow,
                                 contentDescription = null,
                                 tint = colors.primary,
-                                modifier = Modifier.size(18.dp)
+                                modifier = Modifier.size(16.dp)
                             )
                         }
                     }
+
                     DownloadItemState.FAILED -> {
                         IconButton(
                             onClick = onRetry,
-                            modifier = Modifier.size(36.dp)
+                            modifier = Modifier.size(32.dp)
                         ) {
                             Icon(
                                 Icons.Default.Refresh,
                                 contentDescription = null,
                                 tint = colors.danger,
-                                modifier = Modifier.size(18.dp)
+                                modifier = Modifier.size(16.dp)
                             )
                         }
                     }
-                    else -> {}
+
+                    else -> Unit
                 }
+
                 IconButton(
                     onClick = onDelete,
-                    modifier = Modifier.size(36.dp)
+                    modifier = Modifier.size(32.dp)
                 ) {
                     Icon(
                         Icons.Default.Delete,
                         contentDescription = null,
                         tint = colors.textSecondary,
-                        modifier = Modifier.size(18.dp)
+                        modifier = Modifier.size(16.dp)
                     )
                 }
             }
         }
-        
-        // 进度条
-        when {
-            percent != null && item.state != DownloadItemState.SUCCEEDED -> {
-                Spacer(modifier = Modifier.height(8.dp))
-                Box(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .height(6.dp)
-                        .clip(RoundedCornerShape(3.dp))
-                        .background(colors.surfaceVariant)
-                ) {
-                    val animatedProgress by animateFloatAsState(
-                        targetValue = percent / 100f,
-                        animationSpec = tween(durationMillis = 300),
-                        label = "file_progress"
-                    )
-                    Box(
-                        modifier = Modifier
-                            .fillMaxWidth(animatedProgress)
-                            .fillMaxHeight()
-                            .background(colors.primary)
-                    )
-                }
-            }
-            item.state == DownloadItemState.SUCCEEDED -> {
-                Spacer(modifier = Modifier.height(8.dp))
-                Box(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .height(6.dp)
-                        .clip(RoundedCornerShape(3.dp))
-                        .background(colors.primary.copy(alpha = 0.3f))
-                )
-            }
-            item.total <= 0 && item.state == DownloadItemState.RUNNING -> {
-                Spacer(modifier = Modifier.height(8.dp))
-                LinearProgressIndicator(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .height(6.dp)
-                        .clip(RoundedCornerShape(3.dp)),
-                    color = colors.primary,
-                    trackColor = colors.surfaceVariant
-                )
-            }
+    }
+}
+
+@Composable
+private fun rememberTaskSummary(
+    downloadedBytes: Long,
+    totalBytes: Long?,
+    speed: Long,
+    hasUnknownTotalRunning: Boolean,
+    state: DownloadItemState
+) : androidx.compose.runtime.State<String> {
+    val latestDownloadedBytes = rememberUpdatedState(downloadedBytes)
+    val latestTotalBytes = rememberUpdatedState(totalBytes)
+    val latestSpeed = rememberUpdatedState(speed)
+    val latestHasUnknownTotalRunning = rememberUpdatedState(hasUnknownTotalRunning)
+    val latestState = rememberUpdatedState(state)
+
+    return produceState(
+        initialValue = buildTaskSummaryText(
+            downloadedBytes = downloadedBytes,
+            totalBytes = totalBytes,
+            speed = speed,
+            hasUnknownTotalRunning = hasUnknownTotalRunning,
+            state = state
+        )
+    ) {
+        while (true) {
+            value = buildTaskSummaryText(
+                downloadedBytes = latestDownloadedBytes.value,
+                totalBytes = latestTotalBytes.value,
+                speed = latestSpeed.value,
+                hasUnknownTotalRunning = latestHasUnknownTotalRunning.value,
+                state = latestState.value
+            )
+            delay(1_000)
         }
+    }
+}
+
+private fun buildTaskSummaryText(
+    downloadedBytes: Long,
+    totalBytes: Long?,
+    speed: Long,
+    hasUnknownTotalRunning: Boolean,
+    state: DownloadItemState
+): String {
+    val progressText = buildString {
+        append(Formatting.formatFileSize(downloadedBytes))
+        totalBytes?.takeIf { it > 0L }?.let {
+            append(" / ")
+            append(Formatting.formatFileSize(it))
+        }
+    }
+    val speedText = when {
+        speed > 0L -> formatSpeed(speed)
+        hasUnknownTotalRunning || state == DownloadItemState.RUNNING -> "下载中"
+        else -> ""
+    }
+    return when {
+        progressText.isBlank() -> speedText
+        speedText.isBlank() -> progressText
+        else -> "$progressText · $speedText"
+    }
+}
+
+@Composable
+private fun TaskProgressMeta(
+    progressFraction: Float?,
+    hasUnknownTotalRunning: Boolean,
+    state: DownloadItemState,
+    emphasizeProgress: Boolean = false
+) {
+    val colors = AsmrTheme.colorScheme
+    val text = when {
+        progressFraction != null -> "${(progressFraction * 100).toInt()}%"
+        hasUnknownTotalRunning -> "下载中"
+        else -> downloadItemStateLabel(state)
+    }
+    val color = when (state) {
+        DownloadItemState.FAILED -> colors.danger
+        DownloadItemState.RUNNING, DownloadItemState.ENQUEUED, DownloadItemState.SUCCEEDED -> if (emphasizeProgress) colors.textSecondary else colors.primary
+        else -> colors.textSecondary
+    }
+
+    Text(
+        text = text,
+        style = MaterialTheme.typography.labelSmall.copy(fontWeight = FontWeight.Medium),
+        color = color,
+        maxLines = 1
+    )
+}
+
+@Composable
+private fun CompactProgressBar(
+    progress: Float?,
+    trackColor: Color,
+    progressColor: Color,
+    indeterminate: Boolean,
+    modifier: Modifier = Modifier
+) {
+    if (indeterminate) {
+        LinearProgressIndicator(
+            modifier = modifier
+                .fillMaxWidth()
+                .height(6.dp)
+                .clip(RoundedCornerShape(3.dp)),
+            color = progressColor,
+            trackColor = trackColor
+        )
+        return
+    }
+
+    val animatedProgress by animateFloatAsState(
+        targetValue = progress?.coerceIn(0f, 1f) ?: 0f,
+        animationSpec = tween(durationMillis = 300),
+        label = "compact_progress"
+    )
+
+    Box(
+        modifier = modifier
+            .fillMaxWidth()
+            .height(6.dp)
+            .clip(RoundedCornerShape(3.dp))
+            .background(trackColor)
+    ) {
+        Box(
+            modifier = Modifier
+                .fillMaxWidth(animatedProgress)
+                .fillMaxHeight()
+                .background(progressColor)
+        )
+    }
+}
+
+private fun downloadItemStateLabel(state: DownloadItemState): String {
+    return when (state) {
+        DownloadItemState.SUCCEEDED -> "已完成"
+        DownloadItemState.FAILED -> "失败"
+        DownloadItemState.RUNNING -> "下载中"
+        DownloadItemState.PAUSED -> "已暂停"
+        DownloadItemState.CANCELLED -> "已取消"
+        DownloadItemState.ENQUEUED -> "等待中"
     }
 }
 
@@ -815,7 +936,7 @@ private fun pickFileIcon(fileName: String): androidx.compose.ui.graphics.vector.
         ext in setOf("lrc", "srt", "vtt") -> Icons.Default.Subtitles
         ext in setOf("jpg", "jpeg", "png", "webp") -> Icons.Default.Image
         ext in setOf("mp4", "m4v", "webm", "mkv", "mov") -> Icons.Default.Movie
-        else -> Icons.Default.InsertDriveFile
+        else -> Icons.AutoMirrored.Filled.InsertDriveFile
     }
 }
 

--- a/app/src/main/java/com/asmr/player/ui/downloads/DownloadsViewModel.kt
+++ b/app/src/main/java/com/asmr/player/ui/downloads/DownloadsViewModel.kt
@@ -27,6 +27,7 @@ import java.util.UUID
 import androidx.work.workDataOf
 import javax.inject.Inject
 import com.asmr.player.util.MessageManager
+import kotlin.math.max
 
 enum class DownloadItemState {
     ENQUEUED,
@@ -59,6 +60,9 @@ data class DownloadTaskUi(
     val state: DownloadItemState,
     val progressFraction: Float?,
     val hasUnknownTotalRunning: Boolean,
+    val downloadedBytes: Long,
+    val totalBytes: Long?,
+    val speed: Long,
     val items: List<DownloadItemUi>
 )
 
@@ -123,6 +127,15 @@ class DownloadsViewModel @Inject constructor(
                         allSucceeded = allSucceeded,
                         hasUnknownTotalRunning = hasUnknownTotalRunning
                     )
+                    val downloadedBytes = items.sumOf { it.downloaded.coerceAtLeast(0L) }
+                    val totalBytes = resolveTaskTotalBytes(
+                        items = items,
+                        allSucceeded = allSucceeded,
+                        progressFraction = progressFraction
+                    )
+                    val speed = items.sumOf { item ->
+                        if (item.state == DownloadItemState.RUNNING) item.speed.coerceAtLeast(0L) else 0L
+                    }
 
                     DownloadTaskUi(
                         taskId = task.id,
@@ -133,6 +146,9 @@ class DownloadsViewModel @Inject constructor(
                         state = state,
                         progressFraction = progressFraction,
                         hasUnknownTotalRunning = hasUnknownTotalRunning,
+                        downloadedBytes = downloadedBytes,
+                        totalBytes = totalBytes,
+                        speed = speed,
                         items = items
                     )
                 }
@@ -182,6 +198,39 @@ class DownloadsViewModel @Inject constructor(
 
         if (aggregateProgress <= 0.0 && hasUnknownTotalRunning) return null
         return aggregateProgress.toFloat().coerceIn(0f, 1f)
+    }
+
+    private fun resolveTaskTotalBytes(
+        items: List<DownloadItemUi>,
+        allSucceeded: Boolean,
+        progressFraction: Float?
+    ): Long? {
+        if (items.isEmpty()) return null
+
+        val downloadedBytes = items.sumOf { it.downloaded.coerceAtLeast(0L) }
+        val knownTotalBytes = items.sumOf { item ->
+            when {
+                item.total > 0L -> item.total
+                item.state == DownloadItemState.SUCCEEDED -> item.downloaded.coerceAtLeast(0L)
+                else -> 0L
+            }
+        }
+
+        if (allSucceeded) {
+            return items.sumOf { item -> max(item.total, item.downloaded).coerceAtLeast(0L) }
+        }
+
+        val estimatedTotalBytes = progressFraction
+            ?.takeIf { it > 0f && it < 1f && downloadedBytes > 0L }
+            ?.let { fraction ->
+                (downloadedBytes.toDouble() / fraction.toDouble()).toLong().coerceAtLeast(downloadedBytes)
+            }
+
+        return when {
+            estimatedTotalBytes != null -> max(estimatedTotalBytes, knownTotalBytes).takeIf { it > 0L }
+            knownTotalBytes > downloadedBytes -> knownTotalBytes
+            else -> null
+        }
     }
 
     fun cancelItem(workId: String) {

--- a/app/src/main/java/com/asmr/player/ui/library/AlbumDetailScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/AlbumDetailScreen.kt
@@ -944,6 +944,18 @@ private fun AlbumHeader(
         .padding(horizontal = AlbumDetailHorizontalPadding, vertical = 12.dp)
         .clip(RoundedCornerShape(24.dp))
         .background(colorScheme.surface.copy(alpha = 0.5f))
+    val langCandidates = remember(dlsiteEditions) {
+        dlsiteEditions
+            .filter { it.lang in setOf("JPN", "CHI_HANS", "CHI_HANT") }
+            .distinctBy { it.lang }
+            .sortedWith(compareBy({ it.displayOrder }, { it.lang }))
+    }
+    val selectedLangLabel = remember(dlsiteSelectedLang, langCandidates) {
+        langCandidates.firstOrNull { it.lang.equals(dlsiteSelectedLang, ignoreCase = true) }
+            ?.let { dlsiteLanguageButtonLabel(it.lang) }
+            ?: dlsiteLanguageButtonLabel(dlsiteSelectedLang)
+    }
+    var languageMenuExpanded by rememberSaveable { mutableStateOf(false) }
 
     Column(
         modifier = dlsiteElasticItemModifier(
@@ -1047,45 +1059,6 @@ private fun AlbumHeader(
                     }
                 }
 
-                val langCandidates = remember(dlsiteEditions) {
-                    dlsiteEditions
-                        .filter { it.lang in setOf("JPN", "CHI_HANS", "CHI_HANT") }
-                        .distinctBy { it.lang }
-                        .sortedWith(compareBy({ it.displayOrder }, { it.lang }))
-                }
-
-                if (langCandidates.size > 1) {
-                    FlowRow(
-                        horizontalArrangement = Arrangement.spacedBy(8.dp),
-                        verticalArrangement = Arrangement.spacedBy(6.dp)
-                    ) {
-                        langCandidates.forEach { edition ->
-                            val selected = edition.lang.equals(dlsiteSelectedLang, ignoreCase = true)
-                            val label = when (edition.lang) {
-                                "CHI_HANS" -> "简中"
-                                "CHI_HANT" -> "繁中"
-                                else -> "日语"
-                            }
-                            FilterChip(
-                                selected = selected,
-                                onClick = { onDlsiteLangSelected(edition.lang) },
-                                label = { Text(label) },
-                                colors = FilterChipDefaults.filterChipColors(
-                                    selectedContainerColor = colorScheme.primary.copy(alpha = 0.2f),
-                                    selectedLabelColor = colorScheme.primary,
-                                    selectedLeadingIconColor = colorScheme.primary
-                                ),
-                                border = FilterChipDefaults.filterChipBorder(
-                                    enabled = true,
-                                    selected = selected,
-                                    borderColor = colorScheme.primary.copy(alpha = 0.3f),
-                                    selectedBorderColor = colorScheme.primary
-                                )
-                            )
-                        }
-                    }
-                }
-
                 if (album.tags.isNotEmpty()) {
                     AlbumHeaderInfoReveal(
                         revealKey = "$headerAnimationScopeKey:tags",
@@ -1106,103 +1079,205 @@ private fun AlbumHeader(
                     delayMillis = 160,
                     enabled = animateIntro
                 ) {
-                Row(
-                    modifier = Modifier.padding(top = 4.dp),
-                    horizontalArrangement = Arrangement.spacedBy(10.dp)
-                ) {
-                    Row(modifier = Modifier.height(36.dp).weight(1f)) {
-                        val radius = 10.dp
-                        val leftShape = if (canSaveOnline) {
-                            RoundedCornerShape(topStart = radius, bottomStart = radius, topEnd = 0.dp, bottomEnd = 0.dp)
-                        } else {
-                            RoundedCornerShape(radius)
+                    BoxWithConstraints(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(top = 4.dp)
+                    ) {
+                        val compact = maxWidth < 400.dp
+                        val ultraCompact = maxWidth < 340.dp
+                        val actionGap = if (compact) 8.dp else 10.dp
+                        val primaryButtonPadding = when {
+                            ultraCompact -> 6.dp
+                            compact -> 8.dp
+                            else -> 12.dp
                         }
-                        val rightShape = RoundedCornerShape(topStart = 0.dp, bottomStart = 0.dp, topEnd = radius, bottomEnd = radius)
+                        val smallButtonPadding = when {
+                            ultraCompact -> 6.dp
+                            compact -> 8.dp
+                            else -> 12.dp
+                        }
+                        val primaryIconSize = if (compact) 16.dp else 18.dp
+                        val primaryIconGap = if (compact) 4.dp else 6.dp
+                        val selectorMinWidth = when {
+                            ultraCompact -> 68.dp
+                            compact -> 76.dp
+                            else -> 96.dp
+                        }
+                        val selectorMaxWidth = when {
+                            ultraCompact -> 92.dp
+                            compact -> 104.dp
+                            else -> 140.dp
+                        }
+                        val externalMinWidth = when {
+                            ultraCompact -> 46.dp
+                            compact -> 50.dp
+                            else -> 56.dp
+                        }
+                        val externalMaxWidth = when {
+                            ultraCompact -> 58.dp
+                            compact -> 64.dp
+                            else -> 76.dp
+                        }
 
-                        Button(
-                            onClick = onDownloadClick,
-                            enabled = downloadEnabled,
-                            modifier = Modifier.fillMaxHeight().weight(1f),
-                            shape = leftShape,
-                            contentPadding = PaddingValues(horizontal = 12.dp, vertical = 0.dp),
-                            colors = ButtonDefaults.buttonColors(containerColor = colorScheme.primary)
+                        Row(
+                            modifier = Modifier.fillMaxWidth(),
+                            horizontalArrangement = Arrangement.spacedBy(actionGap),
+                            verticalAlignment = Alignment.CenterVertically
                         ) {
-                            Icon(Icons.Default.Download, contentDescription = null, modifier = Modifier.size(18.dp))
-                            Spacer(modifier = Modifier.width(6.dp))
-                            Text("下载", style = MaterialTheme.typography.labelMedium)
-                        }
-
-                        if (canSaveOnline) {
-                            Button(
-                                onClick = onSaveClick,
-                                enabled = saveEnabled,
-                                modifier = Modifier.fillMaxHeight().weight(1f),
-                                shape = rightShape,
-                                contentPadding = PaddingValues(horizontal = 12.dp, vertical = 0.dp),
-                                colors = ButtonDefaults.buttonColors(
-                                    containerColor = colorScheme.primary.copy(alpha = 0.14f),
-                                    contentColor = colorScheme.primary
-                                )
+                            Row(
+                                modifier = Modifier
+                                    .height(36.dp)
+                                    .weight(1f)
                             ) {
-                                Icon(Icons.Default.Bookmark, contentDescription = null, modifier = Modifier.size(18.dp))
-                                Spacer(modifier = Modifier.width(6.dp))
-                                Text("保存", style = MaterialTheme.typography.labelMedium)
+                                val radius = 10.dp
+                                val leftShape = if (canSaveOnline) {
+                                    RoundedCornerShape(topStart = radius, bottomStart = radius, topEnd = 0.dp, bottomEnd = 0.dp)
+                                } else {
+                                    RoundedCornerShape(radius)
+                                }
+                                val rightShape = RoundedCornerShape(topStart = 0.dp, bottomStart = 0.dp, topEnd = radius, bottomEnd = radius)
+
+                                Button(
+                                    onClick = onDownloadClick,
+                                    enabled = downloadEnabled,
+                                    modifier = Modifier
+                                        .fillMaxHeight()
+                                        .weight(1f),
+                                    shape = leftShape,
+                                    contentPadding = PaddingValues(horizontal = primaryButtonPadding, vertical = 0.dp),
+                                    colors = ButtonDefaults.buttonColors(containerColor = colorScheme.primary)
+                                ) {
+                                    Icon(Icons.Default.Download, contentDescription = null, modifier = Modifier.size(primaryIconSize))
+                                    Spacer(modifier = Modifier.width(primaryIconGap))
+                                    Text("下载", style = MaterialTheme.typography.labelMedium, maxLines = 1)
+                                }
+
+                                if (canSaveOnline) {
+                                    Button(
+                                        onClick = onSaveClick,
+                                        enabled = saveEnabled,
+                                        modifier = Modifier
+                                            .fillMaxHeight()
+                                            .weight(1f),
+                                        shape = rightShape,
+                                        contentPadding = PaddingValues(horizontal = primaryButtonPadding, vertical = 0.dp),
+                                        colors = ButtonDefaults.buttonColors(
+                                            containerColor = colorScheme.primary.copy(alpha = 0.14f),
+                                            contentColor = colorScheme.primary
+                                        )
+                                    ) {
+                                        Icon(Icons.Default.Bookmark, contentDescription = null, modifier = Modifier.size(primaryIconSize))
+                                        Spacer(modifier = Modifier.width(primaryIconGap))
+                                        Text("保存", style = MaterialTheme.typography.labelMedium, maxLines = 1)
+                                    }
+                                }
+                            }
+
+                            if (showGroupButton) {
+                                OutlinedButton(
+                                    onClick = {
+                                        val id = album.id
+                                        if (id > 0L) onOpenGroupPicker(id)
+                                    },
+                                    enabled = album.id > 0L,
+                                    modifier = Modifier
+                                        .height(36.dp)
+                                        .widthIn(min = selectorMinWidth, max = selectorMaxWidth),
+                                    shape = RoundedCornerShape(10.dp),
+                                    contentPadding = PaddingValues(horizontal = smallButtonPadding, vertical = 0.dp),
+                                    border = androidx.compose.foundation.BorderStroke(1.dp, colorScheme.primary.copy(alpha = 0.3f))
+                                ) {
+                                    Icon(
+                                        Icons.Default.CreateNewFolder,
+                                        contentDescription = null,
+                                        tint = colorScheme.primary,
+                                        modifier = Modifier.size(primaryIconSize)
+                                    )
+                                    Spacer(modifier = Modifier.width(primaryIconGap))
+                                    Text("分组", style = MaterialTheme.typography.labelMedium, color = colorScheme.primary, maxLines = 1)
+                                }
+                            }
+
+                            if (langCandidates.size > 1) {
+                                Box {
+                                    OutlinedButton(
+                                        onClick = { languageMenuExpanded = true },
+                                        modifier = Modifier
+                                            .height(36.dp)
+                                            .widthIn(min = selectorMinWidth, max = selectorMaxWidth),
+                                        shape = RoundedCornerShape(10.dp),
+                                        contentPadding = PaddingValues(horizontal = smallButtonPadding, vertical = 0.dp),
+                                        border = androidx.compose.foundation.BorderStroke(1.dp, colorScheme.primary.copy(alpha = 0.3f))
+                                    ) {
+                                        Text(
+                                            text = selectedLangLabel,
+                                            style = MaterialTheme.typography.labelMedium,
+                                            color = colorScheme.primary,
+                                            maxLines = 1
+                                        )
+                                        Spacer(modifier = Modifier.width(if (compact) 2.dp else 4.dp))
+                                        Icon(
+                                            imageVector = Icons.Default.ArrowDropDown,
+                                            contentDescription = null,
+                                            tint = colorScheme.primary,
+                                            modifier = Modifier.size(primaryIconSize)
+                                        )
+                                    }
+                                    DropdownMenu(
+                                        expanded = languageMenuExpanded,
+                                        onDismissRequest = { languageMenuExpanded = false }
+                                    ) {
+                                        langCandidates.forEach { edition ->
+                                            DropdownMenuItem(
+                                                text = { Text(dlsiteLanguageButtonLabel(edition.lang)) },
+                                                onClick = {
+                                                    languageMenuExpanded = false
+                                                    onDlsiteLangSelected(edition.lang)
+                                                }
+                                            )
+                                        }
+                                    }
+                                }
+                            }
+
+                            listOf(
+                                "DLsite" to dlsiteUrl,
+                                "ONE" to asmrOneUrl
+                            ).forEach { (label, url) ->
+                                OutlinedButton(
+                                    onClick = {
+                                        if (url.isNotBlank()) {
+                                            context.startActivity(
+                                                Intent(Intent.ACTION_VIEW, Uri.parse(url)).addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                                            )
+                                        }
+                                    },
+                                    enabled = url.isNotBlank(),
+                                    modifier = Modifier
+                                        .height(36.dp)
+                                        .widthIn(min = externalMinWidth, max = externalMaxWidth),
+                                    shape = RoundedCornerShape(10.dp),
+                                    contentPadding = PaddingValues(horizontal = smallButtonPadding, vertical = 0.dp),
+                                    border = androidx.compose.foundation.BorderStroke(1.dp, colorScheme.primary.copy(alpha = 0.3f))
+                                ) {
+                                    Text(label, style = MaterialTheme.typography.labelMedium, color = colorScheme.primary, maxLines = 1)
+                                }
                             }
                         }
                     }
-                    
-                    if (showGroupButton) {
-                        OutlinedButton(
-                            onClick = {
-                                val id = album.id
-                                if (id > 0L) onOpenGroupPicker(id)
-                            },
-                            enabled = album.id > 0L,
-                            modifier = Modifier
-                                .height(36.dp)
-                                .widthIn(min = 98.dp, max = 140.dp),
-                            shape = RoundedCornerShape(10.dp),
-                            contentPadding = PaddingValues(horizontal = 12.dp, vertical = 0.dp),
-                            border = androidx.compose.foundation.BorderStroke(1.dp, colorScheme.primary.copy(alpha = 0.3f))
-                        ) {
-                            Icon(
-                                Icons.Default.CreateNewFolder,
-                                contentDescription = null,
-                                tint = colorScheme.primary,
-                                modifier = Modifier.size(18.dp)
-                            )
-                            Spacer(modifier = Modifier.width(6.dp))
-                            Text("分组", style = MaterialTheme.typography.labelMedium, color = colorScheme.primary)
-                        }
-                    }
-
-                    listOf(
-                        "DLsite" to dlsiteUrl,
-                        "ONE" to asmrOneUrl
-                    ).forEach { (label, url) ->
-                        OutlinedButton(
-                            onClick = {
-                                if (url.isNotBlank()) {
-                                    context.startActivity(
-                                        Intent(Intent.ACTION_VIEW, Uri.parse(url)).addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-                                    )
-                                }
-                            },
-                            enabled = url.isNotBlank(),
-                            modifier = Modifier
-                                .height(36.dp)
-                                .widthIn(min = 56.dp, max = 76.dp),
-                            shape = RoundedCornerShape(10.dp),
-                            contentPadding = PaddingValues(horizontal = 6.dp, vertical = 0.dp),
-                            border = androidx.compose.foundation.BorderStroke(1.dp, colorScheme.primary.copy(alpha = 0.3f))
-                        ) {
-                            Text(label, style = MaterialTheme.typography.labelMedium, color = colorScheme.primary)
-                        }
-                    }
-                }
                 }
             }
         }
+    }
+}
+
+private fun dlsiteLanguageButtonLabel(lang: String): String {
+    return when (lang.trim().uppercase()) {
+        "CHI_HANS" -> "简中"
+        "CHI_HANT" -> "繁中"
+        "JPN" -> "日语"
+        else -> lang.trim().ifBlank { "日语" }
     }
 }
 


### PR DESCRIPTION
## Summary
- move album detail language switching into the action row and tighten the header action layout
- compact download task cards and file rows to better match the library list style
- show task-level progress summary and throttle download speed updates to a stable 1s cadence

- ## Verification
- ./gradlew.bat :app:compileDebugKotlin