### PR TITLE
fix: refine search pagination and persist online subtitle links

### DIFF
--- a/app/src/main/java/com/asmr/player/data/lyrics/LyricsLoader.kt
+++ b/app/src/main/java/com/asmr/player/data/lyrics/LyricsLoader.kt
@@ -81,7 +81,7 @@ class LyricsLoader @Inject constructor(
         }
 
         if (track == null) {
-            val remoteSources = OnlineLyricsStore.get(target.mediaId)
+            val remoteSources = target.remoteSubtitleSources.ifEmpty { OnlineLyricsStore.get(target.mediaId) }
             val remoteLyrics = if (remoteSources.isNotEmpty()) loadRemoteLyrics(remoteSources) else emptyList()
             return LyricsResult(title = title, lyrics = remoteLyrics)
         }
@@ -102,10 +102,12 @@ class LyricsLoader @Inject constructor(
         }
 
         if (subs.isEmpty() && track.path.trim().startsWith("http", ignoreCase = true)) {
-            val remoteSources = remoteSubtitleSourceDao.getSourcesForTrackOnce(track.id).mapNotNull { src ->
-                val url = src.url.trim()
-                if (url.isBlank()) return@mapNotNull null
-                RemoteSubtitleSource(url = url, language = src.language, ext = src.ext)
+            val remoteSources = target.remoteSubtitleSources.ifEmpty {
+                remoteSubtitleSourceDao.getSourcesForTrackOnce(track.id).mapNotNull { src ->
+                    val url = src.url.trim()
+                    if (url.isBlank()) return@mapNotNull null
+                    RemoteSubtitleSource(url = url, language = src.language, ext = src.ext)
+                }
             }
             val remoteLyrics = if (remoteSources.isNotEmpty()) loadRemoteLyrics(remoteSources) else emptyList()
             if (remoteLyrics.isNotEmpty()) {

--- a/app/src/main/java/com/asmr/player/data/lyrics/LyricsTargetContext.kt
+++ b/app/src/main/java/com/asmr/player/data/lyrics/LyricsTargetContext.kt
@@ -4,11 +4,13 @@ import androidx.media3.common.MediaItem
 import com.asmr.player.domain.model.Album
 import com.asmr.player.domain.model.Track
 import com.asmr.player.playback.MediaItemRequest
+import com.asmr.player.util.RemoteSubtitleSource
 import com.asmr.player.util.TrackKeyNormalizer
 
 const val EXTRA_ALBUM_WORK_ID = "album_work_id"
 const val EXTRA_LYRICS_RELATIVE_PATH_NO_EXT = "lyrics_relative_path_no_ext"
 const val EXTRA_TRACK_GROUP = "track_group"
+const val EXTRA_REMOTE_SUBTITLE_SOURCES_JSON = "remote_subtitle_sources_json"
 
 data class LyricsTargetContext(
     val mediaId: String,
@@ -20,7 +22,8 @@ data class LyricsTargetContext(
     val trackId: Long,
     val albumId: Long,
     val albumIdentity: String,
-    val relativePathNoExt: String
+    val relativePathNoExt: String,
+    val remoteSubtitleSources: List<RemoteSubtitleSource> = emptyList()
 )
 
 fun lyricsTargetContextFromMediaItem(item: MediaItem?): LyricsTargetContext? {
@@ -37,6 +40,7 @@ fun lyricsTargetContextFromMediaItem(item: MediaItem?): LyricsTargetContext? {
     val workId = extras?.getString(EXTRA_ALBUM_WORK_ID).orEmpty()
     val albumIdentity = rjCode.trim().ifBlank { workId.trim() }
     val relativePathNoExt = extras?.getString(EXTRA_LYRICS_RELATIVE_PATH_NO_EXT).orEmpty()
+    val remoteSubtitleSources = decodeRemoteSubtitleSources(extras?.getString(EXTRA_REMOTE_SUBTITLE_SOURCES_JSON))
     return buildLyricsTargetContext(
         mediaId = mediaId,
         title = title,
@@ -44,7 +48,8 @@ fun lyricsTargetContextFromMediaItem(item: MediaItem?): LyricsTargetContext? {
         trackId = trackId,
         albumId = albumId,
         albumIdentity = albumIdentity,
-        relativePathNoExt = relativePathNoExt
+        relativePathNoExt = relativePathNoExt,
+        remoteSubtitleSources = remoteSubtitleSources
     )
 }
 
@@ -63,7 +68,8 @@ fun lyricsTargetContextFromTrack(album: Album, track: Track): LyricsTargetContex
         trackId = track.id,
         albumId = album.id,
         albumIdentity = albumIdentity,
-        relativePathNoExt = relativePathNoExt
+        relativePathNoExt = relativePathNoExt,
+        remoteSubtitleSources = emptyList()
     )
 }
 
@@ -78,7 +84,8 @@ fun lyricsTargetContextFromRequest(request: MediaItemRequest): LyricsTargetConte
         trackId = request.trackId,
         albumId = request.albumId,
         albumIdentity = albumIdentity,
-        relativePathNoExt = request.lyricsRelativePathNoExt
+        relativePathNoExt = request.lyricsRelativePathNoExt,
+        remoteSubtitleSources = request.remoteSubtitleSources
     )
 }
 
@@ -98,7 +105,8 @@ private fun buildLyricsTargetContext(
     trackId: Long,
     albumId: Long,
     albumIdentity: String,
-    relativePathNoExt: String
+    relativePathNoExt: String,
+    remoteSubtitleSources: List<RemoteSubtitleSource>
 ): LyricsTargetContext {
     val normalizedRelativePath = TrackKeyNormalizer.normalizeRelativePath(relativePathNoExt)
     val exactTargetKey = buildExactTargetKey(
@@ -130,8 +138,25 @@ private fun buildLyricsTargetContext(
         trackId = trackId,
         albumId = albumId,
         albumIdentity = normalizeAlbumIdentity(albumIdentity),
-        relativePathNoExt = normalizedRelativePath
+        relativePathNoExt = normalizedRelativePath,
+        remoteSubtitleSources = remoteSubtitleSources
     )
+}
+
+private fun decodeRemoteSubtitleSources(raw: String?): List<RemoteSubtitleSource> {
+    val trimmed = raw.orEmpty().trim()
+    if (trimmed.isBlank()) return emptyList()
+    return trimmed.split('\n')
+        .mapNotNull { line ->
+            val parts = line.split('\t')
+            val url = parts.getOrNull(0).orEmpty().trim()
+            if (url.isBlank()) return@mapNotNull null
+            RemoteSubtitleSource(
+                url = url,
+                language = parts.getOrNull(1).orEmpty().ifBlank { "default" },
+                ext = parts.getOrNull(2).orEmpty().ifBlank { url.substringAfterLast('.', "vtt") }
+            )
+        }
 }
 
 private fun buildCanonicalMediaId(

--- a/app/src/main/java/com/asmr/player/domain/model/Track.kt
+++ b/app/src/main/java/com/asmr/player/domain/model/Track.kt
@@ -1,5 +1,7 @@
 package com.asmr.player.domain.model
 
+import com.asmr.player.util.RemoteSubtitleSource
+
 data class Track(
     val id: Long = 0L,
     val albumId: Long,
@@ -7,6 +9,7 @@ data class Track(
     val path: String,
     val duration: Double = 0.0,
     val group: String = "",
-    val lyricsRelativePathNoExt: String = ""
+    val lyricsRelativePathNoExt: String = "",
+    val remoteSubtitleSources: List<RemoteSubtitleSource> = emptyList()
 )
 

--- a/app/src/main/java/com/asmr/player/playback/MediaItemFactory.kt
+++ b/app/src/main/java/com/asmr/player/playback/MediaItemFactory.kt
@@ -7,10 +7,12 @@ import androidx.media3.common.MediaItem
 import androidx.media3.common.MediaMetadata
 import com.asmr.player.data.lyrics.EXTRA_ALBUM_WORK_ID
 import com.asmr.player.data.lyrics.EXTRA_LYRICS_RELATIVE_PATH_NO_EXT
+import com.asmr.player.data.lyrics.EXTRA_REMOTE_SUBTITLE_SOURCES_JSON
 import com.asmr.player.data.lyrics.EXTRA_TRACK_GROUP
 import com.asmr.player.data.lyrics.deriveLyricsRelativePathNoExt
 import com.asmr.player.domain.model.Album
 import com.asmr.player.domain.model.Track
+import com.asmr.player.util.RemoteSubtitleSource
 import java.io.File
 
 data class MediaItemRequest(
@@ -26,6 +28,7 @@ data class MediaItemRequest(
     val albumWorkId: String = "",
     val trackGroup: String = "",
     val lyricsRelativePathNoExt: String = "",
+    val remoteSubtitleSources: List<RemoteSubtitleSource> = emptyList(),
     val mimeType: String? = null,
     val isVideo: Boolean = false
 )
@@ -55,7 +58,8 @@ object MediaItemFactory {
                 trackGroup = track.group,
                 lyricsRelativePathNoExt = track.lyricsRelativePathNoExt.ifBlank {
                     deriveLyricsRelativePathNoExt(track.path, album.getAllLocalPaths())
-                }
+                },
+                remoteSubtitleSources = track.remoteSubtitleSources
             )
         )
     }
@@ -73,6 +77,7 @@ object MediaItemFactory {
         albumWorkId: String = "",
         trackGroup: String = "",
         lyricsRelativePathNoExt: String = "",
+        remoteSubtitleSources: List<RemoteSubtitleSource> = emptyList(),
         mimeType: String? = null,
         isVideo: Boolean = false
     ): MediaItem {
@@ -90,6 +95,7 @@ object MediaItemFactory {
                 albumWorkId = albumWorkId,
                 trackGroup = trackGroup,
                 lyricsRelativePathNoExt = lyricsRelativePathNoExt,
+                remoteSubtitleSources = remoteSubtitleSources,
                 mimeType = mimeType,
                 isVideo = isVideo
             )
@@ -110,6 +116,9 @@ object MediaItemFactory {
                     if (request.trackGroup.isNotBlank()) putString(EXTRA_TRACK_GROUP, request.trackGroup)
                     if (request.lyricsRelativePathNoExt.isNotBlank()) {
                         putString(EXTRA_LYRICS_RELATIVE_PATH_NO_EXT, request.lyricsRelativePathNoExt)
+                    }
+                    encodeRemoteSubtitleSources(request.remoteSubtitleSources)?.let { encoded ->
+                        putString(EXTRA_REMOTE_SUBTITLE_SOURCES_JSON, encoded)
                     }
                     if (request.isVideo) putBoolean("is_video", true)
                 }
@@ -170,5 +179,17 @@ object MediaItemFactory {
             "mov" -> "video/quicktime"
             else -> null
         }
+    }
+
+    private fun encodeRemoteSubtitleSources(sources: List<RemoteSubtitleSource>): String? {
+        val normalized = sources.mapNotNull { source ->
+            val url = source.url.trim()
+            if (url.isBlank()) return@mapNotNull null
+            val language = source.language.trim().ifBlank { "default" }
+            val ext = source.ext.trim().ifBlank { url.substringAfterLast('.', "vtt") }
+            listOf(url, language, ext).joinToString("\t")
+        }
+        if (normalized.isEmpty()) return null
+        return normalized.joinToString("\n")
     }
 }

--- a/app/src/main/java/com/asmr/player/playback/PlaybackStateStore.kt
+++ b/app/src/main/java/com/asmr/player/playback/PlaybackStateStore.kt
@@ -37,7 +37,14 @@ data class PersistedPlaybackQueueItem(
     val artworkUri: String?,
     val albumId: Long?,
     val trackId: Long?,
-    val rjCode: String?
+    val rjCode: String?,
+    val remoteSubtitleSources: List<PersistedRemoteSubtitleSource> = emptyList()
+)
+
+data class PersistedRemoteSubtitleSource(
+    val url: String,
+    val language: String?,
+    val ext: String?
 )
 
 data class PersistedPlaybackStateV2(
@@ -100,7 +107,8 @@ class PlaybackStateStore @Inject constructor(
                         artworkUri = null,
                         albumId = null,
                         trackId = null,
-                        rjCode = null
+                        rjCode = null,
+                        remoteSubtitleSources = emptyList()
                     )
                 },
                 currentIndex = v1.currentIndex,

--- a/app/src/main/java/com/asmr/player/playback/PlayerConnection.kt
+++ b/app/src/main/java/com/asmr/player/playback/PlayerConnection.kt
@@ -14,6 +14,7 @@ import androidx.media3.session.MediaController
 import androidx.media3.session.SessionToken
 import com.asmr.player.data.local.db.dao.AlbumDao
 import com.asmr.player.data.local.db.dao.TrackDao
+import com.asmr.player.data.lyrics.EXTRA_REMOTE_SUBTITLE_SOURCES_JSON
 import com.asmr.player.data.repository.TrackSliceRepository
 import com.asmr.player.data.settings.SettingsRepository
 import com.asmr.player.service.PlaybackService
@@ -23,6 +24,7 @@ import com.asmr.player.util.MessageManager
 import com.asmr.player.playback.AppVolume
 import dagger.hilt.android.qualifiers.ApplicationContext
 import com.asmr.player.util.NetworkMeteredChecker
+import com.asmr.player.util.RemoteSubtitleSource
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -342,8 +344,35 @@ class PlayerConnection @Inject constructor(
         if (c.mediaItemCount > 0) return false
 
         val saved = playbackStateStore.load() ?: return false
-        val persisted = saved.queue.map { it.copy(mediaId = it.mediaId.trim(), uri = it.uri.trim()) }
-            .filter { it.mediaId.isNotBlank() }
+        val persisted = runCatching { saved.queue }.getOrNull().orEmpty()
+            .mapNotNull { item ->
+                val mediaId = runCatching { item.mediaId }.getOrNull().orEmpty().trim()
+                if (mediaId.isBlank()) return@mapNotNull null
+                val uri = runCatching { item.uri }.getOrNull().orEmpty().trim()
+                val remoteSubtitleSources = runCatching { item.remoteSubtitleSources }.getOrNull().orEmpty()
+                    .mapNotNull { sourceItem ->
+                        val url = runCatching { sourceItem.url }.getOrNull().orEmpty().trim()
+                        if (url.isBlank()) return@mapNotNull null
+                        PersistedRemoteSubtitleSource(
+                            url = url,
+                            language = sourceItem.language,
+                            ext = sourceItem.ext
+                        )
+                    }
+                PersistedPlaybackQueueItem(
+                    mediaId = mediaId,
+                    uri = uri,
+                    mimeType = item.mimeType,
+                    title = item.title,
+                    artist = item.artist,
+                    albumTitle = item.albumTitle,
+                    artworkUri = item.artworkUri,
+                    albumId = item.albumId,
+                    trackId = item.trackId,
+                    rjCode = item.rjCode,
+                    remoteSubtitleSources = remoteSubtitleSources
+                )
+            }
         if (persisted.isEmpty()) return false
         val items = buildMediaItemsFromPersistedItems(persisted)
         if (items.isEmpty()) return false
@@ -398,10 +427,28 @@ class PlayerConnection @Inject constructor(
                     path = track.path,
                     duration = track.duration,
                     group = track.group,
-                    lyricsRelativePathNoExt = ""
+                    lyricsRelativePathNoExt = "",
+                    remoteSubtitleSources = persisted.remoteSubtitleSources.mapNotNull { persistedSource ->
+                        val url = persistedSource.url.trim()
+                        if (url.isBlank()) return@mapNotNull null
+                        RemoteSubtitleSource(
+                            url = url,
+                            language = persistedSource.language.orEmpty().ifBlank { "default" },
+                            ext = persistedSource.ext.orEmpty().ifBlank { url.substringAfterLast('.', "vtt") }
+                        )
+                    }
                 )
                 MediaItemFactory.fromTrack(album, t)
             } else {
+                val restoredRemoteSubtitleSources = persisted.remoteSubtitleSources.mapNotNull { persistedSource ->
+                    val url = persistedSource.url.trim()
+                    if (url.isBlank()) return@mapNotNull null
+                    RemoteSubtitleSource(
+                        url = url,
+                        language = persistedSource.language.orEmpty().ifBlank { "default" },
+                        ext = persistedSource.ext.orEmpty().ifBlank { url.substringAfterLast('.', "vtt") }
+                    )
+                }
                 val uri = toPlayableUri(persisted.uri.ifBlank { id })
                 val title = persisted.title.orEmpty().ifBlank { deriveTitleFromId(id) }
                 val meta = MediaMetadata.Builder()
@@ -414,6 +461,9 @@ class PlayerConnection @Inject constructor(
                             if (persisted.albumId != null) putLong("album_id", persisted.albumId)
                             if (persisted.trackId != null) putLong("track_id", persisted.trackId)
                             if (!persisted.rjCode.isNullOrBlank()) putString("rj_code", persisted.rjCode)
+                            encodeRemoteSubtitleSources(restoredRemoteSubtitleSources)?.let { encoded ->
+                                putString(EXTRA_REMOTE_SUBTITLE_SOURCES_JSON, encoded)
+                            }
                         }
                     )
                     .build()
@@ -464,6 +514,33 @@ class PlayerConnection @Inject constructor(
         }
     }
 
+    private fun decodeRemoteSubtitleSources(raw: String?): List<PersistedRemoteSubtitleSource> {
+        val trimmed = raw.orEmpty().trim()
+        if (trimmed.isBlank()) return emptyList()
+        return trimmed.split('\n').mapNotNull { line ->
+            val parts = line.split('\t')
+            val url = parts.getOrNull(0).orEmpty().trim()
+            if (url.isBlank()) return@mapNotNull null
+            PersistedRemoteSubtitleSource(
+                url = url,
+                language = parts.getOrNull(1)?.trim().orEmpty().ifBlank { "default" },
+                ext = parts.getOrNull(2)?.trim().orEmpty().ifBlank { url.substringAfterLast('.', "vtt") }
+            )
+        }
+    }
+
+    private fun encodeRemoteSubtitleSources(sources: List<RemoteSubtitleSource>): String? {
+        val normalized = sources.mapNotNull { source ->
+            val url = source.url.trim()
+            if (url.isBlank()) return@mapNotNull null
+            val language = source.language.trim().ifBlank { "default" }
+            val ext = source.ext.trim().ifBlank { url.substringAfterLast('.', "vtt") }
+            listOf(url, language, ext).joinToString("\t")
+        }
+        if (normalized.isEmpty()) return null
+        return normalized.joinToString("\n")
+    }
+
     private suspend fun savePlaybackState() {
         val c = controller ?: return
         val items = _queue.value.ifEmpty { (0 until c.mediaItemCount).map { idx -> c.getMediaItemAt(idx) } }
@@ -487,7 +564,8 @@ class PlayerConnection @Inject constructor(
                 artworkUri = meta.artworkUri?.toString(),
                 albumId = albumId,
                 trackId = trackId,
-                rjCode = rjCode
+                rjCode = rjCode,
+                remoteSubtitleSources = decodeRemoteSubtitleSources(extras?.getString(EXTRA_REMOTE_SUBTITLE_SOURCES_JSON))
             )
         }
         if (persistedQueue.isEmpty()) return

--- a/app/src/main/java/com/asmr/player/ui/common/SearchBar.kt
+++ b/app/src/main/java/com/asmr/player/ui/common/SearchBar.kt
@@ -70,7 +70,7 @@ fun CustomSearchBar(
         value = value,
         onValueChange = onValueChange,
         modifier = modifier
-            .height(50.dp)
+            .height(48.dp)
             .shadow(
                 elevation = if (isDark) 12.dp else 8.dp,
                 shape = CircleShape,
@@ -98,12 +98,12 @@ fun CustomSearchBar(
             Row(
                 modifier = Modifier
                     .fillMaxSize()
-                    .padding(horizontal = 16.dp),
+                    .padding(horizontal = 14.dp),
                 verticalAlignment = Alignment.CenterVertically
             ) {
                 if (leadingIcon != null) {
                     leadingIcon()
-                    Spacer(modifier = Modifier.width(8.dp))
+                    Spacer(modifier = Modifier.width(6.dp))
                 }
                 Box(modifier = Modifier.weight(1f), contentAlignment = Alignment.CenterStart) {
                     if (value.isEmpty()) {
@@ -118,7 +118,7 @@ fun CustomSearchBar(
                     innerTextField()
                 }
                 if (trailingIcon != null) {
-                    Spacer(modifier = Modifier.width(8.dp))
+                    Spacer(modifier = Modifier.width(6.dp))
                     trailingIcon()
                 }
             }

--- a/app/src/main/java/com/asmr/player/ui/library/AlbumDetailScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/AlbumDetailScreen.kt
@@ -1417,6 +1417,7 @@ internal data class PlaylistAddTarget(
     val albumWorkId: String = "",
     val trackGroup: String = "",
     val lyricsRelativePathNoExt: String = "",
+    val remoteSubtitleSources: List<RemoteSubtitleSource> = emptyList(),
     val mimeType: String? = null,
     val isVideo: Boolean = false
 ) {
@@ -1434,6 +1435,7 @@ internal data class PlaylistAddTarget(
             albumWorkId = albumWorkId,
             trackGroup = trackGroup,
             lyricsRelativePathNoExt = lyricsRelativePathNoExt,
+            remoteSubtitleSources = remoteSubtitleSources,
             mimeType = mimeType,
             isVideo = isVideo
         )

--- a/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailDirectorySupport.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailDirectorySupport.kt
@@ -699,7 +699,7 @@ internal fun buildRemoteTreeIndex(
                         group = path.substringBeforeLast('/', "").substringAfterLast('/', ""),
                         lyricsRelativePathNoExt = path.substringBeforeLast('.')
                     )
-                )
+                ).copy(remoteSubtitleSources = subtitleSources)
                 TreeFileType.Video -> PlaylistAddTarget.fromVideo(album, leaf.displayTitle, leaf.url)
                 else -> null
             }
@@ -1167,7 +1167,8 @@ fun toTrack(): Track {
             path = url,
             duration = duration ?: 0.0,
             group = group,
-            lyricsRelativePathNoExt = normalizedRelativePath.substringBeforeLast('.')
+            lyricsRelativePathNoExt = normalizedRelativePath.substringBeforeLast('.'),
+            remoteSubtitleSources = subtitles
         )
     }
 }

--- a/app/src/main/java/com/asmr/player/ui/search/SearchScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/search/SearchScreen.kt
@@ -6,6 +6,7 @@ import androidx.compose.animation.core.snap
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.awaitEachGesture
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -39,6 +40,7 @@ import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.automirrored.filled.ArrowForward
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Search
+import androidx.compose.material.icons.filled.SkipPrevious
 import androidx.compose.material.icons.filled.WifiOff
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.DropdownMenu
@@ -71,6 +73,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.graphics.vector.rememberVectorPainter
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.compositeOver
@@ -113,6 +116,7 @@ internal const val SEARCH_LANGUAGE_BUTTON_TAG = "search_language_button"
 internal const val SEARCH_CLEAR_BUTTON_TAG = "search_clear_button"
 internal const val SEARCH_SUBMIT_BUTTON_TAG = "search_submit_button"
 internal const val SEARCH_SUBMIT_SPINNER_TAG = "search_submit_spinner"
+internal const val SEARCH_FIRST_PAGE_BUTTON_TAG = "search_first_page_button"
 internal const val SEARCH_PREV_BUTTON_TAG = "search_prev_button"
 internal const val SEARCH_NEXT_BUTTON_TAG = "search_next_button"
 internal const val SEARCH_PAGINATION_TAG = "search_pagination"
@@ -625,6 +629,10 @@ fun SearchScreen(
                                 locale = locale
                             )
                         },
+                        onFirstPage = {
+                            scrollResultsToTop()
+                            viewModel.firstPage()
+                        },
                         onPrev = {
                             scrollResultsToTop()
                             viewModel.prevPage()
@@ -716,6 +724,7 @@ internal fun SearchChrome(
     onSearchSubmit: () -> Unit,
     onFilterSelected: (SearchFilterOption) -> Unit,
     onLocaleSelected: (String) -> Unit,
+    onFirstPage: () -> Unit,
     onPrev: () -> Unit,
     onNext: () -> Unit
 ) {
@@ -748,6 +757,7 @@ internal fun SearchChrome(
                 canGoPrev = canGoPrev,
                 canGoNext = canGoNext,
                 controlsLocked = controlsLocked,
+                onFirstPage = onFirstPage,
                 onPrev = onPrev,
                 onNext = onNext
             )
@@ -980,11 +990,13 @@ internal fun SearchPaginationHeader(
     canGoPrev: Boolean,
     canGoNext: Boolean,
     controlsLocked: Boolean,
+    onFirstPage: () -> Unit,
     onPrev: () -> Unit,
     onNext: () -> Unit
 ) {
     val colorScheme = AsmrTheme.colorScheme
     val isDark = colorScheme.isDark
+    val canGoFirst = canGoPrev
     val paginationContainerColor = lerp(
         colorScheme.surface,
         colorScheme.primarySoft,
@@ -1000,14 +1012,14 @@ internal fun SearchPaginationHeader(
     Box(
         modifier = Modifier
             .fillMaxWidth()
-            .padding(horizontal = SearchPageHorizontalPadding, vertical = 2.dp)
+            .padding(horizontal = SearchPageHorizontalPadding, vertical = 1.dp)
     ) {
         Box(
             modifier = Modifier
                 .fillMaxWidth()
                 .shadow(
-                    elevation = if (isDark) 12.dp else 8.dp,
-                    shape = RoundedCornerShape(14.dp),
+                    elevation = if (isDark) 10.dp else 6.dp,
+                    shape = RoundedCornerShape(12.dp),
                     spotColor = if (isDark) Color.Black.copy(alpha = 0.8f) else Color.Black.copy(alpha = 0.25f),
                     ambientColor = if (isDark) Color.Black.copy(alpha = 0.8f) else Color.Black.copy(alpha = 0.25f)
                 )
@@ -1015,10 +1027,10 @@ internal fun SearchPaginationHeader(
                     Modifier.border(
                         width = 1.dp,
                         color = paginationBorderColor,
-                        shape = RoundedCornerShape(14.dp)
+                        shape = RoundedCornerShape(12.dp)
                     )
                 )
-                .clip(RoundedCornerShape(14.dp))
+                .clip(RoundedCornerShape(12.dp))
                 .background(paginationContainerColor)
                 .testTag(SEARCH_PAGINATION_TAG)
         ) {
@@ -1031,64 +1043,83 @@ internal fun SearchPaginationHeader(
             Row(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(horizontal = 8.dp, vertical = 6.dp),
+                    .padding(horizontal = 6.dp, vertical = 4.dp),
                 verticalAlignment = Alignment.CenterVertically
             ) {
-            IconButton(
-                onClick = onPrev,
-                enabled = canGoPrev && !controlsLocked,
-                modifier = Modifier
-                    .size(36.dp)
-                    .testTag(SEARCH_PREV_BUTTON_TAG)
-            ) {
-                Icon(
-                    imageVector = Icons.AutoMirrored.Filled.ArrowBack,
-                    contentDescription = null,
-                    tint = if (canGoPrev && !controlsLocked) {
-                        colorScheme.primary
-                    } else if (isDark) {
-                        colorScheme.textTertiary
-                    } else {
-                        colorScheme.textTertiary
+                Box(
+                    modifier = Modifier.weight(1f),
+                    contentAlignment = Alignment.CenterStart
+                ) {
+                    Row(
+                        horizontalArrangement = Arrangement.spacedBy(4.dp),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        SearchPaginationIconButton(
+                            onClick = onFirstPage,
+                            enabled = canGoFirst && !controlsLocked,
+                            imageVector = Icons.Default.SkipPrevious,
+                            contentDescription = "回到第一页",
+                            modifier = Modifier.testTag(SEARCH_FIRST_PAGE_BUTTON_TAG)
+                        )
+                        SearchPaginationIconButton(
+                            onClick = onPrev,
+                            enabled = canGoPrev && !controlsLocked,
+                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = "上一页",
+                            modifier = Modifier.testTag(SEARCH_PREV_BUTTON_TAG)
+                        )
                     }
-                )
-            }
+                }
 
-            Spacer(modifier = Modifier.weight(1f))
+                Box(
+                    modifier = Modifier.weight(1f),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Text(
+                        text = "第 ${page.coerceAtLeast(1)} 页",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = if (isDark) colorScheme.textPrimary else Color.Black
+                    )
+                }
 
-            Row(
-                horizontalArrangement = Arrangement.spacedBy(8.dp),
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                Text(
-                    text = "第 ${page.coerceAtLeast(1)} 页",
-                    style = MaterialTheme.typography.bodySmall,
-                    color = if (isDark) colorScheme.textPrimary else Color.Black
-                )
-            }
-
-            Spacer(modifier = Modifier.weight(1f))
-
-            IconButton(
-                onClick = onNext,
-                enabled = canGoNext && !controlsLocked,
-                modifier = Modifier
-                    .size(36.dp)
-                    .testTag(SEARCH_NEXT_BUTTON_TAG)
-            ) {
-                Icon(
-                    imageVector = Icons.AutoMirrored.Filled.ArrowForward,
-                    contentDescription = null,
-                    tint = if (canGoNext && !controlsLocked) {
-                        colorScheme.primary
-                    } else if (isDark) {
-                        colorScheme.textTertiary
-                    } else {
-                        colorScheme.textTertiary
-                    }
-                )
-            }
+                Box(
+                    modifier = Modifier.weight(1f),
+                    contentAlignment = Alignment.CenterEnd
+                ) {
+                    SearchPaginationIconButton(
+                        onClick = onNext,
+                        enabled = canGoNext && !controlsLocked,
+                        imageVector = Icons.AutoMirrored.Filled.ArrowForward,
+                        contentDescription = "下一页",
+                        modifier = Modifier.testTag(SEARCH_NEXT_BUTTON_TAG)
+                    )
+                }
             }
         }
+    }
+}
+
+@Composable
+private fun SearchPaginationIconButton(
+    onClick: () -> Unit,
+    enabled: Boolean,
+    imageVector: ImageVector,
+    contentDescription: String,
+    modifier: Modifier = Modifier,
+) {
+    val colorScheme = AsmrTheme.colorScheme
+    Box(
+        modifier = modifier
+            .size(30.dp)
+            .clip(CircleShape)
+            .clickable(enabled = enabled, onClick = onClick),
+        contentAlignment = Alignment.Center
+    ) {
+        Icon(
+            imageVector = imageVector,
+            contentDescription = contentDescription,
+            tint = if (enabled) colorScheme.primary else colorScheme.textTertiary,
+            modifier = Modifier.size(17.dp)
+        )
     }
 }

--- a/app/src/main/java/com/asmr/player/ui/search/SearchViewModel.kt
+++ b/app/src/main/java/com/asmr/player/ui/search/SearchViewModel.kt
@@ -187,6 +187,12 @@ class SearchViewModel @Inject constructor(
         requestPage(current.keyword, current.page - 1, SearchPendingRequestKind.Page)
     }
 
+    fun firstPage() {
+        val current = _uiState.value as? SearchUiState.Success ?: return
+        if (!current.canGoPrev || current.isBusy) return
+        requestPage(current.keyword, 1, SearchPendingRequestKind.Page)
+    }
+
     fun refreshPage() {
         val current = _uiState.value as? SearchUiState.Success ?: return
         if (current.isBusy) return


### PR DESCRIPTION
## Summary
- tighten the online search pagination bar and add a first-page icon action
- slightly reduce shared search bar padding for online search and local library
- persist remote webvtt subtitle sources with playback queue items so online audio lyrics can recover after app restart
- harden playback state restore against older saved queue entries that do not contain subtitle source fields

## Verification
- ./gradlew :app:compileDebugKotlin
- ./gradlew :app:installDebug