### PR TITLE
fix: avoid album meta clipping on narrow layouts

### DIFF
--- a/app/src/main/java/com/asmr/player/ui/common/CoverContentRow.kt
+++ b/app/src/main/java/com/asmr/player/ui/common/CoverContentRow.kt
@@ -50,8 +50,9 @@ fun CoverContentRow(
 
         layout(width = maxWidth, height = finalHeight) {
             val coverY = ((finalHeight - coverWidthPx) / 2).coerceAtLeast(0)
+            val contentY = ((finalHeight - contentPlaceable.height) / 2).coerceAtLeast(0)
             coverPlaceable.placeRelative(0, coverY)
-            contentPlaceable.placeRelative(coverWidthPx + spacingPx, 0)
+            contentPlaceable.placeRelative(coverWidthPx + spacingPx, contentY)
         }
     }
 }

--- a/app/src/main/java/com/asmr/player/ui/library/AlbumItem.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/AlbumItem.kt
@@ -11,10 +11,8 @@ import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.aspectRatio
-import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -31,6 +29,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -53,6 +52,8 @@ private val AlbumItemMetaLineVerticalPadding = 1.dp
 private val AlbumItemCoverContentSpacing = 8.dp
 private val AlbumGridInfoHorizontalPadding = 6.dp
 private val AlbumGridInfoVerticalPadding = 8.dp
+internal const val ALBUM_ITEM_CARD_TAG = "album_item_card"
+internal const val ALBUM_ITEM_STATS_TAG = "album_item_stats"
 
 @Composable
 @OptIn(ExperimentalFoundationApi::class)
@@ -93,6 +94,7 @@ fun AlbumItem(
         modifier = modifier
             .fillMaxWidth()
             .padding(horizontal = AlbumItemHorizontalPadding, vertical = AlbumItemVerticalPadding)
+            .testTag(ALBUM_ITEM_CARD_TAG)
             .clip(shape)
             .background(colorScheme.surface.copy(alpha = 0.5f))
             .combinedClickable(
@@ -106,7 +108,7 @@ fun AlbumItem(
             spacing = AlbumItemCoverContentSpacing,
             modifier = Modifier
                 .fillMaxWidth()
-                .height(listItemHeight),
+                .heightIn(min = listItemHeight),
             cover = {
                 Box(
                     modifier = Modifier
@@ -135,7 +137,6 @@ fun AlbumItem(
             content = {
                 Column(
                     modifier = Modifier
-                        .fillMaxHeight()
                         .padding(top = 3.dp, bottom = 3.dp, end = 12.dp),
                     verticalArrangement = Arrangement.spacedBy(2.dp, Alignment.CenterVertically)
                 ) {
@@ -218,7 +219,9 @@ fun AlbumItem(
                                 color = colorScheme.textTertiary,
                                 maxLines = 1,
                                 overflow = TextOverflow.Ellipsis,
-                                modifier = Modifier.fillMaxWidth()
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .testTag(ALBUM_ITEM_STATS_TAG)
                             )
                         }
                     }

--- a/app/src/main/java/com/asmr/player/ui/library/LibraryScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/LibraryScreen.kt
@@ -1507,7 +1507,7 @@ private fun AlbumItem(
             spacing = 8.dp,
             modifier = Modifier
                 .fillMaxWidth()
-                .height(listItemHeight),
+                .heightIn(min = listItemHeight),
             cover = {
                 Box(
                     modifier = Modifier
@@ -1581,7 +1581,6 @@ private fun AlbumItem(
 
                 BalancedColumn(
                     modifier = Modifier
-                        .fillMaxHeight()
                         .padding(top = 4.dp, bottom = 4.dp, end = 12.dp),
                     minGap = 4.dp,
                     maxGap = 12.dp,

--- a/app/src/test/java/com/asmr/player/ui/library/AlbumItemLayoutTest.kt
+++ b/app/src/test/java/com/asmr/player/ui/library/AlbumItemLayoutTest.kt
@@ -1,0 +1,78 @@
+package com.asmr.player.ui.library
+
+import android.content.res.Configuration
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.width
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.test.getUnclippedBoundsInRoot
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.dp
+import com.asmr.player.domain.model.Album
+import com.asmr.player.ui.theme.AsmrPlayerTheme
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+
+class AlbumItemLayoutTest {
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    @Test
+    fun albumItem_expandsHeightSoStatsLineIsNotClippedOnNarrowLayouts() {
+        val album = Album(
+            id = 1L,
+            title = "A very long album title for narrow layouts",
+            path = "/tmp/album",
+            circle = "Example Circle With Longer Name",
+            cv = "CV A / CV B / CV C",
+            tags = listOf("binaural", "long-tag", "exclusive"),
+            workId = "RJ999999",
+            rjCode = "RJ999999",
+            ratingValue = 4.9,
+            ratingCount = 3210,
+            dlCount = 98765,
+            priceJpy = 123456,
+            releaseDate = "2026-05-19"
+        )
+
+        composeRule.setContent {
+            val base = LocalConfiguration.current
+            val compactConfig = Configuration(base).apply {
+                screenWidthDp = 310
+                smallestScreenWidthDp = 310
+            }
+
+            CompositionLocalProvider(
+                LocalConfiguration provides compactConfig,
+                LocalDensity provides Density(2.75f, 1f)
+            ) {
+                AsmrPlayerTheme {
+                    Box(modifier = Modifier.width(310.dp)) {
+                        AlbumItem(
+                            album = album,
+                            onClick = {}
+                        )
+                    }
+                }
+            }
+        }
+
+        val cardBounds = composeRule.onNodeWithTag(ALBUM_ITEM_CARD_TAG).getUnclippedBoundsInRoot()
+        val statsBounds = composeRule.onNodeWithTag(ALBUM_ITEM_STATS_TAG).getUnclippedBoundsInRoot()
+        val cardHeight = cardBounds.bottom - cardBounds.top
+
+        assertTrue(
+            "Expected stats row to remain inside the album card bounds",
+            statsBounds.bottom <= cardBounds.bottom
+        )
+        assertTrue(
+            "Expected album card height to expand beyond the old 140dp minimum when metadata is dense",
+            cardHeight > 140.dp
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- allow album list cards to grow beyond the previous fixed minimum height when metadata gets dense
- center cover/content vertically inside `CoverContentRow` so the last metadata row is less likely to get pinned to the bottom edge
- add a regression test for narrow-width album cards with dense metadata

## Why
On the API 36 Pixel 8 Pro emulator, the last metadata row in online search results could be clipped when rating, price, and release date were all present. The underlying issue was not API-specific business logic, but a fixed-height album card layout that became too tight on narrower or differently measured displays.

## Validation
- `:app:compileDebugKotlin`
- installed debug build on the API 36 emulator and verified the app still launches normally
