### PR TITLE
feat: refine online search filters and add chinese works

### DIFF
--- a/app/src/main/java/com/asmr/player/data/local/datastore/SearchCacheStore.kt
+++ b/app/src/main/java/com/asmr/player/data/local/datastore/SearchCacheStore.kt
@@ -20,6 +20,7 @@ data class LastSearchStateV1(
     val orderName: String,
     val purchasedOnly: Boolean,
     val presaleOnly: Boolean = false,
+    val chineseTranslatedOnly: Boolean = false,
     val locale: String?,
     val page: Int,
     val canGoNext: Boolean,

--- a/app/src/main/java/com/asmr/player/data/remote/scraper/DLSiteScraper.kt
+++ b/app/src/main/java/com/asmr/player/data/remote/scraper/DLSiteScraper.kt
@@ -38,13 +38,31 @@ internal fun buildDlsiteSearchUrls(
     page: Int,
     order: String,
     locale: String? = null,
-    presaleOnly: Boolean = false
+    presaleOnly: Boolean = false,
+    chineseTranslatedOnly: Boolean = false
 ): List<String> {
     val normalizedKeyword = keyword.trim()
     val encodedKeyword = URLEncoder.encode(normalizedKeyword, "UTF-8")
     val normalizedOrder = order.trim().ifBlank { "trend" }
     val encodedOrder = URLEncoder.encode(normalizedOrder, "UTF-8")
     val safePage = page.coerceAtLeast(1)
+
+    if (chineseTranslatedOnly) {
+        val translationBase =
+            "https://www.dlsite.com/maniax/works/translation?langs%5B0%5D=CHI_HANS&work_type%5B0%5D=SOU&order=$encodedOrder"
+        val translation = buildString {
+            append(translationBase)
+            if (normalizedKeyword.isNotBlank()) {
+                append("&keyword=")
+                append(encodedKeyword)
+            }
+            if (safePage > 1) {
+                append("&page=")
+                append(safePage)
+            }
+        }
+        return listOf(translation)
+    }
 
     if (presaleOnly) {
         val primaryBase =
@@ -101,6 +119,11 @@ data class DlsiteRecommendations(
     val circleWorks: List<DlsiteRecommendedWork> = emptyList(),
     val sameVoiceWorks: List<DlsiteRecommendedWork> = emptyList(),
     val alsoBoughtWorks: List<DlsiteRecommendedWork> = emptyList()
+)
+
+data class DlsiteSearchResult(
+    val items: List<Album>,
+    val canGoNext: Boolean
 )
 
 @Singleton
@@ -270,8 +293,9 @@ class DLSiteScraper @Inject constructor(
         page: Int = 1,
         order: String = "trend",
         locale: String? = null,
-        presaleOnly: Boolean = false
-    ): List<Album> = withContext(Dispatchers.IO) {
+        presaleOnly: Boolean = false,
+        chineseTranslatedOnly: Boolean = false
+    ): DlsiteSearchResult = withContext(Dispatchers.IO) {
         fun parseItems(items: List<Element>, doc: Document): List<Album> {
             val results = mutableListOf<Album>()
 
@@ -361,7 +385,24 @@ class DLSiteScraper @Inject constructor(
             return results
         }
 
-        fun parseDoc(doc: Document): List<Album> {
+        fun parseCanGoNext(doc: Document, itemCount: Int): Boolean {
+            val infoScript = doc.select("script")
+                .firstOrNull { it.data().contains("\"page_info\"") }
+                ?.data()
+                .orEmpty()
+            val pageInfo = Regex("""\"page_info\":\{\"count\":(\d+),\"first_indice\":(\d+),\"last_indice\":(\d+)\}""")
+                .find(infoScript)
+            if (pageInfo != null) {
+                val total = pageInfo.groupValues.getOrNull(1)?.toIntOrNull() ?: 0
+                val lastIndex = pageInfo.groupValues.getOrNull(3)?.toIntOrNull() ?: 0
+                if (total > 0 && lastIndex > 0) {
+                    return lastIndex < total
+                }
+            }
+            return itemCount >= if (chineseTranslatedOnly) 100 else 30
+        }
+
+        fun parseDoc(doc: Document): DlsiteSearchResult {
             val container = doc.selectFirst("#search_result_list.loading_display_open")
                 ?: doc.select("#search_result_list").lastOrNull()
 
@@ -374,10 +415,15 @@ class DLSiteScraper @Inject constructor(
             for (items in candidates) {
                 if (items.isEmpty()) continue
                 val parsed = parseItems(items, doc)
-                if (parsed.isNotEmpty()) return parsed
+                if (parsed.isNotEmpty()) {
+                    return DlsiteSearchResult(
+                        items = parsed,
+                        canGoNext = parseCanGoNext(doc, parsed.size)
+                    )
+                }
             }
 
-            return emptyList()
+            return DlsiteSearchResult(items = emptyList(), canGoNext = false)
         }
 
         val urls = buildDlsiteSearchUrls(
@@ -385,14 +431,15 @@ class DLSiteScraper @Inject constructor(
             page = page,
             order = order,
             locale = locale,
-            presaleOnly = presaleOnly
+            presaleOnly = presaleOnly,
+            chineseTranslatedOnly = chineseTranslatedOnly
         )
-        var lastEmpty: List<Album> = emptyList()
+        var lastEmpty = DlsiteSearchResult(items = emptyList(), canGoNext = false)
         for (u in urls) {
             Log.d("DLSiteScraper", "Searching URL: $u")
             val doc = runInterruptible { connect(u, locale = locale).get() }
             val parsed = parseDoc(doc)
-            if (parsed.isNotEmpty()) return@withContext parsed
+            if (parsed.items.isNotEmpty()) return@withContext parsed
             lastEmpty = parsed
         }
         lastEmpty

--- a/app/src/main/java/com/asmr/player/ui/library/AlbumDetailViewModel.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/AlbumDetailViewModel.kt
@@ -433,7 +433,7 @@ class AlbumDetailViewModel @Inject constructor(
             keyword = entity.title.trim(),
             baseWorkno = baseWorkno,
             search = { searchKeyword, locale ->
-                dlsiteScraper.search(searchKeyword, page = 1, order = "trend", locale = locale)
+                dlsiteScraper.search(searchKeyword, page = 1, order = "trend", locale = locale).items
             },
             fetchLanguageEditions = { productId ->
                 dlsiteProductInfoClient.fetchLanguageEditions(productId)

--- a/app/src/main/java/com/asmr/player/ui/library/libraryviewmodel.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/libraryviewmodel.kt
@@ -1158,7 +1158,7 @@ class LibraryViewModel @Inject constructor(
             keyword = entity.title.trim(),
             baseWorkno = entity.rjCode.ifBlank { entity.workId }.trim().uppercase(),
             search = { searchKeyword, locale ->
-                dlsiteScraper.search(searchKeyword, page = 1, order = "trend", locale = locale)
+                dlsiteScraper.search(searchKeyword, page = 1, order = "trend", locale = locale).items
             },
             fetchLanguageEditions = { productId ->
                 dlsiteProductInfoClient.fetchLanguageEditions(productId)

--- a/app/src/main/java/com/asmr/player/ui/search/SearchFilterOption.kt
+++ b/app/src/main/java/com/asmr/player/ui/search/SearchFilterOption.kt
@@ -1,33 +1,90 @@
 package com.asmr.player.ui.search
 
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.AutoStories
+import androidx.compose.material.icons.filled.LocalFireDepartment
+import androidx.compose.material.icons.filled.Lock
+import androidx.compose.material.icons.filled.NewReleases
+import androidx.compose.material.icons.filled.Payments
+import androidx.compose.material.icons.filled.Schedule
+import androidx.compose.material.icons.filled.Sell
+import androidx.compose.ui.graphics.vector.ImageVector
+
 enum class SearchFilterOption(
     val label: String,
-    val isPurchasedOnly: Boolean = false,
-    val isPresaleOnly: Boolean = false,
+    val icon: ImageVector,
+    val mode: SearchFilterMode,
     val sortOption: SearchSortOption? = null
 ) {
-    PurchasedOnly(label = "仅已购", isPurchasedOnly = true),
-    Presale(label = "预售", isPresaleOnly = true),
-    Trend(label = SearchSortOption.Trend.label, sortOption = SearchSortOption.Trend),
-    ReleaseNew(label = SearchSortOption.ReleaseNew.label, sortOption = SearchSortOption.ReleaseNew),
-    ReleaseOld(label = SearchSortOption.ReleaseOld.label, sortOption = SearchSortOption.ReleaseOld),
-    DLCount(label = SearchSortOption.DLCount.label, sortOption = SearchSortOption.DLCount),
-    PriceLow(label = SearchSortOption.PriceLow.label, sortOption = SearchSortOption.PriceLow),
-    PriceHigh(label = SearchSortOption.PriceHigh.label, sortOption = SearchSortOption.PriceHigh),
-    Rating(label = SearchSortOption.Rating.label, sortOption = SearchSortOption.Rating),
-    ReviewCount(label = SearchSortOption.ReviewCount.label, sortOption = SearchSortOption.ReviewCount);
+    PurchasedOnly(
+        label = "已购",
+        icon = Icons.Default.Lock,
+        mode = SearchFilterMode.PurchasedOnly
+    ),
+    ChineseTranslated(
+        label = "中文作品",
+        icon = Icons.Default.AutoStories,
+        mode = SearchFilterMode.ChineseTranslated
+    ),
+    Presale(
+        label = "预售",
+        icon = Icons.Default.Schedule,
+        mode = SearchFilterMode.PresaleOnly
+    ),
+    Trend(
+        label = SearchSortOption.Trend.label,
+        icon = Icons.Default.LocalFireDepartment,
+        mode = SearchFilterMode.Standard,
+        sortOption = SearchSortOption.Trend
+    ),
+    ReleaseNew(
+        label = SearchSortOption.ReleaseNew.label,
+        icon = Icons.Default.NewReleases,
+        mode = SearchFilterMode.Standard,
+        sortOption = SearchSortOption.ReleaseNew
+    ),
+    DLCount(
+        label = SearchSortOption.DLCount.label,
+        icon = Icons.Default.Sell,
+        mode = SearchFilterMode.Standard,
+        sortOption = SearchSortOption.DLCount
+    ),
+    PriceHigh(
+        label = SearchSortOption.PriceHigh.label,
+        icon = Icons.Default.Payments,
+        mode = SearchFilterMode.Standard,
+        sortOption = SearchSortOption.PriceHigh
+    );
+
+    val isPurchasedOnly: Boolean
+        get() = mode == SearchFilterMode.PurchasedOnly
+
+    val isPresaleOnly: Boolean
+        get() = mode == SearchFilterMode.PresaleOnly
+
+    val isChineseTranslated: Boolean
+        get() = mode == SearchFilterMode.ChineseTranslated
 
     companion object {
         fun fromState(
             order: SearchSortOption,
             purchasedOnly: Boolean,
-            presaleOnly: Boolean
+            presaleOnly: Boolean,
+            chineseTranslatedOnly: Boolean
         ): SearchFilterOption {
             return when {
                 purchasedOnly -> PurchasedOnly
+                chineseTranslatedOnly -> ChineseTranslated
                 presaleOnly -> Presale
                 else -> values().firstOrNull { it.sortOption == order } ?: Trend
             }
         }
     }
+}
+
+enum class SearchFilterMode {
+    Standard,
+    PurchasedOnly,
+    PresaleOnly,
+    ChineseTranslated
 }

--- a/app/src/main/java/com/asmr/player/ui/search/SearchScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/search/SearchScreen.kt
@@ -148,16 +148,18 @@ fun SearchScreen(
     var keyword by rememberSaveable { mutableStateOf("") }
     var purchasedOnly by rememberSaveable { mutableStateOf(false) }
     var presaleOnly by rememberSaveable { mutableStateOf(false) }
+    var chineseTranslatedOnly by rememberSaveable { mutableStateOf(false) }
     var selectedLocale by rememberSaveable { mutableStateOf("ja_JP") }
     var selectedOrderName by rememberSaveable { mutableStateOf(SearchSortOption.Trend.name) }
     val selectedOrder = remember(selectedOrderName) {
         SearchSortOption.values().firstOrNull { it.name == selectedOrderName } ?: SearchSortOption.Trend
     }
-    val selectedFilter = remember(selectedOrderName, purchasedOnly, presaleOnly) {
+    val selectedFilter = remember(selectedOrderName, purchasedOnly, presaleOnly, chineseTranslatedOnly) {
         SearchFilterOption.fromState(
             order = selectedOrder,
             purchasedOnly = purchasedOnly,
-            presaleOnly = presaleOnly
+            presaleOnly = presaleOnly,
+            chineseTranslatedOnly = chineseTranslatedOnly
         )
     }
     val viewMode by viewModel.viewMode.collectAsState()
@@ -190,11 +192,19 @@ fun SearchScreen(
         }
     }
 
-    LaunchedEffect(success?.pendingRequest, success?.order, success?.purchasedOnly, success?.presaleOnly, success?.locale) {
+    LaunchedEffect(
+        success?.pendingRequest,
+        success?.order,
+        success?.purchasedOnly,
+        success?.presaleOnly,
+        success?.chineseTranslatedOnly,
+        success?.locale
+    ) {
         val state = success ?: return@LaunchedEffect
         if (!optionsSyncedFromState || state.pendingRequest == null) {
             purchasedOnly = state.purchasedOnly
             presaleOnly = state.presaleOnly
+            chineseTranslatedOnly = state.chineseTranslatedOnly
             selectedLocale = state.locale ?: "ja_JP"
             selectedOrderName = state.order.name
             optionsSyncedFromState = true
@@ -570,12 +580,14 @@ fun SearchScreen(
                                 order = nextOrder,
                                 purchasedOnly = option.isPurchasedOnly,
                                 presaleOnly = option.isPresaleOnly,
+                                chineseTranslatedOnly = option.isChineseTranslated,
                                 locale = selectedLocale
                             )
                             if (accepted) {
                                 selectedOrderName = nextOrder.name
                                 purchasedOnly = option.isPurchasedOnly
                                 presaleOnly = option.isPresaleOnly
+                                chineseTranslatedOnly = option.isChineseTranslated
                             }
                         },
                         onLocaleSelected = { locale ->
@@ -584,6 +596,7 @@ fun SearchScreen(
                                 order = selectedOrder,
                                 purchasedOnly = purchasedOnly,
                                 presaleOnly = presaleOnly,
+                                chineseTranslatedOnly = chineseTranslatedOnly,
                                 locale = locale
                             )
                         },
@@ -762,7 +775,6 @@ internal fun SearchToolbar(
                 .weight(1f)
                 .testTag(SEARCH_INPUT_TAG),
             leadingIcon = {
-                val label = selectedFilter.label
                 Box {
                     TextButton(
                         onClick = { scopeMenuExpanded = true },
@@ -775,7 +787,22 @@ internal fun SearchToolbar(
                             contentColor = colorScheme.primary
                         )
                     ) {
-                        Text(label, style = MaterialTheme.typography.labelSmall, maxLines = 1)
+                        Row(
+                            horizontalArrangement = Arrangement.spacedBy(4.dp),
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            Icon(
+                                imageVector = selectedFilter.icon,
+                                contentDescription = null,
+                                tint = colorScheme.primary,
+                                modifier = Modifier.size(14.dp)
+                            )
+                            Text(
+                                text = selectedFilter.label,
+                                style = MaterialTheme.typography.labelSmall,
+                                maxLines = 1
+                            )
+                        }
                     }
                     DropdownMenu(
                         expanded = scopeMenuExpanded,
@@ -792,10 +819,21 @@ internal fun SearchToolbar(
                             }
                             DropdownMenuItem(
                                 text = {
-                                    Text(
-                                        text = option.label,
-                                        color = if (option == selectedFilter) colorScheme.primary else colorScheme.textPrimary
-                                    )
+                                    Row(
+                                        horizontalArrangement = Arrangement.spacedBy(8.dp),
+                                        verticalAlignment = Alignment.CenterVertically
+                                    ) {
+                                        Icon(
+                                            imageVector = option.icon,
+                                            contentDescription = null,
+                                            tint = if (option == selectedFilter) colorScheme.primary else colorScheme.textSecondary,
+                                            modifier = Modifier.size(18.dp)
+                                        )
+                                        Text(
+                                            text = option.label,
+                                            color = if (option == selectedFilter) colorScheme.primary else colorScheme.textPrimary
+                                        )
+                                    }
                                 },
                                 onClick = {
                                     scopeMenuExpanded = false

--- a/app/src/main/java/com/asmr/player/ui/search/SearchSortOption.kt
+++ b/app/src/main/java/com/asmr/player/ui/search/SearchSortOption.kt
@@ -5,12 +5,8 @@ enum class SearchSortOption(
     val dlsiteOrder: String
 ) {
     Trend("人气顺序", "trend"),
-    ReleaseNew("发售日期最新", "release_d"),
-    ReleaseOld("发售日期最旧", "release"),
+    ReleaseNew("最新发售", "release_d"),
     DLCount("销量最高", "dl_d"),
-    PriceLow("价格最低", "price"),
-    PriceHigh("价格最高", "price_d"),
-    Rating("评分最高", "rate_d"),
-    ReviewCount("赏析最多", "review_d")
+    PriceHigh("价格最高", "price_d")
 }
 

--- a/app/src/main/java/com/asmr/player/ui/search/SearchViewModel.kt
+++ b/app/src/main/java/com/asmr/player/ui/search/SearchViewModel.kt
@@ -65,6 +65,7 @@ class SearchViewModel @Inject constructor(
     private var currentOrder: SearchSortOption = SearchSortOption.Trend
     private var purchasedOnly: Boolean = false
     private var presaleOnly: Boolean = false
+    private var chineseTranslatedOnly: Boolean = false
     private var enrichJob: Job? = null
     private var asmrOneJob: Job? = null
     private var cacheWriteJob: Job? = null
@@ -98,6 +99,7 @@ class SearchViewModel @Inject constructor(
             } else {
                 purchasedOnly = initialPurchasedOnly
                 presaleOnly = false
+                chineseTranslatedOnly = false
                 currentLocale = initialLocale
                 lastRequestedKeyword = initialKeyword.trim()
                 requestPage(lastRequestedKeyword, 1, SearchPendingRequestKind.Search)
@@ -148,23 +150,26 @@ class SearchViewModel @Inject constructor(
         order: SearchSortOption = currentOrder,
         purchasedOnly: Boolean = this.purchasedOnly,
         presaleOnly: Boolean = this.presaleOnly,
+        chineseTranslatedOnly: Boolean = this.chineseTranslatedOnly,
         locale: String? = currentLocale
     ): Boolean {
         val current = _uiState.value as? SearchUiState.Success ?: return false
         if (current.isBusy) return false
         if (purchasedOnly && !dlsitePlayLibraryClient.hasStoredCredentials()) {
-            messageManager.showWarning("请先登录 DLsite 后再使用\"仅已购\"搜索")
+            messageManager.showWarning("请先登录 DLsite 后再使用\"已购\"搜索")
             return false
         }
         if (
             currentOrder == order &&
             this.purchasedOnly == purchasedOnly &&
             this.presaleOnly == presaleOnly &&
+            this.chineseTranslatedOnly == chineseTranslatedOnly &&
             currentLocale == locale
         ) return true
         currentOrder = order
         this.purchasedOnly = purchasedOnly
         this.presaleOnly = presaleOnly
+        this.chineseTranslatedOnly = chineseTranslatedOnly
         currentLocale = locale
         requestPage(current.keyword, 1, SearchPendingRequestKind.Search)
         return true
@@ -215,7 +220,8 @@ class SearchViewModel @Inject constructor(
                     page = page,
                     order = currentOrder,
                     purchasedOnly = purchasedOnly,
-                    presaleOnly = presaleOnly
+                    presaleOnly = presaleOnly,
+                    chineseTranslatedOnly = chineseTranslatedOnly
                 )
                 _uiState.value = SearchUiState.Success(
                     results = pageResult.items,
@@ -224,6 +230,7 @@ class SearchViewModel @Inject constructor(
                     order = currentOrder,
                     purchasedOnly = purchasedOnly,
                     presaleOnly = presaleOnly,
+                    chineseTranslatedOnly = chineseTranslatedOnly,
                     locale = currentLocale,
                     canGoPrev = page > 1,
                     canGoNext = pageResult.canGoNext,
@@ -269,6 +276,7 @@ class SearchViewModel @Inject constructor(
                     currentOrder = previousSuccess.order
                     purchasedOnly = previousSuccess.purchasedOnly
                     presaleOnly = previousSuccess.presaleOnly
+                    chineseTranslatedOnly = previousSuccess.chineseTranslatedOnly
                     currentLocale = previousSuccess.locale
                     _uiState.value = previousSuccess.copy(
                         pendingRequest = null,
@@ -311,7 +319,8 @@ class SearchViewModel @Inject constructor(
         page: Int,
         order: SearchSortOption,
         purchasedOnly: Boolean,
-        presaleOnly: Boolean
+        presaleOnly: Boolean,
+        chineseTranslatedOnly: Boolean
     ): SearchPageResult {
         if (purchasedOnly) {
             val resp = dlsitePlayLibraryClient.searchPurchased(keyword, page, pageSize)
@@ -319,7 +328,7 @@ class SearchViewModel @Inject constructor(
         }
         val normalizedKeyword = keyword.trim()
         val normalizedRj = normalizedKeyword.uppercase()
-        if (!presaleOnly && page == 1 && Regex("""RJ\d{6,}""").matches(normalizedRj)) {
+        if (!presaleOnly && !chineseTranslatedOnly && page == 1 && Regex("""RJ\d{6,}""").matches(normalizedRj)) {
             val preferred = currentLocale
             val info = when {
                 !preferred.isNullOrBlank() -> {
@@ -340,14 +349,15 @@ class SearchViewModel @Inject constructor(
                 return SearchPageResult(items = listOf(album), canGoNext = false)
             }
         }
-        val items = dlsiteScraper.search(
+        val result = dlsiteScraper.search(
             keyword = keyword,
             page = page,
             order = order.dlsiteOrder,
             locale = currentLocale,
-            presaleOnly = presaleOnly
+            presaleOnly = presaleOnly,
+            chineseTranslatedOnly = chineseTranslatedOnly
         )
-        return SearchPageResult(items = items, canGoNext = items.size >= pageSize)
+        return SearchPageResult(items = result.items, canGoNext = result.canGoNext)
     }
 
     private fun startEnrichDlsiteDetails(keyword: String, page: Int, baseItems: List<Album>) {
@@ -415,6 +425,7 @@ class SearchViewModel @Inject constructor(
         currentOrder = order
         purchasedOnly = cached.purchasedOnly
         presaleOnly = cached.presaleOnly
+        chineseTranslatedOnly = cached.chineseTranslatedOnly
         currentLocale = cached.locale
         _uiState.value = SearchUiState.Success(
             results = cached.results,
@@ -423,6 +434,7 @@ class SearchViewModel @Inject constructor(
             order = order,
             purchasedOnly = cached.purchasedOnly,
             presaleOnly = cached.presaleOnly,
+            chineseTranslatedOnly = cached.chineseTranslatedOnly,
             locale = cached.locale,
             canGoPrev = page > 1,
             canGoNext = cached.canGoNext,
@@ -451,6 +463,7 @@ class SearchViewModel @Inject constructor(
                         orderName = latest.order.name,
                         purchasedOnly = latest.purchasedOnly,
                         presaleOnly = latest.presaleOnly,
+                        chineseTranslatedOnly = latest.chineseTranslatedOnly,
                         locale = latest.locale,
                         page = latest.page,
                         canGoNext = latest.canGoNext,
@@ -463,7 +476,7 @@ class SearchViewModel @Inject constructor(
 
     private fun toUserMessage(e: Throwable): String {
         val raw = e.message.orEmpty()
-        if (raw.contains("请先登录")) return "请先登录后再使用\"仅已购\"搜索"
+        if (raw.contains("请先登录")) return "请先登录后再使用\"已购\"搜索"
         return when (e) {
             is SocketTimeoutException -> "连接超时，请稍后重试"
             is IOException -> "网络连接失败，请检查网络后重试"
@@ -832,6 +845,7 @@ sealed class SearchUiState {
         val order: SearchSortOption,
         val purchasedOnly: Boolean,
         val presaleOnly: Boolean,
+        val chineseTranslatedOnly: Boolean,
         val locale: String?,
         val canGoPrev: Boolean,
         val canGoNext: Boolean,

--- a/app/src/test/java/com/asmr/player/data/remote/scraper/DLSiteScraperUrlBuilderTest.kt
+++ b/app/src/test/java/com/asmr/player/data/remote/scraper/DLSiteScraperUrlBuilderTest.kt
@@ -39,4 +39,21 @@ class DLSiteScraperUrlBuilderTest {
         assertTrue(urls.last().contains("/without_order/1/order/trend"))
         assertTrue(urls.none { it.contains("ana_flg/on") })
     }
+
+    @Test
+    fun buildDlsiteSearchUrls_usesChineseTranslationListingWhenRequested() {
+        val urls = buildDlsiteSearchUrls(
+            keyword = "耳",
+            page = 2,
+            order = "price_d",
+            locale = "zh_CN",
+            chineseTranslatedOnly = true
+        )
+
+        assertEquals(1, urls.size)
+        assertEquals(
+            "https://www.dlsite.com/maniax/works/translation?langs%5B0%5D=CHI_HANS&work_type%5B0%5D=SOU&order=price_d&keyword=%E8%80%B3&page=2",
+            urls.first()
+        )
+    }
 }

--- a/app/src/test/java/com/asmr/player/ui/search/SearchScreenChromeTest.kt
+++ b/app/src/test/java/com/asmr/player/ui/search/SearchScreenChromeTest.kt
@@ -18,6 +18,7 @@ import androidx.compose.ui.test.assertIsNotEnabled
 import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onAllNodesWithTag
+import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performImeAction
@@ -108,6 +109,35 @@ class SearchScreenChromeTest {
         composeRule.onNodeWithTag(SEARCH_SUBMIT_SPINNER_TAG).assert(
             SemanticsMatcher.expectValue(SemanticsProperties.TestTag, SEARCH_SUBMIT_SPINNER_TAG)
         )
+    }
+
+    @Test
+    fun scopeMenu_displaysIconsAndUpdatedFilterOptions() {
+        composeRule.setContent {
+            AsmrPlayerTheme {
+                SearchToolbar(
+                    keyword = "",
+                    onKeywordChange = {},
+                    selectedFilter = SearchFilterOption.ChineseTranslated,
+                    selectedLocale = "zh_CN",
+                    filterControlsLocked = false,
+                    searchSubmitLocked = false,
+                    showSearchSpinner = false,
+                    onSearchSubmit = {},
+                    onFilterSelected = {},
+                    onLocaleSelected = {}
+                )
+            }
+        }
+
+        composeRule.onNodeWithTag(SEARCH_SCOPE_BUTTON_TAG).performClick()
+        composeRule.onNodeWithText("中文作品").assertExists()
+        composeRule.onNodeWithText("已购").assertExists()
+        composeRule.onNodeWithText("预售").assertExists()
+        composeRule.onNodeWithText("人气顺序").assertExists()
+        composeRule.onNodeWithText("最新发售").assertExists()
+        composeRule.onNodeWithText("销量最高").assertExists()
+        composeRule.onNodeWithText("价格最高").assertExists()
     }
 
     @Test


### PR DESCRIPTION
## Summary
- simplify the online search left filter options to 已购、中文作品、预售、人气顺序、最新发售、销量最高、价格最高
- add semantic icons for the left filter button and dropdown options
- add DLsite 中文作品抓取入口 based on the translation listing and keep pagination/state cache in sync

## Verification
- `./gradlew :app:compileDebugKotlin`