### PR TITLE
feat(theme): adopt Monet dynamic theme and monochrome preset

### DIFF
--- a/app/src/main/java/com/asmr/player/MainActivity.kt
+++ b/app/src/main/java/com/asmr/player/MainActivity.kt
@@ -193,6 +193,8 @@ import androidx.compose.ui.window.DialogProperties
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 
+private const val MONOCHROME_THEME_SENTINEL = 0x01000000
+
 private enum class OverlaySheet {
     Queue,
     SleepTimer
@@ -279,10 +281,15 @@ class MainActivity : ComponentActivity() {
             val staticHue: HuePalette? = remember(staticHueArgb, mode, neutral) {
                 staticHueArgb?.let { argb ->
                     deriveHuePalette(
-                        primary = Color(argb),
+                        primary = if (argb == MONOCHROME_THEME_SENTINEL) {
+                            if (mode.isDark) Color(0xFFAFB8C2) else Color(0xFF5D6670)
+                        } else {
+                            Color(argb)
+                        },
                         mode = mode,
                         neutral = neutral,
-                        fallbackOnPrimary = if (mode.isDark) Color.White else Color.Black
+                        fallbackOnPrimary = if (mode.isDark) Color.White else Color.Black,
+                        forceMonochrome = argb == MONOCHROME_THEME_SENTINEL
                     )
                 }
             }

--- a/app/src/main/java/com/asmr/player/ui/common/SearchBar.kt
+++ b/app/src/main/java/com/asmr/player/ui/common/SearchBar.kt
@@ -33,6 +33,8 @@ import com.asmr.player.ui.theme.AsmrTheme
 import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Color
 import androidx.compose.foundation.border
+import androidx.compose.ui.graphics.compositeOver
+import androidx.compose.ui.graphics.lerp
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -49,6 +51,20 @@ fun CustomSearchBar(
     val colorScheme = AsmrTheme.colorScheme
     val interactionSource = remember { MutableInteractionSource() }
     val isDark = colorScheme.isDark
+    val containerBaseColor = if (isDark) {
+        lerp(colorScheme.surface, colorScheme.primarySoft, 0.05f)
+    } else {
+        lerp(colorScheme.surface, colorScheme.primarySoft, 0.08f)
+    }
+    val containerColor = containerBaseColor.copy(alpha = if (isDark) 0.93f else 0.95f)
+        .compositeOver(colorScheme.background)
+    val borderColor = if (isDark) {
+        Color.White.copy(alpha = 0.14f)
+    } else {
+        colorScheme.primaryStrong.copy(alpha = 0.14f)
+    }
+    val textColor = colorScheme.textPrimary
+    val placeholderColor = colorScheme.textSecondary.copy(alpha = if (isDark) 0.72f else 0.82f)
     
     BasicTextField(
         value = value,
@@ -62,19 +78,17 @@ fun CustomSearchBar(
                 ambientColor = if (isDark) Color.Black.copy(alpha = 0.8f) else Color.Black.copy(alpha = 0.25f)
             )
             .then(
-                if (isDark) {
-                    Modifier.border(
-                        width = 1.dp,
-                        color = Color.White.copy(alpha = 0.2f),
-                        shape = CircleShape
-                    )
-                } else Modifier
+                Modifier.border(
+                    width = 1.dp,
+                    color = borderColor,
+                    shape = CircleShape
+                )
             )
             .background(
-                color = if (isDark) colorScheme.surface else Color.White,
+                color = containerColor,
                 shape = CircleShape
             ),
-        textStyle = MaterialTheme.typography.bodyLarge.copy(color = if (isDark) colorScheme.textPrimary else Color.Black),
+        textStyle = MaterialTheme.typography.bodyLarge.copy(color = textColor),
         singleLine = true,
         cursorBrush = SolidColor(colorScheme.primary),
         interactionSource = interactionSource,
@@ -96,7 +110,7 @@ fun CustomSearchBar(
                         Text(
                             text = placeholder,
                             style = MaterialTheme.typography.bodyLarge,
-                            color = if (isDark) colorScheme.textSecondary.copy(alpha = 0.5f) else Color.Gray,
+                            color = placeholderColor,
                             maxLines = 1,
                             overflow = TextOverflow.Ellipsis
                         )
@@ -120,6 +134,18 @@ fun ActionButton(
 ) {
     val colorScheme = AsmrTheme.colorScheme
     val isDark = colorScheme.isDark
+    val containerBaseColor = if (isDark) {
+        lerp(colorScheme.surface, colorScheme.primarySoft, 0.05f)
+    } else {
+        lerp(colorScheme.surface, colorScheme.primarySoft, 0.08f)
+    }
+    val containerColor = containerBaseColor.copy(alpha = if (isDark) 0.93f else 0.95f)
+        .compositeOver(colorScheme.background)
+    val borderColor = if (isDark) {
+        Color.White.copy(alpha = 0.14f)
+    } else {
+        colorScheme.primaryStrong.copy(alpha = 0.14f)
+    }
     Box(
         modifier = modifier
             .size(50.dp)
@@ -130,15 +156,13 @@ fun ActionButton(
                 ambientColor = if (isDark) Color.Black.copy(alpha = 0.8f) else Color.Black.copy(alpha = 0.25f)
             )
             .then(
-                if (isDark) {
-                    Modifier.border(
-                        width = 1.dp,
-                        color = Color.White.copy(alpha = 0.2f),
-                        shape = CircleShape
-                    )
-                } else Modifier
+                Modifier.border(
+                    width = 1.dp,
+                    color = borderColor,
+                    shape = CircleShape
+                )
             )
-            .background(if (isDark) colorScheme.surface else Color.White, CircleShape)
+            .background(containerColor, CircleShape)
             .clip(CircleShape)
             .clickable(onClick = onClick),
         contentAlignment = Alignment.Center
@@ -146,7 +170,7 @@ fun ActionButton(
         Icon(
             imageVector = icon,
             contentDescription = null,
-            tint = if (isDark) colorScheme.onSurfaceVariant else Color.Black,
+            tint = colorScheme.onSurfaceVariant,
             modifier = Modifier.size(24.dp)
         )
     }

--- a/app/src/main/java/com/asmr/player/ui/library/AlbumDetailScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/AlbumDetailScreen.kt
@@ -49,6 +49,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.compositeOver
+import androidx.compose.ui.graphics.lerp
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.foundation.gestures.detectTransformGestures
@@ -760,6 +762,17 @@ private fun AlbumDetailTabChrome(
     val tabContainerShape = RoundedCornerShape(26.dp)
     val tabItemShape = RoundedCornerShape(18.dp)
     val collapseOvershootPx = with(LocalDensity.current) { AlbumDetailTabCollapseOvershoot.toPx() }
+    val tabContainerColor = lerp(
+        colorScheme.surface,
+        colorScheme.primarySoft,
+        if (isDark) 0.18f else 0.28f
+    ).copy(alpha = if (isDark) 0.95f else 0.97f)
+        .compositeOver(colorScheme.background)
+    val tabBorderColor = if (isDark) {
+        colorScheme.primary.copy(alpha = 0.11f)
+    } else {
+        colorScheme.primary.copy(alpha = 0.09f)
+    }
 
     BoxWithConstraints(
         modifier = modifier
@@ -792,21 +805,13 @@ private fun AlbumDetailTabChrome(
                     ambientColor = if (isDark) Color.Black.copy(alpha = 0.8f) else Color.Black.copy(alpha = 0.25f)
                 )
                 .then(
-                    if (isDark) {
-                        Modifier.border(
-                            width = 1.dp,
-                            color = Color.White.copy(alpha = 0.2f),
-                            shape = tabContainerShape
-                        )
-                    } else {
-                        Modifier
-                    }
+                    Modifier.border(
+                        width = 1.dp,
+                        color = tabBorderColor,
+                        shape = tabContainerShape
+                    )
                 ),
-            color = if (isDark) {
-                colorScheme.surface.copy(alpha = 0.96f)
-            } else {
-                colorScheme.surface.copy(alpha = 0.96f)
-            },
+            color = tabContainerColor,
             contentColor = colorScheme.textPrimary,
             shape = tabContainerShape,
             tonalElevation = 0.dp,

--- a/app/src/main/java/com/asmr/player/ui/library/LibraryScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/LibraryScreen.kt
@@ -122,6 +122,8 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.layout.size
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.compositeOver
+import androidx.compose.ui.graphics.lerp
 import com.asmr.player.ui.theme.AsmrTheme
 import com.asmr.player.ui.sidepanel.LandscapeRightPanelHost
 import com.asmr.player.ui.sidepanel.RecentAlbumsPanel
@@ -1007,6 +1009,12 @@ internal fun LibraryChrome(
 ) {
     val colorScheme = AsmrTheme.colorScheme
     val collapseOvershootPx = with(LocalDensity.current) { LibraryChromeCollapseOvershoot.toPx() }
+    val chromeActionContainerColor = lerp(
+        colorScheme.surface,
+        colorScheme.primarySoft,
+        if (colorScheme.isDark) 0.16f else 0.26f
+    ).copy(alpha = if (colorScheme.isDark) 0.95f else 0.97f)
+        .compositeOver(colorScheme.background)
 
     Row(
         modifier = modifier
@@ -1062,14 +1070,15 @@ internal fun LibraryChrome(
             )
             MaterialTheme(
                 colorScheme = materialColorScheme.copy(
-                    surface = dynamicContainerColor,
-                    surfaceContainer = dynamicContainerColor
+                    surface = chromeActionContainerColor,
+                    surfaceContainer = chromeActionContainerColor,
+                    surfaceVariant = chromeActionContainerColor
                 )
             ) {
                 DropdownMenu(
                     expanded = sortMenuExpanded,
                     onDismissRequest = { onSortMenuExpandedChange(false) },
-                    modifier = Modifier.background(dynamicContainerColor)
+                    modifier = Modifier.background(chromeActionContainerColor)
                 ) {
                     DropdownMenuItem(
                         text = { Text("最近播放") },

--- a/app/src/main/java/com/asmr/player/ui/nav/BottomChrome.kt
+++ b/app/src/main/java/com/asmr/player/ui/nav/BottomChrome.kt
@@ -739,7 +739,7 @@ private fun BottomNavigationPillSurface(
         }
     }
     val containerColor = colorScheme.primarySoft
-        .copy(alpha = if (colorScheme.isDark) 0.10f else 0.14f)
+        .copy(alpha = if (colorScheme.isDark) 0.05f else 0.08f)
         .compositeOver(colorScheme.surface)
     val borderColor = if (colorScheme.isDark) {
         Color.White.copy(alpha = 0.14f)

--- a/app/src/main/java/com/asmr/player/ui/player/MiniPlayer.kt
+++ b/app/src/main/java/com/asmr/player/ui/player/MiniPlayer.kt
@@ -31,6 +31,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.border
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.PlaylistPlay
 import androidx.compose.material.icons.filled.Favorite
@@ -56,6 +57,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.compositeOver
+import androidx.compose.ui.graphics.lerp
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
@@ -90,6 +92,11 @@ fun MiniPlayer(
     val barHeight = if (largeLayout) 64.dp else 56.dp
     val coverSize = if (largeLayout) 60.dp else 52.dp
     val coverInset = 2.dp
+    val miniPlayerBorderColor = if (colorScheme.isDark) {
+        Color.White.copy(alpha = 0.14f)
+    } else {
+        colorScheme.primaryStrong.copy(alpha = 0.14f)
+    }
 
     var optimisticIsPlaying by remember { mutableStateOf<Boolean?>(null) }
     var stableMediaId by remember { mutableStateOf(currentMediaId) }
@@ -163,9 +170,12 @@ fun MiniPlayer(
                             bottomEnd = if (largeLayout) 26.dp else 22.dp
                         ),
                         colors = CardDefaults.elevatedCardColors(
-                            containerColor = colorScheme.primarySoft
-                                .copy(alpha = if (colorScheme.isDark) 0.10f else 0.16f)
-                                .compositeOver(colorScheme.surface)
+                            containerColor = lerp(
+                                colorScheme.surface,
+                                colorScheme.primarySoft,
+                                if (colorScheme.isDark) 0.05f else 0.08f
+                            ).copy(alpha = if (colorScheme.isDark) 0.93f else 0.95f)
+                                .compositeOver(colorScheme.background)
                         ),
                         elevation = CardDefaults.elevatedCardElevation(defaultElevation = 0.dp)
                     ) {
@@ -274,6 +284,20 @@ fun MiniPlayer(
                             )
                         }
                     }
+                    Box(
+                        modifier = Modifier
+                            .matchParentSize()
+                            .border(
+                                width = 1.dp,
+                                color = miniPlayerBorderColor,
+                                shape = RoundedCornerShape(
+                                    topStart = coverSize / 2,
+                                    bottomStart = coverSize / 2,
+                                    topEnd = if (largeLayout) 26.dp else 22.dp,
+                                    bottomEnd = if (largeLayout) 26.dp else 22.dp
+                                )
+                            )
+                    )
                 }
             }
         }
@@ -292,6 +316,11 @@ private fun MiniPlayerCoverOnly(
     val compactMinWidth = if (largeLayout) 76.dp else 64.dp
     val barHeight = if (largeLayout) 64.dp else 56.dp
     val coverSize = if (largeLayout) 60.dp else 52.dp
+    val miniPlayerBorderColor = if (colorScheme.isDark) {
+        Color.White.copy(alpha = 0.14f)
+    } else {
+        colorScheme.primaryStrong.copy(alpha = 0.14f)
+    }
     Box(
         modifier = modifier
             .widthIn(min = compactMinWidth)
@@ -303,6 +332,7 @@ private fun MiniPlayerCoverOnly(
                 .size(coverSize)
                 .clip(CircleShape)
                 .background(colorScheme.surface)
+                .border(width = 1.dp, color = miniPlayerBorderColor, shape = CircleShape)
                 .clickable(onClick = onExpand),
             contentAlignment = Alignment.Center
         ) {

--- a/app/src/main/java/com/asmr/player/ui/search/SearchScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/search/SearchScreen.kt
@@ -72,6 +72,8 @@ import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.graphics.compositeOver
+import androidx.compose.ui.graphics.lerp
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
@@ -735,6 +737,12 @@ internal fun SearchToolbar(
     val colorScheme = AsmrTheme.colorScheme
     var scopeMenuExpanded by remember { mutableStateOf(false) }
     var languageMenuExpanded by remember { mutableStateOf(false) }
+    val dropdownContainerColor = lerp(
+        colorScheme.surface,
+        colorScheme.primarySoft,
+        if (colorScheme.isDark) 0.16f else 0.26f
+    ).copy(alpha = if (colorScheme.isDark) 0.95f else 0.97f)
+        .compositeOver(colorScheme.background)
 
     LaunchedEffect(filterControlsLocked, searchSubmitLocked) {
         if (filterControlsLocked || searchSubmitLocked) {
@@ -775,7 +783,7 @@ internal fun SearchToolbar(
                     DropdownMenu(
                         expanded = scopeMenuExpanded,
                         onDismissRequest = { scopeMenuExpanded = false },
-                        modifier = Modifier.background(colorScheme.surface)
+                        modifier = Modifier.background(dropdownContainerColor)
                     ) {
                         DropdownMenuItem(
                             text = { Text("仅已购", color = colorScheme.textPrimary) },
@@ -852,7 +860,7 @@ internal fun SearchToolbar(
                         DropdownMenu(
                             expanded = languageMenuExpanded,
                             onDismissRequest = { languageMenuExpanded = false },
-                            modifier = Modifier.background(colorScheme.surface)
+                            modifier = Modifier.background(dropdownContainerColor)
                         ) {
                             listOf(
                                 "ja_JP" to "日语",
@@ -926,6 +934,17 @@ internal fun SearchPaginationHeader(
 ) {
     val colorScheme = AsmrTheme.colorScheme
     val isDark = colorScheme.isDark
+    val paginationContainerColor = lerp(
+        colorScheme.surface,
+        colorScheme.primarySoft,
+        if (isDark) 0.06f else 0.10f
+    ).copy(alpha = if (isDark) 0.93f else 0.95f)
+        .compositeOver(colorScheme.background)
+    val paginationBorderColor = if (isDark) {
+        Color.White.copy(alpha = 0.14f)
+    } else {
+        colorScheme.primaryStrong.copy(alpha = 0.14f)
+    }
 
     Box(
         modifier = Modifier
@@ -942,18 +961,14 @@ internal fun SearchPaginationHeader(
                     ambientColor = if (isDark) Color.Black.copy(alpha = 0.8f) else Color.Black.copy(alpha = 0.25f)
                 )
                 .then(
-                    if (isDark) {
-                        Modifier.border(
-                            width = 1.dp,
-                            color = Color.White.copy(alpha = 0.2f),
-                            shape = RoundedCornerShape(14.dp)
-                        )
-                    } else {
-                        Modifier
-                    }
+                    Modifier.border(
+                        width = 1.dp,
+                        color = paginationBorderColor,
+                        shape = RoundedCornerShape(14.dp)
+                    )
                 )
                 .clip(RoundedCornerShape(14.dp))
-                .background(if (isDark) colorScheme.surface else Color.White)
+                .background(paginationContainerColor)
                 .testTag(SEARCH_PAGINATION_TAG)
         ) {
             Box(
@@ -983,7 +998,7 @@ internal fun SearchPaginationHeader(
                     } else if (isDark) {
                         colorScheme.textTertiary
                     } else {
-                        Color.Gray
+                        colorScheme.textTertiary
                     }
                 )
             }
@@ -1018,7 +1033,7 @@ internal fun SearchPaginationHeader(
                     } else if (isDark) {
                         colorScheme.textTertiary
                     } else {
-                        Color.Gray
+                        colorScheme.textTertiary
                     }
                 )
             }

--- a/app/src/main/java/com/asmr/player/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/settings/SettingsScreen.kt
@@ -74,6 +74,7 @@ import java.io.File
 import kotlin.math.abs
 
 private val SettingsPageHorizontalPadding = 8.dp
+private const val MONOCHROME_THEME_SENTINEL = 0x01000000
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -341,6 +342,10 @@ fun SettingsScreen(
                         color = null,
                         selected = currentHueArgb == null,
                         onClick = { viewModel.setStaticHueArgb(null) }
+                    )
+                    ThemeMonochromeDot(
+                        selected = currentHueArgb == MONOCHROME_THEME_SENTINEL,
+                        onClick = { viewModel.setStaticHueArgb(MONOCHROME_THEME_SENTINEL) }
                     )
                 // 浅色主题用深色调（深红、深蓝、墨綠等），深色/柔和深色主题用高饱和亮色
                 val presets = if (themeMode == "light") {
@@ -1308,6 +1313,24 @@ private fun ThemeColorDot(color: Color?, selected: Boolean, onClick: () -> Unit)
             .size(28.dp)
             .clip(CircleShape)
             .background(fill)
+            .border(borderWidth, borderColor, CircleShape)
+            .clickable(onClick = onClick)
+    )
+}
+
+@Composable
+private fun ThemeMonochromeDot(selected: Boolean, onClick: () -> Unit) {
+    val borderColor = if (selected) AsmrTheme.colorScheme.onSurface else AsmrTheme.colorScheme.onSurface.copy(alpha = 0.35f)
+    val borderWidth = if (selected) 2.dp else 1.dp
+    Box(
+        modifier = Modifier
+            .size(28.dp)
+            .clip(CircleShape)
+            .background(
+                brush = androidx.compose.ui.graphics.Brush.horizontalGradient(
+                    colors = listOf(Color(0xFF68717C), Color(0xFFE1E7ED))
+                )
+            )
             .border(borderWidth, borderColor, CircleShape)
             .clickable(onClick = onClick)
     )

--- a/app/src/main/java/com/asmr/player/ui/theme/DynamicHueGenerator.kt
+++ b/app/src/main/java/com/asmr/player/ui/theme/DynamicHueGenerator.kt
@@ -16,16 +16,10 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.asAndroidBitmap
-import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.IntSize
-import androidx.core.graphics.ColorUtils
-import androidx.palette.graphics.Palette
 import com.asmr.player.cache.CachePolicy
 import com.asmr.player.cache.ImageCacheEntryPoint
-import com.asmr.player.ui.common.adjustHslForUi
-import com.asmr.player.ui.common.computeCenterWeightedHintColorInt
-import com.asmr.player.ui.common.pickBestColorInt
 import dagger.hilt.android.EntryPointAccessors
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Deferred
@@ -63,8 +57,6 @@ fun rememberDynamicHuePalette(
     }
 
 
-    val preferDarkBackground = mode.isDark
-    
     LaunchedEffect(key, mode) { // Removed fallbackHue.primary from key to avoid restart on fallback change
         if (baseKey.isBlank()) {
             return@LaunchedEffect
@@ -97,23 +89,11 @@ fun rememberDynamicHuePalette(
                         
                     if (bitmap.width < 10 || bitmap.height < 10) return@withContext null
 
-                    val colorInt = runCatching {
-                        val palette = Palette.from(bitmap).generate()
-                        val hint = computeCenterWeightedHintColorInt(bitmap, centerRegionRatio)
-                        pickBestColorInt(
-                            palette = palette,
-                            fallbackColorInt = fallbackHue.primary.toArgb(),
-                            preferDarkBackground = preferDarkBackground,
-                            hintColorInt = hint
-                        )
-                    }.getOrNull() ?: fallbackHue.primary.toArgb()
-
-                    val hsl = FloatArray(3)
-                    ColorUtils.colorToHSL(colorInt, hsl)
-                    adjustHslForUi(hsl, preferDarkBackground)
-                    clampPrimaryHslForMode(hsl, mode)
-
-                    Color(ColorUtils.HSLToColor(hsl))
+                    monetSeedColorFromBitmap(
+                        bitmap = bitmap,
+                        fallbackColor = fallbackHue.primary,
+                        centerRegionRatio = centerRegionRatio
+                    )
                 }
             }
             attempt++
@@ -169,8 +149,6 @@ fun rememberDynamicHuePaletteFromVideoFrame(
         Animatable(DynamicHueCache.get(key) ?: fallbackHue.primary, ColorVectorConverter)
     }
 
-    val preferDarkBackground = mode.isDark
-
     LaunchedEffect(key, mode) {
         if (baseKey.isBlank() || videoUri == null) return@LaunchedEffect
 
@@ -184,23 +162,11 @@ fun rememberDynamicHuePaletteFromVideoFrame(
             withContext(Dispatchers.Default) {
                 withTimeoutOrNull(timeoutMs) {
                     val bitmap = extractMeaningfulVideoFrameBitmap(context, videoUri, imageSizePx) ?: return@withTimeoutOrNull null
-                    val colorInt = runCatching {
-                        val palette = Palette.from(bitmap).generate()
-                        val hint = computeCenterWeightedHintColorInt(bitmap, centerRegionRatio)
-                        pickBestColorInt(
-                            palette = palette,
-                            fallbackColorInt = fallbackHue.primary.toArgb(),
-                            preferDarkBackground = preferDarkBackground,
-                            hintColorInt = hint
-                        )
-                    }.getOrNull() ?: fallbackHue.primary.toArgb()
-
-                    val hsl = FloatArray(3)
-                    ColorUtils.colorToHSL(colorInt, hsl)
-                    adjustHslForUi(hsl, preferDarkBackground)
-                    clampPrimaryHslForMode(hsl, mode)
-
-                    Color(ColorUtils.HSLToColor(hsl))
+                    monetSeedColorFromBitmap(
+                        bitmap = bitmap,
+                        fallbackColor = fallbackHue.primary,
+                        centerRegionRatio = centerRegionRatio
+                    )
                 }
             }
         }

--- a/app/src/main/java/com/asmr/player/ui/theme/DynamicHueGenerator.kt
+++ b/app/src/main/java/com/asmr/player/ui/theme/DynamicHueGenerator.kt
@@ -50,20 +50,20 @@ fun rememberDynamicHuePalette(
     }
     val baseKey = if (rawBaseKey.isNotBlank()) rawBaseKey else lastNonBlankBaseKeyState.value
     val regionKey = (centerRegionRatio * 100).toInt().coerceIn(10, 100)
-    val key = "hue:cw:$regionKey:$baseKey:${mode.name}"
+    val seedKey = "hue:cw:$regionKey:$baseKey"
     
-    val animatable = remember(key) { // Removed fallbackHue.primary dependency to avoid reset on theme change
-        Animatable(DynamicHueCache.get(key) ?: fallbackHue.primary, ColorVectorConverter)
+    val animatable = remember(seedKey) {
+        Animatable(DynamicHueCache.get(seedKey) ?: fallbackHue.primary, ColorVectorConverter)
     }
 
 
-    LaunchedEffect(key, mode) { // Removed fallbackHue.primary from key to avoid restart on fallback change
+    LaunchedEffect(seedKey) {
         if (baseKey.isBlank()) {
             return@LaunchedEffect
         }
         
         // If we have it in cache, snap immediately to avoid animation if we are just scrolling/recomposing?
-        DynamicHueCache.get(key)?.let {
+        DynamicHueCache.get(seedKey)?.let {
             if (cachedTransitionDurationMs <= 0) animatable.snapTo(it)
             else animatable.animateTo(it, animationSpec = tween(cachedTransitionDurationMs))
             return@LaunchedEffect
@@ -75,7 +75,7 @@ fun rememberDynamicHuePalette(
         while (constrainedPrimary == null && attempt < 3) {
             if (attempt > 0) kotlinx.coroutines.delay(300)
             
-            constrainedPrimary = DynamicHueCache.getOrCompute(key) {
+            constrainedPrimary = DynamicHueCache.getOrCompute(seedKey) {
                 withContext(Dispatchers.Default) {
                     val m = artworkModel ?: return@withContext null
                     val img = runCatching {
@@ -143,22 +143,22 @@ fun rememberDynamicHuePaletteFromVideoFrame(
     }
     val baseKey = if (rawBaseKey.isNotBlank()) rawBaseKey else lastNonBlankBaseKeyState.value
     val regionKey = (centerRegionRatio * 100).toInt().coerceIn(10, 100)
-    val key = "hue:vf:cw:$regionKey:$baseKey:${mode.name}"
+    val seedKey = "hue:vf:cw:$regionKey:$baseKey"
 
-    val animatable = remember(key) {
-        Animatable(DynamicHueCache.get(key) ?: fallbackHue.primary, ColorVectorConverter)
+    val animatable = remember(seedKey) {
+        Animatable(DynamicHueCache.get(seedKey) ?: fallbackHue.primary, ColorVectorConverter)
     }
 
-    LaunchedEffect(key, mode) {
+    LaunchedEffect(seedKey) {
         if (baseKey.isBlank() || videoUri == null) return@LaunchedEffect
 
-        DynamicHueCache.get(key)?.let {
+        DynamicHueCache.get(seedKey)?.let {
             if (cachedTransitionDurationMs <= 0) animatable.snapTo(it)
             else animatable.animateTo(it, animationSpec = tween(cachedTransitionDurationMs))
             return@LaunchedEffect
         }
 
-        val constrainedPrimary = DynamicHueCache.getOrCompute(key) {
+        val constrainedPrimary = DynamicHueCache.getOrCompute(seedKey) {
             withContext(Dispatchers.Default) {
                 withTimeoutOrNull(timeoutMs) {
                     val bitmap = extractMeaningfulVideoFrameBitmap(context, videoUri, imageSizePx) ?: return@withTimeoutOrNull null

--- a/app/src/main/java/com/asmr/player/ui/theme/HueDerivation.kt
+++ b/app/src/main/java/com/asmr/player/ui/theme/HueDerivation.kt
@@ -3,6 +3,14 @@ package com.asmr.player.ui.theme
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
 import androidx.core.graphics.ColorUtils
+import com.google.android.material.color.utilities.DislikeAnalyzer
+import com.google.android.material.color.utilities.DynamicScheme
+import com.google.android.material.color.utilities.Hct
+import com.google.android.material.color.utilities.MaterialDynamicColors
+import com.google.android.material.color.utilities.SchemeMonochrome
+import com.google.android.material.color.utilities.SchemeTonalSpot
+
+private const val MONOCHROME_CHROMA_THRESHOLD = 5.0
 
 internal fun deriveHuePalette(
     primary: Color,
@@ -10,55 +18,130 @@ internal fun deriveHuePalette(
     neutral: NeutralPalette,
     fallbackOnPrimary: Color
 ): HuePalette {
-    val primaryArgb = primary.toArgb()
-    val bgArgb = neutral.background.toArgb()
+    val sourceHct = sanitizedSourceHct(primary)
+    val scheme = dynamicSchemeFor(sourceHct, mode)
+    val dynamicColors = MaterialDynamicColors()
 
-    val softStrength = when (mode) {
-        ThemeMode.Light -> 0.12f
-        ThemeMode.Dark -> 0.22f
-        ThemeMode.SoftDark -> 0.18f
-    }
-    val strongBlend = when (mode) {
-        ThemeMode.Light -> 0.88f
-        ThemeMode.Dark -> 0.90f
-        ThemeMode.SoftDark -> 0.88f
-    }
-
-    val primarySoft = Color(ColorUtils.blendARGB(bgArgb, primaryArgb, softStrength))
-    val primaryStrong = run {
-        val hsl = FloatArray(3)
-        ColorUtils.colorToHSL(primaryArgb, hsl)
-        val saturationBoost = when (mode) {
-            ThemeMode.Light -> 0.05f
-            ThemeMode.Dark -> 0.06f
-            ThemeMode.SoftDark -> 0.05f
-        }
-        val lightnessShift = when (mode) {
-            ThemeMode.Light -> -0.06f
-            ThemeMode.Dark -> 0.05f
-            ThemeMode.SoftDark -> 0.04f
-        }
-        if (hsl[1] >= 0.12f) {
-            hsl[1] = (hsl[1] + saturationBoost).coerceIn(0f, 1f)
-        }
-        hsl[2] = (hsl[2] + lightnessShift).coerceIn(0f, 1f)
-        clampPrimaryHslForMode(hsl, mode)
-        val target = Color(ColorUtils.HSLToColor(hsl))
-        Color(ColorUtils.blendARGB(primaryArgb, target.toArgb(), strongBlend))
-    }
-
-    val onPrimary = bestOnPrimary(primaryStrong, fallbackOnPrimary)
+    val primarySoft = Color(dynamicColors.primaryContainer().getArgb(scheme))
+    val primaryStrong = Color(dynamicColors.primary().getArgb(scheme))
+    val secondary = Color(dynamicColors.secondary().getArgb(scheme))
+    val onPrimary = Color(dynamicColors.onPrimary().getArgb(scheme))
+    val onPrimaryContainer = Color(dynamicColors.onPrimaryContainer().getArgb(scheme))
+    val onSecondary = Color(dynamicColors.onSecondary().getArgb(scheme))
+    val background = Color(dynamicColors.background().getArgb(scheme))
+    val onBackground = Color(dynamicColors.onBackground().getArgb(scheme))
+    val surface = Color(dynamicColors.surfaceContainer().getArgb(scheme))
+    val onSurface = Color(dynamicColors.onSurface().getArgb(scheme))
+    val surfaceVariant = Color(dynamicColors.surfaceVariant().getArgb(scheme))
+    val onSurfaceVariant = Color(dynamicColors.onSurfaceVariant().getArgb(scheme))
+    val blendedBackground = blendOpaqueWithFallback(
+        dynamic = background,
+        fallback = neutral.background,
+        amount = neutralBlendAmount(mode)
+    )
+    val blendedSurface = blendOpaqueWithFallback(
+        dynamic = surface,
+        fallback = neutral.surface,
+        amount = surfaceBlendAmount(mode)
+    )
+    val blendedSurfaceVariant = blendOpaqueWithFallback(
+        dynamic = surfaceVariant,
+        fallback = neutral.surfaceVariant,
+        amount = surfaceVariantBlendAmount(mode)
+    )
 
     return HuePalette(
         primary = primary,
         primarySoft = primarySoft,
         primaryStrong = primaryStrong,
-        onPrimary = onPrimary
+        onPrimary = bestForeground(
+            background = primaryStrong,
+            candidate = onPrimary,
+            fallback = fallbackOnPrimary
+        ),
+        secondary = secondary,
+        onPrimaryContainer = onPrimaryContainerFor(
+            primaryContainer = primarySoft,
+            candidate = onPrimaryContainer,
+            fallback = neutral.onSurface
+        ),
+        onSecondary = bestForeground(
+            background = secondary,
+            candidate = onSecondary,
+            fallback = onPrimary
+        ),
+        background = blendedBackground,
+        onBackground = bestForeground(
+            background = blendedBackground,
+            candidate = blendWithFallback(
+                dynamic = onBackground,
+                fallback = neutral.onBackground,
+                amount = textBlendAmount(mode)
+            ),
+            fallback = neutral.onBackground
+        ),
+        surface = blendedSurface,
+        onSurface = bestForeground(
+            background = blendedSurface,
+            candidate = blendWithFallback(
+                dynamic = onSurface,
+                fallback = neutral.onSurface,
+                amount = textBlendAmount(mode)
+            ),
+            fallback = neutral.onSurface
+        ),
+        surfaceVariant = blendedSurfaceVariant,
+        onSurfaceVariant = bestForeground(
+            background = blendedSurfaceVariant,
+            candidate = blendWithFallback(
+                dynamic = onSurfaceVariant,
+                fallback = neutral.onSurfaceVariant,
+                amount = textSecondaryBlendAmount(mode)
+            ),
+            fallback = neutral.onSurfaceVariant
+        ),
+        textPrimary = bestForeground(
+            background = blendedSurface,
+            candidate = blendWithFallback(
+                dynamic = onSurface,
+                fallback = neutral.textPrimary,
+                amount = textBlendAmount(mode)
+            ),
+            fallback = neutral.textPrimary
+        ),
+        textSecondary = blendWithFallback(
+            dynamic = onSurfaceVariant,
+            fallback = neutral.textSecondary,
+            amount = textSecondaryBlendAmount(mode)
+        ),
+        textTertiary = blendWithFallback(
+            dynamic = onSurfaceVariant,
+            fallback = neutral.textTertiary,
+            amount = textTertiaryBlendAmount(mode)
+        )
     )
 }
 
+private fun sanitizedSourceHct(primary: Color): Hct {
+    val source = Hct.fromInt(primary.toArgb())
+    val fixed = DislikeAnalyzer.fixIfDisliked(source)
+    return if (fixed.chroma < MONOCHROME_CHROMA_THRESHOLD) {
+        Hct.from(fixed.hue, 0.0, fixed.tone)
+    } else {
+        fixed
+    }
+}
+
+private fun dynamicSchemeFor(source: Hct, mode: ThemeMode): DynamicScheme {
+    return if (source.chroma < MONOCHROME_CHROMA_THRESHOLD) {
+        SchemeMonochrome(source, mode.isDark, 0.0)
+    } else {
+        SchemeTonalSpot(source, mode.isDark, 0.0)
+    }
+}
+
 internal fun bestOnPrimary(primary: Color, fallback: Color): Color {
-    val bg = primary.toArgb()
+    val bg = asOpaqueArgb(primary)
     val white = Color.White.toArgb()
     val black = Color.Black.toArgb()
     val contrastWhite = ColorUtils.calculateContrast(white, bg)
@@ -67,6 +150,110 @@ internal fun bestOnPrimary(primary: Color, fallback: Color): Color {
     val contrastPick = if (pick == Color.White) contrastWhite else contrastBlack
     if (contrastPick >= 4.5) return pick
     return fallback
+}
+
+private fun bestForeground(
+    background: Color,
+    candidate: Color,
+    fallback: Color
+): Color {
+    val opaqueBackground = asOpaqueColor(background)
+    val opaqueBackgroundArgb = opaqueBackground.toArgb()
+
+    val candidateContrast = ColorUtils.calculateContrast(candidate.toArgb(), opaqueBackgroundArgb)
+    if (candidateContrast >= 4.5) return candidate
+
+    val fallbackContrast = ColorUtils.calculateContrast(fallback.toArgb(), opaqueBackgroundArgb)
+    if (fallbackContrast >= 4.5) return fallback
+
+    return bestOnPrimary(opaqueBackground, fallback)
+}
+
+private fun onPrimaryContainerFor(
+    primaryContainer: Color,
+    candidate: Color,
+    fallback: Color
+): Color {
+    val opaquePrimaryContainer = asOpaqueColor(primaryContainer)
+    val contrast = ColorUtils.calculateContrast(
+        candidate.toArgb(),
+        opaquePrimaryContainer.toArgb()
+    )
+    if (contrast >= 4.5) return candidate
+
+    val fallbackContrast = ColorUtils.calculateContrast(
+        fallback.toArgb(),
+        opaquePrimaryContainer.toArgb()
+    )
+    if (fallbackContrast >= 4.5) return fallback
+
+    return bestOnPrimary(opaquePrimaryContainer, candidate)
+}
+
+private fun blendWithFallback(dynamic: Color, fallback: Color, amount: Float): Color {
+    if (amount <= 0f) return fallback
+    if (amount >= 1f) return dynamic
+    return Color(ColorUtils.blendARGB(fallback.toArgb(), dynamic.toArgb(), amount))
+}
+
+private fun blendOpaqueWithFallback(dynamic: Color, fallback: Color, amount: Float): Color {
+    return asOpaqueColor(blendWithFallback(dynamic = dynamic, fallback = fallback, amount = amount))
+}
+
+private fun asOpaqueColor(color: Color): Color {
+    return Color(asOpaqueArgb(color))
+}
+
+private fun asOpaqueArgb(color: Color): Int {
+    return ColorUtils.setAlphaComponent(color.toArgb(), 0xFF)
+}
+
+private fun neutralBlendAmount(mode: ThemeMode): Float {
+    return when (mode) {
+        ThemeMode.Light -> 0.38f
+        ThemeMode.Dark -> 0.46f
+        ThemeMode.SoftDark -> 0.42f
+    }
+}
+
+private fun surfaceBlendAmount(mode: ThemeMode): Float {
+    return when (mode) {
+        ThemeMode.Light -> 0.44f
+        ThemeMode.Dark -> 0.52f
+        ThemeMode.SoftDark -> 0.48f
+    }
+}
+
+private fun surfaceVariantBlendAmount(mode: ThemeMode): Float {
+    return when (mode) {
+        ThemeMode.Light -> 0.48f
+        ThemeMode.Dark -> 0.56f
+        ThemeMode.SoftDark -> 0.52f
+    }
+}
+
+private fun textBlendAmount(mode: ThemeMode): Float {
+    return when (mode) {
+        ThemeMode.Light -> 0.26f
+        ThemeMode.Dark -> 0.30f
+        ThemeMode.SoftDark -> 0.28f
+    }
+}
+
+private fun textSecondaryBlendAmount(mode: ThemeMode): Float {
+    return when (mode) {
+        ThemeMode.Light -> 0.22f
+        ThemeMode.Dark -> 0.26f
+        ThemeMode.SoftDark -> 0.24f
+    }
+}
+
+private fun textTertiaryBlendAmount(mode: ThemeMode): Float {
+    return when (mode) {
+        ThemeMode.Light -> 0.16f
+        ThemeMode.Dark -> 0.20f
+        ThemeMode.SoftDark -> 0.18f
+    }
 }
 
 internal fun clampPrimaryHslForMode(hsl: FloatArray, mode: ThemeMode) {
@@ -115,4 +302,3 @@ internal fun clampPrimaryHslForMode(hsl: FloatArray, mode: ThemeMode) {
     hsl[1] = hsl[1].coerceIn(0f, saturationMax)
     hsl[2] = hsl[2].coerceIn(lightnessMin, lightnessMax)
 }
-

--- a/app/src/main/java/com/asmr/player/ui/theme/HueDerivation.kt
+++ b/app/src/main/java/com/asmr/player/ui/theme/HueDerivation.kt
@@ -11,6 +11,9 @@ import com.google.android.material.color.utilities.SchemeMonochrome
 import com.google.android.material.color.utilities.SchemeTonalSpot
 
 private const val MONOCHROME_CHROMA_THRESHOLD = 5.0
+private const val MONET_PRIMARY_STRONG_CHROMA_SCALE = 0.82
+private const val MONET_PRIMARY_SOFT_CHROMA_SCALE = 0.68
+private const val MONET_SECONDARY_CHROMA_SCALE = 0.76
 
 internal fun deriveHuePalette(
     primary: Color,
@@ -27,9 +30,18 @@ internal fun deriveHuePalette(
     val scheme = dynamicSchemeFor(sourceHct, mode, forceMonochrome)
     val dynamicColors = MaterialDynamicColors()
 
-    val primarySoft = Color(dynamicColors.primaryContainer().getArgb(scheme))
-    val primaryStrong = Color(dynamicColors.primary().getArgb(scheme))
-    val secondary = Color(dynamicColors.secondary().getArgb(scheme))
+    val primarySoft = softenDynamicAccentColor(
+        Color(dynamicColors.primaryContainer().getArgb(scheme)),
+        chromaScale = MONET_PRIMARY_SOFT_CHROMA_SCALE
+    )
+    val primaryStrong = softenDynamicAccentColor(
+        Color(dynamicColors.primary().getArgb(scheme)),
+        chromaScale = MONET_PRIMARY_STRONG_CHROMA_SCALE
+    )
+    val secondary = softenDynamicAccentColor(
+        Color(dynamicColors.secondary().getArgb(scheme)),
+        chromaScale = MONET_SECONDARY_CHROMA_SCALE
+    )
     val onPrimary = Color(dynamicColors.onPrimary().getArgb(scheme))
     val onPrimaryContainer = Color(dynamicColors.onPrimaryContainer().getArgb(scheme))
     val onSecondary = Color(dynamicColors.onSecondary().getArgb(scheme))
@@ -259,6 +271,17 @@ private fun sanitizedSourceHct(primary: Color, forceMonochrome: Boolean): Hct {
     } else {
         fixed
     }
+}
+
+private fun softenDynamicAccentColor(color: Color, chromaScale: Double): Color {
+    if (chromaScale >= 0.999) return color
+    val hct = Hct.fromInt(color.toArgb())
+    val softened = Hct.from(
+        hct.hue,
+        (hct.chroma * chromaScale).coerceAtLeast(0.0),
+        hct.tone
+    )
+    return Color(softened.toInt())
 }
 
 private fun dynamicSchemeFor(source: Hct, mode: ThemeMode, forceMonochrome: Boolean): DynamicScheme {

--- a/app/src/main/java/com/asmr/player/ui/theme/HueDerivation.kt
+++ b/app/src/main/java/com/asmr/player/ui/theme/HueDerivation.kt
@@ -16,10 +16,15 @@ internal fun deriveHuePalette(
     primary: Color,
     mode: ThemeMode,
     neutral: NeutralPalette,
-    fallbackOnPrimary: Color
+    fallbackOnPrimary: Color,
+    forceMonochrome: Boolean = false
 ): HuePalette {
-    val sourceHct = sanitizedSourceHct(primary)
-    val scheme = dynamicSchemeFor(sourceHct, mode)
+    if (forceMonochrome) {
+        return deriveMonochromeHuePalette(mode, neutral, fallbackOnPrimary)
+    }
+
+    val sourceHct = sanitizedSourceHct(primary, forceMonochrome)
+    val scheme = dynamicSchemeFor(sourceHct, mode, forceMonochrome)
     val dynamicColors = MaterialDynamicColors()
 
     val primarySoft = Color(dynamicColors.primaryContainer().getArgb(scheme))
@@ -122,18 +127,142 @@ internal fun deriveHuePalette(
     )
 }
 
-private fun sanitizedSourceHct(primary: Color): Hct {
+private fun deriveMonochromeHuePalette(
+    mode: ThemeMode,
+    neutral: NeutralPalette,
+    fallbackOnPrimary: Color
+): HuePalette {
+    val primary = when (mode) {
+        ThemeMode.Light -> Color(0xFF5D6670)
+        ThemeMode.Dark -> Color(0xFFBBC4CE)
+        ThemeMode.SoftDark -> Color(0xFFAFB8C2)
+    }
+    val primarySoft = when (mode) {
+        ThemeMode.Light -> Color(0xFFDCE2E8)
+        ThemeMode.Dark -> Color(0xFF59616A)
+        ThemeMode.SoftDark -> Color(0xFF525A64)
+    }
+    val primaryStrong = when (mode) {
+        ThemeMode.Light -> Color(0xFF4E5660)
+        ThemeMode.Dark -> Color(0xFFCDD5DE)
+        ThemeMode.SoftDark -> Color(0xFFC1CAD4)
+    }
+    val secondary = when (mode) {
+        ThemeMode.Light -> Color(0xFF737C86)
+        ThemeMode.Dark -> Color(0xFFAAB3BD)
+        ThemeMode.SoftDark -> Color(0xFF9EA8B3)
+    }
+    val background = when (mode) {
+        ThemeMode.Light -> Color(0xFFF4F6F8)
+        ThemeMode.Dark -> Color(0xFF16181C)
+        ThemeMode.SoftDark -> Color(0xFF1A1D22)
+    }
+    val surface = when (mode) {
+        ThemeMode.Light -> Color(0xFFFFFFFF)
+        ThemeMode.Dark -> Color(0xFF20242A)
+        ThemeMode.SoftDark -> Color(0xFF232830)
+    }
+    val surfaceVariant = when (mode) {
+        ThemeMode.Light -> Color(0xFFE6EBF0)
+        ThemeMode.Dark -> Color(0xFF343A43)
+        ThemeMode.SoftDark -> Color(0xFF373E48)
+    }
+
+    val onPrimary = bestForeground(
+        background = primaryStrong,
+        candidate = when (mode) {
+            ThemeMode.Light -> Color.White
+            ThemeMode.Dark -> Color(0xFF1F2328)
+            ThemeMode.SoftDark -> Color(0xFF1F2328)
+        },
+        fallback = fallbackOnPrimary
+    )
+    val onPrimaryContainer = bestForeground(
+        background = primarySoft,
+        candidate = when (mode) {
+            ThemeMode.Light -> Color(0xFF2F353C)
+            ThemeMode.Dark -> Color(0xFFF3F6F9)
+            ThemeMode.SoftDark -> Color(0xFFEFF3F7)
+        },
+        fallback = neutral.onSurface
+    )
+    val onSecondary = bestForeground(
+        background = secondary,
+        candidate = when (mode) {
+            ThemeMode.Light -> Color.White
+            ThemeMode.Dark -> Color(0xFF20242A)
+            ThemeMode.SoftDark -> Color(0xFF20242A)
+        },
+        fallback = onPrimary
+    )
+    val onBackground = bestForeground(
+        background = background,
+        candidate = when (mode) {
+            ThemeMode.Light -> Color(0xFF252A31)
+            ThemeMode.Dark -> Color(0xFFE7ECF2)
+            ThemeMode.SoftDark -> Color(0xFFE4EAF0)
+        },
+        fallback = neutral.onBackground
+    )
+    val onSurface = bestForeground(
+        background = surface,
+        candidate = when (mode) {
+            ThemeMode.Light -> Color(0xFF252A31)
+            ThemeMode.Dark -> Color(0xFFE7ECF2)
+            ThemeMode.SoftDark -> Color(0xFFE4EAF0)
+        },
+        fallback = neutral.onSurface
+    )
+    val onSurfaceVariant = bestForeground(
+        background = surfaceVariant,
+        candidate = when (mode) {
+            ThemeMode.Light -> Color(0xFF5B6470)
+            ThemeMode.Dark -> Color(0xFFC3CBD4)
+            ThemeMode.SoftDark -> Color(0xFFBAC3CD)
+        },
+        fallback = neutral.onSurfaceVariant
+    )
+
+    return HuePalette(
+        primary = primary,
+        primarySoft = primarySoft,
+        primaryStrong = primaryStrong,
+        onPrimary = onPrimary,
+        secondary = secondary,
+        onPrimaryContainer = onPrimaryContainer,
+        onSecondary = onSecondary,
+        background = background,
+        onBackground = onBackground,
+        surface = surface,
+        onSurface = onSurface,
+        surfaceVariant = surfaceVariant,
+        onSurfaceVariant = onSurfaceVariant,
+        textPrimary = onSurface,
+        textSecondary = when (mode) {
+            ThemeMode.Light -> Color(0xFF68717C)
+            ThemeMode.Dark -> Color(0xFFB3BCC6)
+            ThemeMode.SoftDark -> Color(0xFFAAB4BE)
+        },
+        textTertiary = when (mode) {
+            ThemeMode.Light -> Color(0xFF88919B)
+            ThemeMode.Dark -> Color(0xFF8D97A2)
+            ThemeMode.SoftDark -> Color(0xFF87919C)
+        }
+    )
+}
+
+private fun sanitizedSourceHct(primary: Color, forceMonochrome: Boolean): Hct {
     val source = Hct.fromInt(primary.toArgb())
     val fixed = DislikeAnalyzer.fixIfDisliked(source)
-    return if (fixed.chroma < MONOCHROME_CHROMA_THRESHOLD) {
+    return if (forceMonochrome || fixed.chroma < MONOCHROME_CHROMA_THRESHOLD) {
         Hct.from(fixed.hue, 0.0, fixed.tone)
     } else {
         fixed
     }
 }
 
-private fun dynamicSchemeFor(source: Hct, mode: ThemeMode): DynamicScheme {
-    return if (source.chroma < MONOCHROME_CHROMA_THRESHOLD) {
+private fun dynamicSchemeFor(source: Hct, mode: ThemeMode, forceMonochrome: Boolean): DynamicScheme {
+    return if (forceMonochrome || source.chroma < MONOCHROME_CHROMA_THRESHOLD) {
         SchemeMonochrome(source, mode.isDark, 0.0)
     } else {
         SchemeTonalSpot(source, mode.isDark, 0.0)

--- a/app/src/main/java/com/asmr/player/ui/theme/HuePalette.kt
+++ b/app/src/main/java/com/asmr/player/ui/theme/HuePalette.kt
@@ -8,6 +8,18 @@ data class HuePalette(
     val primary: Color,
     val primarySoft: Color,
     val primaryStrong: Color,
-    val onPrimary: Color
+    val onPrimary: Color,
+    val secondary: Color,
+    val onPrimaryContainer: Color,
+    val onSecondary: Color,
+    val background: Color,
+    val onBackground: Color,
+    val surface: Color,
+    val onSurface: Color,
+    val surfaceVariant: Color,
+    val onSurfaceVariant: Color,
+    val textPrimary: Color,
+    val textSecondary: Color,
+    val textTertiary: Color
 )
 

--- a/app/src/main/java/com/asmr/player/ui/theme/MonetSeedColor.kt
+++ b/app/src/main/java/com/asmr/player/ui/theme/MonetSeedColor.kt
@@ -1,0 +1,119 @@
+package com.asmr.player.ui.theme
+
+import android.graphics.Bitmap
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.toArgb
+import androidx.core.graphics.ColorUtils
+import com.google.android.material.color.utilities.Hct
+import com.google.android.material.color.utilities.QuantizerCelebi
+import com.google.android.material.color.utilities.Score
+import com.asmr.player.ui.common.computeCenterWeightedHintColorInt
+import kotlin.math.sqrt
+
+private const val DEFAULT_MAX_COLORS = 24
+private const val MIN_VISIBLE_ALPHA = 32
+private const val MONOCHROME_CHROMA_THRESHOLD = 5.0
+
+internal fun monetSeedColorFromBitmap(
+    bitmap: Bitmap,
+    fallbackColor: Color,
+    centerRegionRatio: Float
+): Color {
+    val pixels = sampledPixelsForMonet(bitmap)
+    if (pixels.isEmpty()) return fallbackColor
+
+    val quantized = runCatching {
+        QuantizerCelebi.quantize(pixels, DEFAULT_MAX_COLORS)
+    }.getOrNull().orEmpty()
+
+    if (quantized.isEmpty()) return fallbackColor
+
+    val hintColorInt = computeCenterWeightedHintColorInt(bitmap, centerRegionRatio)
+    val ranked = Score.score(quantized, 4, fallbackColor.toArgb(), true)
+    val best = ranked
+        .asSequence()
+        .mapNotNull { candidate ->
+            val hct = Hct.fromInt(candidate)
+            if (isColorUnsuitableForTheme(hct)) return@mapNotNull null
+            candidate to candidateScore(
+                candidate = candidate,
+                population = quantized[candidate] ?: 0,
+                maxPopulation = quantized.values.maxOrNull()?.coerceAtLeast(1) ?: 1,
+                hintColorInt = hintColorInt
+            )
+        }
+        .maxByOrNull { it.second }
+        ?.first
+
+    return Color(best ?: fallbackColor.toArgb())
+}
+
+private fun sampledPixelsForMonet(bitmap: Bitmap): IntArray {
+    val width = bitmap.width
+    val height = bitmap.height
+    if (width <= 1 || height <= 1) return IntArray(0)
+
+    val allPixels = IntArray(width * height)
+    runCatching { bitmap.getPixels(allPixels, 0, width, 0, 0, width, height) }.getOrNull() ?: return IntArray(0)
+
+    val step = when {
+        width * height <= 24_000 -> 1
+        width * height <= 96_000 -> 2
+        else -> 3
+    }
+
+    val sampled = ArrayList<Int>(allPixels.size / (step * step).coerceAtLeast(1))
+    var y = 0
+    while (y < height) {
+        val row = y * width
+        var x = 0
+        while (x < width) {
+            val argb = allPixels[row + x]
+            val alpha = (argb ushr 24) and 0xFF
+            if (alpha >= MIN_VISIBLE_ALPHA) {
+                sampled += argb or (0xFF shl 24)
+            }
+            x += step
+        }
+        y += step
+    }
+    return sampled.toIntArray()
+}
+
+private fun candidateScore(
+    candidate: Int,
+    population: Int,
+    maxPopulation: Int,
+    hintColorInt: Int?
+): Float {
+    val populationScore = (population.toFloat() / maxPopulation.toFloat()).coerceIn(0f, 1f)
+    val hct = Hct.fromInt(candidate)
+    val chromaScore = (hct.chroma / 48.0).toFloat().coerceIn(0f, 1f)
+    val toneScore = when {
+        hct.tone in 20.0..85.0 -> 1f
+        hct.tone in 10.0..92.0 -> 0.75f
+        else -> 0.45f
+    }
+
+    val hintScore = if (hintColorInt == null) {
+        1f
+    } else {
+        val hintLab = DoubleArray(3)
+        val candidateLab = DoubleArray(3)
+        ColorUtils.colorToLAB(hintColorInt, hintLab)
+        ColorUtils.colorToLAB(candidate, candidateLab)
+        val dl = (candidateLab[0] - hintLab[0]).toFloat()
+        val da = (candidateLab[1] - hintLab[1]).toFloat()
+        val db = (candidateLab[2] - hintLab[2]).toFloat()
+        val dist = sqrt(dl * dl + da * da + db * db)
+        (1f - (dist / 70f)).coerceIn(0f, 1f)
+    }
+
+    return (populationScore * 0.50f) + (chromaScore * 0.22f) + (toneScore * 0.10f) + (hintScore * 0.18f)
+}
+
+private fun isColorUnsuitableForTheme(hct: Hct): Boolean {
+    if (hct.tone <= 4.0 || hct.tone >= 97.0) return true
+    if (hct.chroma < MONOCHROME_CHROMA_THRESHOLD && hct.tone !in 12.0..88.0) return true
+    return false
+}

--- a/app/src/main/java/com/asmr/player/ui/theme/Theme.kt
+++ b/app/src/main/java/com/asmr/player/ui/theme/Theme.kt
@@ -55,16 +55,16 @@ val LocalAsmrColorScheme = staticCompositionLocalOf {
         primaryStrong = hue.primaryStrong,
         onPrimary = hue.onPrimary,
         primaryContainer = hue.primarySoft,
-        onPrimaryContainer = neutral.onSurface,
-        background = neutral.background,
-        onBackground = neutral.onBackground,
-        surface = neutral.surface,
-        onSurface = neutral.onSurface,
-        surfaceVariant = neutral.surfaceVariant,
-        onSurfaceVariant = neutral.onSurfaceVariant,
-        textPrimary = neutral.textPrimary,
-        textSecondary = neutral.textSecondary,
-        textTertiary = neutral.textTertiary,
+        onPrimaryContainer = hue.onPrimaryContainer,
+        background = hue.background,
+        onBackground = hue.onBackground,
+        surface = hue.surface,
+        onSurface = hue.onSurface,
+        surfaceVariant = hue.surfaceVariant,
+        onSurfaceVariant = hue.onSurfaceVariant,
+        textPrimary = hue.textPrimary,
+        textSecondary = hue.textSecondary,
+        textTertiary = hue.textTertiary,
         accent = hue.primaryStrong,
         danger = Color(0xFFAB0000),
         isDark = mode.isDark
@@ -87,7 +87,7 @@ fun AsmrPlayerTheme(
         )
     }
     val materialColorScheme = remember(resolvedHue, neutral, mode) {
-        materialColorSchemeFor(mode, neutral, resolvedHue)
+        materialColorSchemeFor(mode, resolvedHue)
     }
     val asmrColorScheme = remember(resolvedHue, neutral, mode) {
         AsmrColorScheme(
@@ -96,16 +96,16 @@ fun AsmrPlayerTheme(
             primaryStrong = resolvedHue.primaryStrong,
             onPrimary = resolvedHue.onPrimary,
             primaryContainer = resolvedHue.primarySoft,
-            onPrimaryContainer = neutral.onSurface,
-            background = neutral.background,
-            onBackground = neutral.onBackground,
-            surface = neutral.surface,
-            onSurface = neutral.onSurface,
-            surfaceVariant = neutral.surfaceVariant,
-            onSurfaceVariant = neutral.onSurfaceVariant,
-            textPrimary = neutral.textPrimary,
-            textSecondary = neutral.textSecondary,
-            textTertiary = neutral.textTertiary,
+            onPrimaryContainer = resolvedHue.onPrimaryContainer,
+            background = resolvedHue.background,
+            onBackground = resolvedHue.onBackground,
+            surface = resolvedHue.surface,
+            onSurface = resolvedHue.onSurface,
+            surfaceVariant = resolvedHue.surfaceVariant,
+            onSurfaceVariant = resolvedHue.onSurfaceVariant,
+            textPrimary = resolvedHue.textPrimary,
+            textSecondary = resolvedHue.textSecondary,
+            textTertiary = resolvedHue.textTertiary,
             accent = resolvedHue.primaryStrong,
             danger = Color(0xFFAB0000),
             isDark = mode.isDark
@@ -132,7 +132,6 @@ fun AsmrPlayerTheme(
 
 private fun materialColorSchemeFor(
     mode: ThemeMode,
-    neutral: NeutralPalette,
     hue: HuePalette
 ): ColorScheme {
     return if (mode.isDark) {
@@ -140,32 +139,32 @@ private fun materialColorSchemeFor(
             primary = hue.primaryStrong,
             onPrimary = hue.onPrimary,
             primaryContainer = hue.primarySoft,
-            onPrimaryContainer = neutral.onSurface,
-            secondary = hue.primary,
-            onSecondary = hue.onPrimary,
-            background = neutral.background,
-            onBackground = neutral.onBackground,
-            surface = neutral.surface,
+            onPrimaryContainer = hue.onPrimaryContainer,
+            secondary = hue.secondary,
+            onSecondary = hue.onSecondary,
+            background = hue.background,
+            onBackground = hue.onBackground,
+            surface = hue.surface,
             surfaceTint = Color.Transparent,
-            onSurface = neutral.onSurface,
-            surfaceVariant = neutral.surfaceVariant,
-            onSurfaceVariant = neutral.onSurfaceVariant
+            onSurface = hue.onSurface,
+            surfaceVariant = hue.surfaceVariant,
+            onSurfaceVariant = hue.onSurfaceVariant
         )
     } else {
         lightColorScheme(
             primary = hue.primaryStrong,
             onPrimary = hue.onPrimary,
             primaryContainer = hue.primarySoft,
-            onPrimaryContainer = neutral.onSurface,
-            secondary = hue.primary,
-            onSecondary = hue.onPrimary,
-            background = neutral.background,
-            onBackground = neutral.onBackground,
-            surface = neutral.surface,
+            onPrimaryContainer = hue.onPrimaryContainer,
+            secondary = hue.secondary,
+            onSecondary = hue.onSecondary,
+            background = hue.background,
+            onBackground = hue.onBackground,
+            surface = hue.surface,
             surfaceTint = Color.Transparent,
-            onSurface = neutral.onSurface,
-            surfaceVariant = neutral.surfaceVariant,
-            onSurfaceVariant = neutral.onSurfaceVariant
+            onSurface = hue.onSurface,
+            surfaceVariant = hue.surfaceVariant,
+            onSurfaceVariant = hue.onSurfaceVariant
         )
     }
 }

--- a/app/src/main/java/com/asmr/player/ui/theme/Theme.kt
+++ b/app/src/main/java/com/asmr/player/ui/theme/Theme.kt
@@ -15,8 +15,8 @@ import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 
-val DefaultBrandPrimaryLight = Color(0xFF0B3D2E)
-val DefaultBrandPrimaryDark = Color(0xFF2E7D32)
+val DefaultBrandPrimaryLight = Color(0xFF5D6670)
+val DefaultBrandPrimaryDark = Color(0xFFAFB8C2)
 
 @Immutable
 data class AsmrColorScheme(

--- a/app/src/test/java/com/asmr/player/ui/theme/HueDerivationTest.kt
+++ b/app/src/test/java/com/asmr/player/ui/theme/HueDerivationTest.kt
@@ -3,18 +3,15 @@ package com.asmr.player.ui.theme
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
 import androidx.core.graphics.ColorUtils
-import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
-import org.junit.runner.RunWith
 import kotlin.math.sqrt
 
-@RunWith(AndroidJUnit4::class)
-class HueDerivationAndroidTest {
+class HueDerivationTest {
 
     @Test
-    fun deriveHuePalette_doesNotInventHue_forGrayPrimary() {
+    fun deriveHuePalette_keepsGraySeedCloseToNeutral() {
         val mode = ThemeMode.Dark
         val neutral = neutralPaletteForMode(mode)
         val primary = Color(0xFF2A2A2A)
@@ -39,7 +36,7 @@ class HueDerivationAndroidTest {
     }
 
     @Test
-    fun deriveHuePalette_buildsMonetLikeContainers_forChromaticPrimary() {
+    fun deriveHuePalette_createsReadableMonetLayersForChromaticSeed() {
         val mode = ThemeMode.Light
         val neutral = neutralPaletteForMode(mode)
         val primary = Color(0xFF1E88E5)
@@ -79,4 +76,3 @@ class HueDerivationAndroidTest {
         return sqrt(dl * dl + da * da + db * db)
     }
 }
-


### PR DESCRIPTION
## Summary
- adopt a Monet-style dynamic theme pipeline based on Material Color Utilities
- smooth theme-mode switching so dynamic theme no longer flashes back to fallback colors
- tune themed chrome surfaces across search/library/player screens and add a monochrome grayscale preset

## Changes
- replace palette/HSL-style dynamic hue derivation with Monet-like seed extraction and tonal palette generation
- add grayscale monochrome preset support in theme settings and make grayscale the default fallback palette
- reduce saturation of Monet accent roles for a calmer look
- update themed chrome surfaces for search bars, pagination, album detail tabs, bottom chrome, and mini player
- add matching fine border lines to the adjusted chrome containers

## Verification
- `./gradlew :app:compileDebugKotlin`