### PR TITLE
fix: polish album backgrounds, headers, and metadata UI

### DIFF
--- a/app/src/main/java/com/asmr/player/main/MainContainer.kt
+++ b/app/src/main/java/com/asmr/player/main/MainContainer.kt
@@ -859,13 +859,15 @@ fun MainContainer(
                     Box(
                         modifier = Modifier
                             .fillMaxSize()
-                            .background(colorScheme.background.copy(alpha = 0.88f))
+                            .background(colorScheme.background)
                     )
-                    Box(
-                        modifier = Modifier
-                            .fillMaxSize()
-                            .background(colorScheme.primarySoft.copy(alpha = 0.16f))
-                    )
+                    if (!colorScheme.isDark) {
+                        Box(
+                            modifier = Modifier
+                                .fillMaxSize()
+                                .background(colorScheme.primarySoft.copy(alpha = 0.16f))
+                        )
+                    }
                     Scaffold(
                         contentWindowInsets = WindowInsets(0, 0, 0, 0),
                         containerColor = Color.Transparent,
@@ -1659,15 +1661,13 @@ fun MainContainer(
                             .fillMaxSize()
                             .background(colorScheme.background)
                     )
-                    Box(
-                        modifier = Modifier
-                            .fillMaxSize()
-                            .background(
-                                colorScheme.primarySoft.copy(
-                                    alpha = if (colorScheme.isDark) 0.18f else 0.14f
-                                )
-                            )
-                    )
+                    if (!colorScheme.isDark) {
+                        Box(
+                            modifier = Modifier
+                                .fillMaxSize()
+                                .background(colorScheme.primarySoft.copy(alpha = 0.14f))
+                        )
+                    }
                 }
                 Box(
                     modifier = Modifier

--- a/app/src/main/java/com/asmr/player/ui/library/AlbumDetailScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/AlbumDetailScreen.kt
@@ -1,4 +1,4 @@
-package com.asmr.player.ui.library
+﻿package com.asmr.player.ui.library
 
 import android.content.Intent
 import android.net.Uri
@@ -247,7 +247,7 @@ fun AlbumDetailScreen(
         modifier = Modifier
             .fillMaxSize()
             .background(Color.Transparent), // Background handled by MainActivity
-        contentAlignment = Alignment.TopCenter // 仅用于平板适配：居中显示内容
+        contentAlignment = Alignment.TopCenter // 浠呯敤浜庡钩鏉块€傞厤锛氬眳涓樉绀哄唴瀹?
     ) {
         val isCompact = windowSizeClass.widthSizeClass == WindowWidthSizeClass.Compact
         
@@ -255,7 +255,7 @@ fun AlbumDetailScreen(
             modifier = if (isCompact) {
                 Modifier.fillMaxSize()
             } else {
-                // 仅用于平板适配：限制内容区域最大宽度并填充可用空间
+                // 浠呯敤浜庡钩鏉块€傞厤锛氶檺鍒跺唴瀹瑰尯鍩熸渶澶у搴﹀苟濉厖鍙敤绌洪棿
                 Modifier
                     .fillMaxHeight()
                     .widthIn(max = 800.dp)
@@ -988,7 +988,7 @@ private fun AlbumHeader(
                     ) {
                         Icon(
                             imageVector = Icons.Default.Photo,
-                            contentDescription = "选择封面",
+                            contentDescription = "閫夋嫨灏侀潰",
                             tint = Color.White,
                             modifier = Modifier.size(18.dp)
                         )
@@ -1037,6 +1037,7 @@ private fun AlbumHeader(
                                 rjOnClick = { copyMeta("RJ", rj) },
                                 circleOnClick = { copyMeta("社团", circle) },
                                 appearance = AlbumMetaAppearance.OnImage,
+                                leadingVisual = AlbumMetaLeadingVisual.Icon,
                             )
                         }
                     }
@@ -1055,6 +1056,7 @@ private fun AlbumHeader(
                             horizontalArrangement = Arrangement.spacedBy(8.dp),
                             verticalArrangement = Arrangement.spacedBy(6.dp),
                             onCvClick = { cv -> copyMeta("CV", cv) },
+                            leadingVisual = AlbumMetaLeadingVisual.Icon,
                         )
                     }
                 }
@@ -1070,6 +1072,7 @@ private fun AlbumHeader(
                             horizontalArrangement = Arrangement.spacedBy(8.dp),
                             verticalArrangement = Arrangement.spacedBy(6.dp),
                             onTagClick = { tag -> copyMeta("标签", tag) },
+                            leadingVisual = AlbumMetaLeadingVisual.Icon,
                         )
                     }
                 }
@@ -1450,3 +1453,6 @@ internal data class PlaylistAddTarget(
         }
     }
 }
+
+
+

--- a/app/src/main/java/com/asmr/player/ui/library/AlbumItem.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/AlbumItem.kt
@@ -39,6 +39,7 @@ import com.asmr.player.cache.CacheImageModel
 import com.asmr.player.ui.common.AsmrAsyncImage
 import com.asmr.player.ui.common.CoverContentRow
 import com.asmr.player.ui.common.AsmrShimmerPlaceholder
+import com.asmr.player.ui.library.AlbumMetaLeadingVisual.Icon
 import com.asmr.player.util.DlsiteAntiHotlink
 
 import com.asmr.player.ui.theme.AsmrTheme
@@ -48,6 +49,8 @@ internal val AlbumGridItemCornerRadius = 6.dp
 internal val AlbumGridItemSpacing = 6.dp
 private val AlbumItemHorizontalPadding = 8.dp
 private val AlbumItemVerticalPadding = 2.dp
+private val AlbumItemMetaLineVerticalPadding = 1.dp
+private val AlbumItemCoverContentSpacing = 8.dp
 
 @Composable
 @OptIn(ExperimentalFoundationApi::class)
@@ -98,7 +101,7 @@ fun AlbumItem(
         CoverContentRow(
             coverWidth = coverSize,
             minHeight = coverSize,
-            spacing = 16.dp,
+            spacing = AlbumItemCoverContentSpacing,
             modifier = Modifier
                 .fillMaxWidth()
                 .height(listItemHeight),
@@ -131,7 +134,7 @@ fun AlbumItem(
                 Column(
                     modifier = Modifier
                         .fillMaxHeight()
-                        .padding(top = 4.dp, bottom = 4.dp, end = 12.dp),
+                        .padding(top = 3.dp, bottom = 3.dp, end = 12.dp),
                     verticalArrangement = Arrangement.spacedBy(2.dp, Alignment.CenterVertically)
                 ) {
                     val rj = album.rjCode.ifBlank { album.workId }
@@ -142,22 +145,27 @@ fun AlbumItem(
                         maxLines = 1,
                         overflow = TextOverflow.Ellipsis
                     )
-                
-                    AlbumPrimaryMetaRow(
-                        rjCode = rj,
-                        circle = album.circle,
-                        modifier = Modifier.fillMaxWidth(),
-                        rjOnClick = onRjClick?.let { click -> { click(rj) } },
-                        circleOnClick = onCircleClick?.let { click -> { click(album.circle) } },
-                    )
+
+                    AlbumItemMetaLine {
+                        AlbumPrimaryMetaRow(
+                            rjCode = rj,
+                            circle = album.circle,
+                            modifier = Modifier.fillMaxWidth(),
+                            rjOnClick = onRjClick?.let { click -> { click(rj) } },
+                            circleOnClick = onCircleClick?.let { click -> { click(album.circle) } },
+                            leadingVisual = Icon,
+                        )
+                    }
 
                     if (album.cv.isNotBlank()) {
-                        Spacer(modifier = Modifier.height(4.dp))
-                        AlbumCvChipsSingleLine(
-                            cvText = album.cv,
-                            modifier = Modifier.fillMaxWidth(),
-                            onCvClick = onCvClick,
-                        )
+                        AlbumItemMetaLine {
+                            AlbumCvChipsSingleLine(
+                                cvText = album.cv,
+                                modifier = Modifier.fillMaxWidth(),
+                                onCvClick = onCvClick,
+                                leadingVisual = Icon,
+                            )
+                        }
                     }
 
                     val statsText = remember(
@@ -188,22 +196,28 @@ fun AlbumItem(
                             }
                         }
                     }
-                    if (statsText.isNotBlank()) {
-                        Text(
-                            text = statsText,
-                            style = MaterialTheme.typography.labelSmall,
-                            color = colorScheme.textTertiary,
-                            maxLines = 1,
-                            overflow = TextOverflow.Ellipsis
-                        )
+                    if (album.tags.isNotEmpty()) {
+                        AlbumItemMetaLine {
+                            AlbumTagsSingleLine(
+                                tags = album.tags,
+                                modifier = Modifier.fillMaxWidth(),
+                                onTagClick = onTagClick,
+                                leadingVisual = Icon,
+                            )
+                        }
                     }
 
-                    if (album.tags.isNotEmpty()) {
-                        AlbumTagsSingleLine(
-                            tags = album.tags,
-                            modifier = Modifier.fillMaxWidth(),
-                            onTagClick = onTagClick,
-                        )
+                    if (statsText.isNotBlank()) {
+                        AlbumItemMetaLine {
+                            Text(
+                                text = statsText,
+                                style = MaterialTheme.typography.labelSmall,
+                                color = colorScheme.textTertiary,
+                                maxLines = 1,
+                                overflow = TextOverflow.Ellipsis,
+                                modifier = Modifier.fillMaxWidth()
+                            )
+                        }
                     }
                 }
             },
@@ -216,6 +230,21 @@ fun AlbumItem(
                     .padding(8.dp)
             )
         }
+    }
+}
+
+@Composable
+private fun AlbumItemMetaLine(
+    modifier: Modifier = Modifier,
+    content: @Composable () -> Unit
+) {
+    Box(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(vertical = AlbumItemMetaLineVerticalPadding),
+        contentAlignment = Alignment.CenterStart
+    ) {
+        content()
     }
 }
 
@@ -339,11 +368,13 @@ fun AlbumGridItem(
                 circle = album.circle,
                 modifier = Modifier.fillMaxWidth(),
                 circleOnClick = onCircleClick?.let { click -> { click(album.circle) } },
+                leadingVisual = Icon,
             )
 
             AlbumCvChipsFlow(
                 cvText = album.cv,
                 onCvClick = onCvClick,
+                leadingVisual = Icon,
             )
 
             val statsText = remember(album.ratingValue, album.ratingCount, album.priceJpy) {
@@ -360,6 +391,15 @@ fun AlbumGridItem(
                     }
                 }
             }
+            if (album.tags.isNotEmpty()) {
+                AlbumTagsFlow(
+                    tags = album.tags,
+                    modifier = Modifier.padding(top = 2.dp),
+                    onTagClick = onTagClick,
+                    leadingVisual = Icon,
+                )
+            }
+
             if (statsText.isNotBlank()) {
                 Text(
                     text = statsText,
@@ -367,14 +407,6 @@ fun AlbumGridItem(
                     color = colorScheme.textTertiary,
                     maxLines = 1,
                     overflow = TextOverflow.Ellipsis
-                )
-            }
-
-            if (album.tags.isNotEmpty()) {
-                AlbumTagsFlow(
-                    tags = album.tags,
-                    modifier = Modifier.padding(top = 2.dp),
-                    onTagClick = onTagClick,
                 )
             }
         }

--- a/app/src/main/java/com/asmr/player/ui/library/AlbumMetaChips.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/AlbumMetaChips.kt
@@ -8,10 +8,12 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -21,10 +23,13 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import com.asmr.player.R
 import com.asmr.player.ui.theme.AsmrTheme
 import com.asmr.player.util.MessageManager
 
@@ -41,6 +46,11 @@ private data class AlbumMetaPalette(
 internal enum class AlbumMetaAppearance {
     Default,
     OnImage,
+}
+
+internal enum class AlbumMetaLeadingVisual {
+    None,
+    Icon,
 }
 
 @Composable
@@ -84,6 +94,7 @@ internal fun AlbumPrimaryMetaRow(
     rjOnClick: (() -> Unit)? = null,
     circleOnClick: (() -> Unit)? = null,
     appearance: AlbumMetaAppearance = AlbumMetaAppearance.Default,
+    leadingVisual: AlbumMetaLeadingVisual = AlbumMetaLeadingVisual.None,
 ) {
     val normalizedRj = remember(rjCode) { rjCode.trim() }
     val normalizedCircle = remember(circle) { circle.trim() }
@@ -112,6 +123,7 @@ internal fun AlbumPrimaryMetaRow(
                 shape = AlbumMetaPillShape,
                 onClick = circleOnClick,
                 appearance = appearance,
+                leadingIcon = if (leadingVisual == AlbumMetaLeadingVisual.Icon) AlbumMetaLeadingIconKind.Club else null,
             )
         }
     }
@@ -123,6 +135,7 @@ internal fun AlbumCvChipsSingleLine(
     modifier: Modifier = Modifier,
     showLabel: Boolean = true,
     onCvClick: ((String) -> Unit)? = null,
+    leadingVisual: AlbumMetaLeadingVisual = AlbumMetaLeadingVisual.None,
 ) {
     val cvs = remember(cvText) { parseAlbumCvNames(cvText) }
     if (cvs.isEmpty()) return
@@ -135,12 +148,21 @@ internal fun AlbumCvChipsSingleLine(
         verticalAlignment = Alignment.CenterVertically,
     ) {
         if (showLabel) {
-            AlbumMetaBadge(
-                text = "CV",
-                tone = AlbumMetaTone.CvLabel,
-                shape = AlbumMetaPillShape,
-                textWeight = FontWeight.SemiBold,
-            )
+            if (leadingVisual == AlbumMetaLeadingVisual.Icon) {
+                AlbumMetaBadge(
+                    text = "",
+                    tone = AlbumMetaTone.CvLabel,
+                    shape = AlbumMetaPillShape,
+                    leadingIcon = AlbumMetaLeadingIconKind.Cv,
+                )
+            } else {
+                AlbumMetaBadge(
+                    text = "CV",
+                    tone = AlbumMetaTone.CvLabel,
+                    shape = AlbumMetaPillShape,
+                    textWeight = FontWeight.SemiBold,
+                )
+            }
         }
         cvs.forEach { cv ->
             AlbumMetaBadge(
@@ -163,6 +185,7 @@ internal fun AlbumCvChipsFlow(
     verticalArrangement: Arrangement.Vertical = Arrangement.spacedBy(4.dp),
     showLabel: Boolean = true,
     onCvClick: ((String) -> Unit)? = null,
+    leadingVisual: AlbumMetaLeadingVisual = AlbumMetaLeadingVisual.None,
 ) {
     val cvs = remember(cvText) { parseAlbumCvNames(cvText) }
     if (cvs.isEmpty()) return
@@ -173,12 +196,21 @@ internal fun AlbumCvChipsFlow(
         verticalArrangement = verticalArrangement,
     ) {
         if (showLabel) {
-            AlbumMetaBadge(
-                text = "CV",
-                tone = AlbumMetaTone.CvLabel,
-                shape = AlbumMetaPillShape,
-                textWeight = FontWeight.SemiBold,
-            )
+            if (leadingVisual == AlbumMetaLeadingVisual.Icon) {
+                AlbumMetaBadge(
+                    text = "",
+                    tone = AlbumMetaTone.CvLabel,
+                    shape = AlbumMetaPillShape,
+                    leadingIcon = AlbumMetaLeadingIconKind.Cv,
+                )
+            } else {
+                AlbumMetaBadge(
+                    text = "CV",
+                    tone = AlbumMetaTone.CvLabel,
+                    shape = AlbumMetaPillShape,
+                    textWeight = FontWeight.SemiBold,
+                )
+            }
         }
         cvs.forEach { cv ->
             AlbumMetaBadge(
@@ -197,6 +229,7 @@ internal fun AlbumTagsSingleLine(
     tags: List<String>,
     modifier: Modifier = Modifier,
     onTagClick: ((String) -> Unit)? = null,
+    leadingVisual: AlbumMetaLeadingVisual = AlbumMetaLeadingVisual.None,
 ) {
     val normalizedTags = remember(tags) { normalizeAlbumTags(tags) }
     if (normalizedTags.isEmpty()) return
@@ -208,6 +241,14 @@ internal fun AlbumTagsSingleLine(
         horizontalArrangement = Arrangement.spacedBy(4.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
+        if (leadingVisual == AlbumMetaLeadingVisual.Icon) {
+            AlbumMetaBadge(
+                text = "",
+                tone = AlbumMetaTone.Tag,
+                shape = AlbumMetaTagShape,
+                leadingIcon = AlbumMetaLeadingIconKind.Tags,
+            )
+        }
         normalizedTags.forEach { tag ->
             AlbumMetaBadge(
                 text = if (tag.startsWith("#")) tag else "#$tag",
@@ -228,6 +269,7 @@ internal fun AlbumTagsFlow(
     horizontalArrangement: Arrangement.Horizontal = Arrangement.spacedBy(4.dp),
     verticalArrangement: Arrangement.Vertical = Arrangement.spacedBy(4.dp),
     onTagClick: ((String) -> Unit)? = null,
+    leadingVisual: AlbumMetaLeadingVisual = AlbumMetaLeadingVisual.None,
 ) {
     val normalizedTags = remember(tags) { normalizeAlbumTags(tags) }
     if (normalizedTags.isEmpty()) return
@@ -237,6 +279,14 @@ internal fun AlbumTagsFlow(
         horizontalArrangement = horizontalArrangement,
         verticalArrangement = verticalArrangement,
     ) {
+        if (leadingVisual == AlbumMetaLeadingVisual.Icon) {
+            AlbumMetaBadge(
+                text = "",
+                tone = AlbumMetaTone.Tag,
+                shape = AlbumMetaTagShape,
+                leadingIcon = AlbumMetaLeadingIconKind.Tags,
+            )
+        }
         normalizedTags.forEach { tag ->
             AlbumMetaBadge(
                 text = if (tag.startsWith("#")) tag else "#$tag",
@@ -257,6 +307,35 @@ private enum class AlbumMetaTone {
     Tag,
 }
 
+private enum class AlbumMetaLeadingIconKind {
+    Club,
+    Cv,
+    Tags,
+}
+
+@Composable
+private fun AlbumMetaLeadingIcon(
+    kind: AlbumMetaLeadingIconKind,
+    modifier: Modifier = Modifier,
+    appearance: AlbumMetaAppearance = AlbumMetaAppearance.Default,
+    iconSize: Dp = 14.dp,
+) {
+    val colorScheme = AsmrTheme.colorScheme
+    val (iconRes, tone) = when (kind) {
+        AlbumMetaLeadingIconKind.Club -> R.drawable.ic_album_meta_club to AlbumMetaTone.Circle
+        AlbumMetaLeadingIconKind.Cv -> R.drawable.ic_album_meta_cv to AlbumMetaTone.CvLabel
+        AlbumMetaLeadingIconKind.Tags -> R.drawable.ic_album_meta_tags to AlbumMetaTone.Tag
+    }
+    val tint = albumMetaPalette(tone, colorScheme, appearance).content
+
+    Icon(
+        painter = painterResource(id = iconRes),
+        contentDescription = null,
+        tint = tint,
+        modifier = modifier.size(iconSize)
+    )
+}
+
 @Composable
 private fun AlbumMetaBadge(
     text: String,
@@ -267,6 +346,7 @@ private fun AlbumMetaBadge(
     onClick: (() -> Unit)? = null,
     textWeight: FontWeight? = null,
     appearance: AlbumMetaAppearance = AlbumMetaAppearance.Default,
+    leadingIcon: AlbumMetaLeadingIconKind? = null,
 ) {
     val colorScheme = AsmrTheme.colorScheme
     val palette = albumMetaPalette(tone, colorScheme, appearance)
@@ -280,15 +360,29 @@ private fun AlbumMetaBadge(
         )
         .let { if (onClick != null) it.clickable(onClick = onClick) else it }
 
-    Text(
-        text = text,
-        style = MaterialTheme.typography.labelSmall,
-        fontWeight = textWeight,
-        color = palette.content,
-        maxLines = 1,
-        overflow = TextOverflow.Ellipsis,
+    Row(
         modifier = styledModifier,
-    )
+        horizontalArrangement = Arrangement.spacedBy(if (leadingIcon != null && text.isNotBlank()) 4.dp else 0.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        if (leadingIcon != null) {
+            AlbumMetaLeadingIcon(
+                kind = leadingIcon,
+                appearance = appearance,
+                iconSize = if (text.isBlank()) 14.dp else 12.dp,
+            )
+        }
+        if (text.isNotBlank()) {
+            Text(
+                text = text,
+                style = MaterialTheme.typography.labelSmall,
+                fontWeight = textWeight,
+                color = palette.content,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+        }
+    }
 }
 
 @Composable

--- a/app/src/main/java/com/asmr/player/ui/library/LibraryScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/LibraryScreen.kt
@@ -173,6 +173,7 @@ private val LibraryChromeContentGap = 20.dp
 private val LibraryChromeCollapseOvershoot = 12.dp
 private val LibraryPageHorizontalPadding = 8.dp
 private val LibraryTrackListHeaderCornerRadius = 10.dp
+private val LibraryTrackListItemCornerRadius = 10.dp
 private val LibraryAlbumItemVerticalPadding = 2.dp
 
 private fun Album.withUserTags(userTags: List<String>): Album {
@@ -547,9 +548,15 @@ fun LibraryScreen(
                                             val albumId = header.albumId
                                             val expanded = expandedAlbumIds.contains(albumId)
                                             val rows = expandedAlbumTracks[albumId].orEmpty()
+                                            val isFirstAlbumHeader = headerIndex == 0
+                                            val isLastAlbumHeader = headerIndex == headerCount - 1
 
                                             stickyHeader(key = "album:$albumId") {
-                                                Column {
+                                                Column(
+                                                    modifier = Modifier
+                                                        .fillMaxWidth()
+                                                        .background(colorScheme.background)
+                                                ) {
                                                     if (headerIndex > 0) {
                                                         HorizontalDivider(
                                                             modifier = Modifier.padding(horizontal = LibraryPageHorizontalPadding),
@@ -566,6 +573,9 @@ fun LibraryScreen(
                                                             ?: rememberAlbumTrackListTotalSizeBytes(rows),
                                                         coverModel = header.coverPath.takeIf { it.isNotBlank() }.takeIf { it != "null" }
                                                             ?: header.coverUrl.takeIf { it.isNotBlank() },
+                                                        expanded = expanded,
+                                                        isFirstInList = isFirstAlbumHeader,
+                                                        isLastInList = isLastAlbumHeader,
                                                         onToggle = {
                                                             if (expanded) expandedAlbumIds.remove(albumId) else expandedAlbumIds.add(albumId)
                                                         }
@@ -620,6 +630,7 @@ fun LibraryScreen(
                                                             subtitle = meta.leadingText,
                                                             fixedTrailingSubtitle = meta.trailingText,
                                                             showSubtitleStamp = row.hasSubtitles,
+                                                            isLastInSection = index == rows.lastIndex,
                                                             onClick = {
                                                                 scope.launch {
                                                                     val tracksForAlbum = withContext(Dispatchers.Default) {
@@ -1129,14 +1140,32 @@ private fun TrackAlbumHeader(
     totalDurationSeconds: Double,
     totalSizeBytes: Long?,
     coverModel: Any?,
+    expanded: Boolean,
+    isFirstInList: Boolean,
+    isLastInList: Boolean,
     onToggle: () -> Unit
 ) {
     val colorScheme = AsmrTheme.colorScheme
+    val containerShape = if (expanded) {
+        RoundedCornerShape(
+            topStart = if (isFirstInList) LibraryTrackListHeaderCornerRadius else 0.dp,
+            topEnd = if (isFirstInList) LibraryTrackListHeaderCornerRadius else 0.dp,
+            bottomStart = 0.dp,
+            bottomEnd = 0.dp
+        )
+    } else {
+        RoundedCornerShape(
+            topStart = if (isFirstInList) LibraryTrackListHeaderCornerRadius else 0.dp,
+            topEnd = if (isFirstInList) LibraryTrackListHeaderCornerRadius else 0.dp,
+            bottomStart = if (isLastInList) LibraryTrackListHeaderCornerRadius else 0.dp,
+            bottomEnd = if (isLastInList) LibraryTrackListHeaderCornerRadius else 0.dp
+        )
+    }
     Row(
         modifier = Modifier
             .fillMaxWidth()
-            .clip(RoundedCornerShape(LibraryTrackListHeaderCornerRadius))
-            .background(colorScheme.surface.copy(alpha = 0.5f))
+            .clip(containerShape)
+            .background(colorScheme.surface)
             .clickable { onToggle() }
             .padding(horizontal = LibraryPageHorizontalPadding, vertical = 10.dp),
         verticalAlignment = Alignment.CenterVertically
@@ -1199,19 +1228,35 @@ private fun TrackListRow(
     subtitle: String,
     fixedTrailingSubtitle: String,
     showSubtitleStamp: Boolean,
+    isLastInSection: Boolean,
     onClick: () -> Unit,
     onAddToQueue: () -> Unit,
     onAddToPlaylist: () -> Unit,
     onManageTags: () -> Unit,
     onRemove: () -> Unit
 ) {
+    val colorScheme = AsmrTheme.colorScheme
+    val rowShape = if (isLastInSection) {
+        RoundedCornerShape(
+            topStart = 0.dp,
+            topEnd = 0.dp,
+            bottomStart = LibraryTrackListItemCornerRadius,
+            bottomEnd = LibraryTrackListItemCornerRadius
+        )
+    } else {
+        RoundedCornerShape(0.dp)
+    }
+
     AudioItemRow(
         title = title,
         subtitle = subtitle,
         fixedTrailingSubtitle = fixedTrailingSubtitle,
         showSubtitleStamp = showSubtitleStamp,
         onClick = onClick,
-        modifier = Modifier.fillMaxWidth(),
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(rowShape)
+            .background(colorScheme.surface),
         actions = listOf(
             AudioItemMenuAction(
                 label = "添加到播放队列",
@@ -1366,11 +1411,13 @@ private fun AlbumGridItem(
                 circle = album.circle,
                 modifier = Modifier.fillMaxWidth(),
                 circleOnClick = onCircleClick?.let { click -> { click(album.circle) } },
+                leadingVisual = AlbumMetaLeadingVisual.Icon,
             )
 
             AlbumCvChipsFlow(
                 cvText = album.cv,
                 onCvClick = onCvClick,
+                leadingVisual = AlbumMetaLeadingVisual.Icon,
             )
 
             val statsText = buildString {
@@ -1400,6 +1447,7 @@ private fun AlbumGridItem(
                     tags = album.tags,
                     modifier = Modifier.padding(top = 2.dp),
                     onTagClick = onTagClick,
+                    leadingVisual = AlbumMetaLeadingVisual.Icon,
                 )
             }
         }
@@ -1445,7 +1493,7 @@ private fun AlbumItem(
         CoverContentRow(
             coverWidth = coverSize,
             minHeight = coverSize,
-            spacing = 16.dp,
+            spacing = 8.dp,
             modifier = Modifier
                 .fillMaxWidth()
                 .height(listItemHeight),
@@ -1542,6 +1590,7 @@ private fun AlbumItem(
                         modifier = Modifier.fillMaxWidth(),
                         rjOnClick = onRjClick?.let { click -> { click(rj) } },
                         circleOnClick = onCircleClick?.let { click -> { click(album.circle) } },
+                        leadingVisual = AlbumMetaLeadingVisual.Icon,
                     )
 
                     if (album.cv.isNotBlank()) {
@@ -1549,6 +1598,7 @@ private fun AlbumItem(
                             cvText = album.cv,
                             modifier = Modifier.fillMaxWidth(),
                             onCvClick = onCvClick,
+                            leadingVisual = AlbumMetaLeadingVisual.Icon,
                         )
                     }
 
@@ -1567,6 +1617,7 @@ private fun AlbumItem(
                             tags = album.tags,
                             modifier = Modifier.fillMaxWidth(),
                             onTagClick = onTagClick,
+                            leadingVisual = AlbumMetaLeadingVisual.Icon,
                         )
                     }
                 }

--- a/app/src/main/res/drawable/ic_album_meta_club.xml
+++ b/app/src/main/res/drawable/ic_album_meta_club.xml
@@ -1,0 +1,20 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:pathData="M8.62,13.8A2.25,2.25 0,1 1,12 10.836a2.25,2.25 0,1 1,3.38 2.966l-2.626,2.856a0.998,0.998 0,0 1,-1.507 0z"
+        android:strokeColor="#FF000000"
+        android:strokeWidth="2"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round"
+        android:fillColor="@android:color/transparent" />
+    <path
+        android:pathData="M3,10a2,2 0,0 1,0.709 -1.528l7,-6a2,2 0,0 1,2.582 0l7,6A2,2 0,0 1,21 10v9a2,2 0,0 1,-2 2H5a2,2 0,0 1,-2 -2z"
+        android:strokeColor="#FF000000"
+        android:strokeWidth="2"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round"
+        android:fillColor="@android:color/transparent" />
+</vector>

--- a/app/src/main/res/drawable/ic_album_meta_cv.xml
+++ b/app/src/main/res/drawable/ic_album_meta_cv.xml
@@ -1,0 +1,41 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:pathData="M16,10h2"
+        android:strokeColor="#FF000000"
+        android:strokeWidth="2"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round"
+        android:fillColor="@android:color/transparent" />
+    <path
+        android:pathData="M16,14h2"
+        android:strokeColor="#FF000000"
+        android:strokeWidth="2"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round"
+        android:fillColor="@android:color/transparent" />
+    <path
+        android:pathData="M6.17,15a3,3 0,0 1,5.66 0"
+        android:strokeColor="#FF000000"
+        android:strokeWidth="2"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round"
+        android:fillColor="@android:color/transparent" />
+    <path
+        android:pathData="M9,11m-2,0a2,2 0,1 1,4 0a2,2 0,1 1,-4 0"
+        android:strokeColor="#FF000000"
+        android:strokeWidth="2"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round"
+        android:fillColor="@android:color/transparent" />
+    <path
+        android:pathData="M4,5h16a2,2 0,0 1,2 2v10a2,2 0,0 1,-2 2H4a2,2 0,0 1,-2 -2V7a2,2 0,0 1,2 -2z"
+        android:strokeColor="#FF000000"
+        android:strokeWidth="2"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round"
+        android:fillColor="@android:color/transparent" />
+</vector>

--- a/app/src/main/res/drawable/ic_album_meta_tags.xml
+++ b/app/src/main/res/drawable/ic_album_meta_tags.xml
@@ -1,0 +1,25 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:pathData="M13.172,2a2,2 0,0 1,1.414 0.586l6.71,6.71a2.4,2.4 0,0 1,0 3.408l-4.592,4.592a2.4,2.4 0,0 1,-3.408 0l-6.71,-6.71A2,2 0,0 1,6 9.172V3a1,1 0,0 1,1 -1z"
+        android:strokeColor="#FF000000"
+        android:strokeWidth="2"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round"
+        android:fillColor="@android:color/transparent" />
+    <path
+        android:pathData="M2,7v6.172a2,2 0,0 0,0.586 1.414l6.71,6.71a2.4,2.4 0,0 0,3.191 0.193"
+        android:strokeColor="#FF000000"
+        android:strokeWidth="2"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round"
+        android:fillColor="@android:color/transparent" />
+    <path
+        android:pathData="M10.5,6.5m-0.5,0a0.5,0.5 0,1 1,1 0a0.5,0.5 0,1 1,-1 0"
+        android:fillColor="#FF000000"
+        android:strokeColor="#FF000000"
+        android:strokeWidth="1" />
+</vector>


### PR DESCRIPTION
## Summary
- remove unwanted theme tint from dark mode page backgrounds and make track list sticky headers opaque
- refine album list/search metadata layout, spacing, and icon treatment across list, grid, and detail views
- adjust track-list corner rules and fix visible Chinese text garbling in album detail

## Verification
- ./gradlew :app:compileDebugKotlin