### PR TITLE
feat: add scene effect presets to audio panel

### DIFF
--- a/app/src/main/java/com/asmr/player/data/settings/AudioEffectController.kt
+++ b/app/src/main/java/com/asmr/player/data/settings/AudioEffectController.kt
@@ -33,6 +33,10 @@ data class EqualizerSettings(
     val volumeThresholdMinDb: Float = -24f,
     val volumeThresholdMaxDb: Float = -6f,
     val volumeLoudnessTargetDb: Float = -18f,
+    val sceneEffectEnabled: Boolean = false,
+    val sceneEffectPresetId: String = SceneEffectPresets.DefaultPresetId,
+    val sceneEffectAmount: Int = SceneEffectPresets.DefaultAmount,
+    val sceneEffectExpanded: Boolean = true,
     val speedPitchEnabled: Boolean = true,
     val speedPitchExpanded: Boolean = true,
     val equalizerExpanded: Boolean = true
@@ -64,6 +68,10 @@ class AudioEffectController @Inject constructor(
         val vtMaxDb = prefs[SettingsKeys.FX_VOLUME_THRESHOLD_MAX_DB] ?: -6f
         val loudnessTargetDb = prefs[SettingsKeys.FX_VOLUME_LOUDNESS_TARGET_DB] ?: -18f
         val volumeThresholdExpanded = prefs[SettingsKeys.UI_FX_VOLUME_THRESHOLD_EXPANDED] ?: true
+        val sceneEffectEnabled = prefs[SettingsKeys.FX_SCENE_ENABLED] ?: false
+        val sceneEffectPresetId = prefs[SettingsKeys.FX_SCENE_PRESET_ID] ?: SceneEffectPresets.DefaultPresetId
+        val sceneEffectAmount = (prefs[SettingsKeys.FX_SCENE_AMOUNT] ?: SceneEffectPresets.DefaultAmount).coerceIn(0, 100)
+        val sceneEffectExpanded = prefs[SettingsKeys.UI_FX_SCENE_EXPANDED] ?: true
         val stereoEnabled = prefs[SettingsKeys.FX_STEREO_ENABLED] ?: false
         val stereoExpanded = prefs[SettingsKeys.UI_FX_STEREO_EXPANDED] ?: true
         val orbitAzimuthDeg = prefs[SettingsKeys.FX_ORBIT_AZIMUTH_DEG] ?: 0f
@@ -95,6 +103,10 @@ class AudioEffectController @Inject constructor(
             volumeThresholdMinDb = vtMinDb,
             volumeThresholdMaxDb = vtMaxDb,
             volumeLoudnessTargetDb = loudnessTargetDb,
+            sceneEffectEnabled = sceneEffectEnabled,
+            sceneEffectPresetId = sceneEffectPresetId,
+            sceneEffectAmount = sceneEffectAmount,
+            sceneEffectExpanded = sceneEffectExpanded,
             speedPitchEnabled = speedPitchEnabled,
             speedPitchExpanded = speedPitchExpanded,
             equalizerExpanded = equalizerExpanded

--- a/app/src/main/java/com/asmr/player/data/settings/SceneEffectPresets.kt
+++ b/app/src/main/java/com/asmr/player/data/settings/SceneEffectPresets.kt
@@ -1,0 +1,108 @@
+package com.asmr.player.data.settings
+
+data class SceneDelayTap(
+    val delayMs: Int,
+    val gain: Float,
+    val crossfeed: Float = 0f
+)
+
+data class SceneEffectProfile(
+    val dryMix: Float,
+    val directMix: Float,
+    val reflectionMix: Float,
+    val feedback: Float = 0f,
+    val monoMix: Float = 0f,
+    val stereoWidth: Float = 1f,
+    val highPassHz: Float = 0f,
+    val highPassStages: Int = 0,
+    val lowPassHz: Float = 0f,
+    val lowPassStages: Int = 0,
+    val softClipDrive: Float = 0f,
+    val outputGain: Float = 1f,
+    val taps: List<SceneDelayTap> = emptyList()
+)
+
+data class SceneEffectPreset(
+    val id: String,
+    val label: String,
+    val description: String,
+    val profile: SceneEffectProfile
+)
+
+object SceneEffectPresets {
+    const val DefaultPresetId = "bathroom_echo"
+    const val DefaultAmount = 50
+
+    val All = listOf(
+        SceneEffectPreset(
+            id = DefaultPresetId,
+            label = "浴室回声",
+            description = "瓷砖短回声",
+            profile = SceneEffectProfile(
+                dryMix = 0.58f,
+                directMix = 0.30f,
+                reflectionMix = 0.72f,
+                feedback = 0.52f,
+                monoMix = 0.20f,
+                stereoWidth = 0.88f,
+                highPassHz = 180f,
+                highPassStages = 1,
+                lowPassHz = 6400f,
+                lowPassStages = 1,
+                outputGain = 0.90f,
+                taps = listOf(
+                    SceneDelayTap(delayMs = 16, gain = 0.32f),
+                    SceneDelayTap(delayMs = 27, gain = 0.28f),
+                    SceneDelayTap(delayMs = 41, gain = 0.23f),
+                    SceneDelayTap(delayMs = 63, gain = 0.18f),
+                    SceneDelayTap(delayMs = 96, gain = 0.12f)
+                )
+            )
+        ),
+        SceneEffectPreset(
+            id = "through_wall",
+            label = "被窝闷声",
+            description = "闷声包裹感",
+            profile = SceneEffectProfile(
+                dryMix = 0.03f,
+                directMix = 1.02f,
+                reflectionMix = 0.16f,
+                feedback = 0.20f,
+                monoMix = 0.68f,
+                stereoWidth = 0.18f,
+                highPassHz = 120f,
+                highPassStages = 1,
+                lowPassHz = 1200f,
+                lowPassStages = 3,
+                outputGain = 1.00f,
+                taps = listOf(
+                    SceneDelayTap(delayMs = 14, gain = 0.10f),
+                    SceneDelayTap(delayMs = 24, gain = 0.07f),
+                    SceneDelayTap(delayMs = 39, gain = 0.05f)
+                )
+            )
+        ),
+        SceneEffectPreset(
+            id = "telephone",
+            label = "电话音",
+            description = "窄带通话感",
+            profile = SceneEffectProfile(
+                dryMix = 0f,
+                directMix = 1.08f,
+                reflectionMix = 0f,
+                monoMix = 1.00f,
+                stereoWidth = 0f,
+                highPassHz = 430f,
+                highPassStages = 3,
+                lowPassHz = 2850f,
+                lowPassStages = 3,
+                softClipDrive = 0.34f,
+                outputGain = 1.06f
+            )
+        )
+    )
+
+    fun resolve(id: String?): SceneEffectPreset {
+        return All.firstOrNull { it.id == id } ?: All.first()
+    }
+}

--- a/app/src/main/java/com/asmr/player/data/settings/SettingsDataStore.kt
+++ b/app/src/main/java/com/asmr/player/data/settings/SettingsDataStore.kt
@@ -55,11 +55,15 @@ object SettingsKeys {
     val FX_VOLUME_THRESHOLD_MIN_DB = floatPreferencesKey("fx_volume_threshold_min_db")
     val FX_VOLUME_THRESHOLD_MAX_DB = floatPreferencesKey("fx_volume_threshold_max_db")
     val FX_VOLUME_LOUDNESS_TARGET_DB = floatPreferencesKey("fx_volume_loudness_target_db")
+    val FX_SCENE_ENABLED = booleanPreferencesKey("fx_scene_enabled")
+    val FX_SCENE_PRESET_ID = stringPreferencesKey("fx_scene_preset_id")
+    val FX_SCENE_AMOUNT = intPreferencesKey("fx_scene_amount")
 
     val FX_STEREO_ENABLED = booleanPreferencesKey("fx_stereo_enabled")
 
     val UI_FX_CHANNEL_EXPANDED = booleanPreferencesKey("ui_fx_channel_expanded")
     val UI_FX_VOLUME_THRESHOLD_EXPANDED = booleanPreferencesKey("ui_fx_volume_threshold_expanded")
+    val UI_FX_SCENE_EXPANDED = booleanPreferencesKey("ui_fx_scene_expanded")
     val UI_FX_SPEED_PITCH_ENABLED = booleanPreferencesKey("ui_fx_speed_pitch_enabled")
     val UI_FX_SPEED_PITCH_EXPANDED = booleanPreferencesKey("ui_fx_speed_pitch_expanded")
     val UI_FX_STEREO_EXPANDED = booleanPreferencesKey("ui_fx_stereo_expanded")

--- a/app/src/main/java/com/asmr/player/data/settings/SettingsRepository.kt
+++ b/app/src/main/java/com/asmr/player/data/settings/SettingsRepository.kt
@@ -83,6 +83,10 @@ class SettingsRepository @Inject constructor(
         val vtMaxDb = prefs[SettingsKeys.FX_VOLUME_THRESHOLD_MAX_DB] ?: -6f
         val loudnessTargetDb = prefs[SettingsKeys.FX_VOLUME_LOUDNESS_TARGET_DB] ?: -18f
         val volumeThresholdExpanded = prefs[SettingsKeys.UI_FX_VOLUME_THRESHOLD_EXPANDED] ?: true
+        val sceneEffectEnabled = prefs[SettingsKeys.FX_SCENE_ENABLED] ?: false
+        val sceneEffectPresetId = prefs[SettingsKeys.FX_SCENE_PRESET_ID] ?: SceneEffectPresets.DefaultPresetId
+        val sceneEffectAmount = (prefs[SettingsKeys.FX_SCENE_AMOUNT] ?: SceneEffectPresets.DefaultAmount).coerceIn(0, 100)
+        val sceneEffectExpanded = prefs[SettingsKeys.UI_FX_SCENE_EXPANDED] ?: true
         val stereoEnabled = prefs[SettingsKeys.FX_STEREO_ENABLED] ?: false
         val stereoExpanded = prefs[SettingsKeys.UI_FX_STEREO_EXPANDED] ?: true
         val orbitAzimuthDeg = prefs[SettingsKeys.FX_ORBIT_AZIMUTH_DEG] ?: 0f
@@ -114,6 +118,10 @@ class SettingsRepository @Inject constructor(
             volumeThresholdMinDb = vtMinDb,
             volumeThresholdMaxDb = vtMaxDb,
             volumeLoudnessTargetDb = loudnessTargetDb,
+            sceneEffectEnabled = sceneEffectEnabled,
+            sceneEffectPresetId = sceneEffectPresetId,
+            sceneEffectAmount = sceneEffectAmount,
+            sceneEffectExpanded = sceneEffectExpanded,
             speedPitchEnabled = speedPitchEnabled,
             speedPitchExpanded = speedPitchExpanded,
             equalizerExpanded = equalizerExpanded
@@ -278,8 +286,12 @@ class SettingsRepository @Inject constructor(
                 prefs[SettingsKeys.FX_VOLUME_THRESHOLD_MIN_DB] = settings.volumeThresholdMinDb
                 prefs[SettingsKeys.FX_VOLUME_THRESHOLD_MAX_DB] = settings.volumeThresholdMaxDb
                 prefs[SettingsKeys.FX_VOLUME_LOUDNESS_TARGET_DB] = settings.volumeLoudnessTargetDb
+                prefs[SettingsKeys.FX_SCENE_ENABLED] = settings.sceneEffectEnabled
+                prefs[SettingsKeys.FX_SCENE_PRESET_ID] = settings.sceneEffectPresetId
+                prefs[SettingsKeys.FX_SCENE_AMOUNT] = settings.sceneEffectAmount.coerceIn(0, 100)
                 prefs[SettingsKeys.UI_FX_CHANNEL_EXPANDED] = settings.channelExpanded
                 prefs[SettingsKeys.UI_FX_VOLUME_THRESHOLD_EXPANDED] = settings.volumeThresholdExpanded
+                prefs[SettingsKeys.UI_FX_SCENE_EXPANDED] = settings.sceneEffectExpanded
                 prefs[SettingsKeys.UI_FX_SPEED_PITCH_ENABLED] = settings.speedPitchEnabled
                 prefs[SettingsKeys.UI_FX_SPEED_PITCH_EXPANDED] = settings.speedPitchExpanded
                 prefs[SettingsKeys.UI_FX_STEREO_EXPANDED] = settings.stereoExpanded

--- a/app/src/main/java/com/asmr/player/playback/AsmrRenderersFactory.kt
+++ b/app/src/main/java/com/asmr/player/playback/AsmrRenderersFactory.kt
@@ -13,6 +13,7 @@ class AsmrRenderersFactory(
     private val gainAudioProcessor: GainAudioProcessor,
     private val balanceAudioProcessor: BalanceAudioProcessor,
     private val stereoOrbitAudioProcessor: StereoOrbitAudioProcessor,
+    private val sceneEffectAudioProcessor: SceneEffectAudioProcessor,
     private val channelModeAudioProcessor: ChannelModeAudioProcessor,
     private val volumeThresholdAudioProcessor: VolumeThresholdAudioProcessor,
     private val spectrumTapAudioProcessor: StereoSpectrumTapAudioProcessor
@@ -30,6 +31,7 @@ class AsmrRenderersFactory(
                     graphicEqualizerAudioProcessor,
                     channelModeAudioProcessor,
                     stereoOrbitAudioProcessor,
+                    sceneEffectAudioProcessor,
                     volumeThresholdAudioProcessor,
                     balanceAudioProcessor
                 )

--- a/app/src/main/java/com/asmr/player/playback/SceneEffectAudioProcessor.kt
+++ b/app/src/main/java/com/asmr/player/playback/SceneEffectAudioProcessor.kt
@@ -1,0 +1,392 @@
+package com.asmr.player.playback
+
+import androidx.media3.common.C
+import androidx.media3.common.audio.AudioProcessor.AudioFormat
+import androidx.media3.common.audio.BaseAudioProcessor
+import androidx.media3.common.util.UnstableApi
+import com.asmr.player.data.settings.SceneEffectPresets
+import com.asmr.player.data.settings.SceneDelayTap
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+import kotlin.math.PI
+import kotlin.math.tanh
+
+@UnstableApi
+class SceneEffectAudioProcessor : BaseAudioProcessor() {
+
+    private val lock = Any()
+
+    private var pendingEnabled = false
+    private var pendingPresetId = SceneEffectPresets.DefaultPresetId
+    private var pendingAmount = SceneEffectPresets.DefaultAmount
+    private var settingsDirty = true
+
+    private var passthrough = false
+    private var activeSampleRate = 0
+    private var activeChannels = 0
+
+    private var dryMix = 1f
+    private var directMix = 0f
+    private var reflectionMix = 0f
+    private var feedback = 0f
+    private var monoMix = 0f
+    private var stereoWidth = 1f
+    private var outputGain = 1f
+    private var softClipDrive = 0f
+
+    private var delayLeft = FloatArray(1)
+    private var delayRight = FloatArray(1)
+    private var delayIndex = 0
+    private var delayTaps: List<ResolvedDelayTap> = emptyList()
+    private var feedbackDelaySamples = 0
+    private var feedbackStateLeft = 0f
+    private var feedbackStateRight = 0f
+
+    private var highPassAlpha = 0f
+    private var highPassStages = 0
+    private var highPassInLeft = FloatArray(0)
+    private var highPassInRight = FloatArray(0)
+    private var highPassOutLeft = FloatArray(0)
+    private var highPassOutRight = FloatArray(0)
+
+    private var lowPassAlpha = 1f
+    private var lowPassStages = 0
+    private var lowPassLeft = FloatArray(0)
+    private var lowPassRight = FloatArray(0)
+    private val frameOut = FloatArray(2)
+
+    fun setEnabled(enabled: Boolean) {
+        synchronized(lock) {
+            if (pendingEnabled != enabled) {
+                pendingEnabled = enabled
+                settingsDirty = true
+            }
+        }
+    }
+
+    fun setPreset(presetId: String) {
+        synchronized(lock) {
+            if (pendingPresetId != presetId) {
+                pendingPresetId = presetId
+                settingsDirty = true
+            }
+        }
+    }
+
+    fun setAmount(amountPercent: Int) {
+        val normalized = amountPercent.coerceIn(0, 100)
+        synchronized(lock) {
+            if (pendingAmount != normalized) {
+                pendingAmount = normalized
+                settingsDirty = true
+            }
+        }
+    }
+
+    override fun onConfigure(inputAudioFormat: AudioFormat): AudioFormat {
+        passthrough =
+            inputAudioFormat.channelCount != 2 ||
+                (inputAudioFormat.encoding != C.ENCODING_PCM_16BIT &&
+                    inputAudioFormat.encoding != C.ENCODING_PCM_FLOAT)
+        synchronized(lock) {
+            settingsDirty = true
+        }
+        return inputAudioFormat
+    }
+
+    override fun onFlush() {
+        clearState()
+        rebuildIfNeeded(force = true)
+    }
+
+    override fun onReset() {
+        passthrough = false
+        activeSampleRate = 0
+        activeChannels = 0
+        delayLeft = FloatArray(1)
+        delayRight = FloatArray(1)
+        delayIndex = 0
+        delayTaps = emptyList()
+        feedbackDelaySamples = 0
+        highPassInLeft = FloatArray(0)
+        highPassInRight = FloatArray(0)
+        highPassOutLeft = FloatArray(0)
+        highPassOutRight = FloatArray(0)
+        lowPassLeft = FloatArray(0)
+        lowPassRight = FloatArray(0)
+        clearState()
+        synchronized(lock) {
+            settingsDirty = true
+        }
+    }
+
+    override fun queueInput(inputBuffer: ByteBuffer) {
+        if (!inputBuffer.hasRemaining()) return
+
+        rebuildIfNeeded(force = false)
+
+        val count = inputBuffer.remaining()
+        val outputBuffer = replaceOutputBuffer(count)
+        outputBuffer.order(ByteOrder.LITTLE_ENDIAN)
+
+        if (passthrough || (directMix == 0f && reflectionMix == 0f && dryMix == 1f)) {
+            outputBuffer.put(inputBuffer)
+            outputBuffer.flip()
+            return
+        }
+
+        inputBuffer.order(ByteOrder.LITTLE_ENDIAN)
+        val encoding = inputAudioFormat.encoding
+        if (encoding == C.ENCODING_PCM_FLOAT) {
+            while (inputBuffer.remaining() >= 8) {
+                val left = inputBuffer.float
+                val right = inputBuffer.float
+                processStereoFrame(left, right, frameOut)
+                outputBuffer.putFloat(frameOut[0])
+                outputBuffer.putFloat(frameOut[1])
+            }
+        } else {
+            while (inputBuffer.remaining() >= 4) {
+                val left = inputBuffer.short / 32768f
+                val right = inputBuffer.short / 32768f
+                processStereoFrame(left, right, frameOut)
+                outputBuffer.putShort(floatToShort(frameOut[0]))
+                outputBuffer.putShort(floatToShort(frameOut[1]))
+            }
+        }
+
+        if (inputBuffer.hasRemaining()) {
+            outputBuffer.put(inputBuffer)
+        }
+        outputBuffer.flip()
+    }
+
+    private fun rebuildIfNeeded(force: Boolean) {
+        val sampleRate = inputAudioFormat.sampleRate
+        val channels = inputAudioFormat.channelCount
+
+        val enabled: Boolean
+        val presetId: String
+        val amount: Int
+        synchronized(lock) {
+            if (!force && !settingsDirty && sampleRate == activeSampleRate && channels == activeChannels) {
+                return
+            }
+            enabled = pendingEnabled
+            presetId = pendingPresetId
+            amount = pendingAmount
+            settingsDirty = false
+        }
+
+        activeSampleRate = sampleRate
+        activeChannels = channels
+
+        if (passthrough || !enabled || sampleRate <= 0 || channels != 2 || amount <= 0) {
+            applyBypass()
+            clearState()
+            return
+        }
+
+        val preset = SceneEffectPresets.resolve(presetId)
+        val intensity = amount.coerceIn(0, 100) / 100f
+        val wetBoost = 1f + 0.45f * intensity * intensity
+        val aggressiveBlend = (intensity * (1f + 0.20f * intensity)).coerceAtMost(1.2f)
+        val profile = preset.profile
+
+        dryMix = lerp(1f, profile.dryMix, aggressiveBlend).coerceIn(0f, 1f)
+        directMix = profile.directMix * intensity * wetBoost
+        reflectionMix = profile.reflectionMix * intensity * wetBoost
+        feedback = (profile.feedback * intensity * wetBoost).coerceIn(0f, 0.88f)
+        monoMix = (profile.monoMix * intensity * wetBoost).coerceIn(0f, 1f)
+        stereoWidth = lerp(1f, profile.stereoWidth, aggressiveBlend).coerceIn(0f, 1.25f)
+        outputGain = lerp(1f, profile.outputGain, intensity)
+        softClipDrive = profile.softClipDrive * intensity * wetBoost
+
+        highPassStages = if (profile.highPassHz > 0f) profile.highPassStages.coerceIn(0, 4) else 0
+        lowPassStages = if (profile.lowPassHz > 0f) profile.lowPassStages.coerceIn(0, 4) else 0
+        highPassAlpha = if (highPassStages > 0) computeHighPassAlpha(profile.highPassHz, sampleRate) else 0f
+        lowPassAlpha = if (lowPassStages > 0) computeLowPassAlpha(profile.lowPassHz, sampleRate) else 1f
+
+        highPassInLeft = FloatArray(highPassStages)
+        highPassInRight = FloatArray(highPassStages)
+        highPassOutLeft = FloatArray(highPassStages)
+        highPassOutRight = FloatArray(highPassStages)
+        lowPassLeft = FloatArray(lowPassStages)
+        lowPassRight = FloatArray(lowPassStages)
+
+        delayTaps = preset.profile.taps.mapNotNull { it.resolve(sampleRate) }
+        feedbackDelaySamples = delayTaps.maxOfOrNull { it.delaySamples } ?: 0
+        val maxDelay = (feedbackDelaySamples + 4).coerceAtLeast(1)
+        delayLeft = FloatArray(maxDelay)
+        delayRight = FloatArray(maxDelay)
+        delayIndex = 0
+        feedbackStateLeft = 0f
+        feedbackStateRight = 0f
+    }
+
+    private fun applyBypass() {
+        dryMix = 1f
+        directMix = 0f
+        reflectionMix = 0f
+        feedback = 0f
+        monoMix = 0f
+        stereoWidth = 1f
+        outputGain = 1f
+        softClipDrive = 0f
+        delayTaps = emptyList()
+        feedbackDelaySamples = 0
+        highPassStages = 0
+        lowPassStages = 0
+    }
+
+    private fun clearState() {
+        delayLeft.fill(0f)
+        delayRight.fill(0f)
+        delayIndex = 0
+        feedbackStateLeft = 0f
+        feedbackStateRight = 0f
+        highPassInLeft.fill(0f)
+        highPassInRight.fill(0f)
+        highPassOutLeft.fill(0f)
+        highPassOutRight.fill(0f)
+        lowPassLeft.fill(0f)
+        lowPassRight.fill(0f)
+    }
+
+    private fun processStereoFrame(inputLeft: Float, inputRight: Float, out: FloatArray) {
+        val mono = (inputLeft + inputRight) * 0.5f
+        val widthLeft = mono + (inputLeft - mono) * stereoWidth
+        val widthRight = mono + (inputRight - mono) * stereoWidth
+        val sourceLeft = lerp(widthLeft, mono, monoMix)
+        val sourceRight = lerp(widthRight, mono, monoMix)
+
+        val filteredLeft = filterChain(sourceLeft, isLeft = true)
+        val filteredRight = filterChain(sourceRight, isLeft = false)
+
+        var reflectedLeft = 0f
+        var reflectedRight = 0f
+        if (delayTaps.isNotEmpty()) {
+            for (tap in delayTaps) {
+                val readIndex = wrappedDelayIndex(delayIndex - tap.delaySamples)
+                val tapLeft = delayLeft[readIndex]
+                val tapRight = delayRight[readIndex]
+                val cross = tap.crossfeed.coerceIn(0f, 1f)
+                val direct = 1f - cross
+                reflectedLeft += (tapLeft * direct + tapRight * cross) * tap.gain
+                reflectedRight += (tapRight * direct + tapLeft * cross) * tap.gain
+            }
+        }
+
+        val delayedFeedbackLeft = if (feedbackDelaySamples > 0) delayLeft[wrappedDelayIndex(delayIndex - feedbackDelaySamples)] else 0f
+        val delayedFeedbackRight = if (feedbackDelaySamples > 0) delayRight[wrappedDelayIndex(delayIndex - feedbackDelaySamples)] else 0f
+        val writeLeft = filteredLeft + delayedFeedbackLeft * feedback
+        val writeRight = filteredRight + delayedFeedbackRight * feedback
+        delayLeft[delayIndex] = writeLeft.coerceIn(-1.25f, 1.25f)
+        delayRight[delayIndex] = writeRight.coerceIn(-1.25f, 1.25f)
+        delayIndex = wrappedDelayIndex(delayIndex + 1)
+
+        var outLeft = inputLeft * dryMix + filteredLeft * directMix + reflectedLeft * reflectionMix
+        var outRight = inputRight * dryMix + filteredRight * directMix + reflectedRight * reflectionMix
+
+        outLeft *= outputGain
+        outRight *= outputGain
+
+        if (softClipDrive > 0f) {
+            outLeft = softClip(outLeft, softClipDrive)
+            outRight = softClip(outRight, softClipDrive)
+        }
+
+        out[0] = outLeft.coerceIn(-1f, 1f)
+        out[1] = outRight.coerceIn(-1f, 1f)
+    }
+
+    private fun filterChain(sample: Float, isLeft: Boolean): Float {
+        var out = sample
+
+        if (highPassStages > 0) {
+            for (stage in 0 until highPassStages) {
+                val inputPrev = if (isLeft) highPassInLeft[stage] else highPassInRight[stage]
+                val outputPrev = if (isLeft) highPassOutLeft[stage] else highPassOutRight[stage]
+                val filtered = highPassAlpha * (outputPrev + out - inputPrev)
+                if (isLeft) {
+                    highPassInLeft[stage] = out
+                    highPassOutLeft[stage] = filtered
+                } else {
+                    highPassInRight[stage] = out
+                    highPassOutRight[stage] = filtered
+                }
+                out = filtered
+            }
+        }
+
+        if (lowPassStages > 0) {
+            for (stage in 0 until lowPassStages) {
+                val prev = if (isLeft) lowPassLeft[stage] else lowPassRight[stage]
+                val filtered = prev + lowPassAlpha * (out - prev)
+                if (isLeft) {
+                    lowPassLeft[stage] = filtered
+                } else {
+                    lowPassRight[stage] = filtered
+                }
+                out = filtered
+            }
+        }
+
+        return out
+    }
+
+    private fun computeLowPassAlpha(cutoffHz: Float, sampleRate: Int): Float {
+        val safeCutoff = cutoffHz.coerceIn(10f, sampleRate * 0.45f)
+        val dt = 1f / sampleRate.coerceAtLeast(1)
+        val rc = 1f / (2f * PI.toFloat() * safeCutoff)
+        return (dt / (rc + dt)).coerceIn(0.0001f, 1f)
+    }
+
+    private fun computeHighPassAlpha(cutoffHz: Float, sampleRate: Int): Float {
+        val safeCutoff = cutoffHz.coerceIn(10f, sampleRate * 0.45f)
+        val dt = 1f / sampleRate.coerceAtLeast(1)
+        val rc = 1f / (2f * PI.toFloat() * safeCutoff)
+        return (rc / (rc + dt)).coerceIn(0.0001f, 0.9999f)
+    }
+
+    private fun wrappedDelayIndex(index: Int): Int {
+        val size = delayLeft.size.coerceAtLeast(1)
+        var wrapped = index % size
+        if (wrapped < 0) wrapped += size
+        return wrapped
+    }
+
+    private fun floatToShort(value: Float): Short {
+        return (value.coerceIn(-1f, 1f) * 32767f)
+            .toInt()
+            .coerceIn(Short.MIN_VALUE.toInt(), Short.MAX_VALUE.toInt())
+            .toShort()
+    }
+
+    private fun lerp(start: Float, end: Float, amount: Float): Float {
+        return start + (end - start) * amount.coerceIn(0f, 1f)
+    }
+
+    private fun softClip(value: Float, drive: Float): Float {
+        val scale = (1f + drive * 4f).toDouble()
+        val shaped = tanh((value * scale).coerceIn(-8.0, 8.0))
+        val normalizer = tanh(scale).takeIf { kotlin.math.abs(it) > 1e-6 } ?: 1.0
+        return (shaped / normalizer).toFloat().coerceIn(-1f, 1f)
+    }
+
+    private data class ResolvedDelayTap(
+        val delaySamples: Int,
+        val gain: Float,
+        val crossfeed: Float
+    )
+
+    private fun SceneDelayTap.resolve(sampleRate: Int): ResolvedDelayTap? {
+        if (delayMs <= 0 || gain <= 0f || sampleRate <= 0) return null
+        val samples = ((delayMs.toLong() * sampleRate) / 1000L).toInt().coerceAtLeast(1)
+        return ResolvedDelayTap(
+            delaySamples = samples,
+            gain = gain,
+            crossfeed = crossfeed.coerceIn(0f, 1f)
+        )
+    }
+}

--- a/app/src/main/java/com/asmr/player/service/PlaybackService.kt
+++ b/app/src/main/java/com/asmr/player/service/PlaybackService.kt
@@ -54,6 +54,7 @@ import com.asmr.player.playback.AppVolumeBoostController
 import com.asmr.player.playback.GraphicEqualizerAudioProcessor
 import com.asmr.player.playback.PlaybackMediaCache
 import com.asmr.player.playback.RoutingPlaybackDataSource
+import com.asmr.player.playback.SceneEffectAudioProcessor
 import com.asmr.player.playback.StereoFftAnalyzer
 import com.asmr.player.playback.StereoOrbitAudioProcessor
 import com.asmr.player.playback.StereoPcmRingBuffer
@@ -96,6 +97,7 @@ class PlaybackService : MediaSessionService() {
     private val gainAudioProcessor = GainAudioProcessor()
     private val balanceAudioProcessor = BalanceAudioProcessor()
     private val stereoOrbitAudioProcessor = StereoOrbitAudioProcessor()
+    private val sceneEffectAudioProcessor = SceneEffectAudioProcessor()
     private val channelModeAudioProcessor = ChannelModeAudioProcessor()
     private val volumeThresholdAudioProcessor = VolumeThresholdAudioProcessor()
     private val serviceScope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
@@ -297,6 +299,7 @@ class PlaybackService : MediaSessionService() {
                     gainAudioProcessor,
                     balanceAudioProcessor,
                     stereoOrbitAudioProcessor,
+                    sceneEffectAudioProcessor,
                     channelModeAudioProcessor,
                     volumeThresholdAudioProcessor,
                     spectrumTapAudioProcessor
@@ -824,6 +827,9 @@ class PlaybackService : MediaSessionService() {
                             val vtMinDb = if (args.containsKey("volumeThresholdMinDb")) args.getFloat("volumeThresholdMinDb") else prev.volumeThresholdMinDb
                             val vtMaxDb = if (args.containsKey("volumeThresholdMaxDb")) args.getFloat("volumeThresholdMaxDb") else prev.volumeThresholdMaxDb
                             val loudnessTargetDb = if (args.containsKey("volumeLoudnessTargetDb")) args.getFloat("volumeLoudnessTargetDb") else prev.volumeLoudnessTargetDb
+                            val sceneEffectEnabled = if (args.containsKey("sceneEffectEnabled")) args.getBoolean("sceneEffectEnabled") else prev.sceneEffectEnabled
+                            val sceneEffectPresetId = args.getString("sceneEffectPresetId") ?: prev.sceneEffectPresetId
+                            val sceneEffectAmount = if (args.containsKey("sceneEffectAmount")) args.getInt("sceneEffectAmount") else prev.sceneEffectAmount
                             sessionSettings.value = prev.copy(
                                 enabled = enabled,
                                 bandLevels = levels,
@@ -845,7 +851,10 @@ class PlaybackService : MediaSessionService() {
                                 volumeThresholdMode = vtMode,
                                 volumeThresholdMinDb = vtMinDb,
                                 volumeThresholdMaxDb = vtMaxDb,
-                                volumeLoudnessTargetDb = loudnessTargetDb
+                                volumeLoudnessTargetDb = loudnessTargetDb,
+                                sceneEffectEnabled = sceneEffectEnabled,
+                                sceneEffectPresetId = sceneEffectPresetId,
+                                sceneEffectAmount = sceneEffectAmount
                             )
                             return com.google.common.util.concurrent.Futures.immediateFuture(
                                 androidx.media3.session.SessionResult(androidx.media3.session.SessionResult.RESULT_SUCCESS, android.os.Bundle.EMPTY)
@@ -1017,6 +1026,9 @@ class PlaybackService : MediaSessionService() {
                 volumeThresholdAudioProcessor.setMode(settings.volumeThresholdMode)
                 volumeThresholdAudioProcessor.setThresholds(settings.volumeThresholdMinDb, settings.volumeThresholdMaxDb)
                 volumeThresholdAudioProcessor.setLoudnessTargetDb(settings.volumeLoudnessTargetDb)
+                sceneEffectAudioProcessor.setEnabled(settings.sceneEffectEnabled)
+                sceneEffectAudioProcessor.setPreset(settings.sceneEffectPresetId)
+                sceneEffectAudioProcessor.setAmount(settings.sceneEffectAmount)
                 stereoOrbitAudioProcessor.setEnabled(settings.stereoEnabled)
                 stereoOrbitAudioProcessor.setAutoOrbitEnabled(settings.orbitEnabled)
                 stereoOrbitAudioProcessor.setOrbitSpeedDegPerSec(settings.orbitSpeed)

--- a/app/src/main/java/com/asmr/player/ui/common/EqualizerPanel.kt
+++ b/app/src/main/java/com/asmr/player/ui/common/EqualizerPanel.kt
@@ -40,6 +40,7 @@ import androidx.compose.ui.window.PopupProperties
 import com.asmr.player.data.settings.AsmrPreset
 import com.asmr.player.data.settings.EqualizerPresets
 import com.asmr.player.data.settings.EqualizerSettings
+import com.asmr.player.data.settings.SceneEffectPresets
 import com.asmr.player.ui.theme.AsmrTheme
 import kotlin.math.abs
 
@@ -79,6 +80,7 @@ fun EqualizerPanel(
     val allPresets = remember(customPresets) {
         EqualizerPresets.DefaultPresets + customPresets
     }
+    val scenePresets = remember { SceneEffectPresets.All }
     
     var showSaveDialog by remember { mutableStateOf(false) }
     var newPresetName by remember { mutableStateOf("") }
@@ -340,6 +342,20 @@ fun EqualizerPanel(
         )
     }
 
+    fun updateSceneEffect(
+        enabled: Boolean? = null,
+        presetId: String? = null,
+        amount: Int? = null
+    ) {
+        onSettingsChanged(
+            settings.copy(
+                sceneEffectEnabled = enabled ?: settings.sceneEffectEnabled,
+                sceneEffectPresetId = presetId ?: settings.sceneEffectPresetId,
+                sceneEffectAmount = (amount ?: settings.sceneEffectAmount).coerceIn(0, 100)
+            )
+        )
+    }
+
     @Composable
     fun ModuleCard(
         title: String,
@@ -502,6 +518,175 @@ fun EqualizerPanel(
                         onValueChange = { updateVolumeThreshold(maxDb = it) },
                         valueRange = -60f..0f,
                         enabled = vtEnabled,
+                        colors = sliderColors
+                    )
+                }
+            }
+        }
+
+        val sceneEnabled = settings.sceneEffectEnabled
+        val activeScenePreset = remember(settings.sceneEffectPresetId) {
+            SceneEffectPresets.resolve(settings.sceneEffectPresetId)
+        }
+        ModuleCard(
+            title = "场景效果",
+            enabled = sceneEnabled,
+            onEnabledChange = { updateSceneEffect(enabled = it) },
+            expanded = settings.sceneEffectExpanded,
+            onExpandedChange = { onSettingsChanged(settings.copy(sceneEffectExpanded = it)) },
+            onReset = {
+                updateSceneEffect(
+                    presetId = SceneEffectPresets.DefaultPresetId,
+                    amount = SceneEffectPresets.DefaultAmount
+                )
+            },
+            resetEnabled = sceneEnabled ||
+                settings.sceneEffectPresetId != SceneEffectPresets.DefaultPresetId ||
+                settings.sceneEffectAmount != SceneEffectPresets.DefaultAmount
+        ) {
+            var sceneExpanded by remember { mutableStateOf(false) }
+            Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Text("场景预设", style = MaterialTheme.typography.labelMedium, color = colorScheme.primary)
+                    Spacer(modifier = Modifier.width(8.dp))
+                    InfoTip(
+                        key = "scene_preset",
+                        title = "场景效果",
+                        text = "通过带限、声场收窄和延迟反射来模拟常见空间或传输介质。推荐先选预设，再微调强度。"
+                    )
+                }
+                ExposedDropdownMenuBox(
+                    expanded = sceneExpanded,
+                    onExpandedChange = { if (sceneEnabled) sceneExpanded = it },
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    Text(
+                        text = "预设",
+                        style = MaterialTheme.typography.labelSmall,
+                        color = materialColorScheme.onSurfaceVariant,
+                        modifier = Modifier.padding(start = 6.dp, bottom = 6.dp)
+                    )
+                    Surface(
+                        shape = RoundedCornerShape(12.dp),
+                        color = materialColorScheme.surface.copy(alpha = 0.55f),
+                        contentColor = materialColorScheme.onSurface,
+                        border = androidx.compose.foundation.BorderStroke(
+                            width = 1.dp,
+                            color = materialColorScheme.outlineVariant.copy(alpha = 0.65f)
+                        ),
+                        modifier = Modifier
+                            .menuAnchor()
+                            .fillMaxWidth()
+                            .height(44.dp)
+                            .clickable(enabled = sceneEnabled) { sceneExpanded = true }
+                    ) {
+                        Row(
+                            modifier = Modifier
+                                .fillMaxSize()
+                                .padding(horizontal = 12.dp),
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            Text(
+                                text = activeScenePreset.label,
+                                maxLines = 1,
+                                overflow = TextOverflow.Ellipsis,
+                                style = MaterialTheme.typography.bodyMedium,
+                                modifier = Modifier.widthIn(min = 0.dp, max = 124.dp)
+                            )
+                            Spacer(modifier = Modifier.width(12.dp))
+                            Text(
+                                text = activeScenePreset.description,
+                                maxLines = 1,
+                                overflow = TextOverflow.Ellipsis,
+                                style = MaterialTheme.typography.bodySmall,
+                                color = materialColorScheme.onSurfaceVariant,
+                                modifier = Modifier.weight(1f),
+                                textAlign = androidx.compose.ui.text.style.TextAlign.End
+                            )
+                            Spacer(modifier = Modifier.width(8.dp))
+                            ExposedDropdownMenuDefaults.TrailingIcon(expanded = sceneExpanded)
+                        }
+                    }
+                    MaterialTheme(
+                        colorScheme = materialColorScheme.copy(
+                            surface = moduleCardContainerColor,
+                            surfaceVariant = moduleCardContainerColor
+                        )
+                    ) {
+                        DropdownMenu(
+                            expanded = sceneExpanded,
+                            onDismissRequest = { sceneExpanded = false },
+                            modifier = Modifier
+                                .exposedDropdownSize(matchTextFieldWidth = true)
+                                .background(moduleCardContainerColor, RoundedCornerShape(14.dp))
+                        ) {
+                            scenePresets.forEachIndexed { index, preset ->
+                                if (index > 0) {
+                                    HorizontalDivider(
+                                        modifier = Modifier.padding(horizontal = 8.dp),
+                                        thickness = 0.5.dp,
+                                        color = materialColorScheme.outlineVariant.copy(alpha = 0.3f)
+                                    )
+                                }
+                                DropdownMenuItem(
+                                    text = {
+                                        Row(
+                                            modifier = Modifier.fillMaxWidth(),
+                                            verticalAlignment = Alignment.CenterVertically
+                                        ) {
+                                            Text(
+                                                text = preset.label,
+                                                maxLines = 1,
+                                                overflow = TextOverflow.Ellipsis,
+                                                modifier = Modifier.widthIn(min = 0.dp, max = 124.dp)
+                                            )
+                                            Spacer(modifier = Modifier.width(12.dp))
+                                            Text(
+                                                text = preset.description,
+                                                style = MaterialTheme.typography.bodySmall,
+                                                color = materialColorScheme.onSurfaceVariant,
+                                                maxLines = 1,
+                                                overflow = TextOverflow.Ellipsis,
+                                                modifier = Modifier.weight(1f),
+                                                textAlign = androidx.compose.ui.text.style.TextAlign.End
+                                            )
+                                        }
+                                    },
+                                    onClick = {
+                                        updateSceneEffect(enabled = true, presetId = preset.id)
+                                        sceneExpanded = false
+                                    },
+                                    enabled = sceneEnabled,
+                                    colors = MenuDefaults.itemColors(
+                                        textColor = materialColorScheme.onSurface,
+                                        leadingIconColor = materialColorScheme.onSurface,
+                                        trailingIconColor = materialColorScheme.onSurface,
+                                        disabledTextColor = materialColorScheme.onSurface.copy(alpha = 0.38f),
+                                        disabledLeadingIconColor = materialColorScheme.onSurface.copy(alpha = 0.38f),
+                                        disabledTrailingIconColor = materialColorScheme.onSurface.copy(alpha = 0.38f)
+                                    )
+                                )
+                            }
+                        }
+                    }
+                }
+                Column {
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        Text("效果强度", style = MaterialTheme.typography.labelMedium, color = colorScheme.primary)
+                        Spacer(modifier = Modifier.width(8.dp))
+                        InfoTip(
+                            key = "scene_amount",
+                            title = "效果强度",
+                            text = "强度越高，场景特征越明显。像电话音、被窝闷声这类预设在高强度下会更有辨识度。"
+                        )
+                        Spacer(modifier = Modifier.weight(1f))
+                        Text("${settings.sceneEffectAmount}%", style = MaterialTheme.typography.labelSmall)
+                    }
+                    Slider(
+                        value = settings.sceneEffectAmount.toFloat(),
+                        onValueChange = { updateSceneEffect(enabled = true, amount = it.toInt()) },
+                        valueRange = 0f..100f,
+                        enabled = sceneEnabled,
                         colors = sliderColors
                     )
                 }

--- a/app/src/main/java/com/asmr/player/ui/player/playerviewmodel.kt
+++ b/app/src/main/java/com/asmr/player/ui/player/playerviewmodel.kt
@@ -217,6 +217,9 @@ class PlayerViewModel @Inject constructor(
                         putFloat("volumeThresholdMinDb", settings.volumeThresholdMinDb)
                         putFloat("volumeThresholdMaxDb", settings.volumeThresholdMaxDb)
                         putFloat("volumeLoudnessTargetDb", settings.volumeLoudnessTargetDb)
+                        putBoolean("sceneEffectEnabled", settings.sceneEffectEnabled)
+                        putString("sceneEffectPresetId", settings.sceneEffectPresetId)
+                        putInt("sceneEffectAmount", settings.sceneEffectAmount)
                     }
                     playerConnection.sendCustomCommand("UPDATE_SESSION_EQ", bundle)
                 }

--- a/app/src/test/java/com/asmr/player/data/settings/SettingsRepositoryTest.kt
+++ b/app/src/test/java/com/asmr/player/data/settings/SettingsRepositoryTest.kt
@@ -3,6 +3,7 @@ package com.asmr.player.data.settings
 import kotlinx.coroutines.runBlocking
 import org.junit.After
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -73,6 +74,30 @@ class SettingsRepositoryTest {
 
         assertEquals(72, resolved)
         assertEquals(72, repository.appVolumePercentValue())
+    }
+
+    @Test
+    fun equalizerSettings_includeSceneEffectDefaultsAndStoredValues() = runBlocking {
+        val defaults = repository.equalizerSettings.first()
+        assertFalse(defaults.sceneEffectEnabled)
+        assertEquals(SceneEffectPresets.DefaultPresetId, defaults.sceneEffectPresetId)
+        assertEquals(SceneEffectPresets.DefaultAmount, defaults.sceneEffectAmount)
+        assertEquals(true, defaults.sceneEffectExpanded)
+
+        repository.updateEqualizerSettings(
+            defaults.copy(
+                sceneEffectEnabled = true,
+                sceneEffectPresetId = "tunnel",
+                sceneEffectAmount = 73,
+                sceneEffectExpanded = false
+            )
+        )
+
+        val stored = repository.equalizerSettings.first()
+        assertEquals(true, stored.sceneEffectEnabled)
+        assertEquals("tunnel", stored.sceneEffectPresetId)
+        assertEquals(73, stored.sceneEffectAmount)
+        assertEquals(false, stored.sceneEffectExpanded)
     }
 
     private suspend fun SettingsRepository.appVolumePercentValue(): Int {


### PR DESCRIPTION
## Summary
- add a scene effect module to the audio panel with compact dropdown preset selection and strength control
- introduce a custom ExoPlayer scene effect audio processor plus persisted settings/service sync
- ship a refined preset set focused on ASMR use cases and cover the new defaults in settings tests

## Testing
- ./gradlew.bat :app:compileDebugKotlin
- ./gradlew.bat :app:compileDebugUnitTestKotlin
- ./gradlew.bat :app:testDebugUnitTest