### PR TITLE
fix: improve listen-together count stability and hash with file size

### DIFF
--- a/app/src/main/java/com/asmr/player/listentogether/ListenTogetherIdentityResolver.kt
+++ b/app/src/main/java/com/asmr/player/listentogether/ListenTogetherIdentityResolver.kt
@@ -42,9 +42,10 @@ class ListenTogetherIdentityResolver @Inject constructor() {
 
             val fileProbe = probeFile(context, rawSourcePath) ?: return@withContext null
             val fileSize = fileProbe.fileSizeBytes.takeIf { it > 0L } ?: return@withContext null
-            val hashHex = fileProbe.inputStreamFactory?.invoke()?.use { input ->
-                XxHash64.hashStreamHex(input)
-            } ?: return@withContext null
+            val hashHex = XxHash64.hashStreamHexWithSize(
+                inputStreamFactory = fileProbe.inputStreamFactory ?: return@withContext null,
+                fileSizeBytes = fileSize
+            )
 
             val mediaKind = if (extras?.getBoolean("is_video") == true || mediaItem.localConfiguration?.mimeType?.startsWith("video/") == true) {
                 ListenTogetherMediaKind.VIDEO

--- a/app/src/main/java/com/asmr/player/listentogether/XxHash64.kt
+++ b/app/src/main/java/com/asmr/player/listentogether/XxHash64.kt
@@ -70,6 +70,42 @@ internal object XxHash64 {
         return java.lang.Long.toUnsignedString(hashStream(inputStream, seed), 16).padStart(16, '0')
     }
 
+    fun hashStreamHexWithSize(
+        inputStreamFactory: () -> InputStream?,
+        fileSizeBytes: Long,
+        prefixBytes: Int = 10240
+    ): String {
+        val sizeBytes = ByteArray(8)
+        sizeBytes[0] = (fileSizeBytes ushr 0).toByte()
+        sizeBytes[1] = (fileSizeBytes ushr 8).toByte()
+        sizeBytes[2] = (fileSizeBytes ushr 16).toByte()
+        sizeBytes[3] = (fileSizeBytes ushr 24).toByte()
+        sizeBytes[4] = (fileSizeBytes ushr 32).toByte()
+        sizeBytes[5] = (fileSizeBytes ushr 40).toByte()
+        sizeBytes[6] = (fileSizeBytes ushr 48).toByte()
+        sizeBytes[7] = (fileSizeBytes ushr 56).toByte()
+
+        val state = StreamingState(0L)
+        state.update(sizeBytes, 0, 8)
+
+        val contentBytes = fileSizeBytes.coerceAtMost(prefixBytes.toLong()).toInt()
+        val stream = inputStreamFactory()
+        if (stream != null) {
+            stream.use { input ->
+                val buffer = ByteArray(DEFAULT_BUFFER_SIZE)
+                var remaining = contentBytes
+                while (remaining > 0) {
+                    val read = input.read(buffer, 0, remaining.coerceAtMost(buffer.size))
+                    if (read <= 0) break
+                    state.update(buffer, 0, read)
+                    remaining -= read
+                }
+            }
+        }
+
+        return java.lang.Long.toUnsignedString(state.digest(), 16).padStart(16, '0')
+    }
+
     private fun round(acc: Long, input: Long): Long {
         var value = acc + (input * PRIME64_2)
         value = rotateLeft(value, 31)

--- a/app/src/main/java/com/asmr/player/ui/library/AlbumDetailScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/AlbumDetailScreen.kt
@@ -1,4 +1,4 @@
-﻿package com.asmr.player.ui.library
+package com.asmr.player.ui.library
 
 import android.content.Intent
 import android.net.Uri
@@ -1067,33 +1067,39 @@ private fun AlbumHeader(
                                 )
                                 if (listenTogetherRjListenerCount != null && rj.isNotBlank()) {
                                     Spacer(modifier = Modifier.width(8.dp))
-                                    Surface(
-                                        color = Color.White.copy(alpha = 0.16f),
-                                        contentColor = Color.White.copy(alpha = 0.96f),
-                                        shape = RoundedCornerShape(999.dp),
-                                        border = androidx.compose.foundation.BorderStroke(
-                                            width = 0.5.dp,
-                                            color = Color.White.copy(alpha = 0.2f)
-                                        )
+                                    AlbumHeaderInfoReveal(
+                                        revealKey = "$headerAnimationScopeKey:listenTogetherRjCount",
+                                        delayMillis = 60,
+                                        enabled = animateIntro
                                     ) {
-                                        Row(
-                                            modifier = Modifier.padding(horizontal = 7.dp, vertical = 2.dp),
-                                            horizontalArrangement = Arrangement.spacedBy(4.dp),
-                                            verticalAlignment = Alignment.CenterVertically
+                                        Surface(
+                                            color = Color.White.copy(alpha = 0.16f),
+                                            contentColor = Color.White.copy(alpha = 0.96f),
+                                            shape = RoundedCornerShape(999.dp),
+                                            border = androidx.compose.foundation.BorderStroke(
+                                                width = 0.5.dp,
+                                                color = Color.White.copy(alpha = 0.2f)
+                                            )
                                         ) {
-                                            Icon(
-                                                painter = painterResource(id = com.asmr.player.R.drawable.ic_users_round),
-                                                contentDescription = null,
-                                                tint = Color.White.copy(alpha = 0.96f),
-                                                modifier = Modifier.size(12.dp)
-                                            )
-                                            Text(
-                                                text = "${listenTogetherRjListenerCount.coerceAtLeast(0)} 人正在听",
-                                                style = MaterialTheme.typography.labelSmall,
-                                                color = Color.White.copy(alpha = 0.96f),
-                                                maxLines = 1,
-                                                overflow = TextOverflow.Ellipsis,
-                                            )
+                                            Row(
+                                                modifier = Modifier.padding(horizontal = 7.dp, vertical = 2.dp),
+                                                horizontalArrangement = Arrangement.spacedBy(4.dp),
+                                                verticalAlignment = Alignment.CenterVertically
+                                            ) {
+                                                Icon(
+                                                    painter = painterResource(id = com.asmr.player.R.drawable.ic_users_round),
+                                                    contentDescription = null,
+                                                    tint = Color.White.copy(alpha = 0.96f),
+                                                    modifier = Modifier.size(12.dp)
+                                                )
+                                                Text(
+                                                    text = "${listenTogetherRjListenerCount.coerceAtLeast(0)} 人正在听",
+                                                    style = MaterialTheme.typography.labelSmall,
+                                                    color = Color.White.copy(alpha = 0.96f),
+                                                    maxLines = 1,
+                                                    overflow = TextOverflow.Ellipsis,
+                                                )
+                                            }
                                         }
                                     }
                                 }

--- a/app/src/main/java/com/asmr/player/ui/player/NowPlayingScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/player/NowPlayingScreen.kt
@@ -190,50 +190,6 @@ internal fun resolveListenTogetherAudiencePresentation(
         null
 }
 
-private fun <S> AnimatedContentTransitionScope<S>.listenTogetherLineTransform(): ContentTransform {
-    val enter = fadeIn(
-        animationSpec = tween(
-            durationMillis = NowPlayingMotionSpec.PlayerForegroundEnterDurationMs,
-            easing = LinearOutSlowInEasing
-        )
-    ) + slideInVertically(
-        initialOffsetY = {
-            (it * NowPlayingMotionSpec.PlayerForegroundFloatOffsetFraction).roundToInt()
-        },
-        animationSpec = tween(
-            durationMillis = NowPlayingMotionSpec.PlayerForegroundEnterDurationMs,
-            easing = LinearOutSlowInEasing
-        )
-    ) + scaleIn(
-        initialScale = NowPlayingMotionSpec.PlayerForegroundInitialScale,
-        animationSpec = tween(
-            durationMillis = NowPlayingMotionSpec.PlayerForegroundEnterDurationMs,
-            easing = LinearOutSlowInEasing
-        )
-    )
-    val exit = fadeOut(
-        animationSpec = tween(
-            durationMillis = NowPlayingMotionSpec.PlayerForegroundExitDurationMs,
-            easing = FastOutLinearInEasing
-        )
-    ) + slideOutVertically(
-        targetOffsetY = {
-            (it * NowPlayingMotionSpec.PlayerForegroundSinkOffsetFraction).roundToInt()
-        },
-        animationSpec = tween(
-            durationMillis = NowPlayingMotionSpec.PlayerForegroundExitDurationMs,
-            easing = FastOutLinearInEasing
-        )
-    ) + scaleOut(
-        targetScale = NowPlayingMotionSpec.PlayerForegroundTargetScale,
-        animationSpec = tween(
-            durationMillis = NowPlayingMotionSpec.PlayerForegroundExitDurationMs,
-            easing = FastOutLinearInEasing
-        )
-    )
-    return enter togetherWith exit using SizeTransform(clip = false)
-}
-
 private fun <S> AnimatedContentTransitionScope<S>.listenTogetherInlineTransform(): ContentTransform {
     val enter = fadeIn(
         animationSpec = tween(
@@ -286,9 +242,19 @@ private fun ListenTogetherAudienceCountText(
     modifier: Modifier = Modifier
 ) {
     val textStyle = MaterialTheme.typography.labelSmall
+    var lastNonZeroCount by remember { mutableIntStateOf(0) }
+
+    val displayCount = when {
+        companionCount > 0 -> {
+            lastNonZeroCount = companionCount
+            companionCount
+        }
+        lastNonZeroCount > 0 -> lastNonZeroCount
+        else -> 0
+    }
 
     AnimatedContent(
-        targetState = companionCount > 0,
+        targetState = displayCount > 0,
         transitionSpec = { listenTogetherInlineTransform() },
         label = "listenTogetherAudienceMode"
     ) { hasCompanions ->
@@ -299,7 +265,7 @@ private fun ListenTogetherAudienceCountText(
                 verticalAlignment = Alignment.CenterVertically
             ) {
                 AnimatedContent(
-                    targetState = companionCount,
+                    targetState = displayCount,
                     transitionSpec = { listenTogetherCounterTransform() },
                     label = "listenTogetherAudienceCounter"
                 ) { value ->
@@ -335,50 +301,55 @@ private fun ListenTogetherAudienceCountText(
 private fun ListenTogetherAudienceLine(
     state: ListenTogetherUiState,
     modifier: Modifier = Modifier,
-    accentColor: Color = AsmrTheme.colorScheme.primary
+    accentColor: Color = AsmrTheme.colorScheme.primary,
+    pageEntranceSettled: Boolean = true
 ) {
     val colorScheme = AsmrTheme.colorScheme
     val presentation = resolveListenTogetherAudiencePresentation(state)
-    Box(modifier = modifier.height(18.dp)) {
-        AnimatedContent(
-            targetState = presentation,
-            transitionSpec = { listenTogetherLineTransform() },
-            label = "listenTogetherAudiencePresentation"
-        ) { targetPresentation ->
-            if (targetPresentation == null) {
-                Spacer(modifier = Modifier.fillMaxWidth())
-                return@AnimatedContent
-            }
-            Row(
-                modifier = Modifier
-                    .animateContentSize(
-                        animationSpec = tween(
-                            durationMillis = NowPlayingMotionSpec.PlayerForegroundEnterDurationMs,
-                            easing = LinearOutSlowInEasing
-                        )
-                    ),
-                horizontalArrangement = Arrangement.spacedBy(5.dp),
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                Icon(
-                    painter = painterResource(R.drawable.ic_users_round),
-                    contentDescription = null,
-                    modifier = Modifier.size(13.dp),
-                    tint = accentColor.copy(alpha = 0.82f)
+
+    val displayTarget = if (pageEntranceSettled) presentation else null
+
+    Box(
+        modifier = modifier.height(18.dp),
+        contentAlignment = Alignment.Center
+    ) {
+        Row(
+            modifier = Modifier.animateContentSize(
+                animationSpec = tween(
+                    durationMillis = NowPlayingMotionSpec.PlayerForegroundEnterDurationMs,
+                    easing = LinearOutSlowInEasing
                 )
-                when (targetPresentation) {
+            ),
+            horizontalArrangement = Arrangement.spacedBy(5.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Icon(
+                painter = painterResource(R.drawable.ic_users_round),
+                contentDescription = null,
+                modifier = Modifier.size(13.dp),
+                tint = accentColor.copy(alpha = 0.82f)
+            )
+            AnimatedContent(
+                targetState = displayTarget,
+                transitionSpec = {
+                    fadeIn(tween(300, easing = LinearOutSlowInEasing)) togetherWith
+                        fadeOut(tween(200, easing = FastOutLinearInEasing))
+                },
+                label = "listenTogetherAudienceText"
+            ) { target ->
+                when (target) {
                     is ListenTogetherAudiencePresentation.Status -> Text(
-                        text = targetPresentation.text,
+                        text = target.text,
                         style = MaterialTheme.typography.labelSmall,
                         color = colorScheme.textTertiary,
                         maxLines = 1,
                         overflow = TextOverflow.Ellipsis
                     )
-
                     is ListenTogetherAudiencePresentation.Audience -> ListenTogetherAudienceCountText(
-                        companionCount = targetPresentation.companionCount,
+                        companionCount = target.companionCount,
                         color = colorScheme.textTertiary
                     )
+                    null -> {}
                 }
             }
         }
@@ -395,7 +366,8 @@ private fun ArtistWithListenTogetherInfo(
     textAlign: TextAlign = TextAlign.Start,
     badgeAlignment: Alignment = Alignment.TopStart,
     textAlignment: Alignment = Alignment.CenterStart,
-    accentColor: Color = AsmrTheme.colorScheme.primary
+    accentColor: Color = AsmrTheme.colorScheme.primary,
+    pageEntranceSettled: Boolean = true
 ) {
     Box(modifier = modifier.fillMaxWidth()) {
         ListenTogetherAudienceLine(
@@ -403,7 +375,8 @@ private fun ArtistWithListenTogetherInfo(
             modifier = Modifier
                 .align(badgeAlignment)
                 .offset(y = (-18).dp),
-            accentColor = accentColor
+            accentColor = accentColor,
+            pageEntranceSettled = pageEntranceSettled
         )
         Text(
             text = artist,
@@ -610,6 +583,11 @@ internal fun NowPlayingScreen(
     val latestOnBack = rememberUpdatedState(onBack)
     val latestOnRouteExitStarted = rememberUpdatedState(onRouteExitStarted)
     val routeTransition = updateTransition(targetState = routeVisible, label = "nowPlayingRouteVisibility")
+    val pageEntranceSettled by remember {
+        derivedStateOf {
+            routeTransition.currentState && routeTransition.targetState && !routeTransition.isRunning
+        }
+    }
     val requestClose = remember(pendingRouteExit, currentMotionLayout) {
         {
             if (!pendingRouteExit) {
@@ -899,7 +877,8 @@ internal fun NowPlayingScreen(
                             modifier = Modifier.then(infoMotion),
                             style = MaterialTheme.typography.titleMedium,
                             color = colorScheme.textSecondary,
-                            accentColor = accentColor
+                            accentColor = accentColor,
+                            pageEntranceSettled = pageEntranceSettled
                         )
 
                         if (!isVideo) {
@@ -1297,7 +1276,8 @@ internal fun NowPlayingScreen(
                         textAlign = TextAlign.Center,
                         badgeAlignment = Alignment.TopCenter,
                         textAlignment = Alignment.Center,
-                        accentColor = accentColor
+                        accentColor = accentColor,
+                        pageEntranceSettled = pageEntranceSettled
                     )
 
                     // 封面


### PR DESCRIPTION
## 改动总结

- **XxHash64**: 新增 hashStreamHexWithSize 方法，将文件大小纳入哈希计算，提升去重准确度
- **ListenTogetherIdentityResolver**: 使用 hashStreamHexWithSize 进行身份识别
- **NowPlayingScreen**: 新增 pageEntranceSettled 状态延迟听众信息动画直到页面入场完成；新增 lastNonZeroCount 保持上一次非零人数防止计数器闪烁为 0；将 AnimatedContent 整框动画替换为更简洁的淡入淡出过渡
- **AlbumDetailScreen**: 将一起听人数徽章包裹在 AlbumHeaderInfoReveal 中实现入场动画