### PR TITLE
feat: 新增热门收听功能

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -70,7 +70,7 @@ android {
         applicationId = "com.asmr.player"
         minSdk = 24
         targetSdk = 34
-        versionCode = 10100
+        versionCode = 10101
         versionName = "1.1.0"
         buildConfigField("String", "UPDATE_REPO_OWNER", "\"eValDoll\"")
         buildConfigField("String", "UPDATE_REPO_NAME", "\"EaraAsmrPlayer\"")

--- a/app/src/main/java/com/asmr/player/MainActivity.kt
+++ b/app/src/main/java/com/asmr/player/MainActivity.kt
@@ -216,6 +216,9 @@ class MainActivity : ComponentActivity() {
     @Inject
     lateinit var settingsRepository: SettingsRepository
 
+    @Inject
+    lateinit var listeningTracker: com.asmr.player.hotlistening.ListeningTracker
+
     private lateinit var initialThemeBootstrapPreferences: ThemeBootstrapPreferences
 
     private val volumeKeyEventTick = MutableStateFlow(0L)
@@ -511,6 +514,7 @@ class MainActivity : ComponentActivity() {
                         libraryViewModel = libraryViewModel,
                         settingsDataStore = settingsDataStore,
                         messageManager = messageManager,
+                        listeningTracker = listeningTracker,
                         recentAlbumsPanelExpandedInitial = recentAlbumsPanelExpandedInitial,
                         startRouteFromIntent = startRouteFromIntent,
                         onShowQueue = { overlaySheet = OverlaySheet.Queue },

--- a/app/src/main/java/com/asmr/player/data/settings/SettingsDataStore.kt
+++ b/app/src/main/java/com/asmr/player/data/settings/SettingsDataStore.kt
@@ -18,6 +18,7 @@ object SettingsKeys {
 
     val LIBRARY_VIEW_MODE = intPreferencesKey("library_view_mode")
     val SEARCH_VIEW_MODE = intPreferencesKey("search_view_mode")
+    val HOT_LISTENING_VIEW_MODE = intPreferencesKey("hot_listening_view_mode")
 
     val PLAY_MODE = intPreferencesKey("play_mode")
 

--- a/app/src/main/java/com/asmr/player/data/settings/SettingsRepository.kt
+++ b/app/src/main/java/com/asmr/player/data/settings/SettingsRepository.kt
@@ -38,6 +38,10 @@ class SettingsRepository @Inject constructor(
         prefs[SettingsKeys.SEARCH_VIEW_MODE] ?: 1 // Default to Grid (1)
     }
 
+    val hotListeningViewMode: Flow<Int> = context.settingsDataStore.data.map { prefs ->
+        prefs[SettingsKeys.HOT_LISTENING_VIEW_MODE] ?: 1
+    }
+
     val playMode: Flow<Int> = context.settingsDataStore.data.map { prefs ->
         prefs[SettingsKeys.PLAY_MODE] ?: 0
     }
@@ -342,6 +346,12 @@ class SettingsRepository @Inject constructor(
     suspend fun setSearchViewMode(mode: Int) {
         withContext(Dispatchers.IO) {
             context.settingsDataStore.edit { it[SettingsKeys.SEARCH_VIEW_MODE] = mode }
+        }
+    }
+
+    suspend fun setHotListeningViewMode(mode: Int) {
+        withContext(Dispatchers.IO) {
+            context.settingsDataStore.edit { it[SettingsKeys.HOT_LISTENING_VIEW_MODE] = mode }
         }
     }
 

--- a/app/src/main/java/com/asmr/player/hotlistening/HotListeningApi.kt
+++ b/app/src/main/java/com/asmr/player/hotlistening/HotListeningApi.kt
@@ -1,0 +1,180 @@
+package com.asmr.player.hotlistening
+
+import android.os.Build
+import com.asmr.player.BuildConfig
+import com.asmr.player.data.remote.NetworkHeaders
+import com.google.gson.Gson
+import com.google.gson.annotations.SerializedName
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
+import java.io.IOException
+import java.util.UUID
+import kotlin.text.Charsets.UTF_8
+import javax.inject.Inject
+import javax.inject.Singleton
+
+data class HotListeningReportRequest(
+    val rj: String
+)
+
+data class HotListeningReportResponse(
+    val rj: String,
+    val valid: Boolean
+)
+
+data class HotListeningItem(
+    val rj: String = "",
+    val title: String = "",
+    val circle: String = "",
+    val cv: String = "",
+    val tags: String = "",
+    val coverUrl: String = "",
+    val playCount: Int = 0
+) {
+    val cvList: List<String>
+        get() = cv.split(",").map { it.trim() }.filter { it.isNotBlank() }
+
+    val tagList: List<String>
+        get() = tags.split(",").map { it.trim() }.filter { it.isNotBlank() }
+}
+
+@Singleton
+class HotListeningApi @Inject constructor(
+    private val okHttpClient: OkHttpClient,
+    private val gson: Gson
+) {
+    private val clientSessionId = UUID.randomUUID().toString()
+    private val appHeaderValue = "com.asmr.player/${BuildConfig.VERSION_NAME} (${BuildConfig.VERSION_CODE})"
+    private val deviceFingerprint = buildDeviceFingerprint()
+    private val userAgent = buildUserAgent()
+
+    val isBackendConfigured: Boolean
+        get() = baseUrl.isNotBlank()
+
+    suspend fun reportListen(rj: String): HotListeningReportResponse? {
+        if (!isBackendConfigured) return null
+        val normalizedRj = rj.trim().uppercase()
+        if (normalizedRj.isBlank()) return null
+        return postJson(
+            path = "api/hot-listenings/report",
+            body = HotListeningReportRequest(rj = normalizedRj),
+            responseClass = HotListeningReportResponse::class.java
+        )
+    }
+
+    suspend fun getTopListings(period: String): List<HotListeningItem>? {
+        if (!isBackendConfigured) return null
+        val normalizedPeriod = period.trim().lowercase()
+        if (normalizedPeriod !in setOf("day", "week", "month", "year")) return null
+        val listType = com.google.gson.reflect.TypeToken.getParameterized(
+            List::class.java,
+            HotListeningItem::class.java
+        ).type
+        return getJson(
+            path = "api/hot-listenings/top",
+            queryParameters = mapOf("period" to normalizedPeriod),
+            responseType = listType
+        )
+    }
+
+    private suspend fun <T> getJson(
+        path: String,
+        queryParameters: Map<String, String>,
+        responseType: java.lang.reflect.Type
+    ): T? {
+        return withContext(Dispatchers.IO) {
+            val url = resolveUrl(path)
+                .toHttpUrlOrNull()
+                ?.newBuilder()
+                ?.apply {
+                    queryParameters.forEach { (key, value) ->
+                        addQueryParameter(key, value)
+                    }
+                }
+                ?.build()
+                ?: throw IOException("Invalid HotListening URL: $path")
+
+            val request = Request.Builder()
+                .url(url)
+                .header("User-Agent", userAgent)
+                .header("X-Listen-Together-App", appHeaderValue)
+                .header("X-Listen-Together-Client-Session-Id", clientSessionId)
+                .header("X-Listen-Together-Device-Fingerprint", deviceFingerprint)
+                .header(NetworkHeaders.HEADER_SILENT_IO_ERROR, NetworkHeaders.SILENT_IO_ERROR_ON)
+                .get()
+                .build()
+
+            okHttpClient.newCall(request).execute().use { response ->
+                if (!response.isSuccessful) {
+                    throw IOException("HotListening request failed: ${response.code}")
+                }
+                val raw = response.body?.string().orEmpty()
+                if (raw.isBlank()) return@withContext null
+                @Suppress("UNCHECKED_CAST")
+                gson.fromJson(raw, responseType) as T?
+            }
+        }
+    }
+
+    private suspend fun <T : Any> postJson(path: String, body: Any, responseClass: Class<T>): T? {
+        return withContext(Dispatchers.IO) {
+            val request = Request.Builder()
+                .url(resolveUrl(path))
+                .header("User-Agent", userAgent)
+                .header("X-Listen-Together-App", appHeaderValue)
+                .header("X-Listen-Together-Client-Session-Id", clientSessionId)
+                .header("X-Listen-Together-Device-Fingerprint", deviceFingerprint)
+                .header(NetworkHeaders.HEADER_SILENT_IO_ERROR, NetworkHeaders.SILENT_IO_ERROR_ON)
+                .post(gson.toJson(body).toRequestBody(JSON_MEDIA_TYPE))
+                .build()
+            okHttpClient.newCall(request).execute().use { response ->
+                if (!response.isSuccessful) {
+                    throw IOException("HotListening request failed: ${response.code}")
+                }
+                val raw = response.body?.string().orEmpty()
+                if (raw.isBlank()) return@withContext null
+                gson.fromJson(raw, responseClass)
+            }
+        }
+    }
+
+    private fun resolveUrl(path: String): String {
+        val root = baseUrl.trimEnd('/')
+        val normalizedPath = path.trimStart('/')
+        return "$root/$normalizedPath"
+    }
+
+    private companion object {
+        private val JSON_MEDIA_TYPE = "application/json; charset=utf-8".toMediaType()
+        private val baseUrl: String
+            get() = BuildConfig.LISTEN_TOGETHER_BASE_URL
+    }
+
+    private fun buildDeviceFingerprint(): String {
+        val source = listOf(
+            Build.BRAND,
+            Build.MANUFACTURER,
+            Build.MODEL,
+            Build.DEVICE,
+            Build.PRODUCT,
+            Build.VERSION.SDK_INT.toString(),
+            BuildConfig.APPLICATION_ID,
+            BuildConfig.VERSION_NAME,
+        ).joinToString(separator = "|") { it.trim() }
+        return com.asmr.player.listentogether.XxHash64.hashHex(source.toByteArray(UTF_8))
+    }
+
+    private fun buildUserAgent(): String {
+        val deviceModel = listOf(Build.MANUFACTURER, Build.MODEL)
+            .map { it.trim() }
+            .filter { it.isNotBlank() }
+            .joinToString(separator = " ")
+            .ifBlank { "Android" }
+        return "EaraHotListening/${BuildConfig.VERSION_NAME} (Android ${Build.VERSION.SDK_INT}; $deviceModel)"
+    }
+}

--- a/app/src/main/java/com/asmr/player/hotlistening/ListeningTracker.kt
+++ b/app/src/main/java/com/asmr/player/hotlistening/ListeningTracker.kt
@@ -1,0 +1,106 @@
+package com.asmr.player.hotlistening
+
+import androidx.media3.common.MediaItem
+import com.asmr.player.playback.PlaybackSnapshot
+import com.asmr.player.ui.player.isOnlineMedia
+import com.asmr.player.util.DlsiteWorkNo
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class ListeningTracker @Inject constructor(
+    private val hotListeningApi: HotListeningApi
+) {
+    private var observationJob: Job? = null
+
+    fun start(scope: CoroutineScope, playback: StateFlow<PlaybackSnapshot>) {
+        stop()
+        observationJob = scope.launch {
+            var accumulatedMs = 0L
+            var lastPositionMs = 0L
+            var reportedForCurrentMediaId: String? = null
+            var lastMediaId: String? = null
+
+            playback
+                .map { snapshot ->
+                    val item = snapshot.currentMediaItem
+                    val mediaId = item?.mediaId ?: ""
+                    val isOnline = item.isOnlineMedia()
+                    Triple(snapshot.isPlaying, snapshot.positionMs.coerceAtLeast(0L), isOnline) to mediaId
+                }
+                .distinctUntilChanged { old, new ->
+                    old.first.first == new.first.first &&
+                        old.first.second == new.first.second &&
+                        old.second == new.second
+                }
+                .collect { (triple, mediaId) ->
+                    val (isPlaying, positionMs, isOnline) = triple
+
+                    if (mediaId != lastMediaId) {
+                        accumulatedMs = 0L
+                        lastPositionMs = positionMs
+                        lastMediaId = mediaId
+                        reportedForCurrentMediaId = null
+                        return@collect
+                    }
+
+                    if (!isPlaying) {
+                        lastPositionMs = positionMs
+                        return@collect
+                    }
+
+                    val delta = positionMs - lastPositionMs
+                    if (delta > 0L && delta < 3_000L) {
+                        accumulatedMs = accumulatedMs + delta
+                    }
+                    lastPositionMs = positionMs
+
+                    if (accumulatedMs >= REPORT_THRESHOLD_MS && !isOnline && reportedForCurrentMediaId != mediaId) {
+                        reportedForCurrentMediaId = mediaId
+                        val currentItem = playback.value.currentMediaItem
+                        val rjCode = extractRjCode(item = currentItem)
+                        if (rjCode.isNotBlank() && hotListeningApi.isBackendConfigured) {
+                            scope.launch {
+                                runCatching {
+                                    hotListeningApi.reportListen(rjCode)
+                                }
+                            }
+                        }
+                    }
+                }
+        }
+    }
+
+    fun stop() {
+        observationJob?.cancel()
+        observationJob = null
+    }
+
+    private fun extractRjCode(item: MediaItem?): String {
+        if (item == null) return ""
+        val metadata = item.mediaMetadata
+        val extras = metadata.extras
+        val mediaId = item.mediaId.trim()
+        val uri = item.localConfiguration?.uri?.toString().orEmpty().trim()
+
+        return DlsiteWorkNo.extractRjCode(
+            listOfNotNull(
+                extras?.getString("rj_code"),
+                mediaId,
+                uri,
+                metadata.albumTitle?.toString(),
+                metadata.title?.toString()
+            ).joinToString(" ")
+        )
+    }
+
+    private companion object {
+        private const val REPORT_THRESHOLD_MS = 10_000L
+    }
+}

--- a/app/src/main/java/com/asmr/player/main/MainContainer.kt
+++ b/app/src/main/java/com/asmr/player/main/MainContainer.kt
@@ -81,6 +81,9 @@ import com.asmr.player.ui.downloads.DownloadsViewModel
 import com.asmr.player.ui.downloads.DownloadItemState
 import com.asmr.player.ui.dlsite.DlsiteLoginScreen
 import com.asmr.player.ui.dlsite.DlsiteLoginViewModel
+import com.asmr.player.ui.hotlistening.HotListeningScreen
+import com.asmr.player.ui.hotlistening.HotListeningViewModel
+import com.asmr.player.hotlistening.ListeningTracker
 import com.asmr.player.ui.groups.AlbumGroupsViewModel
 import com.asmr.player.ui.playlists.PlaylistDetailScreen
 import com.asmr.player.ui.playlists.PlaylistPickerScreen
@@ -209,6 +212,7 @@ fun MainContainer(
     libraryViewModel: LibraryViewModel,
     settingsDataStore: SettingsDataStore,
     messageManager: MessageManager,
+    listeningTracker: ListeningTracker,
     recentAlbumsPanelExpandedInitial: Boolean,
     startRouteFromIntent: String?,
     onShowQueue: () -> Unit,
@@ -289,6 +293,9 @@ fun MainContainer(
         withFrameNanos { }
         onContentReady()
     }
+    LaunchedEffect(Unit) {
+        listeningTracker.start(this, playerViewModel.playback)
+    }
     LaunchedEffect(navController, startRoute, initialDestination) {
         if (startRoute.isBlank() || startRoute == initialDestination) return@LaunchedEffect
         withFrameNanos { }
@@ -313,6 +320,7 @@ fun MainContainer(
     val downloadsViewModel: DownloadsViewModel = hiltViewModel()
     val settingsViewModel: SettingsViewModel = hiltViewModel()
     val dlsiteLoginViewModel: DlsiteLoginViewModel = hiltViewModel()
+    val hotListeningViewModel: HotListeningViewModel = hiltViewModel()
     val hasCurrentMediaItem by remember(playerViewModel) {
         playerViewModel.playback
             .map { it.currentMediaItem != null }
@@ -341,6 +349,7 @@ fun MainContainer(
     var groupsScrollToTopSignal by remember { mutableLongStateOf(0L) }
     var downloadsScrollToTopSignal by remember { mutableLongStateOf(0L) }
     var settingsScrollToTopSignal by remember { mutableLongStateOf(0L) }
+    var hotListeningScrollToTopSignal by remember { mutableLongStateOf(0L) }
     val appVolumeWarningSessionState = rememberAppVolumeWarningSessionState()
     val audioOutputRouteKind = rememberCurrentAudioOutputRouteKind()
     
@@ -449,10 +458,10 @@ fun MainContainer(
         when (route) {
             Routes.Library -> libraryScrollToTopSignal += 1L
             Routes.Search -> searchScrollToTopSignal += 1L
+            Routes.HotListening -> hotListeningScrollToTopSignal += 1L
             "playlist_system/favorites" -> favoritesScrollToTopSignal += 1L
             "playlists" -> playlistsScrollToTopSignal += 1L
             "groups" -> groupsScrollToTopSignal += 1L
-            "downloads" -> downloadsScrollToTopSignal += 1L
             "settings" -> settingsScrollToTopSignal += 1L
         }
     }
@@ -893,6 +902,7 @@ fun MainContainer(
                                         currentRoute == "library" ||
                                             currentRoute == "library_filter" ||
                                             currentRoute == "search" ||
+                                            currentRoute == Routes.HotListening ||
                                             currentRoute == "playlists" ||
                                             currentRoute == "playlist/{playlistId}/{playlistName}" ||
                                             currentRoute == "playlist_system/{type}" ||
@@ -923,6 +933,7 @@ fun MainContainer(
                                                         currentRoute == "library" -> "本地库"
                                                         currentRoute == "library_filter" -> "筛选"
                                                         currentRoute == "search" -> "在线搜索"
+                                                        currentRoute == Routes.HotListening -> "热门收听"
                                                         currentRoute == "playlists" -> "我的列表"
                                                         currentRoute == "playlist/{playlistId}/{playlistName}" ->
                                                             playlistName.ifBlank { "我的列表" }
@@ -969,6 +980,11 @@ fun MainContainer(
                                         },
                                         actions = {
                                             val entry = navBackStackEntry
+                                            if (currentRoute != null && isPrimaryRoute(currentRoute)) {
+                                                IconButton(onClick = { navController.navigate("downloads") }) {
+                                                    Icon(Icons.Default.Download, contentDescription = "下载管理")
+                                                }
+                                            }
                                             if (currentRoute == "library") {
                                                 val viewMode by libraryViewModel.libraryViewMode.collectAsState()
                                                 if (viewMode != null) {
@@ -1041,6 +1057,14 @@ fun MainContainer(
                                             } else if (currentRoute == "search") {
                                                 val viewMode by searchViewModel.viewMode.collectAsState()
                                                 IconButton(onClick = { searchViewModel.setViewMode(if (viewMode == 1) 0 else 1) }) {
+                                                    Icon(
+                                                        imageVector = if (viewMode == 1) Icons.AutoMirrored.Filled.ViewList else Icons.Default.ViewModule,
+                                                        contentDescription = null
+                                                    )
+                                                }
+                                            } else if (currentRoute == Routes.HotListening) {
+                                                val viewMode by hotListeningViewModel.viewMode.collectAsState()
+                                                IconButton(onClick = { hotListeningViewModel.setViewMode(if (viewMode == 1) 0 else 1) }) {
                                                     Icon(
                                                         imageVector = if (viewMode == 1) Icons.AutoMirrored.Filled.ViewList else Icons.Default.ViewModule,
                                                         contentDescription = null
@@ -1179,6 +1203,17 @@ fun MainContainer(
                                             )
                                         }
 
+                                        Routes.HotListening -> {
+                                            HotListeningScreen(
+                                                windowSizeClass = windowSizeClass,
+                                                scrollToTopSignal = hotListeningScrollToTopSignal,
+                                                onAlbumClick = { album ->
+                                                    navigator.openAlbumDetailByRj(album.rjCode.ifBlank { album.workId })
+                                                },
+                                                viewModel = hotListeningViewModel
+                                            )
+                                        }
+
                                         "playlist_system/favorites" -> {
                                             SystemPlaylistScreen(
                                                 windowSizeClass = windowSizeClass,
@@ -1212,14 +1247,6 @@ fun MainContainer(
                                                     navController.navigateSingleTop("group/${group.id}/$encoded")
                                                 },
                                                 viewModel = albumGroupsViewModel
-                                            )
-                                        }
-
-                                        "downloads" -> {
-                                            DownloadsScreen(
-                                                windowSizeClass = windowSizeClass,
-                                                scrollToTopSignal = downloadsScrollToTopSignal,
-                                                viewModel = downloadsViewModel
                                             )
                                         }
 
@@ -1268,6 +1295,9 @@ fun MainContainer(
                     )
                 }
                                 composable("search") {
+                    Box(modifier = Modifier.fillMaxSize())
+                }
+                composable("hot_listening") {
                     Box(modifier = Modifier.fillMaxSize())
                 }
                 composable(
@@ -1494,7 +1524,11 @@ fun MainContainer(
                     Box(modifier = Modifier.fillMaxSize())
                 }
                 composable("downloads") {
-                    Box(modifier = Modifier.fillMaxSize())
+                    DownloadsScreen(
+                        windowSizeClass = windowSizeClass,
+                        scrollToTopSignal = downloadsScrollToTopSignal,
+                        viewModel = downloadsViewModel
+                    )
                 }
                 composable("dlsite_login") {
                     Box(modifier = Modifier.fillMaxSize())

--- a/app/src/main/java/com/asmr/player/main/MainNavigationSupport.kt
+++ b/app/src/main/java/com/asmr/player/main/MainNavigationSupport.kt
@@ -252,9 +252,9 @@ internal fun resolveCurrentPrimaryDestinationRoute(
     return when {
         currentRoute == Routes.Library -> Routes.Library
         currentRoute == Routes.Search -> Routes.Search
+        currentRoute == Routes.HotListening -> Routes.HotListening
         currentRoute == "playlists" -> "playlists"
         currentRoute == "groups" -> "groups"
-        currentRoute == "downloads" -> "downloads"
         currentRoute == "settings" -> "settings"
         currentRoute == "dlsite_login" -> "dlsite_login"
         currentRoute == "playlist_system/{type}" && playlistSystemType == "favorites" -> "playlist_system/favorites"

--- a/app/src/main/java/com/asmr/player/ui/hotlistening/HotListeningScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/hotlistening/HotListeningScreen.kt
@@ -1,0 +1,199 @@
+package com.asmr.player.ui.hotlistening
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.foundation.lazy.items as lazyItems
+import androidx.compose.foundation.lazy.staggeredgrid.LazyStaggeredGridState
+import androidx.compose.foundation.lazy.staggeredgrid.LazyVerticalStaggeredGrid
+import androidx.compose.foundation.lazy.staggeredgrid.StaggeredGridCells
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Search
+import androidx.compose.material.icons.filled.Whatshot
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.FilterChipDefaults
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.windowsizeclass.WindowSizeClass
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.asmr.player.domain.model.Album
+import com.asmr.player.ui.common.EaraBrandedEmptyState
+import com.asmr.player.ui.common.EaraLogoLoadingIndicator
+import com.asmr.player.ui.common.LocalBottomOverlayPadding
+import com.asmr.player.ui.common.thinScrollbar
+import com.asmr.player.ui.common.withAddedBottomPadding
+import com.asmr.player.ui.library.AlbumGridItem
+import com.asmr.player.ui.library.AlbumGridItemSpacing
+import com.asmr.player.ui.library.AlbumItem
+import com.asmr.player.ui.theme.AsmrTheme
+import kotlinx.coroutines.launch
+import kotlin.math.absoluteValue
+
+private fun stableAlbumKey(album: Album): String {
+    val id = album.rjCode.ifBlank { album.workId }.trim()
+    if (id.isNotEmpty()) return id
+    val seed = "${album.coverUrl}|${album.title}|${album.circle}|${album.cv}"
+    return "h${seed.hashCode().absoluteValue}"
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun HotListeningScreen(
+    windowSizeClass: WindowSizeClass,
+    onAlbumClick: (Album) -> Unit,
+    scrollToTopSignal: Long = 0L,
+    viewModel: HotListeningViewModel = hiltViewModel()
+) {
+    val uiState by viewModel.uiState.collectAsState()
+    val viewMode by viewModel.viewMode.collectAsState()
+    val colorScheme = AsmrTheme.colorScheme
+    val scope = rememberCoroutineScope()
+
+    val listState = rememberSaveable(saver = LazyListState.Saver) { LazyListState(0, 0) }
+    val gridState = rememberSaveable(saver = LazyStaggeredGridState.Saver) { LazyStaggeredGridState() }
+
+    val periods = listOf("day" to "日", "week" to "周", "month" to "月", "year" to "年")
+    val currentPeriod = (uiState as? HotListeningUiState.Success)?.period ?: "day"
+
+    fun scrollToTop() {
+        scope.launch {
+            runCatching { listState.scrollToItem(0) }
+            runCatching { gridState.scrollToItem(0) }
+        }
+    }
+
+    LaunchedEffect(scrollToTopSignal) {
+        if (scrollToTopSignal == 0L) return@LaunchedEffect
+        when (viewMode) {
+            0 -> runCatching { listState.animateScrollToItem(0) }
+            else -> runCatching { gridState.animateScrollToItem(0) }
+        }
+    }
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(horizontal = 8.dp)
+    ) {
+        Row(
+            modifier = Modifier.fillMaxWidth().padding(vertical = 8.dp),
+            horizontalArrangement = Arrangement.spacedBy(12.dp, Alignment.CenterHorizontally),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            periods.forEach { (period, label) ->
+                FilterChip(
+                    selected = currentPeriod == period,
+                    onClick = {
+                        viewModel.selectPeriod(period)
+                        scrollToTop()
+                    },
+                    label = { Text(label) },
+                    colors = FilterChipDefaults.filterChipColors(
+                        selectedContainerColor = colorScheme.primary.copy(alpha = 0.2f),
+                        selectedLabelColor = colorScheme.primary
+                    )
+                )
+            }
+        }
+
+        when (val state = uiState) {
+            is HotListeningUiState.Loading -> Box(
+                modifier = Modifier.fillMaxSize(),
+                contentAlignment = Alignment.Center
+            ) {
+                EaraLogoLoadingIndicator(tint = colorScheme.primary)
+            }
+
+            is HotListeningUiState.Error -> EaraBrandedEmptyState(
+                sectionTitle = "热门收听",
+                headline = "数据加载失败",
+                description = state.message,
+                sectionIcon = Icons.Default.Whatshot,
+                modifier = Modifier.fillMaxSize(),
+                contentPadding = PaddingValues(bottom = LocalBottomOverlayPadding.current + 24.dp),
+                footer = {
+                    TextButton(onClick = { viewModel.refresh() }) {
+                        Text("重试")
+                    }
+                }
+            )
+
+            is HotListeningUiState.Success -> {
+                if (state.albums.isEmpty()) {
+                    EaraBrandedEmptyState(
+                        sectionTitle = "热门收听",
+                        headline = "暂无排行数据",
+                        description = "热门收听排行数据正在统计中，请稍后再来查看。",
+                        sectionIcon = Icons.Default.Whatshot,
+                        modifier = Modifier.fillMaxSize(),
+                        contentPadding = PaddingValues(bottom = LocalBottomOverlayPadding.current + 24.dp)
+                    )
+                } else if (viewMode == 0) {
+                    LazyColumn(
+                        state = listState,
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .thinScrollbar(listState),
+                        contentPadding = PaddingValues(bottom = 8.dp)
+                            .withAddedBottomPadding(LocalBottomOverlayPadding.current)
+                    ) {
+                        lazyItems(
+                            items = state.albums,
+                            key = { album -> stableAlbumKey(album) },
+                            contentType = { "album" }
+                        ) { album ->
+                            AlbumItem(
+                                album = album,
+                                onClick = { onAlbumClick(album) },
+                                emptyCoverUseShimmer = true
+                            )
+                        }
+                    }
+                } else {
+                    LazyVerticalStaggeredGrid(
+                        columns = StaggeredGridCells.Adaptive(150.dp),
+                        state = gridState,
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .thinScrollbar(gridState),
+                        contentPadding = PaddingValues(
+                            bottom = 16.dp
+                        ).withAddedBottomPadding(LocalBottomOverlayPadding.current),
+                        horizontalArrangement = Arrangement.spacedBy(AlbumGridItemSpacing),
+                        verticalItemSpacing = AlbumGridItemSpacing
+                    ) {
+                        items(
+                            state.albums.size,
+                            key = { index -> stableAlbumKey(state.albums[index]) },
+                            contentType = { "albumGrid" }
+                        ) { index ->
+                            val album = state.albums[index]
+                            AlbumGridItem(
+                                album = album,
+                                onClick = { onAlbumClick(album) },
+                                emptyCoverUseShimmer = true
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/asmr/player/ui/hotlistening/HotListeningViewModel.kt
+++ b/app/src/main/java/com/asmr/player/ui/hotlistening/HotListeningViewModel.kt
@@ -1,0 +1,102 @@
+package com.asmr.player.ui.hotlistening
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.asmr.player.data.settings.SettingsRepository
+import com.asmr.player.domain.model.Album
+import com.asmr.player.hotlistening.HotListeningApi
+import com.asmr.player.hotlistening.HotListeningItem
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class HotListeningViewModel @Inject constructor(
+    private val hotListeningApi: HotListeningApi,
+    private val settingsRepository: SettingsRepository
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow<HotListeningUiState>(HotListeningUiState.Loading)
+    val uiState: StateFlow<HotListeningUiState> = _uiState.asStateFlow()
+
+    val viewMode: StateFlow<Int> = settingsRepository.hotListeningViewMode
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), 1)
+
+    private var currentPeriod: String = "day"
+
+    init {
+        loadTopListings(currentPeriod)
+    }
+
+    fun selectPeriod(period: String) {
+        if (period != currentPeriod) {
+            currentPeriod = period
+            loadTopListings(period)
+        }
+    }
+
+    fun setViewMode(mode: Int) {
+        viewModelScope.launch {
+            settingsRepository.setHotListeningViewMode(mode.coerceIn(0, 1))
+        }
+    }
+
+    fun refresh() {
+        loadTopListings(currentPeriod)
+    }
+
+    private fun loadTopListings(period: String) {
+        if (!hotListeningApi.isBackendConfigured) {
+            _uiState.update { HotListeningUiState.Error("后端未配置") }
+            return
+        }
+        _uiState.update { HotListeningUiState.Loading }
+        viewModelScope.launch {
+            runCatching {
+                val items = hotListeningApi.getTopListings(period)
+                if (items == null) {
+                    _uiState.update { HotListeningUiState.Error("请求失败") }
+                    return@launch
+                }
+                val albums = items.map { it.toAlbum() }
+                _uiState.update {
+                    HotListeningUiState.Success(
+                        albums = albums,
+                        period = period
+                    )
+                }
+            }.onFailure { error ->
+                _uiState.update {
+                    HotListeningUiState.Error(error.message ?: "加载失败")
+                }
+            }
+        }
+    }
+
+    private fun HotListeningItem.toAlbum(): Album {
+        return Album(
+            title = this.title,
+            path = "",
+            circle = this.circle,
+            cv = this.cv,
+            tags = this.tagList,
+            coverUrl = this.coverUrl,
+            rjCode = this.rj
+        )
+    }
+}
+
+sealed class HotListeningUiState {
+    data object Loading : HotListeningUiState()
+    data class Success(
+        val albums: List<Album>,
+        val period: String
+    ) : HotListeningUiState()
+    data class Error(val message: String) : HotListeningUiState()
+}

--- a/app/src/main/java/com/asmr/player/ui/nav/AppNavigator.kt
+++ b/app/src/main/java/com/asmr/player/ui/nav/AppNavigator.kt
@@ -6,6 +6,7 @@ import java.net.URLEncoder
 object Routes {
     const val Library = "library"
     const val Search = "search"
+    const val HotListening = "hot_listening"
     const val NowPlaying = "now_playing"
 
     const val AlbumDetailByIdPattern = "album_detail/{albumId}?rjCode={rjCode}&initialTab={initialTab}"

--- a/app/src/main/java/com/asmr/player/ui/nav/BottomChrome.kt
+++ b/app/src/main/java/com/asmr/player/ui/nav/BottomChrome.kt
@@ -40,6 +40,7 @@ import androidx.compose.material.icons.filled.Person
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material.icons.filled.SwapHoriz
+import androidx.compose.material.icons.filled.Whatshot
 import androidx.compose.material3.Icon
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -256,10 +257,10 @@ private fun bottomChromeMetrics(largeLayout: Boolean): BottomChromeMetrics =
 fun bottomChromeNavItems(): List<BottomChromeNavItem> = listOf(
     BottomChromeNavItem(Icons.Default.Home, "本地库", Routes.Library),
     BottomChromeNavItem(Icons.Default.Search, "在线搜索", Routes.Search),
+    BottomChromeNavItem(Icons.Default.Whatshot, "热门收听", Routes.HotListening),
     BottomChromeNavItem(Icons.Default.Favorite, "我的收藏", "playlist_system/favorites"),
     BottomChromeNavItem(Icons.AutoMirrored.Filled.QueueMusic, "我的列表", "playlists"),
     BottomChromeNavItem(Icons.Default.Folder, "我的分组", "groups"),
-    BottomChromeNavItem(Icons.Default.Download, "下载管理", "downloads"),
     BottomChromeNavItem(Icons.Default.Settings, "设置", "settings"),
     BottomChromeNavItem(Icons.Default.Person, "DLsite 登录", "dlsite_login")
 )
@@ -269,10 +270,10 @@ fun isPrimaryRoute(route: String?): Boolean {
     return route in setOf(
         Routes.Library,
         Routes.Search,
+        Routes.HotListening,
         "playlist_system/favorites",
         "playlists",
         "groups",
-        "downloads",
         "settings",
         "dlsite_login"
     )
@@ -286,9 +287,9 @@ fun resolvePrimaryRoute(
     return when {
         currentRoute == Routes.Library -> Routes.Library
         currentRoute == Routes.Search -> Routes.Search
+        currentRoute == Routes.HotListening -> Routes.HotListening
         currentRoute == "playlists" -> "playlists"
         currentRoute == "groups" -> "groups"
-        currentRoute == "downloads" -> "downloads"
         currentRoute == "settings" -> "settings"
         currentRoute == "dlsite_login" -> "dlsite_login"
         currentRoute == "playlist_system/{type}" && playlistSystemType == "favorites" -> "playlist_system/favorites"


### PR DESCRIPTION
## 变更内容

### 新增
- **HotListeningApi**  网络层，POST /api/hot-listenings/report 上报播放 + GET /api/hot-listenings/top 获取排行
- **ListeningTracker**  播放行为追踪，本地音频播放 >=10s 后自动上报 RJ 号
- **HotListeningScreen + HotListeningViewModel**  热门收听页面，支持日/周/月/年维度切换、列表/网格模式
- **视图模式持久化**  SettingsDataStore 存储 hot_listening_view_mode

### 变更
- **底部导航栏重构**：移除下载管理，新增热门收听（Whatshot 图标），顺序：本地库 | 在线搜索 | 热门收听 | 我的收藏 | 我的列表 | 我的分组 | 设置 | DLsite 登录
- **下载管理**：从 HorizontalPager 主路由摘除，改为 Header 右上角二级子页面入口

### 修复
- 修复热门收听页面完全空白（resolveCurrentPrimaryDestinationRoute 遗漏 HotListening 分支）
- 修复封面不加载（后端返回 camelCase JSON + 裸数组）
- 修复加载指示器残留（移除有冲突的 PullToRefreshContainer）
- 统一各页面 Header 下载按钮间距
- 时段选择器居中 + 按钮间距优化