### PR TITLE
fix: simplify message bubble and prevent replayed exit prompt

### DIFF
--- a/app/src/main/java/com/asmr/player/MainActivity.kt
+++ b/app/src/main/java/com/asmr/player/MainActivity.kt
@@ -373,6 +373,7 @@ class MainActivity : ComponentActivity() {
                 }
 
                 messageManager.messages.collect { appMessage ->
+                    if (!messageManager.tryConsume(appMessage.id)) return@collect
                     val now = System.currentTimeMillis()
                     if ((now - appMessage.createdAtMs) > 10_000L) return@collect
                     val normalized = appMessage.message.trim()

--- a/app/src/main/java/com/asmr/player/ui/common/AppSnackbar.kt
+++ b/app/src/main/java/com/asmr/player/ui/common/AppSnackbar.kt
@@ -7,14 +7,10 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.CheckCircle
@@ -22,7 +18,6 @@ import androidx.compose.material.icons.filled.Error
 import androidx.compose.material.icons.filled.Info
 import androidx.compose.material.icons.filled.Warning
 import androidx.compose.material3.Icon
-import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
@@ -32,8 +27,11 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.drawWithContent
+import androidx.compose.ui.geometry.CornerRadius
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.graphics.compositeOver
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
@@ -58,106 +56,104 @@ fun AppSnackbar(
         MessageType.Warning -> Icons.Default.Warning to Color(0xFFD6942A)
         MessageType.Info -> Icons.Default.Info to Color(0xFF2F7FB6)
     }
-    val shape: Shape = RoundedCornerShape(18.dp)
-    val containerColor = if (appColors.isDark) {
-        MaterialTheme.colorScheme.surfaceContainerHigh.copy(alpha = 0.96f)
-    } else {
-        appColors.primarySoft.copy(alpha = 0.10f).compositeOver(MaterialTheme.colorScheme.surface)
-    }
-    val borderColor = if (appColors.isDark) {
-        MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.42f)
-    } else {
-        appColors.primary.copy(alpha = 0.16f)
-    }
+    val shape = RoundedCornerShape(16.dp)
+    val containerColor = MaterialTheme.colorScheme.surface
+        .copy(alpha = if (appColors.isDark) 0.94f else 0.96f)
+        .compositeOver(appColors.background)
+    val borderColor = MaterialTheme.colorScheme.outlineVariant.copy(
+        alpha = if (appColors.isDark) 0.34f else 0.24f
+    )
     val countTextColor = if (appColors.isDark) {
-        MaterialTheme.colorScheme.onSurfaceVariant
+        MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.92f)
     } else {
         appColors.textSecondary
     }
-    val progressTrackColor = if (appColors.isDark) {
-        MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.22f)
-    } else {
-        accentColor.copy(alpha = 0.12f).compositeOver(containerColor)
+    val iconTint = accentColor.copy(alpha = if (appColors.isDark) 0.92f else 0.78f)
+    val progressColor = accentColor.copy(alpha = if (appColors.isDark) 0.88f else 0.72f)
+    val progressTrackColor = MaterialTheme.colorScheme.onSurface.copy(
+        alpha = if (appColors.isDark) 0.10f else 0.06f
+    ).compositeOver(containerColor)
+    val progress = remember(messageId) { Animatable(1f) }
+
+    LaunchedEffect(messageId, durationMs) {
+        progress.snapTo(1f)
+        progress.animateTo(
+            targetValue = 0f,
+            animationSpec = tween(
+                durationMillis = durationMs.coerceAtLeast(1L).coerceAtMost(Int.MAX_VALUE.toLong()).toInt(),
+                easing = LinearEasing
+            )
+        )
     }
 
     Box(
         modifier = modifier
+            .widthIn(max = 288.dp)
             .clip(shape)
             .background(containerColor, shape)
-            .border(1.dp, borderColor, shape)
-    ) {
-        val progress = remember(messageId) { Animatable(1f) }
-        LaunchedEffect(messageId, durationMs) {
-            progress.snapTo(1f)
-            progress.animateTo(
-                targetValue = 0f,
-                animationSpec = tween(
-                    durationMillis = durationMs.coerceAtLeast(1L).coerceAtMost(Int.MAX_VALUE.toLong()).toInt(),
-                    easing = LinearEasing
-                )
-            )
-        }
+            .drawWithContent {
+                drawContent()
+                val barInset = 1.dp.toPx()
+                val barHeight = 1.5.dp.toPx()
+                val barWidth = (size.width - barInset * 2f).coerceAtLeast(0f)
+                if (barWidth <= 0f) return@drawWithContent
 
-        Box(modifier = Modifier.fillMaxWidth()) {
-            Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(bottom = 3.dp),
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                Box(
-                    modifier = Modifier
-                        .padding(start = 10.dp, top = 10.dp, bottom = 10.dp)
-                        .width(4.dp)
-                        .heightIn(min = 34.dp)
-                        .clip(RoundedCornerShape(999.dp))
-                        .background(accentColor.copy(alpha = if (appColors.isDark) 0.84f else 0.72f))
+                val barTop = (size.height - barInset - barHeight).coerceAtLeast(0f)
+                val barCorner = CornerRadius(x = barHeight, y = barHeight)
+                drawRoundRect(
+                    color = progressTrackColor,
+                    topLeft = Offset(x = barInset, y = barTop),
+                    size = Size(width = barWidth, height = barHeight),
+                    cornerRadius = barCorner
                 )
-                Column(modifier = Modifier.fillMaxWidth()) {
-                    Row(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(start = 12.dp, end = 14.dp, top = 12.dp, bottom = 10.dp),
-                        verticalAlignment = Alignment.CenterVertically,
-                        horizontalArrangement = Arrangement.spacedBy(12.dp)
-                    ) {
-                        Icon(
-                            imageVector = icon,
-                            contentDescription = null,
-                            tint = accentColor,
-                            modifier = Modifier.size(22.dp)
-                        )
-                        androidx.compose.material3.Text(
-                            text = message,
-                            style = MaterialTheme.typography.bodyMedium.copy(
-                                fontWeight = FontWeight.Medium,
-                                letterSpacing = 0.2.sp
-                            ),
-                            color = MaterialTheme.colorScheme.onSurface,
-                            maxLines = 3,
-                            overflow = TextOverflow.Ellipsis,
-                            modifier = Modifier.weight(1f)
-                        )
-                        if (count > 1) {
-                            androidx.compose.material3.Text(
-                                text = "x$count",
-                                style = MaterialTheme.typography.labelSmall.copy(fontWeight = FontWeight.SemiBold),
-                                color = countTextColor
-                            )
-                        }
-                    }
+
+                val progressWidth = (barWidth * progress.value.coerceIn(0f, 1f)).coerceAtLeast(0f)
+                if (progressWidth > 0f) {
+                    drawRoundRect(
+                        color = progressColor,
+                        topLeft = Offset(x = barInset, y = barTop),
+                        size = Size(width = progressWidth, height = barHeight),
+                        cornerRadius = barCorner
+                    )
                 }
             }
-            LinearProgressIndicator(
-                progress = { progress.value.coerceIn(0f, 1f) },
-                color = accentColor.copy(alpha = if (appColors.isDark) 0.85f else 0.72f),
-                trackColor = progressTrackColor,
-                modifier = Modifier
-                    .align(Alignment.BottomEnd)
-                    .fillMaxWidth()
-                    .height(3.dp)
-                    .clip(RoundedCornerShape(bottomStart = 18.dp, bottomEnd = 18.dp))
+            .border(1.dp, borderColor, shape)
+    ) {
+        Row(
+            modifier = Modifier.padding(start = 10.dp, end = 10.dp, top = 8.dp, bottom = 7.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            Icon(
+                imageVector = icon,
+                contentDescription = null,
+                tint = iconTint,
+                modifier = Modifier.size(16.dp)
             )
+            androidx.compose.material3.Text(
+                text = message,
+                style = MaterialTheme.typography.bodySmall.copy(
+                    fontWeight = FontWeight.Medium,
+                    fontSize = 13.sp,
+                    lineHeight = 17.sp,
+                    letterSpacing = 0.1.sp
+                ),
+                color = MaterialTheme.colorScheme.onSurface,
+                maxLines = 3,
+                overflow = TextOverflow.Ellipsis,
+                modifier = Modifier.widthIn(max = 228.dp)
+            )
+            if (count > 1) {
+                androidx.compose.material3.Text(
+                    text = "x$count",
+                    style = MaterialTheme.typography.labelSmall.copy(
+                        fontWeight = FontWeight.SemiBold,
+                        fontSize = 10.sp,
+                        letterSpacing = 0.sp
+                    ),
+                    color = countTextColor
+                )
+            }
         }
     }
 }

--- a/app/src/main/java/com/asmr/player/util/MessageManager.kt
+++ b/app/src/main/java/com/asmr/player/util/MessageManager.kt
@@ -27,6 +27,7 @@ data class AppMessage(
 @Singleton
 class MessageManager @Inject constructor() {
     private val seq = AtomicLong(0L)
+    private val consumedMessageId = AtomicLong(0L)
     private val _messages = MutableSharedFlow<AppMessage>(
         replay = 1,
         extraBufferCapacity = 10,
@@ -57,4 +58,14 @@ class MessageManager @Inject constructor() {
     fun showError(message: String) = showMessage(message, MessageType.Error)
     fun showWarning(message: String) = showMessage(message, MessageType.Warning)
     fun showInfo(message: String) = showMessage(message, MessageType.Info)
+
+    fun tryConsume(messageId: Long): Boolean {
+        while (true) {
+            val current = consumedMessageId.get()
+            if (messageId <= current) return false
+            if (consumedMessageId.compareAndSet(current, messageId)) {
+                return true
+            }
+        }
+    }
 }

--- a/app/src/test/java/com/asmr/player/util/MessageManagerTest.kt
+++ b/app/src/test/java/com/asmr/player/util/MessageManagerTest.kt
@@ -1,0 +1,19 @@
+package com.asmr.player.util
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class MessageManagerTest {
+
+    @Test
+    fun tryConsume_allowsEachMessageOnlyOnce() {
+        val manager = MessageManager()
+
+        assertTrue(manager.tryConsume(1L))
+        assertFalse(manager.tryConsume(1L))
+        assertFalse(manager.tryConsume(0L))
+        assertTrue(manager.tryConsume(2L))
+        assertFalse(manager.tryConsume(2L))
+    }
+}


### PR DESCRIPTION
## Summary
- simplify the in-app message bubble into a lighter and more compact style while keeping the existing animation and stacking behavior
- make the message bubble size adapt more closely to content with reduced padding, icon size, and text size
- prevent replayed message events from showing the 再按一次返回退出应用 prompt after reopening the app

## Testing
- `./gradlew :app:compileDebugKotlin`
- added `MessageManagerTest` for one-time message consumption behavior