### PR TITLE
fix: polish v1.1.0 bottom nav active state transitions

### DIFF
--- a/app/src/main/java/com/asmr/player/main/MainContainer.kt
+++ b/app/src/main/java/com/asmr/player/main/MainContainer.kt
@@ -263,17 +263,27 @@ fun MainContainer(
     )
     val primaryContentStateHolder = rememberSaveableStateHolder()
     var primaryPagerScrollLocked by remember { mutableStateOf(false) }
+    var pendingPrimaryNavigationRoute by remember { mutableStateOf<String?>(null) }
+    val visualPrimaryRoute = remember(activePrimaryRoute, pendingPrimaryNavigationRoute, primaryPagerRoutes) {
+        resolvePrimaryNavVisualRoute(
+            activeRoute = activePrimaryRoute,
+            pendingRoute = pendingPrimaryNavigationRoute,
+            pagerRoutes = primaryPagerRoutes
+        )
+    }
     val primaryNavSelectionProgresses by remember(
         primaryPagerState,
         primaryPagerRoutes,
-        activePrimaryRoute
+        activePrimaryRoute,
+        pendingPrimaryNavigationRoute
     ) {
         derivedStateOf {
             computePrimaryNavSelectionProgresses(
                 pagerRoutes = primaryPagerRoutes,
                 currentPage = primaryPagerState.currentPage,
                 currentPageOffsetFraction = primaryPagerState.currentPageOffsetFraction,
-                fallbackRoute = activePrimaryRoute
+                fallbackRoute = activePrimaryRoute,
+                lockedRoute = pendingPrimaryNavigationRoute
             )
         }
     }
@@ -327,7 +337,6 @@ fun MainContainer(
     var nowPlayingVolumeEventTick by remember { mutableLongStateOf(0L) }
     var lastNonZeroAppVolumePercent by rememberSaveable { mutableIntStateOf(AppVolume.DefaultPercent) }
     var hardwareVolumeOverlayBounds by remember { mutableStateOf<Rect?>(null) }
-    var pendingPrimaryNavigationRoute by remember { mutableStateOf<String?>(null) }
     var libraryScrollToTopSignal by remember { mutableLongStateOf(0L) }
     var searchScrollToTopSignal by remember { mutableLongStateOf(0L) }
     var favoritesScrollToTopSignal by remember { mutableLongStateOf(0L) }
@@ -1587,7 +1596,7 @@ fun MainContainer(
                         .width(chromeWidth)
                 ) {
                     BottomChrome(
-                        activeRoute = activePrimaryRoute,
+                        activeRoute = visualPrimaryRoute,
                         selectionProgresses = primaryNavSelectionProgresses,
                         miniPlayerVisible = miniPlayerVisible,
                         miniPlayerDisplayMode = miniPlayerDisplayMode,

--- a/app/src/main/java/com/asmr/player/main/MainNavigationSupport.kt
+++ b/app/src/main/java/com/asmr/player/main/MainNavigationSupport.kt
@@ -211,10 +211,16 @@ internal fun computePrimaryNavSelectionProgresses(
     pagerRoutes: List<String>,
     currentPage: Int,
     currentPageOffsetFraction: Float,
-    fallbackRoute: String
+    fallbackRoute: String,
+    lockedRoute: String? = null
 ): Map<String, Float> {
     if (pagerRoutes.isEmpty()) {
         return mapOf(fallbackRoute to 1f)
+    }
+
+    val resolvedLockedRoute = lockedRoute?.takeIf { it in pagerRoutes }
+    if (resolvedLockedRoute != null) {
+        return mapOf(resolvedLockedRoute to 1f)
     }
 
     val selectionProgresses = LinkedHashMap<String, Float>(pagerRoutes.size)
@@ -232,6 +238,14 @@ internal fun computePrimaryNavSelectionProgresses(
     }
 
     return selectionProgresses
+}
+
+internal fun resolvePrimaryNavVisualRoute(
+    activeRoute: String,
+    pendingRoute: String?,
+    pagerRoutes: List<String>
+): String {
+    return pendingRoute?.takeIf { it in pagerRoutes } ?: activeRoute
 }
 
 internal fun resolveCurrentPrimaryDestinationRoute(

--- a/app/src/main/java/com/asmr/player/ui/nav/BottomChrome.kt
+++ b/app/src/main/java/com/asmr/player/ui/nav/BottomChrome.kt
@@ -40,8 +40,6 @@ import androidx.compose.material.icons.filled.Person
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material.icons.filled.SwapHoriz
-import androidx.compose.material3.CardDefaults
-import androidx.compose.material3.ElevatedCard
 import androidx.compose.material3.Icon
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -54,6 +52,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.geometry.CornerRadius
 import androidx.compose.ui.geometry.Rect
@@ -1277,7 +1276,6 @@ private fun BottomNavItemChip(
         activeContainer = activeContainer,
         selectedProgress = resolvedSelectedProgress
     )
-    val scale = 1f + (0.04f * resolvedSelectedProgress)
     val iconScale = 1f + (0.16f * resolvedSelectedProgress)
     val glowAlpha = resolvedSelectedProgress
     val glowSize by animateDpAsState(
@@ -1289,6 +1287,7 @@ private fun BottomNavItemChip(
         label = "bottomNavItemGlowSize"
     )
     val glowColor = colorScheme.primaryStrong.copy(alpha = if (colorScheme.isDark) 0.22f else 0.18f)
+    val interactionSource = remember { MutableInteractionSource() }
 
     Box(
         modifier = modifier
@@ -1304,54 +1303,48 @@ private fun BottomNavItemChip(
                     .background(glowColor, CircleShape)
             )
         }
-        ElevatedCard(
-            onClick = onClick,
-            enabled = enabled,
+        Box(
             modifier = Modifier
                 .size(metrics.chipSize)
-                .graphicsLayer {
-                    scaleX = scale
-                    scaleY = scale
-                },
-            shape = CircleShape,
-            colors = CardDefaults.elevatedCardColors(
-                containerColor = containerColor,
-                contentColor = contentColor
-            ),
-            elevation = CardDefaults.elevatedCardElevation(defaultElevation = 0.dp)
+                .background(containerColor, CircleShape)
+                .clip(CircleShape)
+                // ElevatedCard's state layer can briefly show a polygonal highlight during
+                // selection transitions on some devices. Use a plain circular surface instead.
+                .clickable(
+                    enabled = enabled,
+                    interactionSource = interactionSource,
+                    indication = null,
+                    onClick = onClick
+                ),
+            contentAlignment = Alignment.Center
         ) {
-            Box(
-                modifier = Modifier.size(metrics.chipSize),
-                contentAlignment = Alignment.Center
-            ) {
-                AnimatedContent(
-                    targetState = item,
-                    transitionSpec = {
-                        (fadeIn(animationSpec = spring(stiffness = Spring.StiffnessMediumLow)) +
-                            scaleIn(
-                                initialScale = 0.82f,
-                                animationSpec = spring(stiffness = Spring.StiffnessMediumLow)
-                            )) togetherWith
-                            (fadeOut(animationSpec = spring(stiffness = Spring.StiffnessMedium)) +
-                                scaleOut(
-                                    targetScale = 1.08f,
-                                    animationSpec = spring(stiffness = Spring.StiffnessMedium)
-                                )) using SizeTransform(clip = false)
-                    },
-                    label = "bottomNavItemIcon"
-                ) { targetItem ->
-                    Icon(
-                        imageVector = targetItem.icon,
-                        contentDescription = targetItem.label,
-                        modifier = Modifier
-                            .size(metrics.iconSize)
-                            .graphicsLayer {
-                                scaleX = iconScale
-                                scaleY = iconScale
-                            },
-                        tint = contentColor
-                    )
-                }
+            AnimatedContent(
+                targetState = item,
+                transitionSpec = {
+                    (fadeIn(animationSpec = spring(stiffness = Spring.StiffnessMediumLow)) +
+                        scaleIn(
+                            initialScale = 0.82f,
+                            animationSpec = spring(stiffness = Spring.StiffnessMediumLow)
+                        )) togetherWith
+                        (fadeOut(animationSpec = spring(stiffness = Spring.StiffnessMedium)) +
+                            scaleOut(
+                                targetScale = 1.08f,
+                                animationSpec = spring(stiffness = Spring.StiffnessMedium)
+                            )) using SizeTransform(clip = false)
+                },
+                label = "bottomNavItemIcon"
+            ) { targetItem ->
+                Icon(
+                    imageVector = targetItem.icon,
+                    contentDescription = targetItem.label,
+                    modifier = Modifier
+                        .size(metrics.iconSize)
+                        .graphicsLayer {
+                            scaleX = iconScale
+                            scaleY = iconScale
+                        },
+                    tint = contentColor
+                )
             }
         }
     }

--- a/app/src/test/java/com/asmr/player/MainNavigationSupportTest.kt
+++ b/app/src/test/java/com/asmr/player/MainNavigationSupportTest.kt
@@ -20,6 +20,39 @@ class MainNavigationSupportTest {
     }
 
     @Test
+    fun computePrimaryNavSelectionProgresses_locksToPendingRouteDuringProgrammaticJump() {
+        val result = computePrimaryNavSelectionProgresses(
+            pagerRoutes = listOf("library", "search", "favorites", "downloads"),
+            currentPage = 1,
+            currentPageOffsetFraction = 0.4f,
+            fallbackRoute = "library",
+            lockedRoute = "downloads"
+        )
+
+        assertEquals(mapOf("downloads" to 1f), result)
+    }
+
+    @Test
+    fun resolvePrimaryNavVisualRoute_prefersPendingRouteWhenItIsPrimary() {
+        assertEquals(
+            "downloads",
+            resolvePrimaryNavVisualRoute(
+                activeRoute = "search",
+                pendingRoute = "downloads",
+                pagerRoutes = listOf("library", "search", "downloads")
+            )
+        )
+        assertEquals(
+            "search",
+            resolvePrimaryNavVisualRoute(
+                activeRoute = "search",
+                pendingRoute = "album_detail/1",
+                pagerRoutes = listOf("library", "search", "downloads")
+            )
+        )
+    }
+
+    @Test
     fun resolveCurrentPrimaryDestinationRoute_handlesFavoritesSystemPlaylist() {
         assertEquals(
             "playlist_system/favorites",

--- a/app/src/test/java/com/asmr/player/ui/nav/BottomChromeTest.kt
+++ b/app/src/test/java/com/asmr/player/ui/nav/BottomChromeTest.kt
@@ -24,6 +24,7 @@ import com.asmr.player.ui.theme.AsmrPlayerTheme
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
+import kotlin.math.abs
 
 private const val BOTTOM_CHROME_UNDERLAY_TAG = "bottomChromeUnderlay"
 private const val BOTTOM_CHROME_ROOT_TAG = "bottomChromeRoot"
@@ -193,5 +194,20 @@ class BottomChromeTest {
 
         assertEquals(Color.Transparent, inactive)
         assertEquals(activeContainer, active)
+    }
+
+    @Test
+    fun partialNavItemContainer_preservesScaledAlpha() {
+        val activeContainer = Color(0xCCF2D4C3)
+
+        val partial = resolveBottomNavItemContainerColor(
+            activeContainer = activeContainer,
+            selectedProgress = 0.5f
+        )
+
+        assertEquals(activeContainer.red, partial.red, 0.0001f)
+        assertEquals(activeContainer.green, partial.green, 0.0001f)
+        assertEquals(activeContainer.blue, partial.blue, 0.0001f)
+        assertTrue(abs(partial.alpha - (activeContainer.alpha * 0.5f)) <= 0.0001f)
     }
 }


### PR DESCRIPTION
## Summary
- replace the bottom nav active chip surface with a plain circular clickable container to remove the polygonal active highlight artifact
- lock bottom nav selection to the pending target route during programmatic multi-page jumps so intermediate tabs do not flash as active
- add focused tests for nav chip container alpha behavior and primary nav selection locking
