### PR TITLE
fix: unify equalizer panel volume control

### DIFF
--- a/app/src/main/java/com/asmr/player/data/settings/SettingsRepository.kt
+++ b/app/src/main/java/com/asmr/player/data/settings/SettingsRepository.kt
@@ -347,6 +347,23 @@ class SettingsRepository @Inject constructor(
         }
     }
 
+    suspend fun ensureAppVolumePercentInitialized(defaultPercent: Int): Int {
+        return withContext(Dispatchers.IO) {
+            var resolved = AppVolume.clampPercent(defaultPercent)
+            context.settingsDataStore.edit { prefs ->
+                val stored = prefs[SettingsKeys.APP_VOLUME_PERCENT]
+                resolved = if (stored == null) {
+                    AppVolume.clampPercent(defaultPercent).also {
+                        prefs[SettingsKeys.APP_VOLUME_PERCENT] = it
+                    }
+                } else {
+                    AppVolume.clampPercent(stored)
+                }
+            }
+            resolved
+        }
+    }
+
     suspend fun adjustAppVolumePercent(deltaPercent: Int): Int {
         return withContext(Dispatchers.IO) {
             var updated = AppVolume.DefaultPercent

--- a/app/src/main/java/com/asmr/player/main/MainContainer.kt
+++ b/app/src/main/java/com/asmr/player/main/MainContainer.kt
@@ -352,6 +352,7 @@ fun MainContainer(
     val activity = remember(context) { context.findActivity() }
     var nowPlayingVisible by rememberSaveable { mutableStateOf(false) }
     var nowPlayingUsesInlineVolumeControl by remember { mutableStateOf(false) }
+    var nowPlayingEqualizerVisible by remember { mutableStateOf(false) }
     var nowPlayingBackdropActive by rememberSaveable { mutableStateOf(false) }
     var nowPlayingBackdropExitDurationMs by rememberSaveable {
         mutableIntStateOf(NowPlayingMotionSpec.totalExitDurationMs(NowPlayingMotionLayout.PORTRAIT))
@@ -555,6 +556,7 @@ fun MainContainer(
     LaunchedEffect(nowPlayingVisible) {
         if (!nowPlayingVisible) {
             nowPlayingUsesInlineVolumeControl = false
+            nowPlayingEqualizerVisible = false
             return@LaunchedEffect
         }
         showHardwareVolumeOverlay = false
@@ -670,7 +672,7 @@ fun MainContainer(
         if (volumeKeyEventTick <= 0L) return@LaunchedEffect
         if (volumeKeyEventTick == lastHandledVolumeKeyTick) return@LaunchedEffect
         lastHandledVolumeKeyTick = volumeKeyEventTick
-        if (nowPlayingUsesInlineVolumeControl) {
+        if (nowPlayingUsesInlineVolumeControl && !nowPlayingEqualizerVisible) {
             showHardwareVolumeOverlay = false
             nowPlayingVolumeEventTick = volumeKeyEventTick
             return@LaunchedEffect
@@ -679,9 +681,9 @@ fun MainContainer(
         hardwareVolumeOverlayHoldTick = volumeKeyEventTick
     }
 
-    LaunchedEffect(showHardwareVolumeOverlay, hardwareVolumeOverlayHoldTick, hardwareVolumeOverlayInteracting, nowPlayingUsesInlineVolumeControl) {
+    LaunchedEffect(showHardwareVolumeOverlay, hardwareVolumeOverlayHoldTick, hardwareVolumeOverlayInteracting, nowPlayingUsesInlineVolumeControl, nowPlayingEqualizerVisible) {
         if (!showHardwareVolumeOverlay) return@LaunchedEffect
-        if (nowPlayingUsesInlineVolumeControl) {
+        if (nowPlayingUsesInlineVolumeControl && !nowPlayingEqualizerVisible) {
             showHardwareVolumeOverlay = false
             hardwareVolumeOverlayBounds = null
             return@LaunchedEffect
@@ -1668,6 +1670,7 @@ fun MainContainer(
                     windowSizeClass = windowSizeClass,
                     hardwareVolumeEventTick = nowPlayingVolumeEventTick,
                     onInlineVolumeControlVisibilityChanged = { nowPlayingUsesInlineVolumeControl = it },
+                    onEqualizerVisibilityChanged = { nowPlayingEqualizerVisible = it },
                     onBack = closeNowPlaying,
                     onRouteExitStarted = { exitDurationMs ->
                         nowPlayingBackdropExitDurationMs = exitDurationMs

--- a/app/src/main/java/com/asmr/player/service/PlaybackService.kt
+++ b/app/src/main/java/com/asmr/player/service/PlaybackService.kt
@@ -75,6 +75,7 @@ import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.isActive
@@ -216,7 +217,9 @@ class PlaybackService : MediaSessionService() {
         }
         applyPlaybackRuntimeSettings(runtimeSettings)
         runBlocking {
-            settingsRepository.setAppVolumePercent(appVolumeBoostController.currentVolumePercent())
+            settingsRepository.ensureAppVolumePercentInitialized(
+                appVolumeBoostController.currentVolumePercent()
+            )
         }
         runCatching {
             val audioManager = getSystemService(AUDIO_SERVICE) as AudioManager
@@ -996,15 +999,15 @@ class PlaybackService : MediaSessionService() {
         effectApplyJob = serviceScope.launch {
             combine(
                 audioEffectController.equalizerSettings,
-                sessionSettings,
-                settingsRepository.appVolumePercent
-            ) { global, session, appVolumePercent ->
-                (session ?: global) to appVolumePercent
-            }.collect { (settings, appVolumePercent) ->
+                sessionSettings
+            ) { global, session ->
+                session ?: global
+            }
+                .distinctUntilChanged()
+                .collect { settings ->
                 lastEffectiveSettings = settings
                 graphicEqualizerAudioProcessor.setEnabled(settings.enabled)
                 graphicEqualizerAudioProcessor.setBandLevels(settings.bandLevels)
-                sessionPlayer.setBaseVolume(appVolumeBoostController.applyVolumePercent(appVolumePercent))
                 gainAudioProcessor.setGain(1f)
                 val stereoEnabled = settings.stereoEnabled
                 val panActive = stereoEnabled && (settings.orbitEnabled || settings.orbitAzimuthDeg != 0f)
@@ -1020,6 +1023,15 @@ class PlaybackService : MediaSessionService() {
                 stereoOrbitAudioProcessor.setDistance(settings.orbitDistance)
                 stereoOrbitAudioProcessor.setAzimuthDeg(settings.orbitAzimuthDeg)
             }
+        }
+        serviceScope.launch {
+            settingsRepository.appVolumePercent
+                .distinctUntilChanged()
+                .collect { appVolumePercent ->
+                    sessionPlayer.setBaseVolume(
+                        appVolumeBoostController.applyVolumePercent(appVolumePercent)
+                    )
+                }
         }
     }
 

--- a/app/src/main/java/com/asmr/player/ui/player/NowPlayingScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/player/NowPlayingScreen.kt
@@ -7,6 +7,7 @@ import android.content.pm.ActivityInfo
 import android.content.res.Configuration
 import android.content.Intent
 import android.os.SystemClock
+import android.view.KeyEvent as AndroidKeyEvent
 import android.view.LayoutInflater
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
@@ -14,6 +15,7 @@ import androidx.activity.compose.BackHandler
 import androidx.compose.animation.*
 import androidx.compose.animation.core.*
 import androidx.compose.foundation.*
+import androidx.compose.foundation.focusable
 import androidx.compose.foundation.gestures.detectDragGestures
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.interaction.MutableInteractionSource
@@ -54,6 +56,11 @@ import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.nativeCanvas
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.input.key.KeyEventType
+import androidx.compose.ui.input.key.onPreviewKeyEvent
+import androidx.compose.ui.input.key.type
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.layout.boundsInRoot
 import androidx.compose.ui.layout.onGloballyPositioned
@@ -78,6 +85,7 @@ import androidx.media3.common.Player
 import androidx.media3.common.VideoSize
 import androidx.media3.ui.PlayerView
 import com.asmr.player.R
+import com.asmr.player.HardwareVolumeOverlay
 import com.asmr.player.data.lyrics.lyricsTargetContextFromMediaItem
 import com.asmr.player.data.settings.CoverPreviewMode
 import com.asmr.player.data.settings.LyricsPageSettings
@@ -164,6 +172,7 @@ internal fun NowPlayingScreen(
     windowSizeClass: WindowSizeClass,
     hardwareVolumeEventTick: Long,
     onInlineVolumeControlVisibilityChanged: (Boolean) -> Unit = {},
+    onEqualizerVisibilityChanged: (Boolean) -> Unit = {},
     onBack: () -> Unit,
     onRouteExitStarted: (exitDurationMs: Int) -> Unit = {},
     onShowQueue: () -> Unit,
@@ -417,14 +426,26 @@ internal fun NowPlayingScreen(
             !useSplitLayout &&
             !isPhoneLandscape
     val latestOnInlineVolumeControlVisibilityChanged by rememberUpdatedState(onInlineVolumeControlVisibilityChanged)
+    val latestOnEqualizerVisibilityChanged by rememberUpdatedState(onEqualizerVisibilityChanged)
 
     SideEffect {
         latestOnInlineVolumeControlVisibilityChanged(usesInlineVolumeControl)
     }
 
+    SideEffect {
+        latestOnEqualizerVisibilityChanged(showEqualizer)
+    }
+
+    LaunchedEffect(showEqualizer) {
+        if (showEqualizer) {
+            volumeControlExpanded = false
+        }
+    }
+
     DisposableEffect(Unit) {
         onDispose {
             latestOnInlineVolumeControlVisibilityChanged(false)
+            latestOnEqualizerVisibilityChanged(false)
         }
     }
 
@@ -1337,6 +1358,31 @@ internal fun NowPlayingScreen(
         if (showEqualizer) {
             val eqSettings by viewModel.sessionEqualizer.collectAsState()
             val customPresets by viewModel.customPresets.collectAsState()
+            val appVolumePercent by viewModel.appVolumePercent.collectAsState()
+            val equalizerFocusRequester = remember { FocusRequester() }
+            var showEqualizerVolumeOverlay by remember { mutableStateOf(false) }
+            var equalizerVolumeOverlayInteracting by remember { mutableStateOf(false) }
+            var equalizerVolumeOverlayHoldTick by remember { mutableLongStateOf(0L) }
+            var equalizerVolumeOverlayBounds by remember { mutableStateOf<Rect?>(null) }
+            var lastNonZeroEqualizerVolume by remember { mutableIntStateOf(AppVolume.DefaultPercent) }
+            LaunchedEffect(equalizerFocusRequester) {
+                equalizerFocusRequester.requestFocus()
+            }
+            LaunchedEffect(appVolumePercent) {
+                if (appVolumePercent > 0) {
+                    lastNonZeroEqualizerVolume = appVolumePercent
+                }
+            }
+            LaunchedEffect(showEqualizerVolumeOverlay, equalizerVolumeOverlayHoldTick, equalizerVolumeOverlayInteracting) {
+                if (!showEqualizerVolumeOverlay) return@LaunchedEffect
+                if (equalizerVolumeOverlayInteracting) return@LaunchedEffect
+                val snapshot = equalizerVolumeOverlayHoldTick
+                delay(2_000)
+                if (!equalizerVolumeOverlayInteracting && equalizerVolumeOverlayHoldTick == snapshot) {
+                    showEqualizerVolumeOverlay = false
+                    equalizerVolumeOverlayBounds = null
+                }
+            }
             ModalBottomSheet(
                 onDismissRequest = { showEqualizer = false },
                 sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true),
@@ -1344,7 +1390,30 @@ internal fun NowPlayingScreen(
                 contentColor = colorScheme.onSurface
             ) {
                 val scrollState = rememberScrollState()
-                Box(modifier = Modifier.fillMaxHeight()) {
+                Box(
+                    modifier = Modifier
+                        .fillMaxHeight()
+                        .focusRequester(equalizerFocusRequester)
+                        .focusable()
+                        .onPreviewKeyEvent { event ->
+                            if (event.type != KeyEventType.KeyDown) return@onPreviewKeyEvent false
+                            when (event.nativeKeyEvent.keyCode) {
+                                AndroidKeyEvent.KEYCODE_VOLUME_UP -> {
+                                    viewModel.adjustAppVolumePercent(AppVolume.StepPercent)
+                                    showEqualizerVolumeOverlay = true
+                                    equalizerVolumeOverlayHoldTick += 1L
+                                    true
+                                }
+                                AndroidKeyEvent.KEYCODE_VOLUME_DOWN -> {
+                                    viewModel.adjustAppVolumePercent(-AppVolume.StepPercent)
+                                    showEqualizerVolumeOverlay = true
+                                    equalizerVolumeOverlayHoldTick += 1L
+                                    true
+                                }
+                                else -> false
+                            }
+                        }
+                ) {
                     EqualizerPanel(
                         settings = eqSettings,
                         customPresets = customPresets,
@@ -1361,6 +1430,56 @@ internal fun NowPlayingScreen(
                             .verticalScroll(scrollState)
                             .padding(bottom = 32.dp)
                     )
+                    if (showEqualizerVolumeOverlay) {
+                        DismissOutsideBoundsOverlay(
+                            targetBoundsInRoot = equalizerVolumeOverlayBounds,
+                            onDismiss = {
+                                showEqualizerVolumeOverlay = false
+                                equalizerVolumeOverlayBounds = null
+                            }
+                        )
+                    }
+                    Box(
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .padding(end = 18.dp),
+                        contentAlignment = Alignment.CenterEnd
+                    ) {
+                        androidx.compose.animation.AnimatedVisibility(
+                            visible = showEqualizerVolumeOverlay,
+                            enter = fadeIn(animationSpec = tween(140)) + slideInHorizontally(animationSpec = tween(180)) { it / 3 },
+                            exit = fadeOut(animationSpec = tween(160)) + slideOutHorizontally(animationSpec = tween(180)) { it / 3 }
+                        ) {
+                            HardwareVolumeOverlay(
+                                modifier = Modifier.onGloballyPositioned { coordinates ->
+                                    equalizerVolumeOverlayBounds = coordinates.boundsInRoot()
+                                },
+                                volumePercent = appVolumePercent,
+                                audioOutputRouteKind = audioOutputRouteKind,
+                                onVolumeChange = {
+                                    viewModel.setAppVolumePercent(it)
+                                    equalizerVolumeOverlayHoldTick += 1L
+                                },
+                                onToggleMute = {
+                                    if (appVolumePercent > 0) {
+                                        viewModel.setAppVolumePercent(0)
+                                    } else {
+                                        viewModel.setAppVolumePercent(
+                                            lastNonZeroEqualizerVolume.coerceAtLeast(AppVolume.StepPercent)
+                                        )
+                                    }
+                                    equalizerVolumeOverlayHoldTick += 1L
+                                },
+                                onInteractionActiveChanged = { active ->
+                                    equalizerVolumeOverlayInteracting = active
+                                    if (!active) {
+                                        equalizerVolumeOverlayHoldTick += 1L
+                                    }
+                                },
+                                warningSessionState = warningSessionState
+                            )
+                        }
+                    }
                 }
             }
         }

--- a/app/src/test/java/com/asmr/player/data/settings/SettingsRepositoryTest.kt
+++ b/app/src/test/java/com/asmr/player/data/settings/SettingsRepositoryTest.kt
@@ -9,6 +9,7 @@ import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.RuntimeEnvironment
 import androidx.datastore.preferences.core.edit
+import kotlinx.coroutines.flow.first
 
 @RunWith(RobolectricTestRunner::class)
 class SettingsRepositoryTest {
@@ -54,5 +55,27 @@ class SettingsRepositoryTest {
             ),
             repository.loadPlaybackRuntimeSettings()
         )
+    }
+
+    @Test
+    fun ensureAppVolumePercentInitialized_seedsWhenUnset() = runBlocking {
+        val resolved = repository.ensureAppVolumePercentInitialized(46)
+
+        assertEquals(46, resolved)
+        assertEquals(46, repository.appVolumePercentValue())
+    }
+
+    @Test
+    fun ensureAppVolumePercentInitialized_keepsStoredValue() = runBlocking {
+        repository.setAppVolumePercent(72)
+
+        val resolved = repository.ensureAppVolumePercentInitialized(32)
+
+        assertEquals(72, resolved)
+        assertEquals(72, repository.appVolumePercentValue())
+    }
+
+    private suspend fun SettingsRepository.appVolumePercentValue(): Int {
+        return appVolumePercent.first()
     }
 }


### PR DESCRIPTION
## Summary
- keep app volume as the single persisted source of truth instead of reinitializing it from system volume after startup
- decouple equalizer setting updates from service-side volume application so toggling any FX group or slider no longer resets volume
- intercept volume keys inside the equalizer sheet and show the app's custom right-side volume overlay instead of the system volume UI
- add repository regression coverage for one-time app volume initialization behavior

## Verification
- ./gradlew :app:compileDebugKotlin
