### PR TITLE
fix: block tap-through on bottom nav and search pagination

### DIFF
--- a/app/src/main/java/com/asmr/player/ui/nav/BottomChrome.kt
+++ b/app/src/main/java/com/asmr/player/ui/nav/BottomChrome.kt
@@ -11,6 +11,7 @@ import androidx.compose.animation.fadeOut
 import androidx.compose.animation.scaleIn
 import androidx.compose.animation.scaleOut
 import androidx.compose.animation.togetherWith
+import androidx.compose.foundation.gestures.awaitEachGesture
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
@@ -66,6 +67,7 @@ import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.lerp
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.boundsInParent
 import androidx.compose.ui.layout.boundsInRoot
 import androidx.compose.ui.layout.onGloballyPositioned
@@ -538,6 +540,16 @@ private fun computeBottomNavEntryVisibility(
         .coerceIn(0f, 1f)
 }
 
+private fun Modifier.consumeTapThrough(): Modifier =
+    pointerInput(Unit) {
+        awaitEachGesture {
+            do {
+                val event = awaitPointerEvent()
+                event.changes.forEach { change -> change.consume() }
+            } while (event.changes.any { it.pressed })
+        }
+    }
+
 @Composable
 fun BottomChrome(
     activeRoute: String,
@@ -922,6 +934,12 @@ private fun BottomNavigationPillSurface(
                 )
             }
     ) {
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .consumeTapThrough()
+        )
+
         Box(
             modifier = Modifier
                 .align(Alignment.BottomStart)

--- a/app/src/main/java/com/asmr/player/ui/search/SearchScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/search/SearchScreen.kt
@@ -6,6 +6,7 @@ import androidx.compose.animation.core.snap
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
+import androidx.compose.foundation.gestures.awaitEachGesture
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -72,6 +73,7 @@ import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.semantics.semantics
@@ -109,6 +111,7 @@ internal const val SEARCH_SUBMIT_BUTTON_TAG = "search_submit_button"
 internal const val SEARCH_SUBMIT_SPINNER_TAG = "search_submit_spinner"
 internal const val SEARCH_PREV_BUTTON_TAG = "search_prev_button"
 internal const val SEARCH_NEXT_BUTTON_TAG = "search_next_button"
+internal const val SEARCH_PAGINATION_TAG = "search_pagination"
 internal const val SEARCH_CHROME_TAG = "search_chrome"
 private val SearchChromeContentGap = 16.dp
 private const val SearchPullRefreshContentShiftRatio = 1f
@@ -121,6 +124,16 @@ private fun stableAlbumKey(album: Album): String {
     val seed = "${album.coverUrl}|${album.title}|${album.circle}|${album.cv}"
     return "h${seed.hashCode().absoluteValue}"
 }
+
+private fun Modifier.consumeTapThrough(): Modifier =
+    pointerInput(Unit) {
+        awaitEachGesture {
+            do {
+                val event = awaitPointerEvent()
+                event.changes.forEach { change -> change.consume() }
+            } while (event.changes.any { it.pressed })
+        }
+    }
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -584,6 +597,7 @@ fun SearchScreen(
     }
 }
 
+
 @Composable
 private fun SearchPullRefreshIndicator(
     progress: Float,
@@ -918,7 +932,7 @@ internal fun SearchPaginationHeader(
             .fillMaxWidth()
             .padding(horizontal = SearchPageHorizontalPadding, vertical = 2.dp)
     ) {
-        Row(
+        Box(
             modifier = Modifier
                 .fillMaxWidth()
                 .shadow(
@@ -940,9 +954,20 @@ internal fun SearchPaginationHeader(
                 )
                 .clip(RoundedCornerShape(14.dp))
                 .background(if (isDark) colorScheme.surface else Color.White)
-                .padding(horizontal = 8.dp, vertical = 6.dp),
-            verticalAlignment = Alignment.CenterVertically
+                .testTag(SEARCH_PAGINATION_TAG)
         ) {
+            Box(
+                modifier = Modifier
+                    .matchParentSize()
+                    .consumeTapThrough()
+            )
+
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 8.dp, vertical = 6.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
             IconButton(
                 onClick = onPrev,
                 enabled = canGoPrev && !controlsLocked,
@@ -996,6 +1021,7 @@ internal fun SearchPaginationHeader(
                         Color.Gray
                     }
                 )
+            }
             }
         }
     }

--- a/app/src/test/java/com/asmr/player/ui/nav/BottomChromeTest.kt
+++ b/app/src/test/java/com/asmr/player/ui/nav/BottomChromeTest.kt
@@ -1,0 +1,92 @@
+package com.asmr.player.ui.nav
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.size
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTouchInput
+import androidx.compose.ui.unit.dp
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Assert.assertEquals
+import com.asmr.player.ui.player.MiniPlayerDisplayMode
+import com.asmr.player.ui.theme.AsmrPlayerTheme
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+private const val BOTTOM_CHROME_UNDERLAY_TAG = "bottomChromeUnderlay"
+
+@RunWith(AndroidJUnit4::class)
+class BottomChromeTest {
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    @Test
+    fun blankAreaTap_doesNotPassThroughToUnderlyingContent() {
+        var underlayClicks = 0
+
+        composeRule.setContent {
+            AsmrPlayerTheme {
+                Box(modifier = Modifier.size(width = 360.dp, height = 120.dp)) {
+                    Box(
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .testTag(BOTTOM_CHROME_UNDERLAY_TAG)
+                            .clickable { underlayClicks++ }
+                    )
+                    BottomChrome(
+                        activeRoute = Routes.Library,
+                        miniPlayerVisible = false,
+                        miniPlayerDisplayMode = MiniPlayerDisplayMode.CoverOnly,
+                        onMiniPlayerDisplayModeChange = {},
+                        onOpenNowPlaying = {},
+                        onOpenQueue = {},
+                        onNavigate = {},
+                        modifier = Modifier.fillMaxSize()
+                    )
+                }
+            }
+        }
+
+        composeRule.onNodeWithTag(BottomNavBarTag)
+            .performTouchInput {
+                down(centerLeft.copy(y = 4f))
+                up()
+            }
+
+        composeRule.runOnIdle {
+            assertEquals(0, underlayClicks)
+        }
+    }
+
+    @Test
+    fun navItemTap_stillInvokesNavigation() {
+        var lastRoute: String? = null
+
+        composeRule.setContent {
+            AsmrPlayerTheme {
+                BottomChrome(
+                    activeRoute = Routes.Library,
+                    miniPlayerVisible = false,
+                    miniPlayerDisplayMode = MiniPlayerDisplayMode.CoverOnly,
+                    onMiniPlayerDisplayModeChange = {},
+                    onOpenNowPlaying = {},
+                    onOpenQueue = {},
+                    onNavigate = { lastRoute = it },
+                    modifier = Modifier.size(width = 360.dp, height = 120.dp)
+                )
+            }
+        }
+
+        composeRule.onNodeWithTag("bottomNavItem:search").performClick()
+
+        composeRule.runOnIdle {
+            assertEquals(Routes.Search, lastRoute)
+        }
+    }
+}

--- a/app/src/test/java/com/asmr/player/ui/search/SearchScreenChromeTest.kt
+++ b/app/src/test/java/com/asmr/player/ui/search/SearchScreenChromeTest.kt
@@ -1,6 +1,10 @@
 package com.asmr.player.ui.search
 
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
@@ -17,7 +21,9 @@ import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performImeAction
+import androidx.compose.ui.test.performTouchInput
 import androidx.compose.ui.test.performTextInput
+import androidx.compose.ui.unit.dp
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.asmr.player.ui.common.CollapsibleHeaderState
 import com.asmr.player.ui.theme.AsmrPlayerTheme
@@ -144,6 +150,68 @@ class SearchScreenChromeTest {
         composeRule.onNodeWithTag(SEARCH_SUBMIT_BUTTON_TAG).assertIsNotEnabled()
         composeRule.onNodeWithTag(SEARCH_PREV_BUTTON_TAG).assertIsNotEnabled()
         composeRule.onNodeWithTag(SEARCH_NEXT_BUTTON_TAG).assertIsNotEnabled()
+    }
+
+    @Test
+    fun paginationBlankAreaTap_doesNotPassThroughToUnderlyingContent() {
+        var underlayClicks = 0
+
+        composeRule.setContent {
+            AsmrPlayerTheme {
+                Box(modifier = Modifier.size(width = 360.dp, height = 72.dp)) {
+                    Box(
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .clickable { underlayClicks += 1 }
+                    )
+                    SearchPaginationHeader(
+                        page = 2,
+                        canGoPrev = true,
+                        canGoNext = true,
+                        controlsLocked = false,
+                        onPrev = {},
+                        onNext = {}
+                    )
+                }
+            }
+        }
+
+        composeRule.onNodeWithTag(SEARCH_PAGINATION_TAG)
+            .performTouchInput {
+                down(center.copy(x = center.x, y = center.y))
+                up()
+            }
+
+        composeRule.runOnIdle {
+            assertEquals(0, underlayClicks)
+        }
+    }
+
+    @Test
+    fun paginationButtons_remainClickable() {
+        var prevCount = 0
+        var nextCount = 0
+
+        composeRule.setContent {
+            AsmrPlayerTheme {
+                SearchPaginationHeader(
+                    page = 2,
+                    canGoPrev = true,
+                    canGoNext = true,
+                    controlsLocked = false,
+                    onPrev = { prevCount += 1 },
+                    onNext = { nextCount += 1 }
+                )
+            }
+        }
+
+        composeRule.onNodeWithTag(SEARCH_PREV_BUTTON_TAG).performClick()
+        composeRule.onNodeWithTag(SEARCH_NEXT_BUTTON_TAG).performClick()
+
+        composeRule.runOnIdle {
+            assertEquals(1, prevCount)
+            assertEquals(1, nextCount)
+        }
     }
 
     @Test


### PR DESCRIPTION
## Summary
- block tap-through on blank areas inside the bottom navigation chrome
- block tap-through on blank areas inside the online search pagination header
- add regression tests for both chrome containers while keeping button clicks working

## Verification
- ./gradlew.bat :app:compileDebugKotlin :app:compileDebugUnitTestKotlin --no-daemon