### PR TITLE
feat: support downloading dlsite trial media

### DIFF
--- a/app/src/main/java/com/asmr/player/data/remote/download/DownloadManager.kt
+++ b/app/src/main/java/com/asmr/player/data/remote/download/DownloadManager.kt
@@ -1042,14 +1042,6 @@ private suspend fun upsertDownloadedAlbumToLibrary(
         emptyList()
     }
     val prefix = dir.absolutePath.trimEnd('\\', '/') + File.separator
-    val existingLocalTargetsByKey = LinkedHashMap<String, TrackEntity>()
-    val existingLocalTargetsByKeyNoGroup = LinkedHashMap<String, TrackEntity>()
-    existingTracks
-        .filter { it.path.isNotBlank() && !it.path.startsWith(prefix) && !it.path.trim().startsWith("http", ignoreCase = true) }
-        .forEach { t ->
-            existingLocalTargetsByKey.putIfAbsent(TrackKeyNormalizer.buildKey(t.title, t.group, null), t)
-            existingLocalTargetsByKeyNoGroup.putIfAbsent(TrackKeyNormalizer.buildKey(t.title, "", null), t)
-        }
     val toDelete = existingTracks.filter { it.path.startsWith(dir.absolutePath) }.map { it.id }
     if (toDelete.isNotEmpty()) {
         runCatching { trackDao.deleteSubtitlesForTracks(toDelete) }
@@ -1058,30 +1050,7 @@ private suspend fun upsertDownloadedAlbumToLibrary(
 
     val filteredAudioFiles = ArrayList<File>(audioFiles.size)
     audioFiles.forEach { f ->
-        val group = if (f.parentFile != null && f.parentFile?.absolutePath != dir.absolutePath) f.parentFile?.name.orEmpty() else ""
-        val key = TrackKeyNormalizer.buildKey(f.nameWithoutExtension.ifBlank { "track" }, group, null)
-        val keyNoGroup = TrackKeyNormalizer.buildKey(f.nameWithoutExtension.ifBlank { "track" }, "", null)
-        val duplicateLocalTrack = existingLocalTargetsByKey[key] ?: existingLocalTargetsByKeyNoGroup[keyNoGroup]
-        if (duplicateLocalTrack != null) {
-            val entries = parseBestSubtitle(f)
-            if (entries.isNotEmpty()) {
-                runCatching { trackDao.deleteSubtitlesForTrack(duplicateLocalTrack.id) }
-                runCatching {
-                    trackDao.insertSubtitles(
-                        entries.map { e ->
-                            SubtitleEntity(
-                                trackId = duplicateLocalTrack.id,
-                                startMs = e.startMs,
-                                endMs = e.endMs,
-                                text = e.text
-                            )
-                        }
-                    )
-                }
-            }
-        } else {
-            filteredAudioFiles += f
-        }
+        filteredAudioFiles += f
     }
 
     val newTracks = filteredAudioFiles.map { f ->

--- a/app/src/main/java/com/asmr/player/ui/library/AlbumDetailScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/AlbumDetailScreen.kt
@@ -147,7 +147,8 @@ private enum class AlbumPrimaryAction {
 
 private enum class OnlineDownloadSource {
     AsmrOne,
-    DlsitePlay
+    DlsitePlay,
+    DlsiteTrial
 }
 
 internal data class PreparedTrackPlayback(
@@ -278,6 +279,9 @@ fun AlbumDetailScreen(
                     val model = state.model
                     val album = model.displayAlbum
                     val asmrOneTree = model.asmrOneTree
+                    val trialDownloadTree = remember(model.dlsiteTrialTracks) {
+                        buildDlsiteTrialDownloadTree(model.dlsiteTrialTracks)
+                    }
                     val shouldPlayInitialAnimations = !initialIntroSettled && !userSelectedTab
                     val shouldAnimateHeaderIntro = !userSelectedTab
                     val availableTags by viewModel.availableTags.collectAsState()
@@ -496,12 +500,17 @@ fun AlbumDetailScreen(
                                         dlsiteInfo = model.dlsiteInfo,
                                         galleryUrls = model.dlsiteGalleryUrls,
                                         trialTracks = model.dlsiteTrialTracks,
+                                        trialDownloadEnabled = trialDownloadTree.isNotEmpty(),
                                         isLoading = model.isLoadingDlsite,
                                         asmrOneTree = asmrOneTree,
                                         isLoadingAsmrOne = model.isLoadingAsmrOne,
                                         isLoadingTrial = model.isLoadingDlsiteTrial,
                                         onRefreshAsmrOne = { viewModel.refreshAsmrOneSection() },
                                         onRefreshTrial = { viewModel.refreshDlsiteTrialSection() },
+                                        onDownloadTrial = {
+                                            downloadSource = OnlineDownloadSource.DlsiteTrial
+                                            showAsmrDownloadDialog = true
+                                        },
                                         onPlayTracks = onPlayTracks,
                                         onPlayMediaItems = onPlayMediaItems,
                                         onAddToQueue = { track ->
@@ -605,10 +614,10 @@ fun AlbumDetailScreen(
 
                 val canSaveOnline = selectedTab == 1 && asmrOneTree.isNotEmpty()
                 if (showAsmrDownloadDialog) {
-                    val downloadTree = if (downloadSource == OnlineDownloadSource.DlsitePlay) {
-                        model.dlsitePlayTree
-                    } else {
-                        asmrOneTree
+                    val downloadTree = when (downloadSource) {
+                        OnlineDownloadSource.AsmrOne -> asmrOneTree
+                        OnlineDownloadSource.DlsitePlay -> model.dlsitePlayTree
+                        OnlineDownloadSource.DlsiteTrial -> trialDownloadTree
                     }
                     AsmrOneDownloadDialog(
                         albumTitle = album.title,
@@ -618,6 +627,7 @@ fun AlbumDetailScreen(
                             when (downloadSource) {
                                 OnlineDownloadSource.AsmrOne -> viewModel.downloadAsmrOneSelected(selected)
                                 OnlineDownloadSource.DlsitePlay -> viewModel.downloadDlsitePlaySelected(selected)
+                                OnlineDownloadSource.DlsiteTrial -> viewModel.downloadDlsiteTrialSelected(selected)
                             }
                             showAsmrDownloadDialog = false
                         }

--- a/app/src/main/java/com/asmr/player/ui/library/AlbumDetailViewModel.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/AlbumDetailViewModel.kt
@@ -1681,289 +1681,33 @@ class AlbumDetailViewModel @Inject constructor(
 
     fun downloadAsmrOneSelected(selectedLeafPaths: Set<String>) {
         val current = _uiState.value as? AlbumDetailUiState.Success ?: return
-        val model = current.model
-        val album = model.displayAlbum
-        val tree = model.asmrOneTree
-        if (tree.isEmpty()) return
-
-        val leaves = flattenAsmrOneLeafDownloads(tree)
-        val audioExts = setOf("mp3", "flac", "wav", "m4a", "ogg", "aac", "opus")
-        val subExts = setOf("lrc", "srt", "vtt")
-
-        val initialSelected = if (selectedLeafPaths.isEmpty()) {
-            leaves.filter { leaf ->
-                val ext = leaf.relativePath.substringAfterLast('.').lowercase()
-                audioExts.contains(ext)
-            }
-        } else {
-            leaves.filter { selectedLeafPaths.contains(it.relativePath) }
-        }
-
-        if (initialSelected.isEmpty()) return
-
-        // 自动关联字幕逻辑
-        val selected = mutableSetOf<AsmrOneLeafDownload>()
-        initialSelected.forEach { audio ->
-            selected.add(audio)
-            val audioRelPath = audio.relativePath
-            val audioBase = audioRelPath.substringBeforeLast('.')
-            val audioDir = if (audioRelPath.contains('/')) audioRelPath.substringBeforeLast('/') else ""
-
-            leaves.forEach subtitleLoop@{ potentialSub ->
-                val subRelPath = potentialSub.relativePath
-                val subExt = subRelPath.substringAfterLast('.').lowercase()
-                if (!subExts.contains(subExt)) return@subtitleLoop
-
-                val subDir = if (subRelPath.contains('/')) subRelPath.substringBeforeLast('/') else ""
-                if (subDir != audioDir) return@subtitleLoop
-
-                val subBase = subRelPath.substringBeforeLast('.')
-                val isMatch = subBase.equals(audioBase, ignoreCase = true) ||
-                    subBase.startsWith("$audioBase.", ignoreCase = true)
-
-                if (isMatch) {
-                    selected.add(potentialSub)
-                }
-            }
-        }
-
-        messageManager.showInfo("正在加入下载队列（${selected.size}项）：${album.title}")
-
-        val rjOrWorkId = album.rjCode.ifBlank { album.workId }
-        val folderName = safeFolderName(rjOrWorkId.ifBlank { album.title })
-        val baseDir = File(context.getExternalFilesDir(null), "albums")
-        val targetDir = File(baseDir, folderName)
-        if (!targetDir.exists()) targetDir.mkdirs()
-
-        val coverUrl = album.coverUrl.trim()
-        if (coverUrl.startsWith("http", ignoreCase = true)) {
-            val ext = coverUrl.substringBefore('?').substringAfterLast('.', "").takeIf { it.length in 2..5 } ?: "jpg"
-            val coverFileName = "cover.$ext"
-            downloadManager.enqueueDownload(
-                url = coverUrl,
-                fileName = coverFileName,
-                targetDir = targetDir.absolutePath,
-                taskRootDir = targetDir.absolutePath,
-                relativePath = coverFileName,
-                tags = listOf("album:$folderName"),
-                albumTitle = album.title,
-                albumCircle = album.circle,
-                albumCv = album.cv,
-                albumTagsCsv = album.tags.joinToString(","),
-                albumCoverUrl = album.coverUrl,
-                albumWorkId = album.workId,
-                albumRjCode = album.rjCode
-            )
-        }
-
-        val existingLocalKeys = LinkedHashSet<String>()
-        val existingLocalKeysNoGroup = LinkedHashSet<String>()
-        model.localAlbum?.tracks
-            ?.filter { !it.path.trim().startsWith("http", ignoreCase = true) }
-            ?.forEach { t ->
-                existingLocalKeys.add(TrackKeyNormalizer.buildKey(t.title, t.group, null))
-                existingLocalKeysNoGroup.add(TrackKeyNormalizer.buildKey(t.title, "", null))
-            }
-
-        var skipped = 0
-        var enqueued = 0
-        selected.forEach { item ->
-            val relPath = item.relativePath
-            val rawName = relPath.substringAfterLast('/', relPath)
-            val relGroup = relPath.substringBeforeLast('/', "").substringAfterLast('/', "")
-            val titleFromName = rawName.substringBeforeLast('.', rawName)
-            val key = TrackKeyNormalizer.buildKey(titleFromName, relGroup, null)
-            val keyNoGroup = TrackKeyNormalizer.buildKey(titleFromName, "", null)
-            if (existingLocalKeys.contains(key) || existingLocalKeysNoGroup.contains(keyNoGroup)) {
-                skipped += 1
-                return@forEach
-            }
-            val baseName = safeFileName(rawName)
-            val extFromName = baseName.substringAfterLast('.', "").takeIf { it.isNotBlank() }
-            val extFromUrl = item.url.substringBefore('?').substringAfterLast('.', "").takeIf { it.length in 2..6 }
-            val fileName = if (extFromName != null) {
-                baseName
-            } else {
-                val ext = extFromUrl ?: "mp3"
-                "$baseName.$ext"
-            }
-            val relDir = relPath.substringBeforeLast('/', "")
-            val dir = if (relDir.isBlank()) targetDir else File(targetDir, relDir)
-            val url = item.url.trim()
-            if (!url.startsWith("http", ignoreCase = true)) return@forEach
-            val outFile = File(dir, fileName)
-            if (outFile.exists() && outFile.isFile) {
-                skipped += 1
-                return@forEach
-            }
-            val relativeFilePath = if (relDir.isBlank()) fileName else "$relDir/$fileName"
-            downloadManager.enqueueDownload(
-                url = url,
-                fileName = fileName,
-                targetDir = dir.absolutePath,
-                taskRootDir = targetDir.absolutePath,
-                relativePath = relativeFilePath,
-                taskSubtitle = album.title,
-                tags = listOf("album:$folderName"),
-                albumTitle = album.title,
-                albumCircle = album.circle,
-                albumCv = album.cv,
-                albumTagsCsv = album.tags.joinToString(","),
-                albumCoverUrl = album.coverUrl,
-                albumWorkId = album.workId,
-                albumRjCode = album.rjCode
-            )
-            enqueued += 1
-        }
-        if (skipped > 0 && enqueued == 0) {
-            messageManager.showInfo("本地已存在，已跳过下载（${skipped}项）：${album.title}")
-        } else if (skipped > 0) {
-            messageManager.showInfo("已加入下载队列（${enqueued}项），跳过已存在（${skipped}项）：${album.title}")
-        }
+        enqueueRemoteTreeSelectionDownload(
+            album = current.model.displayAlbum,
+            tree = current.model.asmrOneTree,
+            selectedLeafPaths = selectedLeafPaths,
+            relativeBaseDir = ""
+        )
     }
 
     fun downloadDlsitePlaySelected(selectedLeafPaths: Set<String>) {
         val current = _uiState.value as? AlbumDetailUiState.Success ?: return
-        val model = current.model
-        val album = model.displayAlbum
-        val tree = model.dlsitePlayTree
-        if (tree.isEmpty()) return
-
-        val leaves = flattenAsmrOneLeafDownloads(tree)
-        val audioExts = setOf("mp3", "flac", "wav", "m4a", "ogg", "aac", "opus")
-        val subExts = setOf("lrc", "srt", "vtt")
-
-        val initialSelected = if (selectedLeafPaths.isEmpty()) {
-            leaves.filter { leaf ->
-                val ext = leaf.relativePath.substringAfterLast('.').lowercase()
-                audioExts.contains(ext)
-            }
-        } else {
-            leaves.filter { selectedLeafPaths.contains(it.relativePath) }
-        }
-
-        if (initialSelected.isEmpty()) return
-
-        val selected = mutableSetOf<AsmrOneLeafDownload>()
-        initialSelected.forEach { audio ->
-            selected.add(audio)
-            val audioRelPath = audio.relativePath
-            val audioBase = audioRelPath.substringBeforeLast('.')
-            val audioDir = if (audioRelPath.contains('/')) audioRelPath.substringBeforeLast('/') else ""
-
-            leaves.forEach subtitleLoop@{ potentialSub ->
-                val subRelPath = potentialSub.relativePath
-                val subExt = subRelPath.substringAfterLast('.').lowercase()
-                if (!subExts.contains(subExt)) return@subtitleLoop
-
-                val subDir = if (subRelPath.contains('/')) subRelPath.substringBeforeLast('/') else ""
-                if (subDir != audioDir) return@subtitleLoop
-
-                val subBase = subRelPath.substringBeforeLast('.')
-                val isMatch = subBase.equals(audioBase, ignoreCase = true) ||
-                    subBase.startsWith("$audioBase.", ignoreCase = true)
-
-                if (isMatch) {
-                    selected.add(potentialSub)
-                }
-            }
-        }
-
-        messageManager.showInfo("正在加入下载队列（${selected.size}项）：${album.title}")
-
-        val rjOrWorkId = album.rjCode.ifBlank { album.workId }
-        val folderName = safeFolderName(rjOrWorkId.ifBlank { album.title })
-        val baseDir = File(context.getExternalFilesDir(null), "albums")
-        val targetDir = File(baseDir, folderName)
-        if (!targetDir.exists()) targetDir.mkdirs()
-
-        val coverUrl = album.coverUrl.trim()
-        if (coverUrl.startsWith("http", ignoreCase = true)) {
-            val ext = coverUrl.substringBefore('?').substringAfterLast('.', "").takeIf { it.length in 2..5 } ?: "jpg"
-            val coverFileName = "cover.$ext"
-            downloadManager.enqueueDownload(
-                url = coverUrl,
-                fileName = coverFileName,
-                targetDir = targetDir.absolutePath,
-                taskRootDir = targetDir.absolutePath,
-                relativePath = coverFileName,
-                tags = listOf("album:$folderName"),
-                albumTitle = album.title,
-                albumCircle = album.circle,
-                albumCv = album.cv,
-                albumTagsCsv = album.tags.joinToString(","),
-                albumCoverUrl = album.coverUrl,
-                albumWorkId = album.workId,
-                albumRjCode = album.rjCode
-            )
-        }
-
-        val existingLocalKeys = LinkedHashSet<String>()
-        val existingLocalKeysNoGroup = LinkedHashSet<String>()
-        model.localAlbum?.tracks
-            ?.filter { !it.path.trim().startsWith("http", ignoreCase = true) }
-            ?.forEach { t ->
-                existingLocalKeys.add(TrackKeyNormalizer.buildKey(t.title, t.group, null))
-                existingLocalKeysNoGroup.add(TrackKeyNormalizer.buildKey(t.title, "", null))
-            }
-
-        var skipped = 0
-        var enqueued = 0
-        selected.forEach { item ->
-            val relPath = item.relativePath
-            val rawName = relPath.substringAfterLast('/', relPath)
-            val relGroup = relPath.substringBeforeLast('/', "").substringAfterLast('/', "")
-            val titleFromName = rawName.substringBeforeLast('.', rawName)
-            val key = TrackKeyNormalizer.buildKey(titleFromName, relGroup, null)
-            val keyNoGroup = TrackKeyNormalizer.buildKey(titleFromName, "", null)
-            if (existingLocalKeys.contains(key) || existingLocalKeysNoGroup.contains(keyNoGroup)) {
-                skipped += 1
-                return@forEach
-            }
-            val baseName = safeFileName(rawName)
-            val extFromName = baseName.substringAfterLast('.', "").takeIf { it.isNotBlank() }
-            val extFromUrl = item.url.substringBefore('?').substringAfterLast('.', "").takeIf { it.length in 2..6 }
-            val fileName = if (extFromName != null) {
-                baseName
-            } else {
-                val ext = extFromUrl ?: "mp3"
-                "$baseName.$ext"
-            }
-            val relDir = relPath.substringBeforeLast('/', "")
-            val dir = if (relDir.isBlank()) targetDir else File(targetDir, relDir)
-            val url = item.url.trim()
-            if (!url.startsWith("http", ignoreCase = true)) return@forEach
-            val outFile = File(dir, fileName)
-            if (outFile.exists() && outFile.isFile) {
-                skipped += 1
-                return@forEach
-            }
-            val relativeFilePath = if (relDir.isBlank()) fileName else "$relDir/$fileName"
-            downloadManager.enqueueDownload(
-                url = url,
-                fileName = fileName,
-                targetDir = dir.absolutePath,
-                taskRootDir = targetDir.absolutePath,
-                relativePath = relativeFilePath,
-                taskSubtitle = album.title,
-                tags = listOf("album:$folderName"),
-                albumTitle = album.title,
-                albumCircle = album.circle,
-                albumCv = album.cv,
-                albumTagsCsv = album.tags.joinToString(","),
-                albumCoverUrl = album.coverUrl,
-                albumWorkId = album.workId,
-                albumRjCode = album.rjCode
-            )
-            enqueued += 1
-        }
-        if (skipped > 0 && enqueued == 0) {
-            messageManager.showInfo("本地已存在，已跳过下载（${skipped}项）：${album.title}")
-        } else if (skipped > 0) {
-            messageManager.showInfo("已加入下载队列（${enqueued}项），跳过已存在（${skipped}项）：${album.title}")
-        }
+        enqueueRemoteTreeSelectionDownload(
+            album = current.model.displayAlbum,
+            tree = current.model.dlsitePlayTree,
+            selectedLeafPaths = selectedLeafPaths,
+            relativeBaseDir = ""
+        )
     }
 
+    fun downloadDlsiteTrialSelected(selectedLeafPaths: Set<String>) {
+        val current = _uiState.value as? AlbumDetailUiState.Success ?: return
+        enqueueRemoteTreeSelectionDownload(
+            album = current.model.displayAlbum,
+            tree = buildDlsiteTrialDownloadTree(current.model.dlsiteTrialTracks),
+            selectedLeafPaths = selectedLeafPaths,
+            relativeBaseDir = DlsiteTrialDownloadDirectoryName
+        )
+    }
     fun saveOnlineSelectedToLibrary(selectedLeafPaths: Set<String>) {
         val current = _uiState.value as? AlbumDetailUiState.Success ?: return
         val model = current.model
@@ -2525,6 +2269,175 @@ class AlbumDetailViewModel @Inject constructor(
 
     private fun safeFileName(input: String): String {
         return input.trim().ifEmpty { "track" }.replace(Regex("""[\\/:*?"<>|]"""), "_")
+    }
+
+    private fun enqueueRemoteTreeSelectionDownload(
+        album: Album,
+        tree: List<AsmrOneTrackNodeResponse>,
+        selectedLeafPaths: Set<String>,
+        relativeBaseDir: String
+    ) {
+        if (tree.isEmpty()) return
+
+        val leaves = flattenAsmrOneLeafDownloads(tree)
+        val audioExts = setOf("mp3", "flac", "wav", "m4a", "ogg", "aac", "opus")
+        val videoExts = setOf("mp4", "mkv", "webm", "mov", "m4v", "m3u8")
+        val subExts = setOf("lrc", "srt", "vtt")
+        val mediaExts = audioExts + videoExts
+
+        val initialSelected = if (selectedLeafPaths.isEmpty()) {
+            leaves.filter { leaf ->
+                val ext = leaf.relativePath.substringAfterLast('.').lowercase()
+                mediaExts.contains(ext)
+            }
+        } else {
+            leaves.filter { selectedLeafPaths.contains(it.relativePath) }
+        }
+
+        if (initialSelected.isEmpty()) return
+
+        val selected = linkedSetOf<AsmrOneLeafDownload>()
+        initialSelected.forEach { media ->
+            selected.add(media)
+            val mediaRelPath = media.relativePath
+            val mediaBase = mediaRelPath.substringBeforeLast('.')
+            val mediaDir = mediaRelPath.substringBeforeLast('/', "")
+
+            leaves.forEach subtitleLoop@{ potentialSub ->
+                val subRelPath = potentialSub.relativePath
+                val subExt = subRelPath.substringAfterLast('.').lowercase()
+                if (!subExts.contains(subExt)) return@subtitleLoop
+
+                val subDir = subRelPath.substringBeforeLast('/', "")
+                if (subDir != mediaDir) return@subtitleLoop
+
+                val subBase = subRelPath.substringBeforeLast('.')
+                val isMatch = subBase.equals(mediaBase, ignoreCase = true) ||
+                    subBase.startsWith("$mediaBase.", ignoreCase = true)
+                if (isMatch) selected.add(potentialSub)
+            }
+        }
+
+        if (selected.isEmpty()) return
+
+        val rjOrWorkId = album.rjCode.ifBlank { album.workId }
+        val folderName = safeFolderName(rjOrWorkId.ifBlank { album.title })
+        val baseDir = File(context.getExternalFilesDir(null), "albums")
+        val albumDir = File(baseDir, folderName)
+        val normalizedBaseDir = relativeBaseDir.trim().trim('/', '\\')
+        val targetRootDir = if (normalizedBaseDir.isBlank()) albumDir else File(albumDir, normalizedBaseDir)
+        if (!targetRootDir.exists()) targetRootDir.mkdirs()
+
+        val taskKey = buildRemoteDownloadTaskKey(folderName, normalizedBaseDir)
+        val taskSubtitle = album.title
+
+        enqueueRemoteDownloadCover(
+            album = album,
+            targetRootDir = targetRootDir,
+            taskKey = taskKey,
+            taskSubtitle = taskSubtitle
+        )
+
+        var skipped = 0
+        var enqueued = 0
+        selected.forEach { item ->
+            val relPath = item.relativePath.replace('\\', '/')
+            val rawName = relPath.substringAfterLast('/', relPath)
+
+            val url = item.url.trim()
+            if (!url.startsWith("http", ignoreCase = true)) return@forEach
+
+            val baseName = safeFileName(rawName)
+            val extFromName = baseName.substringAfterLast('.', "").takeIf { it.isNotBlank() }
+            val extFromUrl = url.substringBefore('?').substringAfterLast('.', "").takeIf { it.length in 2..6 }
+            val fileName = if (extFromName != null) {
+                baseName
+            } else {
+                val defaultExt = if (videoExts.contains(relPath.substringAfterLast('.').lowercase())) "mp4" else "mp3"
+                val ext = extFromUrl ?: defaultExt
+                "$baseName.$ext"
+            }
+
+            val relDir = relPath.substringBeforeLast('/', "")
+            val dir = if (relDir.isBlank()) targetRootDir else File(targetRootDir, relDir)
+            if (!dir.exists()) dir.mkdirs()
+            val outFile = File(dir, fileName)
+            if (outFile.exists() && outFile.isFile) {
+                skipped += 1
+                return@forEach
+            }
+
+            val relativeFilePath = buildString {
+                if (relDir.isNotBlank()) {
+                    append(relDir)
+                    append('/')
+                }
+                append(fileName)
+            }
+
+            downloadManager.enqueueDownload(
+                url = url,
+                fileName = fileName,
+                targetDir = dir.absolutePath,
+                taskRootDir = targetRootDir.absolutePath,
+                relativePath = relativeFilePath,
+                taskSubtitle = taskSubtitle,
+                tags = listOf(taskKey),
+                albumTitle = album.title,
+                albumCircle = album.circle,
+                albumCv = album.cv,
+                albumTagsCsv = album.tags.joinToString(","),
+                albumCoverUrl = album.coverUrl,
+                albumWorkId = album.workId,
+                albumRjCode = album.rjCode
+            )
+            enqueued += 1
+        }
+
+        if (skipped > 0 && enqueued == 0) {
+            messageManager.showInfo("本地已存在，已跳过下载（${skipped}项）：${album.title}")
+        } else if (skipped > 0) {
+            messageManager.showInfo("已加入下载队列（${enqueued}项），跳过已存在（${skipped}项）：${album.title}")
+        } else if (enqueued > 0) {
+            messageManager.showInfo("正在加入下载队列（${enqueued}项）：${album.title}")
+        }
+    }
+
+    private fun buildRemoteDownloadTaskKey(folderName: String, relativeBaseDir: String): String {
+        return if (relativeBaseDir.isBlank()) {
+            "album:$folderName"
+        } else {
+            "album:$folderName/$relativeBaseDir"
+        }
+    }
+
+    private fun enqueueRemoteDownloadCover(
+        album: Album,
+        targetRootDir: File,
+        taskKey: String,
+        taskSubtitle: String
+    ) {
+        val coverUrl = album.coverUrl.trim()
+        if (!coverUrl.startsWith("http", ignoreCase = true)) return
+
+        val ext = coverUrl.substringBefore('?').substringAfterLast('.', "").takeIf { it.length in 2..5 } ?: "jpg"
+        val coverFileName = "cover.$ext"
+        downloadManager.enqueueDownload(
+            url = coverUrl,
+            fileName = coverFileName,
+            targetDir = targetRootDir.absolutePath,
+            taskRootDir = targetRootDir.absolutePath,
+            relativePath = coverFileName,
+            taskSubtitle = taskSubtitle,
+            tags = listOf(taskKey),
+            albumTitle = album.title,
+            albumCircle = album.circle,
+            albumCv = album.cv,
+            albumTagsCsv = album.tags.joinToString(","),
+            albumCoverUrl = album.coverUrl,
+            albumWorkId = album.workId,
+            albumRjCode = album.rjCode
+        )
     }
 
     override fun onCleared() {

--- a/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailDialogs.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailDialogs.kt
@@ -144,10 +144,11 @@ internal fun AsmrOneDownloadDialog(
     onDismiss: () -> Unit,
     onConfirm: (Set<String>) -> Unit
 ) {
-    val leaves = remember(trackTree) { flattenAsmrOneTracksForUi(trackTree) }
-    val leafPathsByFolder = remember(trackTree) { buildLeafPathIndex(trackTree) }
+    val mediaTree = remember(trackTree) { filterDownloadableMediaTree(trackTree) }
+    val leafPaths = remember(mediaTree) { flattenAsmrOneLeafDownloads(mediaTree).map { it.relativePath } }
+    val leafPathsByFolder = remember(mediaTree) { buildLeafPathIndex(mediaTree) }
     val expanded = remember { mutableStateListOf<String>() }
-    val selected = remember(trackTree) { mutableStateListOf<String>().apply { addAll(leaves.map { it.relativePath }) } }
+    val selected = remember(trackTree) { mutableStateListOf<String>().apply { addAll(leafPaths) } }
     val listState = rememberLazyListState()
 
     Dialog(
@@ -173,7 +174,7 @@ internal fun AsmrOneDownloadDialog(
                     )
                     TextButton(
                         onClick = { onConfirm(selected.toSet()) },
-                        enabled = leaves.isNotEmpty() && selected.isNotEmpty()
+                        enabled = leafPaths.isNotEmpty() && selected.isNotEmpty()
                     ) { Text("开始下载") }
                 }
 
@@ -187,11 +188,11 @@ internal fun AsmrOneDownloadDialog(
                     Row(horizontalArrangement = Arrangement.spacedBy(10.dp)) {
                         OutlinedButton(onClick = {
                             selected.clear()
-                            selected.addAll(leaves.map { it.relativePath })
+                            selected.addAll(leafPaths)
                         }) { Text("全选") }
                         OutlinedButton(onClick = { selected.clear() }) { Text("全不选") }
                     }
-                    if (leaves.isEmpty()) {
+                    if (leafPaths.isEmpty()) {
                         Box(
                             modifier = Modifier
                                 .fillMaxWidth()
@@ -201,7 +202,7 @@ internal fun AsmrOneDownloadDialog(
                             Text("没有可下载的音频/视频文件")
                         }
                     } else {
-                        val entries = flattenAsmrOneTreeForUi(trackTree, expanded.toSet()).entries
+                        val entries = flattenAsmrOneTreeForUi(mediaTree, expanded.toSet()).entries
                         LazyColumn(
                             state = listState,
                             modifier = Modifier.fillMaxSize().thinScrollbar(listState)
@@ -209,12 +210,12 @@ internal fun AsmrOneDownloadDialog(
                             itemsIndexed(items = entries, key = { _, it -> it.path }) { index, entry ->
                                 when (entry) {
                                     is AsmrTreeUiEntry.Folder -> {
-                                        val leafPaths = leafPathsByFolder[entry.path].orEmpty()
-                                        val checkedCount = leafPaths.count { selected.contains(it) }
+                                        val folderLeafPaths = leafPathsByFolder[entry.path].orEmpty()
+                                        val checkedCount = folderLeafPaths.count { selected.contains(it) }
                                         val state = when {
-                                            leafPaths.isEmpty() -> ToggleableState.Off
+                                            folderLeafPaths.isEmpty() -> ToggleableState.Off
                                             checkedCount == 0 -> ToggleableState.Off
-                                            checkedCount == leafPaths.size -> ToggleableState.On
+                                            checkedCount == folderLeafPaths.size -> ToggleableState.On
                                             else -> ToggleableState.Indeterminate
                                         }
                                         AsmrTreeFolderCheckboxRow(
@@ -226,12 +227,12 @@ internal fun AsmrOneDownloadDialog(
                                                 if (expanded.contains(entry.path)) expanded.remove(entry.path) else expanded.add(entry.path)
                                             },
                                             onToggleCheck = {
-                                                if (leafPaths.isEmpty()) return@AsmrTreeFolderCheckboxRow
+                                                if (folderLeafPaths.isEmpty()) return@AsmrTreeFolderCheckboxRow
                                                 val shouldSelectAll = state != ToggleableState.On
                                                 if (shouldSelectAll) {
-                                                    leafPaths.forEach { if (!selected.contains(it)) selected.add(it) }
+                                                    folderLeafPaths.forEach { if (!selected.contains(it)) selected.add(it) }
                                                 } else {
-                                                    selected.removeAll(leafPaths.toSet())
+                                                    selected.removeAll(folderLeafPaths.toSet())
                                                 }
                                             }
                                         )

--- a/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailDlsiteTabs.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailDlsiteTabs.kt
@@ -690,12 +690,14 @@ internal fun AlbumDlsiteInfoBreadcrumbTabV2(
     dlsiteInfo: Album?,
     galleryUrls: List<String>,
     trialTracks: List<Track>,
+    trialDownloadEnabled: Boolean,
     isLoading: Boolean,
     asmrOneTree: List<AsmrOneTrackNodeResponse>,
     isLoadingAsmrOne: Boolean,
     isLoadingTrial: Boolean,
     onRefreshAsmrOne: () -> Unit,
     onRefreshTrial: () -> Unit,
+    onDownloadTrial: () -> Unit,
     onPlayTracks: (Album, List<Track>, Track) -> Unit,
     onPlayMediaItems: (List<MediaItem>, Int) -> Unit,
     onAddToQueue: (Track) -> Boolean,
@@ -1057,6 +1059,9 @@ internal fun AlbumDlsiteInfoBreadcrumbTabV2(
                 Spacer(modifier = Modifier.weight(1f))
                 IconButton(onClick = onRefreshTrial, enabled = !isLoading && !isLoadingTrial) {
                     Icon(Icons.Default.Refresh, contentDescription = "刷新")
+                }
+                IconButton(onClick = onDownloadTrial, enabled = trialDownloadEnabled) {
+                    Icon(Icons.Default.Download, contentDescription = "下载")
                 }
             }
         }

--- a/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailViewModelSupport.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailViewModelSupport.kt
@@ -258,6 +258,8 @@ internal data class AsmrOneLeafDownload(
     val duration: Double?
 )
 
+internal const val DlsiteTrialDownloadDirectoryName = "体验版"
+
 internal fun flattenAsmrOneTracks(tree: List<AsmrOneTrackNodeResponse>): List<Track> {
     val leaves = flattenAsmrOneLeafDownloads(tree)
     return leaves.map {
@@ -267,6 +269,86 @@ internal fun flattenAsmrOneTracks(tree: List<AsmrOneTrackNodeResponse>): List<Tr
             path = it.url,
             duration = it.duration ?: 0.0
         )
+    }
+}
+
+internal fun filterDownloadableMediaTree(tree: List<AsmrOneTrackNodeResponse>): List<AsmrOneTrackNodeResponse> {
+    return tree.mapNotNull { node ->
+        val filteredChildren = filterDownloadableMediaTree(node.children.orEmpty())
+        val url = (node.mediaDownloadUrl ?: node.streamUrl).orEmpty().trim()
+        when {
+            filteredChildren.isNotEmpty() -> node.copy(children = filteredChildren)
+            url.isBlank() -> null
+            else -> when (treeFileTypeForNode(node.title.orEmpty(), url)) {
+                TreeFileType.Audio,
+                TreeFileType.Video -> node.copy(children = null)
+                else -> null
+            }
+        }
+    }
+}
+
+internal fun buildDlsiteTrialDownloadTree(trialTracks: List<Track>): List<AsmrOneTrackNodeResponse> {
+    var mediaIndex = 1
+    return trialTracks.mapNotNull { track ->
+        val url = track.path.trim()
+        if (!url.startsWith("http", ignoreCase = true)) return@mapNotNull null
+
+        val mediaType = inferDlsiteTrialMediaType(track.title, url) ?: return@mapNotNull null
+        val ext = inferDlsiteTrialDownloadExtension(url, mediaType) ?: return@mapNotNull null
+        val fallbackTitle = if (mediaType == TreeFileType.Video) "体验视频" else "体验音频"
+        val safeTitle = sanitizeDlsiteTrialFileBaseName(track.title, fallbackTitle)
+        val fileName = "${mediaIndex.toString().padStart(2, '0')}_$safeTitle.$ext"
+        mediaIndex += 1
+
+        AsmrOneTrackNodeResponse(
+            title = fileName,
+            mediaDownloadUrl = url
+        )
+    }
+}
+
+private fun inferDlsiteTrialMediaType(title: String, url: String): TreeFileType? {
+    val normalizedUrl = url.trim()
+    val normalizedTitle = title.trim()
+    if (normalizedTitle.contains("ZIP", ignoreCase = true)) return null
+    if (normalizedUrl.contains("trial_download", ignoreCase = true)) return null
+    if (isVideoPreviewUrl(normalizedUrl)) return TreeFileType.Video
+
+    return when (treeFileTypeForNode(normalizedTitle, normalizedUrl)) {
+        TreeFileType.Audio -> TreeFileType.Audio
+        TreeFileType.Video -> TreeFileType.Video
+        else -> if (normalizedUrl.startsWith("http", ignoreCase = true)) TreeFileType.Audio else null
+    }
+}
+
+private fun sanitizeDlsiteTrialFileBaseName(title: String, fallback: String): String {
+    return title.trim()
+        .substringBeforeLast('.')
+        .ifBlank { fallback }
+        .replace(Regex("""[\\/:*?\"<>|]"""), "_")
+}
+
+private fun inferDlsiteTrialDownloadExtension(url: String, mediaType: TreeFileType): String? {
+    val ext = url
+        .substringBefore('#')
+        .substringBefore('?')
+        .substringAfterLast('/')
+        .substringAfterLast('\\')
+        .substringAfterLast('.', "")
+        .lowercase()
+
+    if (ext.isNotBlank()) {
+        return when (treeFileTypeForName("sample.$ext")) {
+            mediaType -> ext
+            else -> null
+        }
+    }
+
+    return when (mediaType) {
+        TreeFileType.Audio -> "mp3"
+        TreeFileType.Video -> "mp4"
+        else -> null
     }
 }
 

--- a/app/src/main/java/com/asmr/player/ui/library/libraryviewmodel.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/libraryviewmodel.kt
@@ -1927,14 +1927,6 @@ class LibraryViewModel @Inject constructor(
         audioFiles.sortBy { it.absolutePath }
 
         val allExistingTracks = trackDao.getTracksForAlbumOnce(albumId)
-        val existingLocalTargetsByKey = LinkedHashMap<String, TrackEntity>()
-        val existingLocalTargetsByKeyNoGroup = LinkedHashMap<String, TrackEntity>()
-        allExistingTracks
-            .filter { it.path.isNotBlank() && !it.path.startsWith(prefix) && !it.path.trim().startsWith("http", ignoreCase = true) }
-            .forEach { t ->
-                existingLocalTargetsByKey.putIfAbsent(TrackKeyNormalizer.buildKey(t.title, t.group, null), t)
-                existingLocalTargetsByKeyNoGroup.putIfAbsent(TrackKeyNormalizer.buildKey(t.title, "", null), t)
-            }
 
         val existingTracks = allExistingTracks
             .filter { it.path.startsWith(prefix) }
@@ -1965,17 +1957,7 @@ class LibraryViewModel @Inject constructor(
             val group =
                 if (relPath.contains("/")) relPath.substringBeforeLast('/').substringAfterLast('/', relPath.substringBeforeLast('/')) else ""
             val audioPath = audio.absolutePath
-            val key = TrackKeyNormalizer.buildKey(trackTitle, group, null)
-            val keyNoGroup = TrackKeyNormalizer.buildKey(trackTitle, "", null)
-            val duplicateLocalTrack = existingLocalTargetsByKey[key] ?: existingLocalTargetsByKeyNoGroup[keyNoGroup]
             val relativePathNoExt = relPath.substringBeforeLast('.')
-            if (duplicateLocalTrack != null) {
-                val parsed = parseBestSubtitle(relativePathNoExt)
-                if (parsed.isNotEmpty()) {
-                    subtitleEntriesByExistingTrackId[duplicateLocalTrack.id] = parsed
-                }
-                return@forEach
-            }
             seenPaths.add(audioPath)
 
             val parsed = parseBestSubtitle(relativePathNoExt)
@@ -2150,38 +2132,7 @@ class LibraryViewModel @Inject constructor(
                     trackDao.deleteTracksByIds(toDelete)
                 }
 
-                val existingLocalTargetsByKey = LinkedHashMap<String, TrackEntity>()
-                val existingLocalTargetsByKeyNoGroup = LinkedHashMap<String, TrackEntity>()
-                allExistingTracks
-                    .filter { it.path.isNotBlank() && !it.path.startsWith(albumPath) && !it.path.trim().startsWith("http", ignoreCase = true) }
-                    .forEach { t ->
-                        existingLocalTargetsByKey.putIfAbsent(TrackKeyNormalizer.buildKey(t.title, t.group, null), t)
-                        existingLocalTargetsByKeyNoGroup.putIfAbsent(TrackKeyNormalizer.buildKey(t.title, "", null), t)
-                    }
-
-                val filteredTrackSpecs = trackSpecs.filter { spec ->
-                    val key = TrackKeyNormalizer.buildKey(spec.title, spec.group, null)
-                    val keyNoGroup = TrackKeyNormalizer.buildKey(spec.title, "", null)
-                    val existingTarget = existingLocalTargetsByKey[key] ?: existingLocalTargetsByKeyNoGroup[keyNoGroup]
-                    if (existingTarget != null) {
-                        val entries = subtitlesByAudioPath[spec.path].orEmpty()
-                        if (entries.isNotEmpty()) {
-                            trackDao.deleteSubtitlesForTrack(existingTarget.id)
-                            trackDao.insertSubtitles(
-                                entries.map { e ->
-                                    SubtitleEntity(
-                                        trackId = existingTarget.id,
-                                        startMs = e.startMs,
-                                        endMs = e.endMs,
-                                        text = e.text
-                                    )
-                                }
-                            )
-                            wroteAnySubtitles = true
-                        }
-                    }
-                    existingTarget == null
-                }
+                val filteredTrackSpecs = trackSpecs
 
                 val tracksToInsert = filteredTrackSpecs.map { spec ->
                     TrackEntity(
@@ -2217,16 +2168,13 @@ class LibraryViewModel @Inject constructor(
 
                 val allAfterInsert = trackDao.getTracksForAlbumOnce(insertedAlbumId)
                 val localAfterInsert = allAfterInsert.filter { !it.path.trim().startsWith("http", ignoreCase = true) }
-                val localKeyToId = LinkedHashMap<String, Long>()
+                val localPathToId = LinkedHashMap<String, Long>()
                 localAfterInsert.forEach { t ->
-                    localKeyToId.putIfAbsent(TrackKeyNormalizer.buildKey(t.title, t.group, null), t.id)
-                    localKeyToId.putIfAbsent(TrackKeyNormalizer.buildKey(t.title, "", null), t.id)
+                    localPathToId.putIfAbsent(t.path, t.id)
                 }
                 val onlineTracks = allAfterInsert.filter { it.path.trim().startsWith("http", ignoreCase = true) }
                 onlineTracks.forEach { online ->
-                    val key = TrackKeyNormalizer.buildKey(online.title, online.group, null)
-                    val keyNoGroup = TrackKeyNormalizer.buildKey(online.title, "", null)
-                    val targetId = localKeyToId[key] ?: localKeyToId[keyNoGroup]
+                    val targetId = localPathToId[online.path]
                     if (targetId != null) {
                         val sourceSubs = trackDao.getSubtitlesForTrack(online.id)
                         if (sourceSubs.isNotEmpty()) {
@@ -2536,14 +2484,6 @@ class LibraryViewModel @Inject constructor(
                 .distinct()
 
             val allExistingTracks = trackDao.getTracksForAlbumOnce(albumId)
-            val existingLocalTargetsByKey = LinkedHashMap<String, TrackEntity>()
-            val existingLocalTargetsByKeyNoGroup = LinkedHashMap<String, TrackEntity>()
-            allExistingTracks
-                .filter { it.path.isNotBlank() && !it.path.startsWith(treePrefix) && !it.path.trim().startsWith("http", ignoreCase = true) }
-                .forEach { t ->
-                    existingLocalTargetsByKey.putIfAbsent(TrackKeyNormalizer.buildKey(t.title, t.group, null), t)
-                    existingLocalTargetsByKeyNoGroup.putIfAbsent(TrackKeyNormalizer.buildKey(t.title, "", null), t)
-                }
 
             val toDelete = allExistingTracks.filter { it.path.startsWith(treePrefix) }.map { it.id }
             if (toDelete.isNotEmpty()) {
@@ -2551,29 +2491,7 @@ class LibraryViewModel @Inject constructor(
                 trackDao.deleteTracksByIds(toDelete)
             }
 
-            val filteredTrackSpecs = trackSpecs.filter { spec ->
-                val key = TrackKeyNormalizer.buildKey(spec.title, spec.group, null)
-                val keyNoGroup = TrackKeyNormalizer.buildKey(spec.title, "", null)
-                val existingTarget = existingLocalTargetsByKey[key] ?: existingLocalTargetsByKeyNoGroup[keyNoGroup]
-                if (existingTarget != null) {
-                    val entries = subtitlesByAudioPath[spec.path].orEmpty()
-                    if (entries.isNotEmpty()) {
-                        trackDao.deleteSubtitlesForTrack(existingTarget.id)
-                        trackDao.insertSubtitles(
-                            entries.map { e ->
-                                SubtitleEntity(
-                                    trackId = existingTarget.id,
-                                    startMs = e.startMs,
-                                    endMs = e.endMs,
-                                    text = e.text
-                                )
-                            }
-                        )
-                        wroteAnySubtitles = true
-                    }
-                }
-                existingTarget == null
-            }
+            val filteredTrackSpecs = trackSpecs
 
             val tracksToInsert = filteredTrackSpecs.map { spec ->
                 TrackEntity(

--- a/app/src/test/java/com/asmr/player/ui/library/AlbumDetailDirectorySupportTest.kt
+++ b/app/src/test/java/com/asmr/player/ui/library/AlbumDetailDirectorySupportTest.kt
@@ -5,6 +5,7 @@ import com.asmr.player.domain.model.Album
 import com.asmr.player.domain.model.Track
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
+import org.junit.Assert.assertFalse
 import org.junit.Test
 
 class AlbumDetailDirectorySupportTest {
@@ -132,5 +133,72 @@ class AlbumDetailDirectorySupportTest {
 
         assertTrue(file.subtitleSources.isNotEmpty())
         assertEquals("https://example.com/subs/01.lrc", file.subtitleSources.first().url)
+    }
+
+    @Test
+    fun buildDlsiteTrialDownloadTree_keepsOnlyPlayableMediaWithStableNames() {
+        val tree = buildDlsiteTrialDownloadTree(
+            listOf(
+                Track(albumId = 0L, title = "试听音频", path = "https://example.com/trial/audio/sample.mp3"),
+                Track(albumId = 0L, title = "试看视频", path = "https://example.com/trial/video/preview.mp4"),
+                Track(albumId = 0L, title = "无扩展资源", path = "https://example.com/trial/audio/stream")
+            )
+        )
+
+        val paths = flattenAsmrOneLeafDownloads(tree).map { it.relativePath }
+
+        assertEquals(
+            listOf(
+                "01_试听音频.mp3",
+                "02_试看视频.mp4",
+                "03_无扩展资源.mp3"
+            ),
+            paths
+        )
+    }
+
+    @Test
+    fun filterDownloadableMediaTree_removesSubtitleAndImageLeaves() {
+        val filtered = filterDownloadableMediaTree(
+            listOf(
+                AsmrOneTrackNodeResponse(title = "audio.mp3", mediaDownloadUrl = "https://example.com/audio.mp3"),
+                AsmrOneTrackNodeResponse(title = "cover.jpg", mediaDownloadUrl = "https://example.com/cover.jpg"),
+                AsmrOneTrackNodeResponse(title = "sub.srt", mediaDownloadUrl = "https://example.com/sub.srt")
+            )
+        )
+
+        val leafPaths = flattenAsmrOneLeafDownloads(filtered).map { it.relativePath }
+
+        assertEquals(listOf("audio.mp3"), leafPaths)
+        assertFalse(leafPaths.contains("cover.jpg"))
+        assertFalse(leafPaths.contains("sub.srt"))
+    }
+
+    @Test
+    fun buildLocalTreeIndexFromLeaves_keepsSameNameFilesFromDifferentDirectories() {
+        val tracks = listOf(
+            Track(albumId = 9L, title = "same", path = "/album/one/same.mp3", group = "one"),
+            Track(albumId = 9L, title = "same", path = "/album/体验版/same.mp3", group = "体验版")
+        )
+        val leaves = listOf(
+            LocalTreeLeafCacheEntry(
+                relativePath = "one/same.mp3",
+                absolutePath = "/album/one/same.mp3",
+                fileType = TreeFileType.Audio,
+                sizeBytes = 100L
+            ),
+            LocalTreeLeafCacheEntry(
+                relativePath = "体验版/same.mp3",
+                absolutePath = "/album/体验版/same.mp3",
+                fileType = TreeFileType.Audio,
+                sizeBytes = 120L
+            )
+        )
+
+        val index = buildLocalTreeIndexFromLeaves(leaves = leaves, tracks = tracks)
+        val flattened = flattenLocalTreeIndex(index, expanded = setOf("one", "体验版"))
+
+        val paths = flattened.entries.filterIsInstance<LocalTreeUiEntry.File>().map { it.path }.sorted()
+        assertEquals(listOf("one/same.mp3", "体验版/same.mp3"), paths)
     }
 }


### PR DESCRIPTION
## Summary
- add download support for DLsite trial audio/video in album detail
- store trial downloads under a dedicated 体验版 directory and reuse the existing selection dialog
- stop cross-directory dedup from merging same-name trial and ONE/local files in library detail

## Verification
- ./gradlew.bat :app:compileDebugKotlin --console=plain
- added/updated unit tests for trial download tree filtering and same-name files in different directories

## Notes
- :app:testDebugUnitTest still hits the existing Gradle test worker startup issue in this environment (worker.org.gradle.process.internal.worker.GradleWorkerMain), so only compile verification was run here