### PR TITLE
fix: polish album list and DLsite detail tabs for v1.1.0

### DIFF
--- a/app/src/main/java/com/asmr/player/data/remote/dlsite/DlsitePlayWorkClient.kt
+++ b/app/src/main/java/com/asmr/player/data/remote/dlsite/DlsitePlayWorkClient.kt
@@ -29,7 +29,11 @@ class DlsitePlayWorkClient @Inject constructor(
 
     suspend fun fetchPlayableTree(workno: String): DlsitePlayTreeResult = withContext(Dispatchers.IO) {
         val clean = DlsiteWorkNo.extractRjCode(workno)
-        if (clean.isBlank()) return@withContext DlsitePlayTreeResult(emptyList(), emptyMap())
+        if (clean.isBlank()) return@withContext DlsitePlayTreeResult(
+            tree = emptyList(),
+            subtitlesByUrl = emptyMap(),
+            status = DlsitePlayLoadStatus.NotAvailable
+        )
 
         val cookie = authStore.getPlayCookie().trim()
         if (cookie.isBlank()) {
@@ -219,7 +223,11 @@ class DlsitePlayWorkClient @Inject constructor(
         }
 
         val treeNodes = buildTreeFromFiles(files)
-        DlsitePlayTreeResult(treeNodes, subtitleMap)
+        DlsitePlayTreeResult(
+            tree = treeNodes,
+            subtitlesByUrl = subtitleMap,
+            status = if (treeNodes.isNotEmpty()) DlsitePlayLoadStatus.Success else DlsitePlayLoadStatus.NotAvailable
+        )
     }
 
     private fun fetchDownloadSign(workno: String, cookie: String): Triple<String, Map<String, String>, String> {
@@ -454,5 +462,11 @@ class DlsitePlayWorkClient @Inject constructor(
 
 data class DlsitePlayTreeResult(
     val tree: List<AsmrOneTrackNodeResponse>,
-    val subtitlesByUrl: Map<String, List<RemoteSubtitleSource>>
+    val subtitlesByUrl: Map<String, List<RemoteSubtitleSource>>,
+    val status: DlsitePlayLoadStatus
 )
+
+enum class DlsitePlayLoadStatus {
+    Success,
+    NotAvailable,
+}

--- a/app/src/main/java/com/asmr/player/ui/library/AlbumDetailScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/AlbumDetailScreen.kt
@@ -163,7 +163,8 @@ internal data class PreparedMediaPlayback(
 private val AlbumDetailTabContentGap = 12.dp
 private val AlbumDetailTabCollapseOvershoot = 10.dp
 private const val AlbumDetailInitialIntroDurationMs = 1200L
-private val AlbumDetailHorizontalPadding = 8.dp
+internal val AlbumDetailHorizontalPadding = 8.dp
+private val AlbumDetailHeaderCornerRadius = 10.dp
 
 private val DlsiteElasticResizeSpring = spring<IntSize>(
     dampingRatio = Spring.DampingRatioLowBouncy,
@@ -403,7 +404,6 @@ fun AlbumDetailScreen(
                             }
                             2 -> {
                                 viewModel.ensureDlsiteLoaded()
-                                viewModel.ensureDlsitePlayLoaded()
                             }
                         }
                     }
@@ -549,6 +549,7 @@ fun AlbumDetailScreen(
                                         rjCode = model.rjCode,
                                         tree = model.dlsitePlayTree,
                                         isLoading = model.isLoadingDlsitePlay,
+                                        shouldAutoLoad = selectedTab == 2,
                                         onOpenLogin = onOpenDlsiteLogin,
                                         onEnsureLoaded = { viewModel.ensureDlsitePlayLoaded() },
                                         onPlayTracks = onPlayTracks,
@@ -942,7 +943,7 @@ private fun AlbumHeader(
     val headerContainerModifier = Modifier
         .fillMaxWidth()
         .padding(horizontal = AlbumDetailHorizontalPadding, vertical = 12.dp)
-        .clip(RoundedCornerShape(24.dp))
+        .clip(RoundedCornerShape(AlbumDetailHeaderCornerRadius))
         .background(colorScheme.surface.copy(alpha = 0.5f))
     val langCandidates = remember(dlsiteEditions) {
         dlsiteEditions

--- a/app/src/main/java/com/asmr/player/ui/library/AlbumDetailViewModel.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/AlbumDetailViewModel.kt
@@ -23,6 +23,7 @@ import com.asmr.player.data.remote.crawler.AsmrOneCrawler
 import com.asmr.player.data.remote.dlsite.DlsiteCloudSyncCandidate
 import com.asmr.player.data.remote.dlsite.DlsiteCloudSyncResolveResult
 import com.asmr.player.data.remote.dlsite.DLSITE_PLAY_PREVIEW_CACHE_VERSION
+import com.asmr.player.data.remote.dlsite.DlsitePlayLoadStatus
 import com.asmr.player.data.remote.dlsite.DlsitePlayWorkClient
 import com.asmr.player.data.remote.dlsite.DlsitePlayTreeResult
 import com.asmr.player.data.remote.dlsite.DlsiteLanguageEdition
@@ -169,6 +170,7 @@ class AlbumDetailViewModel @Inject constructor(
     private var lastAlbumKey: String? = null
     private var localTracksObserveJob: Job? = null
     private val asmrOneAttemptedRj = linkedSetOf<String>()
+    private val dlsitePlayAttemptedRj = linkedSetOf<String>()
     private val asmrOneCollectedCache = linkedMapOf<String, Pair<Long, Boolean?>>()
     private val asmrOneResolvedCache = linkedMapOf<String, Pair<Long, Pair<String, Int?>>>()
     private val asmrOneTracksCache = linkedMapOf<String, Pair<Long, List<AsmrOneTrackNodeResponse>>>()
@@ -1167,6 +1169,7 @@ class AlbumDetailViewModel @Inject constructor(
         dlsiteLoadToken++
         asmrOneLoadToken++
         asmrOneAttemptedRj.clear()
+        dlsitePlayAttemptedRj.clear()
         _uiState.value = AlbumDetailUiState.Success(
             model = current.model.copy(
                 dlsiteSelectedLang = target?.lang ?: normalized,
@@ -1454,8 +1457,16 @@ class AlbumDetailViewModel @Inject constructor(
                 baseRj
             )
         )
+        val playCookieFingerprint = DlsiteAuthStore(context).getPlayCookie().trim().hashCode()
+        val attemptKey = candidates0.joinToString("|") + "#" + playCookieFingerprint
 
-        if (candidates0.isEmpty() || current.model.dlsitePlayTree.isNotEmpty() || current.model.isLoadingDlsitePlay) return
+        if (
+            candidates0.isEmpty() ||
+            current.model.dlsitePlayTree.isNotEmpty() ||
+            current.model.isLoadingDlsitePlay ||
+            dlsitePlayAttemptedRj.contains(attemptKey)
+        ) return
+        dlsitePlayAttemptedRj.add(attemptKey)
         viewModelScope.launch {
             _uiState.value = AlbumDetailUiState.Success(model = current.model.copy(isLoadingDlsitePlay = true))
             try {
@@ -1480,6 +1491,7 @@ class AlbumDetailViewModel @Inject constructor(
                 var pickedWorkno: String? = null
                 var pickedResult: DlsitePlayTreeResult? = null
                 var lastError: Exception? = null
+                var sawNotAvailable = false
                 for (workno in candidates) {
                     val res = try {
                         dlsitePlayWorkClient.fetchPlayableTree(workno)
@@ -1487,19 +1499,27 @@ class AlbumDetailViewModel @Inject constructor(
                         lastError = e
                         continue
                     }
-                    if (res.tree.isNotEmpty()) {
+                    if (res.status == DlsitePlayLoadStatus.Success && res.tree.isNotEmpty()) {
                         pickedWorkno = workno
                         pickedResult = res
                         break
                     }
+                    if (res.status == DlsitePlayLoadStatus.NotAvailable) {
+                        sawNotAvailable = true
+                    }
                 }
 
-                val result = pickedResult ?: DlsitePlayTreeResult(emptyList(), emptyMap())
+                val result = pickedResult ?: DlsitePlayTreeResult(
+                    tree = emptyList(),
+                    subtitlesByUrl = emptyMap(),
+                    status = if (sawNotAvailable) DlsitePlayLoadStatus.NotAvailable else DlsitePlayLoadStatus.Success
+                )
                 result.subtitlesByUrl.forEach { (url, subs) ->
                     if (subs.isNotEmpty()) OnlineLyricsStore.set(url, subs)
                 }
                 val updated = (_uiState.value as? AlbumDetailUiState.Success)?.model ?: return@launch
-                if (pickedResult == null && lastError != null) {
+                if (pickedResult == null && lastError != null && !sawNotAvailable) {
+                    dlsitePlayAttemptedRj.remove(attemptKey)
                     messageManager.showError("DLsite Play 加载失败，请稍后重试")
                 }
                 _uiState.value = AlbumDetailUiState.Success(
@@ -1510,6 +1530,7 @@ class AlbumDetailViewModel @Inject constructor(
                     )
                 )
             } catch (e: Exception) {
+                dlsitePlayAttemptedRj.remove(attemptKey)
                 val updated = (_uiState.value as? AlbumDetailUiState.Success)?.model ?: return@launch
                 _uiState.value = AlbumDetailUiState.Success(model = updated.copy(isLoadingDlsitePlay = false))
             }

--- a/app/src/main/java/com/asmr/player/ui/library/AlbumItem.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/AlbumItem.kt
@@ -51,6 +51,8 @@ private val AlbumItemHorizontalPadding = 8.dp
 private val AlbumItemVerticalPadding = 2.dp
 private val AlbumItemMetaLineVerticalPadding = 1.dp
 private val AlbumItemCoverContentSpacing = 8.dp
+private val AlbumGridInfoHorizontalPadding = 6.dp
+private val AlbumGridInfoVerticalPadding = 8.dp
 
 @Composable
 @OptIn(ExperimentalFoundationApi::class)
@@ -154,6 +156,7 @@ fun AlbumItem(
                             rjOnClick = onRjClick?.let { click -> { click(rj) } },
                             circleOnClick = onCircleClick?.let { click -> { click(album.circle) } },
                             leadingVisual = Icon,
+                            order = AlbumPrimaryMetaOrder.CircleThenRj,
                         )
                     }
 
@@ -353,7 +356,7 @@ fun AlbumGridItem(
         }
         
         Column(
-            modifier = Modifier.padding(horizontal = 8.dp, vertical = 8.dp),
+            modifier = Modifier.padding(horizontal = AlbumGridInfoHorizontalPadding, vertical = AlbumGridInfoVerticalPadding),
             verticalArrangement = Arrangement.spacedBy(4.dp)
         ) {
             Text(

--- a/app/src/main/java/com/asmr/player/ui/library/AlbumMetaChips.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/AlbumMetaChips.kt
@@ -53,6 +53,11 @@ internal enum class AlbumMetaLeadingVisual {
     Icon,
 }
 
+internal enum class AlbumPrimaryMetaOrder {
+    RjThenCircle,
+    CircleThenRj,
+}
+
 @Composable
 internal fun rememberAlbumMetaCopyAction(
     messageManager: MessageManager,
@@ -95,18 +100,13 @@ internal fun AlbumPrimaryMetaRow(
     circleOnClick: (() -> Unit)? = null,
     appearance: AlbumMetaAppearance = AlbumMetaAppearance.Default,
     leadingVisual: AlbumMetaLeadingVisual = AlbumMetaLeadingVisual.None,
+    order: AlbumPrimaryMetaOrder = AlbumPrimaryMetaOrder.RjThenCircle,
 ) {
     val normalizedRj = remember(rjCode) { rjCode.trim() }
     val normalizedCircle = remember(circle) { circle.trim() }
     if (normalizedRj.isBlank() && normalizedCircle.isBlank()) return
 
-    Row(
-        modifier = modifier
-            .clipToBounds()
-            .horizontalScroll(rememberScrollState()),
-        horizontalArrangement = Arrangement.spacedBy(4.dp),
-        verticalAlignment = Alignment.CenterVertically,
-    ) {
+    val rjBadge: @Composable () -> Unit = {
         if (normalizedRj.isNotBlank()) {
             AlbumMetaBadge(
                 text = normalizedRj,
@@ -116,6 +116,8 @@ internal fun AlbumPrimaryMetaRow(
                 appearance = appearance,
             )
         }
+    }
+    val circleBadge: @Composable () -> Unit = {
         if (normalizedCircle.isNotBlank()) {
             AlbumMetaBadge(
                 text = normalizedCircle,
@@ -125,6 +127,25 @@ internal fun AlbumPrimaryMetaRow(
                 appearance = appearance,
                 leadingIcon = if (leadingVisual == AlbumMetaLeadingVisual.Icon) AlbumMetaLeadingIconKind.Club else null,
             )
+        }
+    }
+
+    Row(
+        modifier = modifier
+            .clipToBounds()
+            .horizontalScroll(rememberScrollState()),
+        horizontalArrangement = Arrangement.spacedBy(4.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        when (order) {
+            AlbumPrimaryMetaOrder.RjThenCircle -> {
+                rjBadge()
+                circleBadge()
+            }
+            AlbumPrimaryMetaOrder.CircleThenRj -> {
+                circleBadge()
+                rjBadge()
+            }
         }
     }
 }

--- a/app/src/main/java/com/asmr/player/ui/library/LibraryScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/LibraryScreen.kt
@@ -175,6 +175,8 @@ private val LibraryPageHorizontalPadding = 8.dp
 private val LibraryTrackListHeaderCornerRadius = 10.dp
 private val LibraryTrackListItemCornerRadius = 10.dp
 private val LibraryAlbumItemVerticalPadding = 2.dp
+private val LibraryAlbumGridInfoHorizontalPadding = 6.dp
+private val LibraryAlbumGridInfoVerticalPadding = 8.dp
 
 private fun Album.withUserTags(userTags: List<String>): Album {
     if (userTags.isEmpty()) return this
@@ -1396,7 +1398,7 @@ private fun AlbumGridItem(
         }
         
         Column(
-            modifier = Modifier.padding(horizontal = 8.dp, vertical = 8.dp),
+            modifier = Modifier.padding(horizontal = LibraryAlbumGridInfoHorizontalPadding, vertical = LibraryAlbumGridInfoVerticalPadding),
             verticalArrangement = Arrangement.spacedBy(4.dp)
         ) {
             Text(
@@ -1591,6 +1593,7 @@ private fun AlbumItem(
                         rjOnClick = onRjClick?.let { click -> { click(rj) } },
                         circleOnClick = onCircleClick?.let { click -> { click(album.circle) } },
                         leadingVisual = AlbumMetaLeadingVisual.Icon,
+                        order = AlbumPrimaryMetaOrder.CircleThenRj,
                     )
 
                     if (album.cv.isNotBlank()) {

--- a/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailDirectorySupport.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailDirectorySupport.kt
@@ -166,6 +166,45 @@ internal sealed class AsmrTreeUiEntry {
     ) : AsmrTreeUiEntry()
 }
 
+private val DirectoryBrowserPanelCornerRadius = 10.dp
+private val DirectoryFolderRowCornerRadius = 10.dp
+private val DirectoryBrowserPanelVerticalPadding = 4.dp
+
+internal enum class DirectoryFolderPosition {
+    Single,
+    First,
+    Middle,
+    Last,
+}
+
+private fun directoryFolderPosition(index: Int, total: Int): DirectoryFolderPosition {
+    return when {
+        total <= 1 -> DirectoryFolderPosition.Single
+        index == 0 -> DirectoryFolderPosition.First
+        index == total - 1 -> DirectoryFolderPosition.Last
+        else -> DirectoryFolderPosition.Middle
+    }
+}
+
+private fun directoryFolderShape(position: DirectoryFolderPosition): RoundedCornerShape {
+    return when (position) {
+        DirectoryFolderPosition.Single -> RoundedCornerShape(DirectoryFolderRowCornerRadius)
+        DirectoryFolderPosition.First -> RoundedCornerShape(
+            topStart = DirectoryFolderRowCornerRadius,
+            topEnd = DirectoryFolderRowCornerRadius,
+            bottomStart = 0.dp,
+            bottomEnd = 0.dp,
+        )
+        DirectoryFolderPosition.Middle -> RoundedCornerShape(0.dp)
+        DirectoryFolderPosition.Last -> RoundedCornerShape(
+            topStart = 0.dp,
+            topEnd = 0.dp,
+            bottomStart = DirectoryFolderRowCornerRadius,
+            bottomEnd = DirectoryFolderRowCornerRadius,
+        )
+    }
+}
+
 internal sealed class LocalTreeUiEntry {
     abstract val path: String
     abstract val title: String
@@ -2166,12 +2205,12 @@ internal fun DirectoryBrowserPanelV2(
     }
 
     Surface(
-        shape = RoundedCornerShape(18.dp),
+        shape = RoundedCornerShape(DirectoryBrowserPanelCornerRadius),
         tonalElevation = 1.dp,
         color = AsmrTheme.colorScheme.surface.copy(alpha = 0.44f),
         modifier = Modifier
             .fillMaxWidth()
-            .padding(horizontal = 16.dp, vertical = 8.dp)
+            .padding(horizontal = AlbumDetailHorizontalPadding, vertical = DirectoryBrowserPanelVerticalPadding)
     ) {
         Column(modifier = Modifier.fillMaxWidth()) {
             CompactDirectoryBreadcrumbContentV2(
@@ -2367,13 +2406,15 @@ internal fun CompactDirectoryBreadcrumbContentV3(
 @Composable
 internal fun DirectoryFolderRowV3(
     title: String,
-    onClick: () -> Unit
+    onClick: () -> Unit,
+    position: DirectoryFolderPosition = DirectoryFolderPosition.Single,
 ) {
     val colorScheme = AsmrTheme.colorScheme
     Row(
         modifier = Modifier
             .fillMaxWidth()
             .defaultMinSize(minHeight = 56.dp)
+            .clip(directoryFolderShape(position))
             .background(colorScheme.primary.copy(alpha = 0.08f))
             .clickable(onClick = onClick)
             .padding(horizontal = 12.dp, vertical = 12.dp),
@@ -2631,12 +2672,12 @@ internal fun DirectoryBrowserPanelV4(
     }
 
     Surface(
-        shape = RoundedCornerShape(18.dp),
+        shape = RoundedCornerShape(DirectoryBrowserPanelCornerRadius),
         tonalElevation = 1.dp,
         color = AsmrTheme.colorScheme.surface.copy(alpha = 0.44f),
         modifier = Modifier
             .fillMaxWidth()
-            .padding(horizontal = 16.dp, vertical = 8.dp)
+            .padding(horizontal = AlbumDetailHorizontalPadding, vertical = DirectoryBrowserPanelVerticalPadding)
     ) {
         Column(modifier = Modifier.fillMaxWidth()) {
             CompactDirectoryBreadcrumbContentV3(
@@ -2751,9 +2792,14 @@ internal fun DirectoryBrowserPanelV4(
                         key = { folder -> "$folderKeyPrefix:${folder.path}" },
                         contentType = { "folder" }
                     ) { folder ->
+                        val position = directoryFolderPosition(
+                            index = folders.indexOf(folder),
+                            total = folders.size,
+                        )
                         DirectoryFolderRowV3(
                             title = folder.title,
-                            onClick = { onNavigate(folder.path) }
+                            onClick = { onNavigate(folder.path) },
+                            position = position,
                         )
                     }
                     items(

--- a/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailDlsiteTabs.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailDlsiteTabs.kt
@@ -17,6 +17,7 @@ import androidx.compose.animation.fadeOut
 import androidx.compose.animation.slideInHorizontally
 import androidx.compose.animation.slideOutHorizontally
 import androidx.compose.animation.togetherWith
+import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
@@ -47,8 +48,11 @@ import androidx.compose.runtime.*
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.geometry.CornerRadius
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.foundation.gestures.detectTransformGestures
@@ -116,9 +120,12 @@ import kotlinx.coroutines.launch
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.graphics.drawscope.DrawScope
+import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.zIndex
 import com.asmr.player.ui.common.rememberDominantColor
 import com.asmr.player.ui.common.SubtitleStamp
+import com.asmr.player.ui.common.AudioItemMenuButtonSize
 import com.asmr.player.ui.common.DiscPlaceholder
 import com.asmr.player.ui.common.AsmrAsyncImage
 import com.asmr.player.ui.common.AsmrShimmerPlaceholder
@@ -180,12 +187,12 @@ private fun DlsiteDirectoryLoadingPanel() {
         (screenHeight * 0.48f).coerceIn(240.dp, 460.dp)
     }
     Surface(
-        shape = RoundedCornerShape(18.dp),
+        shape = RoundedCornerShape(12.dp),
         tonalElevation = 1.dp,
         color = AsmrTheme.colorScheme.surface.copy(alpha = 0.44f),
         modifier = Modifier
             .fillMaxWidth()
-            .padding(horizontal = 16.dp, vertical = 8.dp)
+            .padding(horizontal = AlbumDetailHorizontalPadding, vertical = 4.dp)
     ) {
         Column(modifier = Modifier.fillMaxWidth()) {
             Column(
@@ -262,13 +269,13 @@ private fun DlsiteTrialLoadingList() {
     Column(
         modifier = Modifier
             .fillMaxWidth()
-            .padding(horizontal = 16.dp, vertical = 8.dp),
+            .padding(horizontal = AlbumDetailHorizontalPadding, vertical = 8.dp),
         verticalArrangement = Arrangement.spacedBy(12.dp)
     ) {
         repeat(3) { index ->
             Surface(
                 modifier = Modifier.fillMaxWidth(),
-                shape = RoundedCornerShape(16.dp),
+                shape = RoundedCornerShape(12.dp),
                 tonalElevation = 1.dp,
                 color = AsmrTheme.colorScheme.surface.copy(alpha = 0.36f)
             ) {
@@ -293,12 +300,326 @@ private fun DlsiteTrialLoadingList() {
 }
 
 @Composable
+private fun DlsiteTrialAudioItem(
+    track: Track,
+    onClick: () -> Unit,
+    onAddToPlaylist: (() -> Unit)? = null,
+) {
+    val colorScheme = AsmrTheme.colorScheme
+    val isOnline = remember(track.path) { track.path.trim().startsWith("http", ignoreCase = true) }
+    val durationText = remember(track.duration) { Formatting.formatTrackSeconds(track.duration) }
+    val subtitleText = remember(isOnline, durationText) {
+        when {
+            isOnline && durationText.isNotBlank() -> "在线 · $durationText"
+            isOnline -> "在线"
+            durationText.isNotBlank() -> durationText
+            else -> "在线播放"
+        }
+    }
+
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick)
+            .padding(horizontal = AlbumDetailHorizontalPadding, vertical = 2.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(10.dp)
+    ) {
+        Icon(
+            imageVector = Icons.Default.PlayArrow,
+            contentDescription = null,
+            tint = colorScheme.primary
+        )
+        Column(
+            modifier = Modifier.weight(1f),
+            verticalArrangement = Arrangement.spacedBy(1.dp)
+        ) {
+            Text(
+                text = track.title,
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis,
+                style = MaterialTheme.typography.titleSmall.copy(fontWeight = FontWeight.Bold),
+                color = colorScheme.textPrimary
+            )
+            Text(
+                text = subtitleText,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                style = MaterialTheme.typography.bodySmall,
+                color = colorScheme.textTertiary
+            )
+        }
+        if (onAddToPlaylist != null) {
+            IconButton(
+                onClick = onAddToPlaylist,
+                modifier = Modifier.size(AudioItemMenuButtonSize)
+            ) {
+                Icon(
+                    imageVector = Icons.AutoMirrored.Filled.PlaylistAdd,
+                    contentDescription = null,
+                    tint = colorScheme.onSurfaceVariant
+                )
+            }
+        }
+    }
+}
+
+private enum class DlsiteEmptyArtworkKind {
+    Gallery,
+    One,
+    Trial,
+}
+
+@Composable
+private fun DlsiteSectionEmptyState(
+    text: String,
+    artworkKind: DlsiteEmptyArtworkKind,
+    modifier: Modifier = Modifier
+) {
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(horizontal = AlbumDetailHorizontalPadding, vertical = 12.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(8.dp)
+    ) {
+        DlsiteSectionEmptyArtwork(
+            kind = artworkKind,
+            modifier = Modifier.size(width = 92.dp, height = 60.dp)
+        )
+        Text(
+            text = text,
+            style = MaterialTheme.typography.bodySmall,
+            color = AsmrTheme.colorScheme.textSecondary
+        )
+    }
+}
+
+@Composable
+private fun DlsiteSectionEmptyArtwork(
+    kind: DlsiteEmptyArtworkKind,
+    modifier: Modifier = Modifier
+) {
+    val colorScheme = AsmrTheme.colorScheme
+    val strokeColor = colorScheme.textTertiary.copy(alpha = if (colorScheme.isDark) 0.86f else 0.76f)
+    val accentColor = colorScheme.primary.copy(alpha = if (colorScheme.isDark) 0.76f else 0.68f)
+
+    Canvas(modifier = modifier) {
+        val strokeWidth = size.minDimension * 0.05f
+        when (kind) {
+            DlsiteEmptyArtworkKind.Gallery -> drawGalleryEmptyArtwork(
+                strokeColor = strokeColor,
+                accentColor = accentColor,
+                strokeWidth = strokeWidth
+            )
+            DlsiteEmptyArtworkKind.One -> drawOneEmptyArtwork(
+                strokeColor = strokeColor,
+                accentColor = accentColor,
+                strokeWidth = strokeWidth
+            )
+            DlsiteEmptyArtworkKind.Trial -> drawTrialEmptyArtwork(
+                strokeColor = strokeColor,
+                accentColor = accentColor,
+                strokeWidth = strokeWidth
+            )
+        }
+    }
+}
+
+private fun DrawScope.drawGalleryEmptyArtwork(
+    strokeColor: Color,
+    accentColor: Color,
+    strokeWidth: Float
+) {
+    val frameSize = Size(size.width * 0.34f, size.height * 0.48f)
+    val corner = CornerRadius(strokeWidth * 1.8f, strokeWidth * 1.8f)
+
+    fun drawPhotoFrame(origin: Offset) {
+        drawRoundRect(
+            color = strokeColor,
+            topLeft = origin,
+            size = frameSize,
+            cornerRadius = corner,
+            style = Stroke(width = strokeWidth)
+        )
+        drawCircle(
+            color = accentColor,
+            radius = strokeWidth * 0.8f,
+            center = origin + Offset(frameSize.width * 0.72f, frameSize.height * 0.24f)
+        )
+        drawLine(
+            color = strokeColor,
+            start = origin + Offset(frameSize.width * 0.16f, frameSize.height * 0.72f),
+            end = origin + Offset(frameSize.width * 0.40f, frameSize.height * 0.48f),
+            strokeWidth = strokeWidth,
+            cap = StrokeCap.Round
+        )
+        drawLine(
+            color = strokeColor,
+            start = origin + Offset(frameSize.width * 0.40f, frameSize.height * 0.48f),
+            end = origin + Offset(frameSize.width * 0.58f, frameSize.height * 0.62f),
+            strokeWidth = strokeWidth,
+            cap = StrokeCap.Round
+        )
+        drawLine(
+            color = strokeColor,
+            start = origin + Offset(frameSize.width * 0.58f, frameSize.height * 0.62f),
+            end = origin + Offset(frameSize.width * 0.82f, frameSize.height * 0.42f),
+            strokeWidth = strokeWidth,
+            cap = StrokeCap.Round
+        )
+    }
+
+    drawPhotoFrame(Offset(size.width * 0.14f, size.height * 0.26f))
+    drawPhotoFrame(Offset(size.width * 0.42f, size.height * 0.14f))
+    drawLine(
+        color = strokeColor,
+        start = Offset(size.width * 0.20f, size.height * 0.84f),
+        end = Offset(size.width * 0.80f, size.height * 0.84f),
+        strokeWidth = strokeWidth,
+        cap = StrokeCap.Round
+    )
+}
+
+private fun DrawScope.drawOneEmptyArtwork(
+    strokeColor: Color,
+    accentColor: Color,
+    strokeWidth: Float
+) {
+    val folderSize = Size(size.width * 0.28f, size.height * 0.18f)
+    val folderTopLeft = Offset(size.width * 0.10f, size.height * 0.14f)
+    val corner = CornerRadius(strokeWidth * 1.6f, strokeWidth * 1.6f)
+
+    drawRoundRect(
+        color = strokeColor,
+        topLeft = folderTopLeft,
+        size = folderSize,
+        cornerRadius = corner,
+        style = Stroke(width = strokeWidth)
+    )
+
+    drawLine(
+        color = strokeColor,
+        start = Offset(size.width * 0.18f, size.height * 0.14f),
+        end = Offset(size.width * 0.26f, size.height * 0.14f),
+        strokeWidth = strokeWidth,
+        cap = StrokeCap.Round
+    )
+
+    val trunkX = size.width * 0.28f
+    val trunkStartY = size.height * 0.40f
+    val branchYs = listOf(size.height * 0.50f, size.height * 0.66f, size.height * 0.82f)
+    drawLine(
+        color = strokeColor,
+        start = Offset(trunkX, trunkStartY),
+        end = Offset(trunkX, branchYs.last()),
+        strokeWidth = strokeWidth,
+        cap = StrokeCap.Round
+    )
+    drawLine(
+        color = strokeColor,
+        start = Offset(size.width * 0.24f, size.height * 0.32f),
+        end = Offset(trunkX, trunkStartY),
+        strokeWidth = strokeWidth,
+        cap = StrokeCap.Round
+    )
+
+    branchYs.forEach { y ->
+        drawLine(
+            color = strokeColor,
+            start = Offset(trunkX, y),
+            end = Offset(size.width * 0.48f, y),
+            strokeWidth = strokeWidth,
+            cap = StrokeCap.Round
+        )
+        drawCircle(
+            color = accentColor,
+            radius = strokeWidth * 0.72f,
+            center = Offset(size.width * 0.48f, y)
+        )
+        drawLine(
+            color = strokeColor,
+            start = Offset(size.width * 0.58f, y),
+            end = Offset(size.width * 0.82f, y),
+            strokeWidth = strokeWidth,
+            cap = StrokeCap.Round
+        )
+    }
+}
+
+private fun DrawScope.drawTrialEmptyArtwork(
+    strokeColor: Color,
+    accentColor: Color,
+    strokeWidth: Float
+) {
+    val screenTopLeft = Offset(size.width * 0.10f, size.height * 0.18f)
+    val screenSize = Size(size.width * 0.46f, size.height * 0.34f)
+    val corner = CornerRadius(strokeWidth * 1.8f, strokeWidth * 1.8f)
+
+    drawRoundRect(
+        color = strokeColor,
+        topLeft = screenTopLeft,
+        size = screenSize,
+        cornerRadius = corner,
+        style = Stroke(width = strokeWidth)
+    )
+
+    val playCenter = screenTopLeft + Offset(screenSize.width * 0.50f, screenSize.height * 0.50f)
+    drawLine(
+        color = accentColor,
+        start = Offset(playCenter.x - size.width * 0.03f, playCenter.y - size.height * 0.09f),
+        end = Offset(playCenter.x - size.width * 0.03f, playCenter.y + size.height * 0.09f),
+        strokeWidth = strokeWidth,
+        cap = StrokeCap.Round
+    )
+    drawLine(
+        color = accentColor,
+        start = Offset(playCenter.x - size.width * 0.03f, playCenter.y - size.height * 0.09f),
+        end = Offset(playCenter.x + size.width * 0.08f, playCenter.y),
+        strokeWidth = strokeWidth,
+        cap = StrokeCap.Round
+    )
+    drawLine(
+        color = accentColor,
+        start = Offset(playCenter.x - size.width * 0.03f, playCenter.y + size.height * 0.09f),
+        end = Offset(playCenter.x + size.width * 0.08f, playCenter.y),
+        strokeWidth = strokeWidth,
+        cap = StrokeCap.Round
+    )
+
+    val barWidth = size.width * 0.07f
+    val barBottom = size.height * 0.80f
+    val barXs = listOf(0.62f, 0.72f, 0.82f)
+    val barHeights = listOf(0.18f, 0.30f, 0.22f)
+    barXs.zip(barHeights).forEach { (xFraction, heightFraction) ->
+        val height = size.height * heightFraction
+        val left = size.width * xFraction - barWidth / 2f
+        val top = barBottom - height
+        drawLine(
+            color = strokeColor,
+            start = Offset(left + barWidth / 2f, barBottom),
+            end = Offset(left + barWidth / 2f, top),
+            strokeWidth = strokeWidth,
+            cap = StrokeCap.Round
+        )
+    }
+
+    drawLine(
+        color = strokeColor,
+        start = Offset(size.width * 0.10f, size.height * 0.80f),
+        end = Offset(size.width * 0.94f, size.height * 0.80f),
+        strokeWidth = strokeWidth,
+        cap = StrokeCap.Round
+    )
+}
+
+@Composable
 private fun DlsiteRecommendationsLoadingBlocks() {
     val placeholders = remember { listOf(0, 1, 2) }
     Column(
         modifier = Modifier
             .fillMaxWidth()
-            .padding(horizontal = 16.dp, vertical = 10.dp),
+            .padding(horizontal = AlbumDetailHorizontalPadding, vertical = 10.dp),
         verticalArrangement = Arrangement.spacedBy(14.dp)
     ) {
         placeholders.forEach { sectionIndex ->
@@ -314,7 +635,7 @@ private fun DlsiteRecommendationsLoadingBlocks() {
                 LazyRow(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
                     items(listOf(0, 1, 2, 3), key = { it }, contentType = { "dlsiteRecommendationLoadingCard" }) {
                         Surface(
-                            shape = RoundedCornerShape(14.dp),
+                            shape = RoundedCornerShape(12.dp),
                             tonalElevation = 1.dp,
                             color = AsmrTheme.colorScheme.surface.copy(alpha = 0.35f),
                             modifier = Modifier.width(132.dp)
@@ -401,13 +722,27 @@ internal fun AlbumDlsiteInfoBreadcrumbTabV2(
     val scope = rememberCoroutineScope()
     val videoTracks = remember(trialTracks) { trialTracks.filter { isVideoPreviewUrl(it.path) } }
     val audioTracks = remember(trialTracks) { trialTracks.filterNot { isVideoPreviewUrl(it.path) } }
-    val asmrLeafTracks = remember(asmrOneTree) { flattenAsmrOneTracksForUi(asmrOneTree) }
-    val asmrLeafByRelPath = remember(asmrLeafTracks) { asmrLeafTracks.associateBy { it.relativePath } }
-    val remoteIndex = remember(asmrOneTree, album.id, album.coverPath, album.coverUrl) {
-        buildRemoteTreeIndex(asmrOneTree, album)
-    }
     var currentPath by rememberSaveable(treeStateKey) { mutableStateOf(initialCurrentPath.trim().trim('/')) }
-    val browser = remember(remoteIndex, currentPath) { buildRemoteDirectoryBrowser(remoteIndex, currentPath) }
+    val asmrLeafTracks by produceState(initialValue = emptyList<AsmrOneLeafUi>(), key1 = asmrOneTree) {
+        value = withContext(Dispatchers.Default) { flattenAsmrOneTracksForUi(asmrOneTree) }
+    }
+    val asmrLeafByRelPath by produceState(initialValue = emptyMap<String, AsmrOneLeafUi>(), key1 = asmrLeafTracks) {
+        value = withContext(Dispatchers.Default) { asmrLeafTracks.associateBy { it.relativePath } }
+    }
+    val remoteIndex by produceState<RemoteTreeIndex?>(
+        initialValue = null,
+        asmrOneTree,
+        album.id,
+        album.coverPath,
+        album.coverUrl,
+    ) {
+        value = withContext(Dispatchers.Default) { buildRemoteTreeIndex(asmrOneTree, album) }
+    }
+    val browser by produceState<DirectoryBrowserResult?>(initialValue = null, key1 = remoteIndex, key2 = currentPath) {
+        value = remoteIndex?.let { index ->
+            withContext(Dispatchers.Default) { buildRemoteDirectoryBrowser(index, currentPath) }
+        }
+    }
     val listState = rememberSaveable("scroll:$treeStateKey", saver = LazyListState.Saver) {
         LazyListState(initialScroll.first, initialScroll.second)
     }
@@ -440,7 +775,7 @@ internal fun AlbumDlsiteInfoBreadcrumbTabV2(
                 Column(modifier = dlsiteAnimatedSectionModifier(Modifier.fillMaxWidth(), animateIntro)) {
                     Text(
                         text = "Gallery",
-                        modifier = Modifier.padding(horizontal = 16.dp, vertical = 10.dp),
+                        modifier = Modifier.padding(horizontal = AlbumDetailHorizontalPadding, vertical = 8.dp),
                         style = MaterialTheme.typography.titleMedium,
                         fontWeight = FontWeight.Bold
                     )
@@ -452,7 +787,7 @@ internal fun AlbumDlsiteInfoBreadcrumbTabV2(
                     modifier = dlsiteAnimatedSectionModifier(
                         Modifier
                             .fillMaxWidth()
-                            .padding(horizontal = 16.dp, vertical = 10.dp),
+                            .padding(horizontal = AlbumDetailHorizontalPadding, vertical = 8.dp),
                         animateIntro = animateIntro
                     ),
                     verticalAlignment = Alignment.CenterVertically
@@ -474,7 +809,7 @@ internal fun AlbumDlsiteInfoBreadcrumbTabV2(
                 Row(
                     modifier = Modifier
                             .fillMaxWidth()
-                            .padding(horizontal = 16.dp, vertical = 10.dp),
+                            .padding(horizontal = AlbumDetailHorizontalPadding, vertical = 8.dp),
                     verticalAlignment = Alignment.CenterVertically
                 ) {
                     Text(
@@ -497,19 +832,19 @@ internal fun AlbumDlsiteInfoBreadcrumbTabV2(
             Column(modifier = dlsiteAnimatedSectionModifier(Modifier.fillMaxWidth(), animateIntro)) {
             Text(
                 text = "Gallery",
-                modifier = Modifier.padding(horizontal = 16.dp, vertical = 10.dp),
+                modifier = Modifier.padding(horizontal = AlbumDetailHorizontalPadding, vertical = 8.dp),
                 style = MaterialTheme.typography.titleMedium,
                 fontWeight = FontWeight.Bold
             )
             if (galleryUrls.isEmpty()) {
-                Text(
+                DlsiteSectionEmptyState(
                     text = "暂无样图",
-                    modifier = Modifier.padding(horizontal = 16.dp, vertical = 6.dp),
-                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                    artworkKind = DlsiteEmptyArtworkKind.Gallery,
+                    modifier = Modifier.then(dlsiteAnimatedSectionModifier(Modifier, animateIntro))
                 )
             } else {
                 LazyRow(
-                    modifier = Modifier.fillMaxWidth().padding(horizontal = 12.dp),
+                    modifier = Modifier.fillMaxWidth().padding(horizontal = AlbumDetailHorizontalPadding),
                     horizontalArrangement = Arrangement.spacedBy(10.dp),
                     contentPadding = PaddingValues(vertical = 10.dp)
                 ) {
@@ -539,7 +874,7 @@ internal fun AlbumDlsiteInfoBreadcrumbTabV2(
                                     }
                                 )?.let(onPreviewImages)
                             },
-                            shape = RoundedCornerShape(12.dp)
+                            shape = RoundedCornerShape(10.dp)
                         ) {
                             AsmrAsyncImage(
                                 model = model,
@@ -557,7 +892,7 @@ internal fun AlbumDlsiteInfoBreadcrumbTabV2(
         item(key = "dlsite-one-header") {
             Row(
                 modifier = dlsiteAnimatedSectionModifier(
-                    Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 10.dp),
+                    Modifier.fillMaxWidth().padding(horizontal = AlbumDetailHorizontalPadding, vertical = 8.dp),
                     animateIntro = animateIntro
                 ),
                 verticalAlignment = Alignment.CenterVertically
@@ -573,16 +908,17 @@ internal fun AlbumDlsiteInfoBreadcrumbTabV2(
                 }
             }
         }
-        if (asmrOneTree.isNotEmpty()) {
+        if (asmrOneTree.isNotEmpty() && browser != null) {
             item(key = "dlsite-one-content") {
                 Box(modifier = dlsiteAnimatedSectionModifier(Modifier.fillMaxWidth(), animateIntro)) {
+                    val browserValue = browser ?: return@Box
                     DirectoryBrowserPanelV4(
                     panelKey = treeStateKey,
                     currentPath = currentPath,
-                    breadcrumbs = browser.breadcrumbs,
-                    batchTargets = browser.batchTargets,
-                    folders = browser.folders,
-                    files = browser.files,
+                    breadcrumbs = browserValue.breadcrumbs,
+                    batchTargets = browserValue.batchTargets,
+                    folders = browserValue.folders,
+                    files = browserValue.files,
                     onNavigate = { path -> currentPath = path },
                     onAddToFavorites = onAddMediaItemsToFavorites,
                         onOpenBatchPlaylistPicker = onOpenBatchPlaylistPicker,
@@ -636,7 +972,7 @@ internal fun AlbumDlsiteInfoBreadcrumbTabV2(
                                     }
                                     TreeFileType.Image -> {
                                         buildDirectoryImagePreviewRequest(
-                                            files = browser.files,
+                                            files = browserValue.files,
                                             clickedPath = file.path,
                                             toPreviewItem = { imageFile ->
                                                 val imageUrl = imageFile.url.takeIf { it.isNotBlank() } ?: return@buildDirectoryImagePreviewRequest null
@@ -690,7 +1026,7 @@ internal fun AlbumDlsiteInfoBreadcrumbTabV2(
                     )
                 }
             }
-        } else if (isLoadingAsmrOne) {
+        } else if (isLoadingAsmrOne || (asmrOneTree.isNotEmpty() && browser == null)) {
             item(key = "dlsite-one-content") {
                 Box(modifier = dlsiteAnimatedSectionModifier(Modifier.fillMaxWidth(), animateIntro)) {
                     DlsiteDirectoryLoadingPanel()
@@ -698,21 +1034,17 @@ internal fun AlbumDlsiteInfoBreadcrumbTabV2(
             }
         } else {
             item(key = "dlsite-one-content") {
-                Box(
-                    modifier = dlsiteAnimatedSectionModifier(
-                        Modifier.fillMaxWidth().height(120.dp),
-                        animateIntro = animateIntro
-                    ),
-                    contentAlignment = Alignment.Center
-                ) {
-                    Text("未收录")
-                }
+                DlsiteSectionEmptyState(
+                    text = "ONE 暂未收录",
+                    artworkKind = DlsiteEmptyArtworkKind.One,
+                    modifier = dlsiteAnimatedSectionModifier(Modifier, animateIntro)
+                )
             }
         }
         item(key = "dlsite-trial-header") {
             Row(
                 modifier = dlsiteAnimatedSectionModifier(
-                    Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 10.dp),
+                    Modifier.fillMaxWidth().padding(horizontal = AlbumDetailHorizontalPadding, vertical = 8.dp),
                     animateIntro = animateIntro
                 ),
                 verticalAlignment = Alignment.CenterVertically
@@ -730,15 +1062,19 @@ internal fun AlbumDlsiteInfoBreadcrumbTabV2(
         }
         if (trialTracks.isEmpty()) {
             item(key = "dlsite-trial-content") {
-                Box(
-                    modifier = dlsiteAnimatedSectionModifier(Modifier.fillMaxWidth(), animateIntro),
-                    contentAlignment = Alignment.Center
-                ) {
-                    if (isLoadingTrial) {
+                if (isLoadingTrial) {
+                    Box(
+                        modifier = dlsiteAnimatedSectionModifier(Modifier.fillMaxWidth(), animateIntro),
+                        contentAlignment = Alignment.Center
+                    ) {
                         DlsiteTrialLoadingList()
-                    } else {
-                        Text("暂无试听")
                     }
+                } else {
+                    DlsiteSectionEmptyState(
+                        text = "暂无试听 / 试看",
+                        artworkKind = DlsiteEmptyArtworkKind.Trial,
+                        modifier = dlsiteAnimatedSectionModifier(Modifier, animateIntro)
+                    )
                 }
             }
         } else {
@@ -748,7 +1084,7 @@ internal fun AlbumDlsiteInfoBreadcrumbTabV2(
                         modifier = dlsiteAnimatedSectionModifier(
                             Modifier
                                 .fillMaxWidth()
-                                .padding(horizontal = 16.dp),
+                                .padding(horizontal = AlbumDetailHorizontalPadding),
                             animateIntro = animateIntro
                         )
                     )
@@ -757,7 +1093,7 @@ internal fun AlbumDlsiteInfoBreadcrumbTabV2(
             items(items = videoTracks, key = { track -> if (track.id > 0L) track.id else track.path }, contentType = { "trialVideo" }) { track ->
                 Column(
                     modifier = dlsiteAnimatedSectionModifier(
-                        Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 8.dp),
+                        Modifier.fillMaxWidth().padding(horizontal = AlbumDetailHorizontalPadding, vertical = 8.dp),
                         animateIntro = animateIntro
                     )
                 ) {
@@ -777,7 +1113,7 @@ internal fun AlbumDlsiteInfoBreadcrumbTabV2(
             }
             items(items = audioTracks, key = { track -> if (track.id > 0L) track.id else track.path }, contentType = { "trialAudioTrack" }) { track ->
                 Box(modifier = dlsiteAnimatedSectionModifier(Modifier.fillMaxWidth(), animateIntro)) {
-                    TrackItem(
+                    DlsiteTrialAudioItem(
                         track = track,
                         onClick = { onPlayTracks(album, audioTracks, track) },
                         onAddToPlaylist = { onAddToPlaylist(track) }
@@ -804,6 +1140,7 @@ internal fun AlbumDlsitePlayBreadcrumbTabV2(
     rjCode: String,
     tree: List<AsmrOneTrackNodeResponse>,
     isLoading: Boolean,
+    shouldAutoLoad: Boolean,
     onOpenLogin: () -> Unit,
     onEnsureLoaded: () -> Unit,
     onPlayTracks: (Album, List<Track>, Track) -> Unit,
@@ -831,12 +1168,12 @@ internal fun AlbumDlsitePlayBreadcrumbTabV2(
     val lifecycleOwner = LocalLifecycleOwner.current
     val authStore = remember { DlsiteAuthStore(context) }
     val scope = rememberCoroutineScope()
-    var loggedIn by remember { mutableStateOf(authStore.isLoggedIn()) }
+    var loggedIn by remember { mutableStateOf(authStore.isPlayLoggedIn()) }
 
     DisposableEffect(lifecycleOwner) {
         val observer = LifecycleEventObserver { _, event ->
             if (event == Lifecycle.Event.ON_RESUME) {
-                loggedIn = authStore.isLoggedIn()
+                loggedIn = authStore.isPlayLoggedIn()
             }
         }
         lifecycleOwner.lifecycle.addObserver(observer)
@@ -854,8 +1191,8 @@ internal fun AlbumDlsitePlayBreadcrumbTabV2(
         return
     }
 
-    LaunchedEffect(loggedIn, rjCode) {
-        if (loggedIn) onEnsureLoaded()
+    LaunchedEffect(loggedIn, rjCode, shouldAutoLoad) {
+        if (loggedIn && shouldAutoLoad) onEnsureLoaded()
     }
 
     val headerItemCount = 2
@@ -878,13 +1215,27 @@ internal fun AlbumDlsitePlayBreadcrumbTabV2(
     }
 
     val rj = rjCode.trim().uppercase()
-    val leafTracks = remember(tree) { flattenAsmrOneTracksForUi(tree) }
-    val leafByRelPath = remember(leafTracks) { leafTracks.associateBy { it.relativePath } }
-    val remoteIndex = remember(tree, album.id, album.coverPath, album.coverUrl) {
-        buildRemoteTreeIndex(tree, album)
-    }
     var currentPath by rememberSaveable(treeStateKey) { mutableStateOf(initialCurrentPath.trim().trim('/')) }
-    val browser = remember(remoteIndex, currentPath) { buildRemoteDirectoryBrowser(remoteIndex, currentPath) }
+    val leafTracks by produceState(initialValue = emptyList<AsmrOneLeafUi>(), key1 = tree) {
+        value = withContext(Dispatchers.Default) { flattenAsmrOneTracksForUi(tree) }
+    }
+    val leafByRelPath by produceState(initialValue = emptyMap<String, AsmrOneLeafUi>(), key1 = leafTracks) {
+        value = withContext(Dispatchers.Default) { leafTracks.associateBy { it.relativePath } }
+    }
+    val remoteIndex by produceState<RemoteTreeIndex?>(
+        initialValue = null,
+        tree,
+        album.id,
+        album.coverPath,
+        album.coverUrl,
+    ) {
+        value = withContext(Dispatchers.Default) { buildRemoteTreeIndex(tree, album) }
+    }
+    val browser by produceState<DirectoryBrowserResult?>(initialValue = null, key1 = remoteIndex, key2 = currentPath) {
+        value = remoteIndex?.let { index ->
+            withContext(Dispatchers.Default) { buildRemoteDirectoryBrowser(index, currentPath) }
+        }
+    }
     LaunchedEffect(currentPath, treeStateKey) {
         onPersistCurrentPath(currentPath)
     }
@@ -900,7 +1251,7 @@ internal fun AlbumDlsitePlayBreadcrumbTabV2(
         item(key = "dlplay-header:$treeStateKey") { header() }
         item {
             Row(
-                modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 10.dp),
+                modifier = Modifier.fillMaxWidth().padding(horizontal = AlbumDetailHorizontalPadding, vertical = 8.dp),
                 horizontalArrangement = Arrangement.spacedBy(10.dp),
                 verticalAlignment = Alignment.CenterVertically
             ) {
@@ -936,14 +1287,24 @@ internal fun AlbumDlsitePlayBreadcrumbTabV2(
             return@LazyColumn
         }
 
+        if (browser == null) {
+            item {
+                Box(modifier = Modifier.fillMaxWidth().height(220.dp), contentAlignment = Alignment.Center) {
+                    EaraLogoLoadingIndicator(tint = AsmrTheme.colorScheme.primary)
+                }
+            }
+            return@LazyColumn
+        }
+
         item {
+            val browserValue = browser ?: return@item
             DirectoryBrowserPanelV4(
                 panelKey = treeStateKey,
                 currentPath = currentPath,
-                breadcrumbs = browser.breadcrumbs,
-                batchTargets = browser.batchTargets,
-                folders = browser.folders,
-                files = browser.files,
+                breadcrumbs = browserValue.breadcrumbs,
+                batchTargets = browserValue.batchTargets,
+                folders = browserValue.folders,
+                files = browserValue.files,
                 onNavigate = { path -> currentPath = path },
                 onAddToFavorites = onAddMediaItemsToFavorites,
                 onOpenBatchPlaylistPicker = onOpenBatchPlaylistPicker,
@@ -963,7 +1324,7 @@ internal fun AlbumDlsitePlayBreadcrumbTabV2(
                                     scope.launch {
                                         val prepared = withContext(Dispatchers.Default) {
                                             val folderPath = file.path.substringBeforeLast('/', "")
-                                            val siblings = browser.files
+                                            val siblings = browserValue.files
                                                 .filter { sibling ->
                                                     sibling.path.substringBeforeLast('/', "") == folderPath &&
                                                         (sibling.fileType == TreeFileType.Audio || sibling.fileType == TreeFileType.Video) &&
@@ -998,7 +1359,7 @@ internal fun AlbumDlsitePlayBreadcrumbTabV2(
                                 }
                                 TreeFileType.Image -> {
                                     val request = buildDirectoryImagePreviewRequest(
-                                        files = browser.files,
+                                        files = browserValue.files,
                                         clickedPath = file.path,
                                         toPreviewItem = { imageFile ->
                                             val imageUrl = imageFile.url.takeIf { it.isNotBlank() } ?: return@buildDirectoryImagePreviewRequest null

--- a/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailSharedSections.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailSharedSections.kt
@@ -165,12 +165,12 @@ internal fun AlbumDescription(album: Album) {
     }
 
     Surface(
-        shape = RoundedCornerShape(20.dp),
+        shape = RoundedCornerShape(14.dp),
         tonalElevation = 1.dp,
         color = colorScheme.surface.copy(alpha = 0.5f),
         modifier = Modifier
             .fillMaxWidth()
-            .padding(horizontal = 16.dp, vertical = 8.dp)
+            .padding(horizontal = AlbumDetailHorizontalPadding, vertical = 8.dp)
     ) {
         Column(
             modifier = Modifier.padding(16.dp),
@@ -249,7 +249,7 @@ internal fun DlsiteRecommendationsBlocks(
     Column(
         modifier = Modifier
             .fillMaxWidth()
-            .padding(horizontal = 16.dp, vertical = 10.dp),
+            .padding(horizontal = AlbumDetailHorizontalPadding, vertical = 10.dp),
         verticalArrangement = Arrangement.spacedBy(14.dp)
     ) {
         DlsiteRecommendationsBlock(
@@ -319,7 +319,7 @@ private fun DlsiteRecommendedWorkCard(
         }
     }
     Surface(
-        shape = RoundedCornerShape(14.dp),
+        shape = RoundedCornerShape(10.dp),
         tonalElevation = 1.dp,
         color = colorScheme.surface.copy(alpha = 0.35f),
         modifier = Modifier
@@ -447,7 +447,7 @@ internal fun AlbumTracks(album: Album, onTrackClick: (Track) -> Unit) {
                         ) {
                             Text(
                                 text = group,
-                                modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
+                                modifier = Modifier.padding(horizontal = AlbumDetailHorizontalPadding, vertical = 8.dp),
                                 style = MaterialTheme.typography.labelLarge,
                                 color = MaterialTheme.colorScheme.primary
                             )
@@ -465,7 +465,7 @@ internal fun AlbumTracks(album: Album, onTrackClick: (Track) -> Unit) {
                     TrackItem(track = track, showSubtitleStamp = showStamp, onClick = { onTrackClick(track) })
                     if (index < tracks.size - 1) {
                         HorizontalDivider(
-                             modifier = Modifier.padding(horizontal = 16.dp),
+                             modifier = Modifier.padding(horizontal = AlbumDetailHorizontalPadding),
                              thickness = 0.5.dp,
                              color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.2f)
                          )


### PR DESCRIPTION
## Summary
- polish album list/grid metadata ordering and spacing
- refine DLsite detail tab loading, empty states, and trial track presentation
- avoid repeated DLsite Play retries when content is unavailable and align play auth checks

## Testing
- not run (not requested)