### PR TITLE
fix: bootstrap cover theme from persisted hue

### DIFF
--- a/app/src/main/java/com/asmr/player/MainActivity.kt
+++ b/app/src/main/java/com/asmr/player/MainActivity.kt
@@ -40,6 +40,7 @@ import androidx.compose.runtime.*
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.BiasAlignment
 import androidx.compose.ui.ExperimentalComposeUiApi
@@ -148,6 +149,7 @@ import com.asmr.player.ui.player.SleepTimerSheetContent
 import com.asmr.player.ui.player.MiniPlayerDisplayMode
 
 import com.asmr.player.data.local.datastore.SettingsDataStore
+import com.asmr.player.data.local.datastore.ThemeBootstrapPreferences
 import com.asmr.player.data.settings.CoverPreviewMode
 import com.asmr.player.data.settings.LyricsPageSettings
 import com.asmr.player.util.MessageManager
@@ -165,6 +167,9 @@ import com.asmr.player.ui.theme.neutralPaletteForMode
 import com.asmr.player.ui.theme.rememberDynamicHuePalette
 import com.asmr.player.ui.theme.rememberDynamicHuePaletteFromVideoFrame
 import com.asmr.player.ui.theme.dynamicPageContainerColor
+import com.asmr.player.ui.theme.dynamicHueCacheKeyForArtwork
+import com.asmr.player.ui.theme.dynamicHueCacheKeyForVideo
+import com.asmr.player.ui.theme.peekDynamicHueSeedColor
 import com.asmr.player.ui.common.AppVolumeHearingWarningDialog
 import com.asmr.player.ui.common.AppVolumeWarningSessionState
 import com.asmr.player.ui.common.rememberAppVolumeWarningSessionState
@@ -179,6 +184,7 @@ import kotlinx.coroutines.withTimeoutOrNull
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.runBlocking
 
 import androidx.compose.foundation.border
 import androidx.compose.foundation.BorderStroke
@@ -210,12 +216,17 @@ class MainActivity : ComponentActivity() {
     @Inject
     lateinit var settingsRepository: SettingsRepository
 
+    private lateinit var initialThemeBootstrapPreferences: ThemeBootstrapPreferences
+
     private val volumeKeyEventTick = MutableStateFlow(0L)
     private var volumeKeyEventSeq = 0L
 
     @OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3WindowSizeClassApi::class)
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        initialThemeBootstrapPreferences = runBlocking {
+            settingsDataStore.loadThemeBootstrapPreferences()
+        }
         val recentAlbumsPanelExpandedInitial = false
         val startRouteFromIntent = intent.getStringExtra("start_route")
         setContent {
@@ -224,25 +235,32 @@ class MainActivity : ComponentActivity() {
             val playerViewModel: PlayerViewModel = hiltViewModel()
             val libraryViewModel: LibraryViewModel = hiltViewModel()
             val volumeKeyTick by volumeKeyEventTick.asStateFlow().collectAsState()
+            var themeBootstrap by remember {
+                mutableStateOf(initialThemeBootstrapPreferences)
+            }
+            LaunchedEffect(settingsDataStore) {
+                settingsDataStore.themeBootstrapPreferences.collect { value ->
+                    themeBootstrap = value
+                }
+            }
             val themeMediaSource by remember(playerViewModel) {
                 playerViewModel.playback
                     .map { it.currentMediaItem.toThemeMediaSource() }
                     .distinctUntilChanged()
             }.collectAsState(initial = ThemeMediaSource())
+            val playbackSnapshot by playerViewModel.playback.collectAsState()
             val systemDark = isSystemInDarkTheme()
-            val themePref by settingsDataStore.theme.collectAsState(initial = "system")
-            val mode = when (themePref.lowercase()) {
-                "light" -> ThemeMode.Light
-                "soft_dark" -> ThemeMode.SoftDark
-                "dark" -> ThemeMode.Dark
-                "system" -> if (systemDark) ThemeMode.Dark else ThemeMode.Light
-                else -> if (systemDark) ThemeMode.Dark else ThemeMode.Light
-            }
+            val themePref = themeBootstrap.theme
+            val mode = resolveThemeMode(themePref = themePref, systemDark = systemDark)
             val artworkUri = themeMediaSource.artworkUri
             val videoUri = themeMediaSource.videoUri
             val isVideo = themeMediaSource.isVideo
-            val globalDynamicHueEnabled by settingsDataStore.dynamicPlayerHueEnabled.collectAsState(initial = false)
-            val staticHueArgb by settingsDataStore.staticHueArgb.collectAsState(initial = null)
+            val globalDynamicHueEnabled = themeBootstrap.dynamicPlayerHueEnabled
+            val staticHueArgb = resolveStaticHueArgb(
+                themePref = themePref,
+                staticHueArgbLight = themeBootstrap.staticHueArgbLight,
+                staticHueArgbDark = themeBootstrap.staticHueArgbDark
+            )
             val coverBackgroundEnabled by settingsDataStore.coverBackgroundEnabled.collectAsState(initial = true)
             val coverBackgroundClarity by settingsDataStore.coverBackgroundClarity.collectAsState(initial = 0.35f)
             val coverPreviewMode by settingsDataStore.coverPreviewMode.collectAsState(initial = CoverPreviewMode.Disabled)
@@ -281,6 +299,34 @@ class MainActivity : ComponentActivity() {
                     )
                 }
             }
+            val activeSourceKey = remember(themeMediaSource) {
+                themeMediaSource.dynamicThemeSourceKey()
+            }
+            val bootstrapDynamicHueSeedArgb = remember(
+                globalDynamicHueEnabled,
+                playbackSnapshot.startupRestoreResolved,
+                activeSourceKey,
+                themeBootstrap.lastDynamicHueSourceKey,
+                themeBootstrap.lastDynamicHueSeedArgb
+            ) {
+                resolveBootstrapDynamicHueSeedArgb(
+                    dynamicHueEnabled = globalDynamicHueEnabled,
+                    playbackRestoreResolved = playbackSnapshot.startupRestoreResolved,
+                    currentSourceKey = activeSourceKey,
+                    persistedSourceKey = themeBootstrap.lastDynamicHueSourceKey,
+                    persistedSeedArgb = themeBootstrap.lastDynamicHueSeedArgb
+                )
+            }
+            val bootstrapDynamicHue: HuePalette? = remember(bootstrapDynamicHueSeedArgb, mode, neutral) {
+                bootstrapDynamicHueSeedArgb?.let { argb ->
+                    deriveHuePalette(
+                        primary = Color(argb),
+                        mode = mode,
+                        neutral = neutral,
+                        fallbackOnPrimary = if (mode.isDark) Color.White else Color.Black
+                    )
+                }
+            }
             val baseStaticHue = remember(mode, neutral, staticHue) {
                 staticHue ?: deriveHuePalette(
                     primary = if (mode.isDark) DefaultBrandPrimaryDark else DefaultBrandPrimaryLight,
@@ -289,15 +335,18 @@ class MainActivity : ComponentActivity() {
                     fallbackOnPrimary = if (mode.isDark) Color.White else Color.Black
                 )
             }
+            val dynamicFallbackHue = remember(baseStaticHue, bootstrapDynamicHue) {
+                bootstrapDynamicHue ?: baseStaticHue
+            }
             if (isVideo && artworkUri == null) {
                 PrewarmDynamicHuePaletteFromVideoFrame(
                     videoUri = videoUri,
-                    fallbackHue = baseStaticHue
+                    fallbackHue = dynamicFallbackHue
                 )
             } else {
                 PrewarmDynamicHuePalette(
                     artworkModel = artworkUri,
-                    fallbackHue = baseStaticHue
+                    fallbackHue = dynamicFallbackHue
                 )
             }
             val globalHue = if (globalDynamicHueEnabled) {
@@ -306,7 +355,7 @@ class MainActivity : ComponentActivity() {
                         videoUri = videoUri,
                         mode = mode,
                         neutral = neutral,
-                        fallbackHue = baseStaticHue,
+                        fallbackHue = dynamicFallbackHue,
                         transitionDurationMs = 0,
                         cachedTransitionDurationMs = 0
                     )
@@ -315,13 +364,57 @@ class MainActivity : ComponentActivity() {
                         artworkModel = artworkUri,
                         mode = mode,
                         neutral = neutral,
-                        fallbackHue = baseStaticHue,
+                        fallbackHue = dynamicFallbackHue,
                         transitionDurationMs = 0,
                         cachedTransitionDurationMs = 0
                     )
                 }
                 state.value
             } else baseStaticHue
+
+            val dynamicHueCacheKey = remember(isVideo, artworkUri, videoUri) {
+                if (isVideo && artworkUri == null) {
+                    dynamicHueCacheKeyForVideo(videoUri)
+                } else {
+                    dynamicHueCacheKeyForArtwork(artworkUri)
+                }
+            }
+            val persistableDynamicHueSeedArgb = remember(globalDynamicHueEnabled, dynamicHueCacheKey, globalHue) {
+                if (!globalDynamicHueEnabled) {
+                    null
+                } else {
+                    peekDynamicHueSeedColor(dynamicHueCacheKey)?.toArgb()
+                }
+            }
+
+            LaunchedEffect(globalDynamicHueEnabled, activeSourceKey, persistableDynamicHueSeedArgb) {
+                if (globalDynamicHueEnabled && activeSourceKey != null && persistableDynamicHueSeedArgb != null) {
+                    settingsDataStore.setLastDynamicHueSeed(
+                        sourceKey = activeSourceKey,
+                        argb = persistableDynamicHueSeedArgb
+                    )
+                }
+            }
+
+            LaunchedEffect(
+                globalDynamicHueEnabled,
+                playbackSnapshot.startupRestoreResolved,
+                activeSourceKey,
+                themeBootstrap.lastDynamicHueSourceKey,
+                themeBootstrap.lastDynamicHueSeedArgb
+            ) {
+                if (
+                    shouldClearPersistedDynamicHueSeed(
+                        dynamicHueEnabled = globalDynamicHueEnabled,
+                        playbackRestoreResolved = playbackSnapshot.startupRestoreResolved,
+                        currentSourceKey = activeSourceKey,
+                        persistedSourceKey = themeBootstrap.lastDynamicHueSourceKey,
+                        persistedSeedArgb = themeBootstrap.lastDynamicHueSeedArgb
+                    )
+                ) {
+                    settingsDataStore.clearLastDynamicHueSeed()
+                }
+            }
 
             var overlaySheet by remember { mutableStateOf<OverlaySheet?>(null) }
 

--- a/app/src/main/java/com/asmr/player/ThemeStartupSupport.kt
+++ b/app/src/main/java/com/asmr/player/ThemeStartupSupport.kt
@@ -1,0 +1,63 @@
+package com.asmr.player
+
+import com.asmr.player.ui.theme.ThemeMode
+
+internal fun resolveThemeMode(themePref: String, systemDark: Boolean): ThemeMode {
+    return when (themePref.trim().lowercase()) {
+        "light" -> ThemeMode.Light
+        "soft_dark" -> ThemeMode.SoftDark
+        "dark" -> ThemeMode.Dark
+        "system" -> if (systemDark) ThemeMode.Dark else ThemeMode.Light
+        else -> if (systemDark) ThemeMode.Dark else ThemeMode.Light
+    }
+}
+
+internal fun resolveStaticHueArgb(
+    themePref: String,
+    staticHueArgbLight: Int?,
+    staticHueArgbDark: Int?
+): Int? {
+    val normalizedThemePref = themePref.trim().lowercase()
+    val usesDarkStaticHue = normalizedThemePref == "dark" || normalizedThemePref == "soft_dark"
+    return if (usesDarkStaticHue) staticHueArgbDark else staticHueArgbLight
+}
+
+internal fun ThemeMediaSource.dynamicThemeSourceKey(): String? {
+    val artwork = artworkUri?.toString().orEmpty().trim()
+    if (artwork.isNotBlank()) return "artwork:$artwork"
+
+    if (!isVideo) return null
+    val video = videoUri?.toString().orEmpty().trim()
+    if (video.isBlank()) return null
+    return "video:$video"
+}
+
+internal fun resolveBootstrapDynamicHueSeedArgb(
+    dynamicHueEnabled: Boolean,
+    playbackRestoreResolved: Boolean,
+    currentSourceKey: String?,
+    persistedSourceKey: String?,
+    persistedSeedArgb: Int?
+): Int? {
+    val seedArgb = persistedSeedArgb ?: return null
+    val sourceKey = persistedSourceKey?.trim().takeUnless { it.isNullOrBlank() } ?: return null
+    if (!dynamicHueEnabled) return null
+
+    return when {
+        currentSourceKey == null && !playbackRestoreResolved -> seedArgb
+        currentSourceKey == sourceKey -> seedArgb
+        else -> null
+    }
+}
+
+internal fun shouldClearPersistedDynamicHueSeed(
+    dynamicHueEnabled: Boolean,
+    playbackRestoreResolved: Boolean,
+    currentSourceKey: String?,
+    persistedSourceKey: String?,
+    persistedSeedArgb: Int?
+): Boolean {
+    if (persistedSeedArgb == null && persistedSourceKey.isNullOrBlank()) return false
+    if (!dynamicHueEnabled) return true
+    return playbackRestoreResolved && currentSourceKey == null
+}

--- a/app/src/main/java/com/asmr/player/data/local/datastore/SettingsDataStore.kt
+++ b/app/src/main/java/com/asmr/player/data/local/datastore/SettingsDataStore.kt
@@ -6,10 +6,22 @@ import com.asmr.player.data.settings.CoverPreviewMode
 import com.asmr.player.data.settings.LyricsPageSettings
 import com.asmr.player.data.settings.settingsDataStore
 import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.withContext
 import javax.inject.Inject
 import javax.inject.Singleton
+
+data class ThemeBootstrapPreferences(
+    val theme: String = "system",
+    val dynamicPlayerHueEnabled: Boolean = false,
+    val staticHueArgbLight: Int? = null,
+    val staticHueArgbDark: Int? = null,
+    val lastDynamicHueSourceKey: String? = null,
+    val lastDynamicHueSeedArgb: Int? = null
+)
 
 @Singleton
 class SettingsDataStore @Inject constructor(
@@ -21,6 +33,8 @@ class SettingsDataStore @Inject constructor(
     private val dynamicPlayerHueEnabledKey = booleanPreferencesKey("dynamic_player_hue_enabled")
     private val staticHueArgbLightKey = intPreferencesKey("static_hue_argb_light")
     private val staticHueArgbDarkKey = intPreferencesKey("static_hue_argb_dark")
+    private val lastDynamicHueSourceKeyKey = stringPreferencesKey("last_dynamic_hue_source_key")
+    private val lastDynamicHueSeedArgbKey = intPreferencesKey("last_dynamic_hue_seed_argb")
     private val coverBackgroundEnabledKey = booleanPreferencesKey("cover_background_enabled")
     private val coverBackgroundClarityKey = floatPreferencesKey("cover_background_clarity")
     private val coverPreviewModeKey = stringPreferencesKey("cover_preview_mode")
@@ -48,6 +62,22 @@ class SettingsDataStore @Inject constructor(
         val isDark = themeMode == "dark" || themeMode == "soft_dark"
         val key = if (isDark) staticHueArgbDarkKey else staticHueArgbLightKey
         if (prefs.contains(key)) prefs[key] else null
+    }
+    val lastDynamicHueSourceKey: Flow<String?> = context.settingsDataStore.data.map { prefs ->
+        prefs[lastDynamicHueSourceKeyKey]
+    }
+    val lastDynamicHueSeedArgb: Flow<Int?> = context.settingsDataStore.data.map { prefs ->
+        if (prefs.contains(lastDynamicHueSeedArgbKey)) prefs[lastDynamicHueSeedArgbKey] else null
+    }
+    val themeBootstrapPreferences: Flow<ThemeBootstrapPreferences> = context.settingsDataStore.data.map { prefs ->
+        ThemeBootstrapPreferences(
+            theme = prefs[themeKey] ?: "system",
+            dynamicPlayerHueEnabled = prefs[dynamicPlayerHueEnabledKey] ?: false,
+            staticHueArgbLight = if (prefs.contains(staticHueArgbLightKey)) prefs[staticHueArgbLightKey] else null,
+            staticHueArgbDark = if (prefs.contains(staticHueArgbDarkKey)) prefs[staticHueArgbDarkKey] else null,
+            lastDynamicHueSourceKey = prefs[lastDynamicHueSourceKeyKey],
+            lastDynamicHueSeedArgb = if (prefs.contains(lastDynamicHueSeedArgbKey)) prefs[lastDynamicHueSeedArgbKey] else null
+        )
     }
     val coverBackgroundEnabled: Flow<Boolean> = context.settingsDataStore.data.map { it[coverBackgroundEnabledKey] ?: true }
     val coverBackgroundClarity: Flow<Float> = context.settingsDataStore.data.map { it[coverBackgroundClarityKey] ?: 0.35f }
@@ -93,6 +123,28 @@ class SettingsDataStore @Inject constructor(
             } else {
                 prefs[key] = argb
             }
+        }
+    }
+
+    suspend fun loadThemeBootstrapPreferences(): ThemeBootstrapPreferences {
+        return withContext(Dispatchers.IO) {
+            themeBootstrapPreferences.first()
+        }
+    }
+
+    suspend fun setLastDynamicHueSeed(sourceKey: String, argb: Int) {
+        val normalizedSourceKey = sourceKey.trim()
+        if (normalizedSourceKey.isBlank()) return
+        context.settingsDataStore.edit { prefs ->
+            prefs[lastDynamicHueSourceKeyKey] = normalizedSourceKey
+            prefs[lastDynamicHueSeedArgbKey] = argb
+        }
+    }
+
+    suspend fun clearLastDynamicHueSeed() {
+        context.settingsDataStore.edit { prefs ->
+            prefs.remove(lastDynamicHueSourceKeyKey)
+            prefs.remove(lastDynamicHueSeedArgbKey)
         }
     }
 

--- a/app/src/main/java/com/asmr/player/playback/PlaybackSnapshot.kt
+++ b/app/src/main/java/com/asmr/player/playback/PlaybackSnapshot.kt
@@ -6,6 +6,7 @@ import androidx.media3.common.C
 @androidx.annotation.OptIn(androidx.media3.common.util.UnstableApi::class)
 data class PlaybackSnapshot(
     val isConnected: Boolean = false,
+    val startupRestoreResolved: Boolean = false,
     val isPlaying: Boolean = false,
     val playbackState: Int = 0,
     val repeatMode: Int = 0,

--- a/app/src/main/java/com/asmr/player/playback/PlayerConnection.kt
+++ b/app/src/main/java/com/asmr/player/playback/PlayerConnection.kt
@@ -90,6 +90,7 @@ class PlayerConnection @Inject constructor(
     private val sliceLoopEngine = SliceLoopEngine()
     private val currentSlices = MutableStateFlow<List<Slice>>(emptyList())
     private var didRestorePlaybackState: Boolean = false
+    private var restoreAttemptResolved: Boolean = false
     private val meteredWarnedMediaIds = LinkedHashSet<String>()
     private var lastMeteredWarnAtMs: Long = 0L
     private val connectMutex = Mutex()
@@ -216,6 +217,7 @@ class PlayerConnection @Inject constructor(
                             this@PlayerConnection.controller = null
                             _snapshot.value = _snapshot.value.copy(
                                 isConnected = false,
+                                startupRestoreResolved = restoreAttemptResolved,
                                 isPlaying = false
                             )
                             _queue.value = emptyList()
@@ -242,7 +244,11 @@ class PlayerConnection @Inject constructor(
 
                     if (shouldUpdateSnapshot) {
                         val prev = _snapshot.value
-                        _snapshot.value = player.toSnapshot(isConnected = true, audioSessionId = prev.audioSessionId)
+                        _snapshot.value = player.toSnapshot(
+                            isConnected = true,
+                            audioSessionId = prev.audioSessionId,
+                            startupRestoreResolved = restoreAttemptResolved
+                        )
                     }
                     if (
                         events.contains(Player.EVENT_TIMELINE_CHANGED) ||
@@ -279,14 +285,24 @@ class PlayerConnection @Inject constructor(
                 }
             }
         )
-            _snapshot.value = c.toSnapshot(isConnected = true, audioSessionId = _snapshot.value.audioSessionId)
+            _snapshot.value = c.toSnapshot(
+                isConnected = true,
+                audioSessionId = _snapshot.value.audioSessionId,
+                startupRestoreResolved = restoreAttemptResolved
+            )
             updateQueue()
 
             val restored = restorePlaybackStateIfNeeded(c)
+            restoreAttemptResolved = true
             if (!restored) {
                 val mode = runCatching { settingsRepository.playMode.first() }.getOrDefault(0)
                 applyPlayModeToController(c, mode)
             }
+            _snapshot.value = c.toSnapshot(
+                isConnected = true,
+                audioSessionId = _snapshot.value.audioSessionId,
+                startupRestoreResolved = restoreAttemptResolved
+            )
         
             try {
                 val cmd = androidx.media3.session.SessionCommand("GET_AUDIO_SESSION_ID", android.os.Bundle.EMPTY)
@@ -345,7 +361,11 @@ class PlayerConnection @Inject constructor(
         c.playWhenReady = false
 
         _queue.value = items
-        _snapshot.value = c.toSnapshot(isConnected = true, audioSessionId = _snapshot.value.audioSessionId)
+        _snapshot.value = c.toSnapshot(
+            isConnected = true,
+            audioSessionId = _snapshot.value.audioSessionId,
+            startupRestoreResolved = restoreAttemptResolved
+        )
         return true
     }
 
@@ -691,9 +711,14 @@ private fun applyPlayModeToController(controller: MediaController, mode: Int) {
     }
 }
 
-private fun Player.toSnapshot(isConnected: Boolean, audioSessionId: Int): PlaybackSnapshot {
+private fun Player.toSnapshot(
+    isConnected: Boolean,
+    audioSessionId: Int,
+    startupRestoreResolved: Boolean
+): PlaybackSnapshot {
     return PlaybackSnapshot(
         isConnected = isConnected,
+        startupRestoreResolved = startupRestoreResolved,
         isPlaying = isPlaying,
         playbackState = playbackState,
         repeatMode = repeatMode,

--- a/app/src/main/java/com/asmr/player/ui/theme/DynamicHueGenerator.kt
+++ b/app/src/main/java/com/asmr/player/ui/theme/DynamicHueGenerator.kt
@@ -27,6 +27,31 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeoutOrNull
 
+internal fun dynamicHueCacheKeyForArtwork(
+    artworkModel: Any?,
+    centerRegionRatio: Float = 0.62f
+): String? {
+    val baseKey = artworkModel?.toString().orEmpty().trim()
+    if (baseKey.isBlank()) return null
+    val regionKey = (centerRegionRatio * 100).toInt().coerceIn(10, 100)
+    return "hue:cw:$regionKey:$baseKey"
+}
+
+internal fun dynamicHueCacheKeyForVideo(
+    videoUri: Uri?,
+    centerRegionRatio: Float = 0.62f
+): String? {
+    val baseKey = videoUri?.toString().orEmpty().trim()
+    if (baseKey.isBlank()) return null
+    val regionKey = (centerRegionRatio * 100).toInt().coerceIn(10, 100)
+    return "hue:vf:cw:$regionKey:$baseKey"
+}
+
+internal fun peekDynamicHueSeedColor(cacheKey: String?): Color? {
+    val key = cacheKey?.trim().takeUnless { it.isNullOrBlank() } ?: return null
+    return DynamicHueCache.get(key)
+}
+
 @Composable
 fun PrewarmDynamicHuePalette(
     artworkModel: Any?,

--- a/app/src/test/java/com/asmr/player/ThemeStartupSupportTest.kt
+++ b/app/src/test/java/com/asmr/player/ThemeStartupSupportTest.kt
@@ -1,0 +1,108 @@
+package com.asmr.player
+
+import android.net.Uri
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ThemeStartupSupportTest {
+
+    @Test
+    fun resolveStaticHueArgb_usesLightSlotForSystemTheme() {
+        val result = resolveStaticHueArgb(
+            themePref = "system",
+            staticHueArgbLight = 0x00112233,
+            staticHueArgbDark = 0x00445566
+        )
+
+        assertEquals(0x00112233, result)
+    }
+
+    @Test
+    fun dynamicThemeSourceKey_prefersArtworkOverVideo() {
+        val source = ThemeMediaSource(
+            artworkUri = Uri.parse("https://example.com/cover.jpg"),
+            videoUri = Uri.parse("file:///sample.mp4"),
+            isVideo = true
+        )
+
+        assertEquals("artwork:https://example.com/cover.jpg", source.dynamicThemeSourceKey())
+    }
+
+    @Test
+    fun resolveBootstrapDynamicHueSeedArgb_usesPersistedSeedBeforePlaybackRestoreResolves() {
+        val result = resolveBootstrapDynamicHueSeedArgb(
+            dynamicHueEnabled = true,
+            playbackRestoreResolved = false,
+            currentSourceKey = null,
+            persistedSourceKey = "artwork:https://example.com/cover.jpg",
+            persistedSeedArgb = 0xFF336699.toInt()
+        )
+
+        assertEquals(0xFF336699.toInt(), result)
+    }
+
+    @Test
+    fun resolveBootstrapDynamicHueSeedArgb_usesPersistedSeedWhenCurrentSourceMatches() {
+        val result = resolveBootstrapDynamicHueSeedArgb(
+            dynamicHueEnabled = true,
+            playbackRestoreResolved = true,
+            currentSourceKey = "artwork:https://example.com/cover.jpg",
+            persistedSourceKey = "artwork:https://example.com/cover.jpg",
+            persistedSeedArgb = 0xFF663399.toInt()
+        )
+
+        assertEquals(0xFF663399.toInt(), result)
+    }
+
+    @Test
+    fun resolveBootstrapDynamicHueSeedArgb_ignoresPersistedSeedAfterRestoreWhenNoCurrentSource() {
+        val result = resolveBootstrapDynamicHueSeedArgb(
+            dynamicHueEnabled = true,
+            playbackRestoreResolved = true,
+            currentSourceKey = null,
+            persistedSourceKey = "artwork:https://example.com/cover.jpg",
+            persistedSeedArgb = 0xFF663399.toInt()
+        )
+
+        assertNull(result)
+    }
+
+    @Test
+    fun shouldClearPersistedDynamicHueSeed_onlyClearsAfterRestoreWhenNoSourceRemains() {
+        assertFalse(
+            shouldClearPersistedDynamicHueSeed(
+                dynamicHueEnabled = true,
+                playbackRestoreResolved = false,
+                currentSourceKey = null,
+                persistedSourceKey = "artwork:https://example.com/cover.jpg",
+                persistedSeedArgb = 0xFF336699.toInt()
+            )
+        )
+
+        assertTrue(
+            shouldClearPersistedDynamicHueSeed(
+                dynamicHueEnabled = true,
+                playbackRestoreResolved = true,
+                currentSourceKey = null,
+                persistedSourceKey = "artwork:https://example.com/cover.jpg",
+                persistedSeedArgb = 0xFF336699.toInt()
+            )
+        )
+    }
+
+    @Test
+    fun shouldClearPersistedDynamicHueSeed_clearsImmediatelyWhenFeatureDisabled() {
+        assertTrue(
+            shouldClearPersistedDynamicHueSeed(
+                dynamicHueEnabled = false,
+                playbackRestoreResolved = false,
+                currentSourceKey = "artwork:https://example.com/cover.jpg",
+                persistedSourceKey = "artwork:https://example.com/cover.jpg",
+                persistedSeedArgb = 0xFF336699.toInt()
+            )
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- bootstrap app theme from the last persisted cover dynamic hue seed on cold start
- avoid flashing the default brand theme before the player restores and cover hue recalculates
- clear the persisted dynamic hue seed when cover theme is disabled or no current media/artwork remains after restore

## Testing
- ./gradlew.bat :app:compileDebugKotlin :app:compileDebugUnitTestKotlin
- full Gradle unit test execution was not treated as blocking because the local environment hit the known path-related Gradle worker/classpath issue
