### PR TITLE
feat: add listen together presence and RJ audience metrics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 .trae/
 *.iml
 .worktrees/
+EaraServer/
 
 local.properties
 keystore.properties

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -61,6 +61,11 @@ android {
         }
     }
 
+    val listenTogetherBaseUrl =
+        System.getenv("LISTEN_TOGETHER_BASE_URL")
+            ?: (project.findProperty("LISTEN_TOGETHER_BASE_URL") as? String)
+            ?: "http://192.168.71.9:8787"
+
     defaultConfig {
         applicationId = "com.asmr.player"
         minSdk = 24
@@ -69,6 +74,7 @@ android {
         versionName = "1.1.0"
         buildConfigField("String", "UPDATE_REPO_OWNER", "\"eValDoll\"")
         buildConfigField("String", "UPDATE_REPO_NAME", "\"EaraAsmrPlayer\"")
+        buildConfigField("String", "LISTEN_TOGETHER_BASE_URL", "\"$listenTogetherBaseUrl\"")
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {
@@ -163,6 +169,7 @@ dependencies {
     implementation("com.squareup.retrofit2:converter-gson:2.9.0")
     implementation("com.squareup.okhttp3:okhttp:4.12.0")
     implementation("com.squareup.okhttp3:logging-interceptor:4.12.0")
+    implementation("com.google.code.gson:gson:2.10.1")
 
     // Jsoup
     implementation("org.jsoup:jsoup:1.17.2")

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -64,7 +64,7 @@ android {
     val listenTogetherBaseUrl =
         System.getenv("LISTEN_TOGETHER_BASE_URL")
             ?: (project.findProperty("LISTEN_TOGETHER_BASE_URL") as? String)
-            ?: "http://192.168.71.9:8787"
+            ?: "https://earaasmr.com"
 
     defaultConfig {
         applicationId = "com.asmr.player"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -17,6 +17,7 @@
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
+        android:usesCleartextTraffic="true"
         android:theme="@style/Theme.AsmrPlayer">
 
         <provider

--- a/app/src/main/design-assets/icons/users-round.svg
+++ b/app/src/main/design-assets/icons/users-round.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-users-round-icon lucide-users-round"><path d="M18 21a8 8 0 0 0-16 0"/><circle cx="10" cy="8" r="5"/><path d="M22 20c0-3.37-2-6.5-4-8a5 5 0 0 0-.45-8.3"/></svg>

--- a/app/src/main/java/com/asmr/player/di/networkmodule.kt
+++ b/app/src/main/java/com/asmr/player/di/networkmodule.kt
@@ -21,11 +21,16 @@ import com.asmr.player.data.remote.TrafficStatsInterceptor
 import com.asmr.player.data.remote.NetworkHeaders
 import com.asmr.player.util.MessageManager
 import com.asmr.player.util.DlsiteAntiHotlink
+import com.google.gson.Gson
 import java.io.IOException
 
 @Module
 @InstallIn(SingletonComponent::class)
 object NetworkModule {
+
+    @Provides
+    @Singleton
+    fun provideGson(): Gson = Gson()
 
     @Provides
     @Singleton

--- a/app/src/main/java/com/asmr/player/listentogether/ListenTogetherApi.kt
+++ b/app/src/main/java/com/asmr/player/listentogether/ListenTogetherApi.kt
@@ -1,0 +1,12 @@
+package com.asmr.player.listentogether
+
+import retrofit2.http.Body
+import retrofit2.http.POST
+
+interface ListenTogetherApi {
+    @POST("presence/upsert")
+    suspend fun upsertPresence(@Body payload: ListenTogetherPresencePayload): ListenTogetherPresenceResponse
+
+    @POST("presence/leave")
+    suspend fun leave(@Body payload: ListenTogetherLeavePayload)
+}

--- a/app/src/main/java/com/asmr/player/listentogether/ListenTogetherIdentityResolver.kt
+++ b/app/src/main/java/com/asmr/player/listentogether/ListenTogetherIdentityResolver.kt
@@ -1,0 +1,132 @@
+package com.asmr.player.listentogether
+
+import android.content.Context
+import android.net.Uri
+import android.provider.DocumentsContract
+import android.provider.OpenableColumns
+import androidx.media3.common.MediaItem
+import com.asmr.player.util.DlsiteWorkNo
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import java.io.File
+import java.io.InputStream
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class ListenTogetherIdentityResolver @Inject constructor() {
+
+    suspend fun resolve(
+        context: Context,
+        mediaItem: MediaItem,
+        fallbackRjCode: String? = null
+    ): ListenTogetherTrackIdentity? {
+        return withContext(Dispatchers.IO) {
+            val metadata = mediaItem.mediaMetadata
+            val extras = metadata.extras
+            val mediaId = mediaItem.mediaId.trim()
+            val rawSourcePath = mediaItem.localConfiguration?.uri?.toString().orEmpty().trim().ifBlank { mediaId }
+            if (rawSourcePath.isBlank()) return@withContext null
+
+            val rjCode = DlsiteWorkNo.extractRjCode(
+                listOfNotNull(
+                    extras?.getString("rj_code"),
+                    fallbackRjCode,
+                    mediaId,
+                    rawSourcePath,
+                    metadata.albumTitle?.toString(),
+                    metadata.title?.toString()
+                ).joinToString(" ")
+            )
+            if (rjCode.isBlank()) return@withContext null
+
+            val fileProbe = probeFile(context, rawSourcePath) ?: return@withContext null
+            val fileSize = fileProbe.fileSizeBytes.takeIf { it > 0L } ?: return@withContext null
+            val hashHex = fileProbe.inputStreamFactory?.invoke()?.use { input ->
+                XxHash64.hashStreamHex(input)
+            } ?: return@withContext null
+
+            val mediaKind = if (extras?.getBoolean("is_video") == true || mediaItem.localConfiguration?.mimeType?.startsWith("video/") == true) {
+                ListenTogetherMediaKind.VIDEO
+            } else {
+                ListenTogetherMediaKind.AUDIO
+            }
+
+            ListenTogetherTrackIdentity(
+                albumKey = rjCode,
+                mediaFingerprint = "size:${fileSize}_xxh64:${hashHex}",
+                fileSizeBytes = fileSize,
+                fingerprintAlgorithm = "size+xxh64",
+                mediaKind = mediaKind,
+                sourcePath = rawSourcePath,
+                mediaId = mediaId,
+                rjCode = rjCode,
+                displayTitle = metadata.title?.toString().orEmpty(),
+                displayArtist = metadata.artist?.toString().orEmpty()
+            )
+        }
+    }
+
+    private data class FileProbe(
+        val fileSizeBytes: Long,
+        val inputStreamFactory: (() -> InputStream?)?
+    )
+
+    private fun probeFile(context: Context, sourcePath: String): FileProbe? {
+        val normalized = sourcePath.trim()
+        if (normalized.isBlank()) return null
+        if (normalized.startsWith("http://", ignoreCase = true) || normalized.startsWith("https://", ignoreCase = true)) {
+            return null
+        }
+        return when {
+            normalized.startsWith("content://", ignoreCase = true) -> {
+                val uri = Uri.parse(normalized)
+                val size = queryContentSize(context, uri) ?: return null
+                FileProbe(
+                    fileSizeBytes = size,
+                    inputStreamFactory = { runCatching { context.contentResolver.openInputStream(uri) }.getOrNull() }
+                )
+            }
+
+            normalized.startsWith("file://", ignoreCase = true) -> {
+                val path = runCatching { Uri.parse(normalized).path }.getOrNull().orEmpty()
+                val file = File(path)
+                if (!file.exists() || !file.isFile) return null
+                FileProbe(
+                    fileSizeBytes = file.length().coerceAtLeast(0L),
+                    inputStreamFactory = { runCatching { file.inputStream() }.getOrNull() }
+                )
+            }
+
+            else -> {
+                val file = File(normalized)
+                if (!file.exists() || !file.isFile) return null
+                FileProbe(
+                    fileSizeBytes = file.length().coerceAtLeast(0L),
+                    inputStreamFactory = { runCatching { file.inputStream() }.getOrNull() }
+                )
+            }
+        }
+    }
+
+    private fun queryContentSize(context: Context, uri: Uri): Long? {
+        return runCatching {
+            context.contentResolver.query(
+                uri,
+                arrayOf(DocumentsContract.Document.COLUMN_SIZE, OpenableColumns.SIZE),
+                null,
+                null,
+                null
+            )?.use { cursor ->
+                if (!cursor.moveToFirst()) return@use null
+                val documentIndex = cursor.getColumnIndex(DocumentsContract.Document.COLUMN_SIZE)
+                val openableIndex = cursor.getColumnIndex(OpenableColumns.SIZE)
+                when {
+                    documentIndex >= 0 && !cursor.isNull(documentIndex) -> cursor.getLong(documentIndex)
+                    openableIndex >= 0 && !cursor.isNull(openableIndex) -> cursor.getLong(openableIndex)
+                    else -> null
+                }
+            }
+        }.getOrNull()?.takeIf { it > 0L }
+    }
+}

--- a/app/src/main/java/com/asmr/player/listentogether/ListenTogetherModels.kt
+++ b/app/src/main/java/com/asmr/player/listentogether/ListenTogetherModels.kt
@@ -54,6 +54,13 @@ data class ListenTogetherPresenceResponse(
     val serverTimeEpochMs: Long? = null
 )
 
+data class ListenTogetherRjSummaryResponse(
+    val rjCode: String,
+    val listenerCount: Int,
+    val sessionCount: Int = 0,
+    val serverTimeEpochMs: Long? = null
+)
+
 data class ListenTogetherUiState(
     val available: Boolean = false,
     val listenerCount: Int? = null,
@@ -66,6 +73,7 @@ data class ListenTogetherUiState(
 enum class ListenTogetherStatus {
     Preparing,
     Ready,
+    OnlineSkipped,
     Unsupported,
     BackendUnavailable,
     Error

--- a/app/src/main/java/com/asmr/player/listentogether/ListenTogetherModels.kt
+++ b/app/src/main/java/com/asmr/player/listentogether/ListenTogetherModels.kt
@@ -1,0 +1,72 @@
+package com.asmr.player.listentogether
+
+data class ListenTogetherTrackIdentity(
+    val albumKey: String,
+    val mediaFingerprint: String,
+    val fileSizeBytes: Long,
+    val fingerprintAlgorithm: String,
+    val mediaKind: ListenTogetherMediaKind,
+    val sourcePath: String,
+    val mediaId: String,
+    val rjCode: String,
+    val displayTitle: String,
+    val displayArtist: String
+) {
+    val sessionKey: String
+        get() = "$albumKey:$mediaFingerprint"
+}
+
+enum class ListenTogetherMediaKind {
+    AUDIO,
+    VIDEO
+}
+
+data class ListenTogetherPresencePayload(
+    val sessionKey: String,
+    val albumKey: String,
+    val mediaFingerprint: String,
+    val fileSizeBytes: Long,
+    val fingerprintAlgorithm: String,
+    val mediaKind: String,
+    val sourcePathHint: String,
+    val mediaId: String,
+    val rjCode: String,
+    val title: String,
+    val artist: String,
+    val playbackPositionMs: Long,
+    val isPlaying: Boolean,
+    val sentAtEpochMs: Long,
+    val clientSessionId: String,
+    val appVersion: String? = null
+)
+
+data class ListenTogetherLeavePayload(
+    val sessionKey: String,
+    val clientSessionId: String,
+    val sentAtEpochMs: Long
+)
+
+data class ListenTogetherPresenceResponse(
+    val listenerCount: Int,
+    val sessionKey: String,
+    val heartbeatIntervalMs: Long = 15_000L,
+    val expiresInMs: Long? = null,
+    val serverTimeEpochMs: Long? = null
+)
+
+data class ListenTogetherUiState(
+    val available: Boolean = false,
+    val listenerCount: Int? = null,
+    val currentIdentity: ListenTogetherTrackIdentity? = null,
+    val syncing: Boolean = false,
+    val backendConfigured: Boolean = false,
+    val status: ListenTogetherStatus = ListenTogetherStatus.Preparing
+)
+
+enum class ListenTogetherStatus {
+    Preparing,
+    Ready,
+    Unsupported,
+    BackendUnavailable,
+    Error
+}

--- a/app/src/main/java/com/asmr/player/listentogether/ListenTogetherRepository.kt
+++ b/app/src/main/java/com/asmr/player/listentogether/ListenTogetherRepository.kt
@@ -1,0 +1,126 @@
+package com.asmr.player.listentogether
+
+import android.os.Build
+import com.asmr.player.BuildConfig
+import com.asmr.player.data.remote.NetworkHeaders
+import com.google.gson.Gson
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+import java.io.IOException
+import java.util.UUID
+import kotlin.text.Charsets.UTF_8
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class ListenTogetherRepository @Inject constructor(
+    private val okHttpClient: OkHttpClient,
+    private val gson: Gson
+) {
+    private val clientSessionId = UUID.randomUUID().toString()
+    private val appHeaderValue = "com.asmr.player/${BuildConfig.VERSION_NAME} (${BuildConfig.VERSION_CODE})"
+    private val deviceFingerprint = buildDeviceFingerprint()
+    private val userAgent = buildUserAgent()
+
+    val isBackendConfigured: Boolean
+        get() = baseUrl.isNotBlank()
+
+    suspend fun upsertPresence(
+        identity: ListenTogetherTrackIdentity,
+        playbackPositionMs: Long,
+        isPlaying: Boolean
+    ): ListenTogetherPresenceResponse? {
+        if (!isBackendConfigured) return null
+        val payload = ListenTogetherPresencePayload(
+            sessionKey = identity.sessionKey,
+            albumKey = identity.albumKey,
+            mediaFingerprint = identity.mediaFingerprint,
+            fileSizeBytes = identity.fileSizeBytes,
+            fingerprintAlgorithm = identity.fingerprintAlgorithm,
+            mediaKind = identity.mediaKind.name.lowercase(),
+            sourcePathHint = identity.sourcePath.substringAfterLast('/').substringAfterLast('\\'),
+            mediaId = identity.mediaId,
+            rjCode = identity.rjCode,
+            title = identity.displayTitle,
+            artist = identity.displayArtist,
+            playbackPositionMs = playbackPositionMs.coerceAtLeast(0L),
+            isPlaying = isPlaying,
+            sentAtEpochMs = System.currentTimeMillis(),
+            clientSessionId = clientSessionId,
+            appVersion = "${BuildConfig.VERSION_NAME} (${BuildConfig.VERSION_CODE}) / Android ${Build.VERSION.SDK_INT}"
+        )
+        return postJson("presence/upsert", payload, ListenTogetherPresenceResponse::class.java)
+    }
+
+    suspend fun leave(identity: ListenTogetherTrackIdentity) {
+        if (!isBackendConfigured) return
+        val payload = ListenTogetherLeavePayload(
+            sessionKey = identity.sessionKey,
+            clientSessionId = clientSessionId,
+            sentAtEpochMs = System.currentTimeMillis()
+        )
+        postJson<Unit>("presence/leave", payload, null)
+    }
+
+    private suspend fun <T : Any> postJson(path: String, body: Any, responseClass: Class<T>?): T? {
+        return withContext(Dispatchers.IO) {
+            val request = Request.Builder()
+                .url(resolveUrl(path))
+                .header("User-Agent", userAgent)
+                .header("X-Listen-Together-App", appHeaderValue)
+                .header("X-Listen-Together-Client-Session-Id", clientSessionId)
+                .header("X-Listen-Together-Device-Fingerprint", deviceFingerprint)
+                .header(NetworkHeaders.HEADER_SILENT_IO_ERROR, NetworkHeaders.SILENT_IO_ERROR_ON)
+                .post(gson.toJson(body).toRequestBody(JSON_MEDIA_TYPE))
+                .build()
+            okHttpClient.newCall(request).execute().use { response ->
+                if (!response.isSuccessful) {
+                    throw IOException("ListenTogether request failed: ${response.code}")
+                }
+                if (responseClass == null) return@withContext null
+                val raw = response.body?.string().orEmpty()
+                if (raw.isBlank()) return@withContext null
+                gson.fromJson(raw, responseClass)
+            }
+        }
+    }
+
+    private fun resolveUrl(path: String): String {
+        val root = baseUrl.trimEnd('/')
+        val normalizedPath = path.trimStart('/')
+        return "$root/$normalizedPath"
+    }
+
+    private companion object {
+        private val JSON_MEDIA_TYPE = "application/json; charset=utf-8".toMediaType()
+        private val baseUrl: String
+            get() = BuildConfig.LISTEN_TOGETHER_BASE_URL
+    }
+
+    private fun buildDeviceFingerprint(): String {
+        val source = listOf(
+            Build.BRAND,
+            Build.MANUFACTURER,
+            Build.MODEL,
+            Build.DEVICE,
+            Build.PRODUCT,
+            Build.VERSION.SDK_INT.toString(),
+            BuildConfig.APPLICATION_ID,
+            BuildConfig.VERSION_NAME,
+        ).joinToString(separator = "|") { it.trim() }
+        return XxHash64.hashHex(source.toByteArray(UTF_8))
+    }
+
+    private fun buildUserAgent(): String {
+        val deviceModel = listOf(Build.MANUFACTURER, Build.MODEL)
+            .map { it.trim() }
+            .filter { it.isNotBlank() }
+            .joinToString(separator = " ")
+            .ifBlank { "Android" }
+        return "EaraListenTogether/${BuildConfig.VERSION_NAME} (Android ${Build.VERSION.SDK_INT}; $deviceModel)"
+    }
+}

--- a/app/src/main/java/com/asmr/player/listentogether/ListenTogetherRepository.kt
+++ b/app/src/main/java/com/asmr/player/listentogether/ListenTogetherRepository.kt
@@ -10,6 +10,7 @@ import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.RequestBody.Companion.toRequestBody
+import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 import java.io.IOException
 import java.util.UUID
 import kotlin.text.Charsets.UTF_8
@@ -66,6 +67,17 @@ class ListenTogetherRepository @Inject constructor(
         postJson<Unit>("presence/leave", payload, null)
     }
 
+    suspend fun getRjSummary(rjCode: String): ListenTogetherRjSummaryResponse? {
+        if (!isBackendConfigured) return null
+        val normalizedRj = rjCode.trim().uppercase()
+        if (normalizedRj.isBlank()) return null
+        return getJson(
+            path = "presence/rj-summary",
+            queryParameters = mapOf("rj" to normalizedRj),
+            responseClass = ListenTogetherRjSummaryResponse::class.java
+        )
+    }
+
     private suspend fun <T : Any> postJson(path: String, body: Any, responseClass: Class<T>?): T? {
         return withContext(Dispatchers.IO) {
             val request = Request.Builder()
@@ -82,6 +94,44 @@ class ListenTogetherRepository @Inject constructor(
                     throw IOException("ListenTogether request failed: ${response.code}")
                 }
                 if (responseClass == null) return@withContext null
+                val raw = response.body?.string().orEmpty()
+                if (raw.isBlank()) return@withContext null
+                gson.fromJson(raw, responseClass)
+            }
+        }
+    }
+
+    private suspend fun <T : Any> getJson(
+        path: String,
+        queryParameters: Map<String, String>,
+        responseClass: Class<T>
+    ): T? {
+        return withContext(Dispatchers.IO) {
+            val url = resolveUrl(path)
+                .toHttpUrlOrNull()
+                ?.newBuilder()
+                ?.apply {
+                    queryParameters.forEach { (key, value) ->
+                        addQueryParameter(key, value)
+                    }
+                }
+                ?.build()
+                ?: throw IOException("Invalid ListenTogether URL: $path")
+
+            val request = Request.Builder()
+                .url(url)
+                .header("User-Agent", userAgent)
+                .header("X-Listen-Together-App", appHeaderValue)
+                .header("X-Listen-Together-Client-Session-Id", clientSessionId)
+                .header("X-Listen-Together-Device-Fingerprint", deviceFingerprint)
+                .header(NetworkHeaders.HEADER_SILENT_IO_ERROR, NetworkHeaders.SILENT_IO_ERROR_ON)
+                .get()
+                .build()
+
+            okHttpClient.newCall(request).execute().use { response ->
+                if (!response.isSuccessful) {
+                    throw IOException("ListenTogether request failed: ${response.code}")
+                }
                 val raw = response.body?.string().orEmpty()
                 if (raw.isBlank()) return@withContext null
                 gson.fromJson(raw, responseClass)

--- a/app/src/main/java/com/asmr/player/listentogether/XxHash64.kt
+++ b/app/src/main/java/com/asmr/player/listentogether/XxHash64.kt
@@ -1,0 +1,196 @@
+package com.asmr.player.listentogether
+
+import java.io.InputStream
+
+internal object XxHash64 {
+    private const val PRIME64_1 = -7046029288634856825L
+    private const val PRIME64_2 = -4417276706812531889L
+    private const val PRIME64_3 = 1609587929392839161L
+    private const val PRIME64_4 = -8796714831421723037L
+    private const val PRIME64_5 = 2870177450012600261L
+
+    fun hash(input: ByteArray, seed: Long = 0L): Long {
+        val length = input.size
+        var index = 0
+        val end = length
+        val hash = if (length >= 32) {
+            var v1 = seed + PRIME64_1 + PRIME64_2
+            var v2 = seed + PRIME64_2
+            var v3 = seed
+            var v4 = seed - PRIME64_1
+            val limit = end - 32
+            while (index <= limit) {
+                v1 = round(v1, littleEndianLong(input, index))
+                index += 8
+                v2 = round(v2, littleEndianLong(input, index))
+                index += 8
+                v3 = round(v3, littleEndianLong(input, index))
+                index += 8
+                v4 = round(v4, littleEndianLong(input, index))
+                index += 8
+            }
+            mergeRound(mergeRound(mergeRound(mergeRound(rotateLeft(v1, 1) + rotateLeft(v2, 7) + rotateLeft(v3, 12) + rotateLeft(v4, 18), v1), v2), v3), v4)
+        } else {
+            seed + PRIME64_5
+        }
+
+        var h64 = hash + length.toLong()
+        while (index <= end - 8) {
+            val k1 = round(0L, littleEndianLong(input, index))
+            h64 = rotateLeft(h64 xor k1, 27) * PRIME64_1 + PRIME64_4
+            index += 8
+        }
+        if (index <= end - 4) {
+            h64 = rotateLeft(h64 xor ((littleEndianInt(input, index).toLong() and 0xFFFF_FFFFL) * PRIME64_1), 23) * PRIME64_2 + PRIME64_3
+            index += 4
+        }
+        while (index < end) {
+            h64 = rotateLeft(h64 xor ((input[index].toLong() and 0xFFL) * PRIME64_5), 11) * PRIME64_1
+            index += 1
+        }
+        return avalanche(h64)
+    }
+
+    fun hashHex(input: ByteArray, seed: Long = 0L): String {
+        return java.lang.Long.toUnsignedString(hash(input, seed), 16).padStart(16, '0')
+    }
+
+    fun hashStream(inputStream: InputStream, seed: Long = 0L): Long {
+        val state = StreamingState(seed)
+        val buffer = ByteArray(DEFAULT_BUFFER_SIZE)
+        while (true) {
+            val read = inputStream.read(buffer)
+            if (read <= 0) break
+            state.update(buffer, 0, read)
+        }
+        return state.digest()
+    }
+
+    fun hashStreamHex(inputStream: InputStream, seed: Long = 0L): String {
+        return java.lang.Long.toUnsignedString(hashStream(inputStream, seed), 16).padStart(16, '0')
+    }
+
+    private fun round(acc: Long, input: Long): Long {
+        var value = acc + (input * PRIME64_2)
+        value = rotateLeft(value, 31)
+        value *= PRIME64_1
+        return value
+    }
+
+    private fun mergeRound(acc: Long, value: Long): Long {
+        var result = acc xor round(0L, value)
+        result = result * PRIME64_1 + PRIME64_4
+        return result
+    }
+
+    private fun avalanche(hash: Long): Long {
+        var value = hash
+        value = value xor (value ushr 33)
+        value *= PRIME64_2
+        value = value xor (value ushr 29)
+        value *= PRIME64_3
+        value = value xor (value ushr 32)
+        return value
+    }
+
+    private fun littleEndianLong(data: ByteArray, index: Int): Long {
+        return (data[index].toLong() and 0xFFL) or
+            ((data[index + 1].toLong() and 0xFFL) shl 8) or
+            ((data[index + 2].toLong() and 0xFFL) shl 16) or
+            ((data[index + 3].toLong() and 0xFFL) shl 24) or
+            ((data[index + 4].toLong() and 0xFFL) shl 32) or
+            ((data[index + 5].toLong() and 0xFFL) shl 40) or
+            ((data[index + 6].toLong() and 0xFFL) shl 48) or
+            ((data[index + 7].toLong() and 0xFFL) shl 56)
+    }
+
+    private fun littleEndianInt(data: ByteArray, index: Int): Int {
+        return (data[index].toInt() and 0xFF) or
+            ((data[index + 1].toInt() and 0xFF) shl 8) or
+            ((data[index + 2].toInt() and 0xFF) shl 16) or
+            ((data[index + 3].toInt() and 0xFF) shl 24)
+    }
+
+    private fun rotateLeft(value: Long, distance: Int): Long =
+        (value shl distance) or (value ushr (64 - distance))
+
+    private class StreamingState(private val seed: Long) {
+        private val buffer = ByteArray(32)
+        private var bufferSize = 0
+        private var totalLength = 0L
+        private var v1 = seed + PRIME64_1 + PRIME64_2
+        private var v2 = seed + PRIME64_2
+        private var v3 = seed
+        private var v4 = seed - PRIME64_1
+
+        fun update(data: ByteArray, offset: Int, length: Int) {
+            if (length <= 0) return
+            var index = offset
+            var remaining = length
+            totalLength += length.toLong()
+
+            if (bufferSize + remaining < 32) {
+                data.copyInto(buffer, destinationOffset = bufferSize, startIndex = index, endIndex = index + remaining)
+                bufferSize += remaining
+                return
+            }
+
+            if (bufferSize > 0) {
+                val needed = 32 - bufferSize
+                data.copyInto(buffer, destinationOffset = bufferSize, startIndex = index, endIndex = index + needed)
+                process(buffer, 0)
+                index += needed
+                remaining -= needed
+                bufferSize = 0
+            }
+
+            while (remaining >= 32) {
+                process(data, index)
+                index += 32
+                remaining -= 32
+            }
+
+            if (remaining > 0) {
+                data.copyInto(buffer, destinationOffset = 0, startIndex = index, endIndex = index + remaining)
+                bufferSize = remaining
+            }
+        }
+
+        fun digest(): Long {
+            var hash = if (totalLength >= 32) {
+                val base = rotateLeft(v1, 1) + rotateLeft(v2, 7) + rotateLeft(v3, 12) + rotateLeft(v4, 18)
+                mergeRound(mergeRound(mergeRound(mergeRound(base, v1), v2), v3), v4)
+            } else {
+                seed + PRIME64_5
+            }
+
+            hash += totalLength
+            var index = 0
+            while (index <= bufferSize - 8) {
+                val k1 = round(0L, littleEndianLong(buffer, index))
+                hash = rotateLeft(hash xor k1, 27) * PRIME64_1 + PRIME64_4
+                index += 8
+            }
+            if (index <= bufferSize - 4) {
+                hash = rotateLeft(hash xor ((littleEndianInt(buffer, index).toLong() and 0xFFFF_FFFFL) * PRIME64_1), 23) * PRIME64_2 + PRIME64_3
+                index += 4
+            }
+            while (index < bufferSize) {
+                hash = rotateLeft(hash xor ((buffer[index].toLong() and 0xFFL) * PRIME64_5), 11) * PRIME64_1
+                index += 1
+            }
+            return avalanche(hash)
+        }
+
+        private fun process(data: ByteArray, offset: Int) {
+            var index = offset
+            v1 = round(v1, littleEndianLong(data, index))
+            index += 8
+            v2 = round(v2, littleEndianLong(data, index))
+            index += 8
+            v3 = round(v3, littleEndianLong(data, index))
+            index += 8
+            v4 = round(v4, littleEndianLong(data, index))
+        }
+    }
+}

--- a/app/src/main/java/com/asmr/player/ui/library/AlbumDetailScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/AlbumDetailScreen.kt
@@ -61,6 +61,7 @@ import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalLifecycleOwner
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.stateDescription
 import androidx.compose.ui.state.ToggleableState
@@ -360,6 +361,7 @@ fun AlbumDetailScreen(
                             val canSaveOnlineForTab = tab == 1 && asmrOneTree.isNotEmpty()
                             AlbumHeader(
                                 album = if (isLocalTab) (model.localAlbum ?: album) else album,
+                                listenTogetherRjListenerCount = model.listenTogetherRjListenerCount,
                                 dlsiteUrl = model.dlsiteWorkno.takeIf { it.isNotBlank() }?.let { "https://www.dlsite.com/maniax/work/=/product_id/$it.html" }.orEmpty(),
                                 asmrOneUrl = model.asmrOneWorkId?.takeIf { it.isNotBlank() }?.let { "https://asmr.one/work/$it" }.orEmpty(),
                                 dlsiteEditions = if (isLocalTab) emptyList() else model.dlsiteEditions,
@@ -911,6 +913,7 @@ private fun AlbumDetailTabChrome(
 @OptIn(ExperimentalLayoutApi::class)
 private fun AlbumHeader(
     album: Album,
+    listenTogetherRjListenerCount: Int?,
     dlsiteUrl: String,
     asmrOneUrl: String,
     dlsiteEditions: List<DlsiteLanguageEdition>,
@@ -1042,20 +1045,59 @@ private fun AlbumHeader(
                     )
                     }
                     val circle = album.circle.trim()
-                    if (rj.isNotBlank() || circle.isNotBlank()) {
+                    val showMetaRow = rj.isNotBlank() || circle.isNotBlank() || listenTogetherRjListenerCount != null
+                    if (showMetaRow) {
                         AlbumHeaderInfoReveal(
                             revealKey = "$headerAnimationScopeKey:meta",
                             delayMillis = 40,
                             enabled = animateIntro
                         ) {
-                            AlbumPrimaryMetaRow(
-                                rjCode = rj,
-                                circle = circle,
-                                rjOnClick = { copyMeta("RJ", rj) },
-                                circleOnClick = { copyMeta("社团", circle) },
-                                appearance = AlbumMetaAppearance.OnImage,
-                                leadingVisual = AlbumMetaLeadingVisual.Icon,
-                            )
+                            Row(
+                                modifier = Modifier.fillMaxWidth(),
+                                verticalAlignment = Alignment.CenterVertically
+                            ) {
+                                AlbumPrimaryMetaRow(
+                                    rjCode = rj,
+                                    circle = circle,
+                                    modifier = Modifier.weight(1f),
+                                    rjOnClick = { copyMeta("RJ", rj) },
+                                    circleOnClick = { copyMeta("社团", circle) },
+                                    appearance = AlbumMetaAppearance.OnImage,
+                                    leadingVisual = AlbumMetaLeadingVisual.Icon,
+                                )
+                                if (listenTogetherRjListenerCount != null && rj.isNotBlank()) {
+                                    Spacer(modifier = Modifier.width(8.dp))
+                                    Surface(
+                                        color = Color.White.copy(alpha = 0.16f),
+                                        contentColor = Color.White.copy(alpha = 0.96f),
+                                        shape = RoundedCornerShape(999.dp),
+                                        border = androidx.compose.foundation.BorderStroke(
+                                            width = 0.5.dp,
+                                            color = Color.White.copy(alpha = 0.2f)
+                                        )
+                                    ) {
+                                        Row(
+                                            modifier = Modifier.padding(horizontal = 7.dp, vertical = 2.dp),
+                                            horizontalArrangement = Arrangement.spacedBy(4.dp),
+                                            verticalAlignment = Alignment.CenterVertically
+                                        ) {
+                                            Icon(
+                                                painter = painterResource(id = com.asmr.player.R.drawable.ic_users_round),
+                                                contentDescription = null,
+                                                tint = Color.White.copy(alpha = 0.96f),
+                                                modifier = Modifier.size(12.dp)
+                                            )
+                                            Text(
+                                                text = "${listenTogetherRjListenerCount.coerceAtLeast(0)} 人正在听",
+                                                style = MaterialTheme.typography.labelSmall,
+                                                color = Color.White.copy(alpha = 0.96f),
+                                                maxLines = 1,
+                                                overflow = TextOverflow.Ellipsis,
+                                            )
+                                        }
+                                    }
+                                }
+                            }
                         }
                     }
                 }

--- a/app/src/main/java/com/asmr/player/ui/library/AlbumDetailViewModel.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/AlbumDetailViewModel.kt
@@ -44,6 +44,7 @@ import com.asmr.player.data.lyrics.LyricsLoader
 import com.asmr.player.data.lyrics.deriveLyricsRelativePathNoExt
 import com.asmr.player.domain.model.Album
 import com.asmr.player.domain.model.Track
+import com.asmr.player.listentogether.ListenTogetherRepository
 import com.asmr.player.ui.common.queryTrackFileSize
 import com.asmr.player.util.OnlineLyricsStore
 import com.asmr.player.util.RemoteSubtitleSource
@@ -59,6 +60,7 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.distinctUntilChanged
@@ -75,6 +77,7 @@ import com.asmr.player.util.TagNormalizer
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.stateIn
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
@@ -102,6 +105,7 @@ class AlbumDetailViewModel @Inject constructor(
     private val downloadManager: DownloadManager,
     private val lyricsLoader: LyricsLoader,
     private val syncCoordinator: SyncCoordinator,
+    private val listenTogetherRepository: ListenTogetherRepository,
     @Named("image") private val imageOkHttpClient: OkHttpClient,
     val messageManager: MessageManager,
     @ApplicationContext private val context: Context
@@ -181,8 +185,45 @@ class AlbumDetailViewModel @Inject constructor(
     private val listScrollByKey = linkedMapOf<String, Pair<Int, Int>>()
     private val treeCurrentPathByKey = linkedMapOf<String, String>()
     private val remoteFileSizeCache = linkedMapOf<String, Long?>()
+    private var listenTogetherRjSummaryJob: Job? = null
     private val preferredTreePathPrefs by lazy {
         context.getSharedPreferences("album_detail_tree_prefs", Context.MODE_PRIVATE)
+    }
+
+    init {
+        viewModelScope.launch {
+            uiState
+                .map { (it as? AlbumDetailUiState.Success)?.model?.rjCode?.trim().orEmpty().uppercase() }
+                .distinctUntilChanged()
+                .collect { rj ->
+                    listenTogetherRjSummaryJob?.cancel()
+                    listenTogetherRjSummaryJob = if (rj.isBlank()) {
+                        null
+                    } else {
+                        viewModelScope.launch {
+                            while (true) {
+                                refreshListenTogetherRjSummary(rj)
+                                delay(15_000L)
+                            }
+                        }
+                    }
+                }
+        }
+    }
+
+    private suspend fun refreshListenTogetherRjSummary(rjCode: String) {
+        val normalizedRj = rjCode.trim().uppercase()
+        if (normalizedRj.isBlank()) return
+        val summary = runCatching {
+            listenTogetherRepository.getRjSummary(normalizedRj)
+        }.getOrNull() ?: return
+        val listenerCount = summary.listenerCount.coerceAtLeast(0)
+        val current = _uiState.value as? AlbumDetailUiState.Success ?: return
+        if (!current.model.rjCode.trim().uppercase().equals(normalizedRj, ignoreCase = true)) return
+        if (current.model.listenTogetherRjListenerCount == listenerCount) return
+        _uiState.value = AlbumDetailUiState.Success(
+            model = current.model.copy(listenTogetherRjListenerCount = listenerCount)
+        )
     }
 
     private suspend fun isAsmrOneCollected(rj: String, timeoutMs: Long = 1_200L): Boolean? {
@@ -524,6 +565,7 @@ class AlbumDetailViewModel @Inject constructor(
                     model = AlbumDetailModel(
                         baseRjCode = rj,
                         rjCode = rj,
+                        listenTogetherRjListenerCount = null,
                         displayAlbum = displayAlbum,
                         localAlbum = localAlbum,
                         dlsiteInfo = null,
@@ -546,7 +588,6 @@ class AlbumDetailViewModel @Inject constructor(
                         isLoadingDlsitePlay = false
                     )
                 )
-
                 localTracksObserveJob?.cancel()
                 localTracksObserveJob = null
                 val localId = localAlbum?.id ?: 0L

--- a/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailViewModelSupport.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailViewModelSupport.kt
@@ -146,6 +146,7 @@ internal fun extractRemoteFileSize(response: Response): Long? {
 data class AlbumDetailModel(
     val baseRjCode: String,
     val rjCode: String,
+    val listenTogetherRjListenerCount: Int?,
     val displayAlbum: Album,
     val localAlbum: Album?,
     val dlsiteInfo: Album?,

--- a/app/src/main/java/com/asmr/player/ui/player/NowPlayingScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/player/NowPlayingScreen.kt
@@ -176,14 +176,18 @@ internal sealed interface ListenTogetherAudiencePresentation {
 internal fun resolveListenTogetherAudiencePresentation(
     state: ListenTogetherUiState
 ): ListenTogetherAudiencePresentation? = when {
+    state.status == ListenTogetherStatus.OnlineSkipped ->
+        ListenTogetherAudiencePresentation.Status("在线音频不参与统计")
     !state.available && state.status == ListenTogetherStatus.Unsupported ->
-        ListenTogetherAudiencePresentation.Status("\u5f53\u524d\u97f3\u9891\u65e0\u6cd5\u53c2\u4e0e\u4e00\u8d77\u542c")
+        ListenTogetherAudiencePresentation.Status("当前音频无法参与一起听")
     state.listenerCount != null ->
         ListenTogetherAudiencePresentation.Audience(
             companionCount = (state.listenerCount - 1).coerceAtLeast(0)
         )
-    else ->
+    state.available ->
         ListenTogetherAudiencePresentation.Audience(companionCount = 0)
+    else ->
+        null
 }
 
 private fun <S> AnimatedContentTransitionScope<S>.listenTogetherLineTransform(): ContentTransform {
@@ -275,14 +279,6 @@ private fun AnimatedContentTransitionScope<Int>.listenTogetherCounterTransform()
     return enter togetherWith exit using SizeTransform(clip = false)
 }
 
-private fun listenTogetherPresentationKey(
-    presentation: ListenTogetherAudiencePresentation?
-): String = when (presentation) {
-    null -> "hidden"
-    is ListenTogetherAudiencePresentation.Status -> "status:${presentation.text}"
-    is ListenTogetherAudiencePresentation.Audience -> "audience"
-}
-
 @Composable
 private fun ListenTogetherAudienceCountText(
     companionCount: Int,
@@ -315,7 +311,7 @@ private fun ListenTogetherAudienceCountText(
                     )
                 }
                 Text(
-                    text = " \u4eba\u6b63\u5728\u548c\u4f60\u4e00\u8d77\u542c",
+                    text = " 人正在和你一起听",
                     style = textStyle,
                     color = color,
                     maxLines = 1,
@@ -324,7 +320,7 @@ private fun ListenTogetherAudienceCountText(
             }
         } else {
             Text(
-                text = "\u5b64\u72ec\u8d4f\u9274\u4e2d",
+                text = "孤独赏鉴中",
                 modifier = modifier,
                 style = textStyle,
                 color = color,
@@ -343,55 +339,16 @@ private fun ListenTogetherAudienceLine(
 ) {
     val colorScheme = AsmrTheme.colorScheme
     val presentation = resolveListenTogetherAudiencePresentation(state)
-    var visible by remember { mutableStateOf(false) }
-    var hasShownPresentation by remember { mutableStateOf(false) }
-
-    LaunchedEffect(presentation) {
-        if (presentation == null) {
-            visible = false
-            hasShownPresentation = false
-        } else {
-            if (!hasShownPresentation) {
-                visible = false
-                delay(80)
-                visible = true
-                hasShownPresentation = true
-            } else {
-                visible = true
-            }
-        }
-    }
-
     Box(modifier = modifier.height(18.dp)) {
-        AnimatedVisibility(
-            visible = visible && presentation != null,
-            enter = fadeIn(
-                animationSpec = tween(
-                    durationMillis = NowPlayingMotionSpec.PlayerForegroundEnterDurationMs,
-                    easing = LinearOutSlowInEasing
-                )
-            ) + slideInVertically(
-                initialOffsetY = { fullHeight -> fullHeight / 3 },
-                animationSpec = tween(
-                    durationMillis = NowPlayingMotionSpec.PlayerForegroundEnterDurationMs,
-                    easing = LinearOutSlowInEasing
-                )
-            ),
-            exit = fadeOut(
-                animationSpec = tween(
-                    durationMillis = NowPlayingMotionSpec.PlayerForegroundExitDurationMs,
-                    easing = FastOutLinearInEasing
-                )
-            ) + slideOutVertically(
-                targetOffsetY = { fullHeight -> -(fullHeight / 4) },
-                animationSpec = tween(
-                    durationMillis = NowPlayingMotionSpec.PlayerForegroundExitDurationMs,
-                    easing = FastOutLinearInEasing
-                )
-            ),
-            label = "listenTogetherAudienceVisibility"
-        ) {
-            val targetPresentation = presentation ?: return@AnimatedVisibility
+        AnimatedContent(
+            targetState = presentation,
+            transitionSpec = { listenTogetherLineTransform() },
+            label = "listenTogetherAudiencePresentation"
+        ) { targetPresentation ->
+            if (targetPresentation == null) {
+                Spacer(modifier = Modifier.fillMaxWidth())
+                return@AnimatedContent
+            }
             Row(
                 modifier = Modifier
                     .animateContentSize(

--- a/app/src/main/java/com/asmr/player/ui/player/NowPlayingScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/player/NowPlayingScreen.kt
@@ -109,6 +109,8 @@ import com.asmr.player.ui.theme.AsmrTheme
 import com.asmr.player.util.Formatting
 import com.asmr.player.util.SubtitleEntry
 import com.asmr.player.util.SubtitleIndexFinder
+import com.asmr.player.listentogether.ListenTogetherStatus
+import com.asmr.player.listentogether.ListenTogetherUiState
 import kotlin.math.abs
 import kotlin.math.roundToInt
 import kotlin.math.roundToLong
@@ -165,6 +167,299 @@ private fun AnimatedContentTransitionScope<NowPlayingSurfaceMode>.nowPlayingSurf
     return enter togetherWith exit using SizeTransform(clip = false)
 }
 
+internal sealed interface ListenTogetherAudiencePresentation {
+    data class Status(val text: String) : ListenTogetherAudiencePresentation
+
+    data class Audience(val companionCount: Int) : ListenTogetherAudiencePresentation
+}
+
+internal fun resolveListenTogetherAudiencePresentation(
+    state: ListenTogetherUiState
+): ListenTogetherAudiencePresentation? = when {
+    !state.available && state.status == ListenTogetherStatus.Unsupported ->
+        ListenTogetherAudiencePresentation.Status("\u5f53\u524d\u97f3\u9891\u65e0\u6cd5\u53c2\u4e0e\u4e00\u8d77\u542c")
+    state.listenerCount != null ->
+        ListenTogetherAudiencePresentation.Audience(
+            companionCount = (state.listenerCount - 1).coerceAtLeast(0)
+        )
+    else ->
+        ListenTogetherAudiencePresentation.Audience(companionCount = 0)
+}
+
+private fun <S> AnimatedContentTransitionScope<S>.listenTogetherLineTransform(): ContentTransform {
+    val enter = fadeIn(
+        animationSpec = tween(
+            durationMillis = NowPlayingMotionSpec.PlayerForegroundEnterDurationMs,
+            easing = LinearOutSlowInEasing
+        )
+    ) + slideInVertically(
+        initialOffsetY = {
+            (it * NowPlayingMotionSpec.PlayerForegroundFloatOffsetFraction).roundToInt()
+        },
+        animationSpec = tween(
+            durationMillis = NowPlayingMotionSpec.PlayerForegroundEnterDurationMs,
+            easing = LinearOutSlowInEasing
+        )
+    ) + scaleIn(
+        initialScale = NowPlayingMotionSpec.PlayerForegroundInitialScale,
+        animationSpec = tween(
+            durationMillis = NowPlayingMotionSpec.PlayerForegroundEnterDurationMs,
+            easing = LinearOutSlowInEasing
+        )
+    )
+    val exit = fadeOut(
+        animationSpec = tween(
+            durationMillis = NowPlayingMotionSpec.PlayerForegroundExitDurationMs,
+            easing = FastOutLinearInEasing
+        )
+    ) + slideOutVertically(
+        targetOffsetY = {
+            (it * NowPlayingMotionSpec.PlayerForegroundSinkOffsetFraction).roundToInt()
+        },
+        animationSpec = tween(
+            durationMillis = NowPlayingMotionSpec.PlayerForegroundExitDurationMs,
+            easing = FastOutLinearInEasing
+        )
+    ) + scaleOut(
+        targetScale = NowPlayingMotionSpec.PlayerForegroundTargetScale,
+        animationSpec = tween(
+            durationMillis = NowPlayingMotionSpec.PlayerForegroundExitDurationMs,
+            easing = FastOutLinearInEasing
+        )
+    )
+    return enter togetherWith exit using SizeTransform(clip = false)
+}
+
+private fun <S> AnimatedContentTransitionScope<S>.listenTogetherInlineTransform(): ContentTransform {
+    val enter = fadeIn(
+        animationSpec = tween(
+            durationMillis = NowPlayingMotionSpec.PlayerForegroundEnterDurationMs,
+            easing = LinearOutSlowInEasing
+        )
+    ) + slideInVertically(
+        initialOffsetY = { fullHeight -> fullHeight / 3 },
+        animationSpec = tween(
+            durationMillis = NowPlayingMotionSpec.PlayerForegroundEnterDurationMs,
+            easing = LinearOutSlowInEasing
+        )
+    )
+    val exit = fadeOut(
+        animationSpec = tween(
+            durationMillis = NowPlayingMotionSpec.PlayerForegroundExitDurationMs,
+            easing = FastOutLinearInEasing
+        )
+    ) + slideOutVertically(
+        targetOffsetY = { fullHeight -> -(fullHeight / 3) },
+        animationSpec = tween(
+            durationMillis = NowPlayingMotionSpec.PlayerForegroundExitDurationMs,
+            easing = FastOutLinearInEasing
+        )
+    )
+    return enter togetherWith exit using SizeTransform(clip = false)
+}
+
+private fun AnimatedContentTransitionScope<Int>.listenTogetherCounterTransform(): ContentTransform {
+    val direction = if (targetState >= initialState) 1 else -1
+    val enter = fadeIn(
+        animationSpec = tween(durationMillis = 220, easing = LinearOutSlowInEasing)
+    ) + slideInVertically(
+        initialOffsetY = { fullHeight -> direction * fullHeight },
+        animationSpec = tween(durationMillis = 220, easing = LinearOutSlowInEasing)
+    )
+    val exit = fadeOut(
+        animationSpec = tween(durationMillis = 140, easing = FastOutLinearInEasing)
+    ) + slideOutVertically(
+        targetOffsetY = { fullHeight -> -direction * fullHeight },
+        animationSpec = tween(durationMillis = 140, easing = FastOutLinearInEasing)
+    )
+    return enter togetherWith exit using SizeTransform(clip = false)
+}
+
+private fun listenTogetherPresentationKey(
+    presentation: ListenTogetherAudiencePresentation?
+): String = when (presentation) {
+    null -> "hidden"
+    is ListenTogetherAudiencePresentation.Status -> "status:${presentation.text}"
+    is ListenTogetherAudiencePresentation.Audience -> "audience"
+}
+
+@Composable
+private fun ListenTogetherAudienceCountText(
+    companionCount: Int,
+    color: Color,
+    modifier: Modifier = Modifier
+) {
+    val textStyle = MaterialTheme.typography.labelSmall
+
+    AnimatedContent(
+        targetState = companionCount > 0,
+        transitionSpec = { listenTogetherInlineTransform() },
+        label = "listenTogetherAudienceMode"
+    ) { hasCompanions ->
+        if (hasCompanions) {
+            Row(
+                modifier = modifier,
+                horizontalArrangement = Arrangement.spacedBy(0.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                AnimatedContent(
+                    targetState = companionCount,
+                    transitionSpec = { listenTogetherCounterTransform() },
+                    label = "listenTogetherAudienceCounter"
+                ) { value ->
+                    Text(
+                        text = value.toString(),
+                        style = textStyle.copy(fontWeight = FontWeight.SemiBold),
+                        color = color,
+                        maxLines = 1
+                    )
+                }
+                Text(
+                    text = " \u4eba\u6b63\u5728\u548c\u4f60\u4e00\u8d77\u542c",
+                    style = textStyle,
+                    color = color,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
+            }
+        } else {
+            Text(
+                text = "\u5b64\u72ec\u8d4f\u9274\u4e2d",
+                modifier = modifier,
+                style = textStyle,
+                color = color,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
+            )
+        }
+    }
+}
+
+@Composable
+private fun ListenTogetherAudienceLine(
+    state: ListenTogetherUiState,
+    modifier: Modifier = Modifier,
+    accentColor: Color = AsmrTheme.colorScheme.primary
+) {
+    val colorScheme = AsmrTheme.colorScheme
+    val presentation = resolveListenTogetherAudiencePresentation(state)
+    var visible by remember { mutableStateOf(false) }
+    var hasShownPresentation by remember { mutableStateOf(false) }
+
+    LaunchedEffect(presentation) {
+        if (presentation == null) {
+            visible = false
+            hasShownPresentation = false
+        } else {
+            if (!hasShownPresentation) {
+                visible = false
+                delay(80)
+                visible = true
+                hasShownPresentation = true
+            } else {
+                visible = true
+            }
+        }
+    }
+
+    Box(modifier = modifier.height(18.dp)) {
+        AnimatedVisibility(
+            visible = visible && presentation != null,
+            enter = fadeIn(
+                animationSpec = tween(
+                    durationMillis = NowPlayingMotionSpec.PlayerForegroundEnterDurationMs,
+                    easing = LinearOutSlowInEasing
+                )
+            ) + slideInVertically(
+                initialOffsetY = { fullHeight -> fullHeight / 3 },
+                animationSpec = tween(
+                    durationMillis = NowPlayingMotionSpec.PlayerForegroundEnterDurationMs,
+                    easing = LinearOutSlowInEasing
+                )
+            ),
+            exit = fadeOut(
+                animationSpec = tween(
+                    durationMillis = NowPlayingMotionSpec.PlayerForegroundExitDurationMs,
+                    easing = FastOutLinearInEasing
+                )
+            ) + slideOutVertically(
+                targetOffsetY = { fullHeight -> -(fullHeight / 4) },
+                animationSpec = tween(
+                    durationMillis = NowPlayingMotionSpec.PlayerForegroundExitDurationMs,
+                    easing = FastOutLinearInEasing
+                )
+            ),
+            label = "listenTogetherAudienceVisibility"
+        ) {
+            val targetPresentation = presentation ?: return@AnimatedVisibility
+            Row(
+                modifier = Modifier
+                    .animateContentSize(
+                        animationSpec = tween(
+                            durationMillis = NowPlayingMotionSpec.PlayerForegroundEnterDurationMs,
+                            easing = LinearOutSlowInEasing
+                        )
+                    ),
+                horizontalArrangement = Arrangement.spacedBy(5.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Icon(
+                    painter = painterResource(R.drawable.ic_users_round),
+                    contentDescription = null,
+                    modifier = Modifier.size(13.dp),
+                    tint = accentColor.copy(alpha = 0.82f)
+                )
+                when (targetPresentation) {
+                    is ListenTogetherAudiencePresentation.Status -> Text(
+                        text = targetPresentation.text,
+                        style = MaterialTheme.typography.labelSmall,
+                        color = colorScheme.textTertiary,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis
+                    )
+
+                    is ListenTogetherAudiencePresentation.Audience -> ListenTogetherAudienceCountText(
+                        companionCount = targetPresentation.companionCount,
+                        color = colorScheme.textTertiary
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ArtistWithListenTogetherInfo(
+    artist: String,
+    listenTogetherState: ListenTogetherUiState,
+    style: androidx.compose.ui.text.TextStyle,
+    color: Color,
+    modifier: Modifier = Modifier,
+    textAlign: TextAlign = TextAlign.Start,
+    badgeAlignment: Alignment = Alignment.TopStart,
+    textAlignment: Alignment = Alignment.CenterStart,
+    accentColor: Color = AsmrTheme.colorScheme.primary
+) {
+    Box(modifier = modifier.fillMaxWidth()) {
+        ListenTogetherAudienceLine(
+            state = listenTogetherState,
+            modifier = Modifier
+                .align(badgeAlignment)
+                .offset(y = (-18).dp),
+            accentColor = accentColor
+        )
+        Text(
+            text = artist,
+            modifier = Modifier.align(textAlignment),
+            style = style,
+            color = color,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+            textAlign = textAlign
+        )
+    }
+}
+
 @Composable
 @androidx.media3.common.util.UnstableApi
 @OptIn(ExperimentalFoundationApi::class, ExperimentalMaterial3Api::class, ExperimentalComposeUiApi::class)
@@ -195,6 +490,7 @@ internal fun NowPlayingScreen(
     val resolvedDurationMs by viewModel.resolvedDurationMs.collectAsState()
     val sliceUiState by viewModel.sliceUiState.collectAsState()
     val isFavorite by viewModel.isFavorite.collectAsState()
+    val listenTogetherUiState by viewModel.listenTogetherUiState.collectAsState()
     val lyricsState by lyricsViewModel.uiState.collectAsState()
     val item = playback.currentMediaItem
     val metadata = item?.mediaMetadata
@@ -640,13 +936,13 @@ internal fun NowPlayingScreen(
                         verticalArrangement = Arrangement.spacedBy(16.dp)
                     ) {
                         // 艺术家 (标题已移动到 header)
-                        Text(
-                            text = metadata?.artist?.toString().orEmpty(),
+                        ArtistWithListenTogetherInfo(
+                            artist = metadata?.artist?.toString().orEmpty(),
+                            listenTogetherState = listenTogetherUiState,
                             modifier = Modifier.then(infoMotion),
                             style = MaterialTheme.typography.titleMedium,
                             color = colorScheme.textSecondary,
-                            maxLines = 1,
-                            overflow = TextOverflow.Ellipsis
+                            accentColor = accentColor
                         )
 
                         if (!isVideo) {
@@ -1027,8 +1323,9 @@ internal fun NowPlayingScreen(
                     }
 
                     // 艺术家
-                    Text(
-                        text = metadata?.artist?.toString().orEmpty(),
+                    ArtistWithListenTogetherInfo(
+                        artist = metadata?.artist?.toString().orEmpty(),
+                        listenTogetherState = listenTogetherUiState,
                         style = MaterialTheme.typography.bodySmall.copy(
                             shadow = if (colorScheme.isDark) {
                                 Shadow(color = Color.Black.copy(alpha = 0.4f), offset = Offset(0f, 1f), blurRadius = 2f)
@@ -1037,12 +1334,13 @@ internal fun NowPlayingScreen(
                             }
                         ),
                         color = colorScheme.textSecondary,
-                        maxLines = 1,
-                        overflow = TextOverflow.Ellipsis,
                         modifier = Modifier
                             .fillMaxWidth()
                             .then(coverMotion),
-                        textAlign = TextAlign.Center
+                        textAlign = TextAlign.Center,
+                        badgeAlignment = Alignment.TopCenter,
+                        textAlignment = Alignment.Center,
+                        accentColor = accentColor
                     )
 
                     // 封面

--- a/app/src/main/java/com/asmr/player/ui/player/nowplaying/NowPlayingControls.kt
+++ b/app/src/main/java/com/asmr/player/ui/player/nowplaying/NowPlayingControls.kt
@@ -120,6 +120,7 @@ internal fun PlaybackControls(
     bottomPadding: Dp = 0.dp,
     actionRowModifier: Modifier = Modifier,
     coreControlsModifier: Modifier = Modifier,
+    supplementalAction: (@Composable () -> Unit)? = null,
     primaryColor: Color = AsmrTheme.colorScheme.primary,
     onPrimaryColor: Color = AsmrTheme.colorScheme.onPrimary
 ) {
@@ -226,6 +227,8 @@ internal fun PlaybackControls(
                         modifier = Modifier.size(24.dp)
                     )
                 }
+
+                supplementalAction?.invoke()
             }
         }
 
@@ -321,6 +324,9 @@ internal fun PlaybackControls(
                     tint = colorScheme.onSurface,
                     modifier = Modifier.size(28.dp)
                 )
+            }
+            if (!showActionRow) {
+                supplementalAction?.invoke()
             }
         }
     }

--- a/app/src/main/java/com/asmr/player/ui/player/playerviewmodel.kt
+++ b/app/src/main/java/com/asmr/player/ui/player/playerviewmodel.kt
@@ -825,6 +825,19 @@ class PlayerViewModel @Inject constructor(
             return
         }
 
+        if (item.isOnlineMedia()) {
+            stopListenTogether(clearCount = true)
+            _listenTogetherUiState.value = ListenTogetherUiState(
+                available = false,
+                listenerCount = null,
+                currentIdentity = null,
+                syncing = false,
+                backendConfigured = listenTogetherRepository.isBackendConfigured,
+                status = ListenTogetherStatus.OnlineSkipped
+            )
+            return
+        }
+
         val currentIdentity = activeListenTogetherIdentity
         if (currentIdentity != null && currentIdentity.mediaId == item.mediaId) {
             _listenTogetherUiState.value = _listenTogetherUiState.value.copy(

--- a/app/src/main/java/com/asmr/player/ui/player/playerviewmodel.kt
+++ b/app/src/main/java/com/asmr/player/ui/player/playerviewmodel.kt
@@ -1,5 +1,7 @@
 package com.asmr.player.ui.player
 
+import android.content.Context
+
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import android.net.Uri
@@ -12,7 +14,14 @@ import com.asmr.player.domain.model.Album
 import com.asmr.player.domain.model.Track
 import com.asmr.player.data.local.db.dao.TrackDao
 import com.asmr.player.data.settings.SettingsRepository
+import com.asmr.player.listentogether.ListenTogetherIdentityResolver
+import com.asmr.player.listentogether.ListenTogetherRepository
+import com.asmr.player.listentogether.ListenTogetherStatus
+import com.asmr.player.listentogether.ListenTogetherTrackIdentity
+import com.asmr.player.listentogether.ListenTogetherUiState
 import dagger.hilt.android.lifecycle.HiltViewModel
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
@@ -28,6 +37,10 @@ import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
 import javax.inject.Inject
 import androidx.media3.common.MediaItem
 import androidx.media3.common.MediaMetadata
@@ -58,11 +71,12 @@ import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
 
-private const val ONLINE_MANUAL_LYRICS_MESSAGE = "在线音频如需替换歌词，请先下载音频到本地"
+private const val ONLINE_MANUAL_LYRICS_MESSAGE = "\u5728\u7ebf\u97f3\u9891\u5982\u9700\u66ff\u6362\u6b4c\u8bcd\uff0c\u8bf7\u5148\u4e0b\u8f7d\u97f3\u9891\u5230\u672c\u5730"
 
 @HiltViewModel
 @OptIn(FlowPreview::class)
 class PlayerViewModel @Inject constructor(
+    @ApplicationContext private val appContext: Context,
     private val playerConnection: PlayerConnection,
     private val settingsRepository: SettingsRepository,
     private val playlistRepository: PlaylistRepository,
@@ -70,6 +84,8 @@ class PlayerViewModel @Inject constructor(
     private val trackSliceRepository: TrackSliceRepository,
     private val slicePlaybackController: SlicePlaybackController,
     private val manualLyricsSourceRepository: ManualLyricsSourceRepository,
+    private val listenTogetherIdentityResolver: ListenTogetherIdentityResolver,
+    private val listenTogetherRepository: ListenTogetherRepository,
     private val messageManager: MessageManager
 ) : ViewModel() {
     val playback: StateFlow<PlaybackSnapshot> = playerConnection.snapshot
@@ -114,6 +130,21 @@ class PlayerViewModel @Inject constructor(
 
     val customPresets: StateFlow<List<AsmrPreset>> = settingsRepository.customEqualizerPresets
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyList())
+
+    private val _listenTogetherUiState = MutableStateFlow(
+        ListenTogetherUiState(
+            backendConfigured = listenTogetherRepository.isBackendConfigured,
+            status = if (listenTogetherRepository.isBackendConfigured) {
+                ListenTogetherStatus.Preparing
+            } else {
+                ListenTogetherStatus.BackendUnavailable
+            }
+        )
+    )
+    val listenTogetherUiState: StateFlow<ListenTogetherUiState> = _listenTogetherUiState
+
+    private var listenTogetherSyncJob: Job? = null
+    private var activeListenTogetherIdentity: ListenTogetherTrackIdentity? = null
 
     fun setSleepTimerMinutes(minutes: Int) {
         if (minutes <= 0) {
@@ -227,6 +258,12 @@ class PlayerViewModel @Inject constructor(
 
         viewModelScope.launch {
             trackMediaIdFlow.collect { }
+        }
+
+        viewModelScope.launch {
+            playback.collectLatest { snapshot ->
+                handleListenTogetherState(snapshot)
+            }
         }
 
     }
@@ -735,6 +772,17 @@ class PlayerViewModel @Inject constructor(
 
     fun playerOrNull(): Player? = playerConnection.getControllerOrNull()
 
+    override fun onCleared() {
+        listenTogetherSyncJob?.cancel()
+        val identity = activeListenTogetherIdentity
+        if (identity != null) {
+            viewModelScope.launch {
+                runCatching { listenTogetherRepository.leave(identity) }
+            }
+        }
+        super.onCleared()
+    }
+
     private suspend fun resolveDurationMs(item: MediaItem?, fallback: Long): Long {
         val safeFallback = fallback.coerceAtLeast(0L)
         if (item == null) return safeFallback
@@ -759,6 +807,148 @@ class PlayerViewModel @Inject constructor(
                 if (d > 0.0) return@withContext (d * 1000.0).roundToLong()
             }
             safeFallback
+        }
+    }
+
+    private suspend fun handleListenTogetherState(snapshot: PlaybackSnapshot) {
+        val item = snapshot.currentMediaItem
+        if (item == null) {
+            stopListenTogether(clearCount = true)
+            _listenTogetherUiState.value = ListenTogetherUiState(
+                available = false,
+                listenerCount = null,
+                currentIdentity = null,
+                syncing = false,
+                backendConfigured = listenTogetherRepository.isBackendConfigured,
+                status = ListenTogetherStatus.Preparing
+            )
+            return
+        }
+
+        val currentIdentity = activeListenTogetherIdentity
+        if (currentIdentity != null && currentIdentity.mediaId == item.mediaId) {
+            _listenTogetherUiState.value = _listenTogetherUiState.value.copy(
+                syncing = listenTogetherRepository.isBackendConfigured,
+                backendConfigured = listenTogetherRepository.isBackendConfigured,
+                status = when {
+                    !listenTogetherRepository.isBackendConfigured -> ListenTogetherStatus.BackendUnavailable
+                    _listenTogetherUiState.value.status == ListenTogetherStatus.Error -> ListenTogetherStatus.Error
+                    else -> ListenTogetherStatus.Ready
+                }
+            )
+            return
+        }
+
+        stopListenTogether(clearCount = false)
+        _listenTogetherUiState.value = ListenTogetherUiState(
+            available = false,
+            listenerCount = null,
+            currentIdentity = null,
+            syncing = true,
+            backendConfigured = listenTogetherRepository.isBackendConfigured,
+            status = ListenTogetherStatus.Preparing
+        )
+
+        val identity = runCatching {
+            listenTogetherIdentityResolver.resolve(
+                context = appContext,
+                mediaItem = item,
+                fallbackRjCode = item.mediaMetadata.extras?.getString("rj_code")
+            )
+        }.getOrNull()
+
+        if (identity == null) {
+            _listenTogetherUiState.value = ListenTogetherUiState(
+                available = false,
+                listenerCount = null,
+                currentIdentity = null,
+                syncing = false,
+                backendConfigured = listenTogetherRepository.isBackendConfigured,
+                status = ListenTogetherStatus.Unsupported
+            )
+            return
+        }
+
+        activeListenTogetherIdentity = identity
+        _listenTogetherUiState.value = ListenTogetherUiState(
+            available = true,
+            listenerCount = if (listenTogetherRepository.isBackendConfigured) null else 1,
+            currentIdentity = identity,
+            syncing = listenTogetherRepository.isBackendConfigured,
+            backendConfigured = listenTogetherRepository.isBackendConfigured,
+            status = if (listenTogetherRepository.isBackendConfigured) {
+                ListenTogetherStatus.Ready
+            } else {
+                ListenTogetherStatus.BackendUnavailable
+            }
+        )
+        startListenTogetherSync(identity)
+    }
+
+    private fun startListenTogetherSync(identity: ListenTogetherTrackIdentity) {
+        listenTogetherSyncJob?.cancel()
+        listenTogetherSyncJob = viewModelScope.launch {
+            if (!listenTogetherRepository.isBackendConfigured) {
+                _listenTogetherUiState.value = _listenTogetherUiState.value.copy(
+                    listenerCount = 1,
+                    syncing = false,
+                    status = ListenTogetherStatus.BackendUnavailable
+                )
+                return@launch
+            }
+
+            while (currentCoroutineContext().isActive) {
+                val snapshot = playback.value
+                if (snapshot.currentMediaItem?.mediaId != identity.mediaId) {
+                    break
+                }
+                runCatching {
+                    listenTogetherRepository.upsertPresence(
+                        identity = identity,
+                        playbackPositionMs = snapshot.positionMs,
+                        isPlaying = snapshot.isPlaying
+                    )
+                }.onSuccess { response ->
+                    _listenTogetherUiState.value = _listenTogetherUiState.value.copy(
+                        available = true,
+                        listenerCount = response?.listenerCount ?: _listenTogetherUiState.value.listenerCount,
+                        currentIdentity = identity,
+                        syncing = true,
+                        backendConfigured = true,
+                        status = ListenTogetherStatus.Ready
+                    )
+                    delay(response?.heartbeatIntervalMs?.coerceIn(5_000L, 60_000L) ?: 15_000L)
+                }.onFailure {
+                    _listenTogetherUiState.value = _listenTogetherUiState.value.copy(
+                        available = true,
+                        currentIdentity = identity,
+                        syncing = false,
+                        backendConfigured = true,
+                        status = ListenTogetherStatus.Error
+                    )
+                    delay(15_000L)
+                }
+            }
+        }
+    }
+
+    private fun stopListenTogether(clearCount: Boolean) {
+        listenTogetherSyncJob?.cancel()
+        listenTogetherSyncJob = null
+        val identity = activeListenTogetherIdentity
+        activeListenTogetherIdentity = null
+        if (identity != null) {
+            viewModelScope.launch {
+                runCatching { listenTogetherRepository.leave(identity) }
+            }
+        }
+        if (clearCount) {
+            _listenTogetherUiState.value = _listenTogetherUiState.value.copy(
+                listenerCount = null,
+                currentIdentity = null,
+                available = false,
+                syncing = false
+            )
         }
     }
 }

--- a/app/src/main/res/drawable/ic_users_round.xml
+++ b/app/src/main/res/drawable/ic_users_round.xml
@@ -1,0 +1,27 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#00000000"
+        android:pathData="M18,21a8,8 0,0 0,-16 0"
+        android:strokeColor="#FF000000"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round"
+        android:strokeWidth="2" />
+    <path
+        android:fillColor="#00000000"
+        android:pathData="M15,8a5,5 0,1 1,-10 0a5,5 0,1 1,10 0"
+        android:strokeColor="#FF000000"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round"
+        android:strokeWidth="2" />
+    <path
+        android:fillColor="#00000000"
+        android:pathData="M22,20c0,-3.37 -2,-6.5 -4,-8a5,5 0,0 0,-0.45 -8.3"
+        android:strokeColor="#FF000000"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round"
+        android:strokeWidth="2" />
+</vector>

--- a/app/src/test/java/com/asmr/player/listentogether/XxHash64Test.kt
+++ b/app/src/test/java/com/asmr/player/listentogether/XxHash64Test.kt
@@ -1,0 +1,38 @@
+package com.asmr.player.listentogether
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Test
+import java.io.ByteArrayInputStream
+
+class XxHash64Test {
+
+    @Test
+    fun hashHex_isStableForSameInput() {
+        val input = "RJ123456-track-a.flac-1234567".encodeToByteArray()
+
+        val first = XxHash64.hashHex(input)
+        val second = XxHash64.hashHex(input)
+
+        assertEquals(first, second)
+        assertEquals(16, first.length)
+    }
+
+    @Test
+    fun hashHex_changesWhenInputChanges() {
+        val first = XxHash64.hashHex("track-a".encodeToByteArray())
+        val second = XxHash64.hashHex("track-b".encodeToByteArray())
+
+        assertNotEquals(first, second)
+    }
+
+    @Test
+    fun streamHash_matchesByteArrayHash() {
+        val input = ByteArray(8192) { index -> (index * 31 % 251).toByte() }
+
+        val byteArrayHash = XxHash64.hashHex(input)
+        val streamHash = XxHash64.hashStreamHex(ByteArrayInputStream(input))
+
+        assertEquals(byteArrayHash, streamHash)
+    }
+}

--- a/app/src/test/java/com/asmr/player/ui/player/ListenTogetherAudiencePresentationTest.kt
+++ b/app/src/test/java/com/asmr/player/ui/player/ListenTogetherAudiencePresentationTest.kt
@@ -3,6 +3,7 @@ package com.asmr.player.ui.player
 import com.asmr.player.listentogether.ListenTogetherStatus
 import com.asmr.player.listentogether.ListenTogetherUiState
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
 import org.junit.Test
 
 class ListenTogetherAudiencePresentationTest {
@@ -13,10 +14,7 @@ class ListenTogetherAudiencePresentationTest {
             ListenTogetherUiState()
         )
 
-        assertEquals(
-            ListenTogetherAudiencePresentation.Audience(companionCount = 0),
-            presentation
-        )
+        assertNull(presentation)
     }
 
     @Test
@@ -60,10 +58,7 @@ class ListenTogetherAudiencePresentationTest {
             )
         )
 
-        assertEquals(
-            ListenTogetherAudiencePresentation.Audience(companionCount = 0),
-            presentation
-        )
+        assertNull(presentation)
     }
 
     @Test
@@ -92,6 +87,21 @@ class ListenTogetherAudiencePresentationTest {
 
         assertEquals(
             ListenTogetherAudiencePresentation.Audience(companionCount = 0),
+            presentation
+        )
+    }
+
+    @Test
+    fun onlineAudioShowsSkippedMessage() {
+        val presentation = resolveListenTogetherAudiencePresentation(
+            ListenTogetherUiState(
+                available = false,
+                status = ListenTogetherStatus.OnlineSkipped
+            )
+        )
+
+        assertEquals(
+            ListenTogetherAudiencePresentation.Status("在线音频不参与统计"),
             presentation
         )
     }

--- a/app/src/test/java/com/asmr/player/ui/player/ListenTogetherAudiencePresentationTest.kt
+++ b/app/src/test/java/com/asmr/player/ui/player/ListenTogetherAudiencePresentationTest.kt
@@ -1,0 +1,98 @@
+package com.asmr.player.ui.player
+
+import com.asmr.player.listentogether.ListenTogetherStatus
+import com.asmr.player.listentogether.ListenTogetherUiState
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ListenTogetherAudiencePresentationTest {
+
+    @Test
+    fun disabledStateHidesAudienceLine() {
+        val presentation = resolveListenTogetherAudiencePresentation(
+            ListenTogetherUiState()
+        )
+
+        assertEquals(
+            ListenTogetherAudiencePresentation.Audience(companionCount = 0),
+            presentation
+        )
+    }
+
+    @Test
+    fun listenerCountExcludesCurrentUser() {
+        val presentation = resolveListenTogetherAudiencePresentation(
+            ListenTogetherUiState(
+                available = true,
+                listenerCount = 5,
+                status = ListenTogetherStatus.Ready
+            )
+        )
+
+        assertEquals(
+            ListenTogetherAudiencePresentation.Audience(companionCount = 4),
+            presentation
+        )
+    }
+
+    @Test
+    fun singleListenerShowsZeroCompanions() {
+        val presentation = resolveListenTogetherAudiencePresentation(
+            ListenTogetherUiState(
+                available = true,
+                listenerCount = 1,
+                status = ListenTogetherStatus.Ready
+            )
+        )
+
+        assertEquals(
+            ListenTogetherAudiencePresentation.Audience(companionCount = 0),
+            presentation
+        )
+    }
+
+    @Test
+    fun preparingStateFallsBackToSoloListening() {
+        val presentation = resolveListenTogetherAudiencePresentation(
+            ListenTogetherUiState(
+                available = false,
+                status = ListenTogetherStatus.Preparing
+            )
+        )
+
+        assertEquals(
+            ListenTogetherAudiencePresentation.Audience(companionCount = 0),
+            presentation
+        )
+    }
+
+    @Test
+    fun errorStateFallsBackToSoloListening() {
+        val presentation = resolveListenTogetherAudiencePresentation(
+            ListenTogetherUiState(
+                available = true,
+                status = ListenTogetherStatus.Error
+            )
+        )
+
+        assertEquals(
+            ListenTogetherAudiencePresentation.Audience(companionCount = 0),
+            presentation
+        )
+    }
+
+    @Test
+    fun backendUnavailableFallsBackToSoloListening() {
+        val presentation = resolveListenTogetherAudiencePresentation(
+            ListenTogetherUiState(
+                available = true,
+                status = ListenTogetherStatus.BackendUnavailable
+            )
+        )
+
+        assertEquals(
+            ListenTogetherAudiencePresentation.Audience(companionCount = 0),
+            presentation
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- add listen together audience presence to the now playing experience
- switch audience aggregation to RJ work identity where applicable
- add the extra backend domain configuration required by this branch

## Testing
- `./gradlew.bat testDebugUnitTest --tests com.asmr.player.listentogether.XxHash64Test --tests com.asmr.player.ui.player.ListenTogetherAudiencePresentationTest` *(fails before execution because existing `SearchScreenChromeTest` calls are missing the new `onFirstPage` parameter in the test suite)*