### PR TITLE
feat: add DLsite presale search filter

### DIFF
--- a/app/src/main/java/com/asmr/player/data/local/datastore/SearchCacheStore.kt
+++ b/app/src/main/java/com/asmr/player/data/local/datastore/SearchCacheStore.kt
@@ -19,6 +19,7 @@ data class LastSearchStateV1(
     val keyword: String,
     val orderName: String,
     val purchasedOnly: Boolean,
+    val presaleOnly: Boolean = false,
     val locale: String?,
     val page: Int,
     val canGoNext: Boolean,

--- a/app/src/main/java/com/asmr/player/data/remote/scraper/DLSiteScraper.kt
+++ b/app/src/main/java/com/asmr/player/data/remote/scraper/DLSiteScraper.kt
@@ -23,6 +23,67 @@ import kotlin.math.absoluteValue
 import javax.inject.Inject
 import javax.inject.Singleton
 
+internal fun languageSegmentForLocale(locale: String?): String {
+    val normalized = locale?.trim().orEmpty()
+    return when {
+        normalized.startsWith("zh_CN", ignoreCase = true) -> "cn"
+        normalized.startsWith("zh_TW", ignoreCase = true) -> "tw"
+        normalized.startsWith("ja", ignoreCase = true) -> "jp"
+        else -> "cn"
+    }
+}
+
+internal fun buildDlsiteSearchUrls(
+    keyword: String,
+    page: Int,
+    order: String,
+    locale: String? = null,
+    presaleOnly: Boolean = false
+): List<String> {
+    val normalizedKeyword = keyword.trim()
+    val encodedKeyword = URLEncoder.encode(normalizedKeyword, "UTF-8")
+    val normalizedOrder = order.trim().ifBlank { "trend" }
+    val encodedOrder = URLEncoder.encode(normalizedOrder, "UTF-8")
+    val safePage = page.coerceAtLeast(1)
+
+    if (presaleOnly) {
+        val primaryBase =
+            "https://www.dlsite.com/maniax/fsr/=/ana_flg/on/order/$encodedOrder/work_type_category%5B0%5D/audio"
+        val primary = if (normalizedKeyword.isBlank()) {
+            "$primaryBase/page/$safePage"
+        } else {
+            "$primaryBase/keyword/$encodedKeyword/page/$safePage"
+        }
+
+        val language = languageSegmentForLocale(locale)
+        val fallbackBase =
+            "https://www.dlsite.com/maniax/fsr/=/language/$language/sex_category%5B0%5D/male/work_category%5B0%5D/doujin/" +
+                "ana_flg/on/order%5B0%5D/$encodedOrder/work_type_category%5B0%5D/audio/per_page/30/show_type/3"
+        val fallback = if (normalizedKeyword.isBlank()) {
+            "$fallbackBase/page/$safePage"
+        } else {
+            "$fallbackBase/keyword/$encodedKeyword/page/$safePage"
+        }
+        return listOf(primary, fallback).distinct()
+    }
+
+    val language = languageSegmentForLocale(locale)
+    val modernBase =
+        "https://www.dlsite.com/maniax/fsr/=/language/$language/sex_category%5B0%5D/male/work_category%5B0%5D/doujin/" +
+            "order%5B0%5D/$encodedOrder/work_type_category%5B0%5D/audio/per_page/30/show_type/3/from/fsr.again"
+    val modern = if (normalizedKeyword.isBlank()) {
+        "$modernBase/page/$safePage"
+    } else {
+        "$modernBase/keyword/$encodedKeyword/page/$safePage"
+    }
+    val legacy = if (normalizedKeyword.isBlank()) {
+        "https://www.dlsite.com/maniax/fsr/=/language/$language/sex_category%5B0%5D/male/work_category%5B0%5D/doujin/work_type_category%5B0%5D/audio/per_page/30/show_type/1/page/$safePage/without_order/1/order/$encodedOrder"
+    } else {
+        "https://www.dlsite.com/maniax/fsr/=/language/$language/sex_category%5B0%5D/male/work_category%5B0%5D/doujin/work_type_category%5B0%5D/audio/per_page/30/show_type/1/keyword/$encodedKeyword/page/$safePage/without_order/1/order/$encodedOrder"
+    }
+    return listOf(modern, legacy)
+}
+
 data class DlsiteWorkInfo(
     val album: Album,
     val galleryUrls: List<String>,
@@ -46,9 +107,8 @@ data class DlsiteRecommendations(
 class DLSiteScraper @Inject constructor(
     @ApplicationContext context: Context
 ) {
-    private val searchBaseUrlLegacy =
-        "https://www.dlsite.com/maniax/fsr/=/language/cn/sex_category%5B0%5D/male/work_category%5B0%5D/doujin/work_type_category%5B0%5D/audio/per_page/30/show_type/1/keyword/"
     private val workBaseUrl = "https://www.dlsite.com/maniax/work/=/product_id/"
+    private val announceBaseUrl = "https://www.dlsite.com/maniax/announce/=/product_id/"
     
     private val authStore = DlsiteAuthStore(context)
     private val gson = Gson()
@@ -94,18 +154,22 @@ class DLSiteScraper @Inject constructor(
             .timeout(10000)
     }
 
-    private fun languageSegmentForLocale(locale: String?): String {
-        val l = locale?.trim().orEmpty()
-        return when {
-            l.startsWith("zh_CN", ignoreCase = true) -> "cn"
-            l.startsWith("zh_TW", ignoreCase = true) -> "tw"
-            l.startsWith("ja", ignoreCase = true) -> "jp"
-            else -> "cn"
-        }
-    }
-
     private fun parseRecommendHtml(doc: Document): List<DlsiteRecommendedWork> {
         return DlsiteRecommendHtmlParser.parse(doc)
+    }
+
+    private suspend fun fetchWorkDocument(workId: String, locale: String? = null): Document? {
+        val clean = workId.trim().uppercase()
+        if (clean.isBlank()) return null
+        val candidates = listOf(
+            "$workBaseUrl$clean.html",
+            "$announceBaseUrl$clean.html"
+        )
+        for (url in candidates) {
+            val doc = runCatching { runInterruptible { connect(url, locale = locale).get() } }.getOrNull() ?: continue
+            if (doc.selectFirst("#work_name") != null) return doc
+        }
+        return null
     }
 
     suspend fun getRecommendationsDetailV2(workId: String, locale: String? = null): DlsiteRecommendations =
@@ -201,44 +265,15 @@ class DLSiteScraper @Inject constructor(
         return embedUrl
     }
 
-    suspend fun search(keyword: String, page: Int = 1, order: String = "trend", locale: String? = null): List<Album> = withContext(Dispatchers.IO) {
-        val normalizedKeyword = keyword.trim()
-        val encodedKeyword = URLEncoder.encode(normalizedKeyword, "UTF-8")
-        val normalizedOrder = order.trim().ifBlank { "trend" }
-        fun buildUrls(): List<String> {
-            val p = page.coerceAtLeast(1)
-            val kw = encodedKeyword
-            val o = URLEncoder.encode(normalizedOrder, "UTF-8")
-            val lang = languageSegmentForLocale(locale)
-            val modernBase =
-                "https://www.dlsite.com/maniax/fsr/=/language/$lang/sex_category%5B0%5D/male/work_category%5B0%5D/doujin/" +
-                    "order%5B0%5D/$o/work_type_category%5B0%5D/audio/per_page/30/show_type/3/from/fsr.again"
-            val modern = if (normalizedKeyword.isBlank()) {
-                "$modernBase/page/$p"
-            } else {
-                "$modernBase/keyword/$kw/page/$p"
-            }
-            val legacy = if (normalizedKeyword.isBlank()) {
-                "https://www.dlsite.com/maniax/fsr/=/language/$lang/sex_category%5B0%5D/male/work_category%5B0%5D/doujin/work_type_category%5B0%5D/audio/per_page/30/show_type/1/page/$p/without_order/1/order/$o"
-            } else {
-                "https://www.dlsite.com/maniax/fsr/=/language/$lang/sex_category%5B0%5D/male/work_category%5B0%5D/doujin/work_type_category%5B0%5D/audio/per_page/30/show_type/1/keyword/$kw/page/$p/without_order/1/order/$o"
-            }
-            return listOf(modern, legacy)
-        }
-
-        fun parseDoc(doc: Document): List<Album> {
+    suspend fun search(
+        keyword: String,
+        page: Int = 1,
+        order: String = "trend",
+        locale: String? = null,
+        presaleOnly: Boolean = false
+    ): List<Album> = withContext(Dispatchers.IO) {
+        fun parseItems(items: List<Element>, doc: Document): List<Album> {
             val results = mutableListOf<Album>()
-
-            val container = doc.selectFirst("#search_result_list.loading_display_open")
-                ?: doc.select("#search_result_list").lastOrNull()
-
-            var items = container?.select("table tr")?.toList().orEmpty().filter { it.select("th").isEmpty() }
-            if (items.isEmpty()) {
-                items = container?.select("li")?.toList().orEmpty()
-            }
-            if (items.isEmpty()) {
-                items = doc.select("#search_result_img_box li").toList()
-            }
 
             for (item in items) {
                 val titleTag = item.selectFirst(".work_name a") ?: continue
@@ -259,8 +294,21 @@ class DLSiteScraper @Inject constructor(
                     return first.split(Regex("\\s+")).firstOrNull().orEmpty().trim()
                 }
 
+                fun extractVueBoundImageSrc(expr: String): String {
+                    val trimmed = expr.trim()
+                    if (trimmed.isEmpty()) return ""
+                    val direct = Regex("""['\"](//[^'\"]+|https?://[^'\"]+|/[^'\"]+)['\"]""")
+                        .findAll(trimmed)
+                        .map { it.groupValues.getOrNull(1).orEmpty().trim() }
+                        .firstOrNull { candidate ->
+                            candidate.isNotBlank() && !candidate.startsWith("data:", ignoreCase = true)
+                        }
+                    return direct.orEmpty()
+                }
+
                 fun pickBestImageUrl(img: Element): String {
                     val candidates = sequenceOf(
+                        extractVueBoundImageSrc(img.attr(":src")),
                         img.attr("data-src"),
                         img.attr("data-original"),
                         img.attr("data-lazy"),
@@ -309,10 +357,36 @@ class DLSiteScraper @Inject constructor(
                     )
                 )
             }
+
             return results
         }
 
-        val urls = buildUrls()
+        fun parseDoc(doc: Document): List<Album> {
+            val container = doc.selectFirst("#search_result_list.loading_display_open")
+                ?: doc.select("#search_result_list").lastOrNull()
+
+            val candidates = listOf(
+                container?.select("li")?.toList().orEmpty(),
+                doc.select("#search_result_img_box li").toList(),
+                container?.select("table tr")?.toList().orEmpty().filter { it.select("th").isEmpty() }
+            )
+
+            for (items in candidates) {
+                if (items.isEmpty()) continue
+                val parsed = parseItems(items, doc)
+                if (parsed.isNotEmpty()) return parsed
+            }
+
+            return emptyList()
+        }
+
+        val urls = buildDlsiteSearchUrls(
+            keyword = keyword,
+            page = page,
+            order = order,
+            locale = locale,
+            presaleOnly = presaleOnly
+        )
         var lastEmpty: List<Album> = emptyList()
         for (u in urls) {
             Log.d("DLSiteScraper", "Searching URL: $u")
@@ -333,8 +407,7 @@ class DLSiteScraper @Inject constructor(
     }
 
     suspend fun getWorkInfo(workId: String, locale: String? = null): DlsiteWorkInfo? = withContext(Dispatchers.IO) {
-        val url = "$workBaseUrl$workId.html"
-        val doc = runCatching { runInterruptible { connect(url, locale = locale).get() } }.getOrNull() ?: return@withContext null
+        val doc = fetchWorkDocument(workId, locale = locale) ?: return@withContext null
 
         val title = doc.selectFirst("#work_name")?.text()?.trim() ?: return@withContext null
         val circle = doc.selectFirst(".maker_name a")?.text()?.trim() ?: ""
@@ -483,8 +556,7 @@ class DLSiteScraper @Inject constructor(
         }
 
         suspend fun internal(workId0: String, allowFallback: Boolean): List<Track> {
-            val url = "$workBaseUrl$workId0.html"
-            val doc = runInterruptible { connect(url, locale = locale).get() }
+            val doc = fetchWorkDocument(workId0, locale = locale) ?: return emptyList()
             val tracks = mutableListOf<Track>()
 
             tracks.addAll(parseTrackListFromDoc(doc))

--- a/app/src/main/java/com/asmr/player/ui/search/SearchFilterOption.kt
+++ b/app/src/main/java/com/asmr/player/ui/search/SearchFilterOption.kt
@@ -1,0 +1,33 @@
+package com.asmr.player.ui.search
+
+enum class SearchFilterOption(
+    val label: String,
+    val isPurchasedOnly: Boolean = false,
+    val isPresaleOnly: Boolean = false,
+    val sortOption: SearchSortOption? = null
+) {
+    PurchasedOnly(label = "仅已购", isPurchasedOnly = true),
+    Presale(label = "预售", isPresaleOnly = true),
+    Trend(label = SearchSortOption.Trend.label, sortOption = SearchSortOption.Trend),
+    ReleaseNew(label = SearchSortOption.ReleaseNew.label, sortOption = SearchSortOption.ReleaseNew),
+    ReleaseOld(label = SearchSortOption.ReleaseOld.label, sortOption = SearchSortOption.ReleaseOld),
+    DLCount(label = SearchSortOption.DLCount.label, sortOption = SearchSortOption.DLCount),
+    PriceLow(label = SearchSortOption.PriceLow.label, sortOption = SearchSortOption.PriceLow),
+    PriceHigh(label = SearchSortOption.PriceHigh.label, sortOption = SearchSortOption.PriceHigh),
+    Rating(label = SearchSortOption.Rating.label, sortOption = SearchSortOption.Rating),
+    ReviewCount(label = SearchSortOption.ReviewCount.label, sortOption = SearchSortOption.ReviewCount);
+
+    companion object {
+        fun fromState(
+            order: SearchSortOption,
+            purchasedOnly: Boolean,
+            presaleOnly: Boolean
+        ): SearchFilterOption {
+            return when {
+                purchasedOnly -> PurchasedOnly
+                presaleOnly -> Presale
+                else -> values().firstOrNull { it.sortOption == order } ?: Trend
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/asmr/player/ui/search/SearchScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/search/SearchScreen.kt
@@ -147,10 +147,18 @@ fun SearchScreen(
 ) {
     var keyword by rememberSaveable { mutableStateOf("") }
     var purchasedOnly by rememberSaveable { mutableStateOf(false) }
+    var presaleOnly by rememberSaveable { mutableStateOf(false) }
     var selectedLocale by rememberSaveable { mutableStateOf("ja_JP") }
     var selectedOrderName by rememberSaveable { mutableStateOf(SearchSortOption.Trend.name) }
     val selectedOrder = remember(selectedOrderName) {
         SearchSortOption.values().firstOrNull { it.name == selectedOrderName } ?: SearchSortOption.Trend
+    }
+    val selectedFilter = remember(selectedOrderName, purchasedOnly, presaleOnly) {
+        SearchFilterOption.fromState(
+            order = selectedOrder,
+            purchasedOnly = purchasedOnly,
+            presaleOnly = presaleOnly
+        )
     }
     val viewMode by viewModel.viewMode.collectAsState()
     val uiState by viewModel.uiState.collectAsState()
@@ -182,10 +190,11 @@ fun SearchScreen(
         }
     }
 
-    LaunchedEffect(success?.pendingRequest, success?.order, success?.purchasedOnly, success?.locale) {
+    LaunchedEffect(success?.pendingRequest, success?.order, success?.purchasedOnly, success?.presaleOnly, success?.locale) {
         val state = success ?: return@LaunchedEffect
         if (!optionsSyncedFromState || state.pendingRequest == null) {
             purchasedOnly = state.purchasedOnly
+            presaleOnly = state.presaleOnly
             selectedLocale = state.locale ?: "ja_JP"
             selectedOrderName = state.order.name
             optionsSyncedFromState = true
@@ -540,8 +549,7 @@ fun SearchScreen(
                         modifier = Modifier.align(Alignment.TopCenter),
                         keyword = keyword,
                         onKeywordChange = { keyword = it },
-                        selectedOrder = selectedOrder,
-                        purchasedOnly = purchasedOnly,
+                        selectedFilter = selectedFilter,
                         selectedLocale = selectedLocale,
                         filterControlsLocked = filterControlsLocked,
                         searchSubmitLocked = searchSubmitLocked,
@@ -556,31 +564,26 @@ fun SearchScreen(
                         collapseFraction = chromeState.collapseFraction,
                         onMeasured = { size: IntSize -> chromeState.updateHeight(size.height.toFloat()) },
                         onSearchSubmit = ::submitSearch,
-                        onPurchasedOnlySelected = {
+                        onFilterSelected = { option ->
+                            val nextOrder = option.sortOption ?: selectedOrder
                             val accepted = viewModel.updateSearchOptions(
-                                order = selectedOrder,
-                                purchasedOnly = true,
+                                order = nextOrder,
+                                purchasedOnly = option.isPurchasedOnly,
+                                presaleOnly = option.isPresaleOnly,
                                 locale = selectedLocale
                             )
                             if (accepted) {
-                                purchasedOnly = true
+                                selectedOrderName = nextOrder.name
+                                purchasedOnly = option.isPurchasedOnly
+                                presaleOnly = option.isPresaleOnly
                             }
-                        },
-                        onOrderSelected = { order ->
-                            selectedOrderName = order.name
-                            purchasedOnly = false
-                            viewModel.updateSearchOptions(
-                                order = order,
-                                purchasedOnly = false,
-                                locale = selectedLocale
-                            )
                         },
                         onLocaleSelected = { locale ->
                             selectedLocale = locale
-                            purchasedOnly = false
                             viewModel.updateSearchOptions(
                                 order = selectedOrder,
-                                purchasedOnly = false,
+                                purchasedOnly = purchasedOnly,
+                                presaleOnly = presaleOnly,
                                 locale = locale
                             )
                         },
@@ -658,8 +661,7 @@ internal fun SearchChrome(
     modifier: Modifier = Modifier,
     keyword: String,
     onKeywordChange: (String) -> Unit,
-    selectedOrder: SearchSortOption,
-    purchasedOnly: Boolean,
+    selectedFilter: SearchFilterOption,
     selectedLocale: String,
     filterControlsLocked: Boolean,
     searchSubmitLocked: Boolean,
@@ -674,8 +676,7 @@ internal fun SearchChrome(
     collapseFraction: Float,
     onMeasured: (IntSize) -> Unit,
     onSearchSubmit: () -> Unit,
-    onPurchasedOnlySelected: () -> Unit,
-    onOrderSelected: (SearchSortOption) -> Unit,
+    onFilterSelected: (SearchFilterOption) -> Unit,
     onLocaleSelected: (String) -> Unit,
     onPrev: () -> Unit,
     onNext: () -> Unit
@@ -693,15 +694,13 @@ internal fun SearchChrome(
         SearchToolbar(
             keyword = keyword,
             onKeywordChange = onKeywordChange,
-            selectedOrder = selectedOrder,
-            purchasedOnly = purchasedOnly,
+            selectedFilter = selectedFilter,
             selectedLocale = selectedLocale,
             filterControlsLocked = filterControlsLocked,
             searchSubmitLocked = searchSubmitLocked,
             showSearchSpinner = showSearchSpinner,
             onSearchSubmit = onSearchSubmit,
-            onPurchasedOnlySelected = onPurchasedOnlySelected,
-            onOrderSelected = onOrderSelected,
+            onFilterSelected = onFilterSelected,
             onLocaleSelected = onLocaleSelected,
             rightPanelToggle = rightPanelToggle
         )
@@ -722,15 +721,13 @@ internal fun SearchChrome(
 internal fun SearchToolbar(
     keyword: String,
     onKeywordChange: (String) -> Unit,
-    selectedOrder: SearchSortOption,
-    purchasedOnly: Boolean,
+    selectedFilter: SearchFilterOption,
     selectedLocale: String,
     filterControlsLocked: Boolean,
     searchSubmitLocked: Boolean,
     showSearchSpinner: Boolean,
     onSearchSubmit: () -> Unit,
-    onPurchasedOnlySelected: () -> Unit,
-    onOrderSelected: (SearchSortOption) -> Unit,
+    onFilterSelected: (SearchFilterOption) -> Unit,
     onLocaleSelected: (String) -> Unit,
     rightPanelToggle: (@Composable (Modifier) -> Unit)? = null
 ) {
@@ -765,7 +762,7 @@ internal fun SearchToolbar(
                 .weight(1f)
                 .testTag(SEARCH_INPUT_TAG),
             leadingIcon = {
-                val label = if (purchasedOnly) "仅已购" else selectedOrder.label
+                val label = selectedFilter.label
                 Box {
                     TextButton(
                         onClick = { scopeMenuExpanded = true },
@@ -785,19 +782,7 @@ internal fun SearchToolbar(
                         onDismissRequest = { scopeMenuExpanded = false },
                         modifier = Modifier.background(dropdownContainerColor)
                     ) {
-                        DropdownMenuItem(
-                            text = { Text("仅已购", color = colorScheme.textPrimary) },
-                            onClick = {
-                                scopeMenuExpanded = false
-                                onPurchasedOnlySelected()
-                            }
-                        )
-                        HorizontalDivider(
-                            modifier = Modifier.padding(horizontal = 8.dp),
-                            thickness = 0.5.dp,
-                            color = colorScheme.textSecondary.copy(alpha = 0.2f)
-                        )
-                        SearchSortOption.values().forEachIndexed { index, option ->
+                        SearchFilterOption.values().forEachIndexed { index, option ->
                             if (index > 0) {
                                 HorizontalDivider(
                                     modifier = Modifier.padding(horizontal = 8.dp),
@@ -806,10 +791,15 @@ internal fun SearchToolbar(
                                 )
                             }
                             DropdownMenuItem(
-                                text = { Text(option.label, color = colorScheme.textPrimary) },
+                                text = {
+                                    Text(
+                                        text = option.label,
+                                        color = if (option == selectedFilter) colorScheme.primary else colorScheme.textPrimary
+                                    )
+                                },
                                 onClick = {
                                     scopeMenuExpanded = false
-                                    onOrderSelected(option)
+                                    onFilterSelected(option)
                                 }
                             )
                         }

--- a/app/src/main/java/com/asmr/player/ui/search/SearchViewModel.kt
+++ b/app/src/main/java/com/asmr/player/ui/search/SearchViewModel.kt
@@ -64,6 +64,7 @@ class SearchViewModel @Inject constructor(
     private val pageSize = 30
     private var currentOrder: SearchSortOption = SearchSortOption.Trend
     private var purchasedOnly: Boolean = false
+    private var presaleOnly: Boolean = false
     private var enrichJob: Job? = null
     private var asmrOneJob: Job? = null
     private var cacheWriteJob: Job? = null
@@ -96,6 +97,7 @@ class SearchViewModel @Inject constructor(
                 lastRequestedKeyword = cached.keyword
             } else {
                 purchasedOnly = initialPurchasedOnly
+                presaleOnly = false
                 currentLocale = initialLocale
                 lastRequestedKeyword = initialKeyword.trim()
                 requestPage(lastRequestedKeyword, 1, SearchPendingRequestKind.Search)
@@ -134,6 +136,10 @@ class SearchViewModel @Inject constructor(
         updateSearchOptions(purchasedOnly = enabled)
     }
 
+    fun setPresaleOnly(enabled: Boolean) {
+        updateSearchOptions(presaleOnly = enabled)
+    }
+
     fun setLocale(locale: String?) {
         updateSearchOptions(locale = locale)
     }
@@ -141,6 +147,7 @@ class SearchViewModel @Inject constructor(
     fun updateSearchOptions(
         order: SearchSortOption = currentOrder,
         purchasedOnly: Boolean = this.purchasedOnly,
+        presaleOnly: Boolean = this.presaleOnly,
         locale: String? = currentLocale
     ): Boolean {
         val current = _uiState.value as? SearchUiState.Success ?: return false
@@ -149,9 +156,15 @@ class SearchViewModel @Inject constructor(
             messageManager.showWarning("请先登录 DLsite 后再使用\"仅已购\"搜索")
             return false
         }
-        if (currentOrder == order && this.purchasedOnly == purchasedOnly && currentLocale == locale) return true
+        if (
+            currentOrder == order &&
+            this.purchasedOnly == purchasedOnly &&
+            this.presaleOnly == presaleOnly &&
+            currentLocale == locale
+        ) return true
         currentOrder = order
         this.purchasedOnly = purchasedOnly
+        this.presaleOnly = presaleOnly
         currentLocale = locale
         requestPage(current.keyword, 1, SearchPendingRequestKind.Search)
         return true
@@ -201,7 +214,8 @@ class SearchViewModel @Inject constructor(
                     keyword = normalizedKeyword,
                     page = page,
                     order = currentOrder,
-                    purchasedOnly = purchasedOnly
+                    purchasedOnly = purchasedOnly,
+                    presaleOnly = presaleOnly
                 )
                 _uiState.value = SearchUiState.Success(
                     results = pageResult.items,
@@ -209,6 +223,7 @@ class SearchViewModel @Inject constructor(
                     page = page,
                     order = currentOrder,
                     purchasedOnly = purchasedOnly,
+                    presaleOnly = presaleOnly,
                     locale = currentLocale,
                     canGoPrev = page > 1,
                     canGoNext = pageResult.canGoNext,
@@ -253,6 +268,7 @@ class SearchViewModel @Inject constructor(
                 if (previousSuccess != null) {
                     currentOrder = previousSuccess.order
                     purchasedOnly = previousSuccess.purchasedOnly
+                    presaleOnly = previousSuccess.presaleOnly
                     currentLocale = previousSuccess.locale
                     _uiState.value = previousSuccess.copy(
                         pendingRequest = null,
@@ -294,7 +310,8 @@ class SearchViewModel @Inject constructor(
         keyword: String,
         page: Int,
         order: SearchSortOption,
-        purchasedOnly: Boolean
+        purchasedOnly: Boolean,
+        presaleOnly: Boolean
     ): SearchPageResult {
         if (purchasedOnly) {
             val resp = dlsitePlayLibraryClient.searchPurchased(keyword, page, pageSize)
@@ -302,7 +319,7 @@ class SearchViewModel @Inject constructor(
         }
         val normalizedKeyword = keyword.trim()
         val normalizedRj = normalizedKeyword.uppercase()
-        if (page == 1 && Regex("""RJ\d{6,}""").matches(normalizedRj)) {
+        if (!presaleOnly && page == 1 && Regex("""RJ\d{6,}""").matches(normalizedRj)) {
             val preferred = currentLocale
             val info = when {
                 !preferred.isNullOrBlank() -> {
@@ -323,7 +340,13 @@ class SearchViewModel @Inject constructor(
                 return SearchPageResult(items = listOf(album), canGoNext = false)
             }
         }
-        val items = dlsiteScraper.search(keyword, page, order.dlsiteOrder, locale = currentLocale)
+        val items = dlsiteScraper.search(
+            keyword = keyword,
+            page = page,
+            order = order.dlsiteOrder,
+            locale = currentLocale,
+            presaleOnly = presaleOnly
+        )
         return SearchPageResult(items = items, canGoNext = items.size >= pageSize)
     }
 
@@ -391,6 +414,7 @@ class SearchViewModel @Inject constructor(
         val page = cached.page.coerceAtLeast(1)
         currentOrder = order
         purchasedOnly = cached.purchasedOnly
+        presaleOnly = cached.presaleOnly
         currentLocale = cached.locale
         _uiState.value = SearchUiState.Success(
             results = cached.results,
@@ -398,6 +422,7 @@ class SearchViewModel @Inject constructor(
             page = page,
             order = order,
             purchasedOnly = cached.purchasedOnly,
+            presaleOnly = cached.presaleOnly,
             locale = cached.locale,
             canGoPrev = page > 1,
             canGoNext = cached.canGoNext,
@@ -425,6 +450,7 @@ class SearchViewModel @Inject constructor(
                         keyword = latest.keyword,
                         orderName = latest.order.name,
                         purchasedOnly = latest.purchasedOnly,
+                        presaleOnly = latest.presaleOnly,
                         locale = latest.locale,
                         page = latest.page,
                         canGoNext = latest.canGoNext,
@@ -805,6 +831,7 @@ sealed class SearchUiState {
         val page: Int,
         val order: SearchSortOption,
         val purchasedOnly: Boolean,
+        val presaleOnly: Boolean,
         val locale: String?,
         val canGoPrev: Boolean,
         val canGoNext: Boolean,

--- a/app/src/test/java/com/asmr/player/data/remote/scraper/DLSiteScraperUrlBuilderTest.kt
+++ b/app/src/test/java/com/asmr/player/data/remote/scraper/DLSiteScraperUrlBuilderTest.kt
@@ -1,0 +1,42 @@
+package com.asmr.player.data.remote.scraper
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class DLSiteScraperUrlBuilderTest {
+    @Test
+    fun buildDlsiteSearchUrls_includesPresaleFlagForPresaleOption() {
+        val urls = buildDlsiteSearchUrls(
+            keyword = "耳",
+            page = 2,
+            order = "trend",
+            locale = "ja_JP",
+            presaleOnly = true
+        )
+
+        assertEquals(2, urls.size)
+        assertEquals(
+            "https://www.dlsite.com/maniax/fsr/=/ana_flg/on/order/trend/work_type_category%5B0%5D/audio/keyword/%E8%80%B3/page/2",
+            urls.first()
+        )
+        assertTrue(urls.all { it.contains("ana_flg/on") })
+    }
+
+    @Test
+    fun buildDlsiteSearchUrls_usesExistingModernAndLegacyTemplatesForNormalSearch() {
+        val urls = buildDlsiteSearchUrls(
+            keyword = "耳",
+            page = 2,
+            order = "trend",
+            locale = "ja_JP",
+            presaleOnly = false
+        )
+
+        assertEquals(2, urls.size)
+        assertTrue(urls.first().contains("order%5B0%5D/trend"))
+        assertTrue(urls.first().contains("/keyword/%E8%80%B3/page/2"))
+        assertTrue(urls.last().contains("/without_order/1/order/trend"))
+        assertTrue(urls.none { it.contains("ana_flg/on") })
+    }
+}

--- a/app/src/test/java/com/asmr/player/ui/search/SearchScreenChromeTest.kt
+++ b/app/src/test/java/com/asmr/player/ui/search/SearchScreenChromeTest.kt
@@ -48,15 +48,13 @@ class SearchScreenChromeTest {
                 SearchToolbar(
                     keyword = keyword,
                     onKeywordChange = { keyword = it },
-                    selectedOrder = SearchSortOption.Trend,
-                    purchasedOnly = false,
+                    selectedFilter = SearchFilterOption.Trend,
                     selectedLocale = "ja_JP",
                     filterControlsLocked = false,
                     searchSubmitLocked = false,
                     showSearchSpinner = false,
                     onSearchSubmit = { submitCount += 1 },
-                    onPurchasedOnlySelected = {},
-                    onOrderSelected = {},
+                    onFilterSelected = {},
                     onLocaleSelected = {}
                 )
             }
@@ -82,15 +80,13 @@ class SearchScreenChromeTest {
                     SearchToolbar(
                         keyword = "test",
                         onKeywordChange = {},
-                        selectedOrder = SearchSortOption.Trend,
-                        purchasedOnly = false,
+                        selectedFilter = SearchFilterOption.Trend,
                         selectedLocale = "ja_JP",
                         filterControlsLocked = true,
                         searchSubmitLocked = true,
                         showSearchSpinner = true,
                         onSearchSubmit = {},
-                        onPurchasedOnlySelected = {},
-                        onOrderSelected = {},
+                        onFilterSelected = {},
                         onLocaleSelected = {}
                     )
                     SearchPaginationHeader(
@@ -122,15 +118,13 @@ class SearchScreenChromeTest {
                     SearchToolbar(
                         keyword = "test",
                         onKeywordChange = {},
-                        selectedOrder = SearchSortOption.Trend,
-                        purchasedOnly = false,
+                        selectedFilter = SearchFilterOption.Trend,
                         selectedLocale = "ja_JP",
                         filterControlsLocked = true,
                         searchSubmitLocked = true,
                         showSearchSpinner = false,
                         onSearchSubmit = {},
-                        onPurchasedOnlySelected = {},
-                        onOrderSelected = {},
+                        onFilterSelected = {},
                         onLocaleSelected = {}
                     )
                     SearchPaginationHeader(
@@ -227,15 +221,13 @@ class SearchScreenChromeTest {
                 SearchToolbar(
                     keyword = keyword,
                     onKeywordChange = { keyword = it },
-                    selectedOrder = SearchSortOption.Trend,
-                    purchasedOnly = false,
+                    selectedFilter = SearchFilterOption.Trend,
                     selectedLocale = "ja_JP",
                     filterControlsLocked = false,
                     searchSubmitLocked = false,
                     showSearchSpinner = false,
                     onSearchSubmit = { submitCount += 1 },
-                    onPurchasedOnlySelected = {},
-                    onOrderSelected = {},
+                    onFilterSelected = {},
                     onLocaleSelected = {}
                 )
             }
@@ -262,8 +254,7 @@ class SearchScreenChromeTest {
                     modifier = Modifier,
                     keyword = "RJ123456",
                     onKeywordChange = {},
-                    selectedOrder = SearchSortOption.Trend,
-                    purchasedOnly = false,
+                    selectedFilter = SearchFilterOption.Trend,
                     selectedLocale = "ja_JP",
                     filterControlsLocked = false,
                     searchSubmitLocked = false,
@@ -278,8 +269,7 @@ class SearchScreenChromeTest {
                     collapseFraction = chromeState.collapseFraction,
                     onMeasured = { chromeState.updateHeight(it.height.toFloat()) },
                     onSearchSubmit = {},
-                    onPurchasedOnlySelected = {},
-                    onOrderSelected = {},
+                    onFilterSelected = {},
                     onLocaleSelected = {},
                     onPrev = {},
                     onNext = {}


### PR DESCRIPTION
## Summary
- add a new `预售` option to online search alongside existing sort/filter entries
- fetch DLsite presale results via `ana_flg/on` and persist the new state in search cache
- fix presale result cover parsing and support `/announce/` detail pages so covers load in album detail

## Testing
- `./gradlew compileDebugKotlin --no-daemon --max-workers=1`
- `./gradlew compileDebugUnitTestKotlin --no-daemon --max-workers=1`