### PR TITLE
fix: 热门收听时间段标签更新为'过去一天/过去一周/过去一月'

### DIFF
--- a/app/src/main/java/com/asmr/player/main/MainContainer.kt
+++ b/app/src/main/java/com/asmr/player/main/MainContainer.kt
@@ -981,8 +981,26 @@ fun MainContainer(
                                         actions = {
                                             val entry = navBackStackEntry
                                             if (currentRoute != null && isPrimaryRoute(currentRoute)) {
-                                                IconButton(onClick = { navController.navigate("downloads") }) {
-                                                    Icon(Icons.Default.Download, contentDescription = "下载管理")
+                                                val downloadTasks by downloadsViewModel.tasks.collectAsState()
+                                                val activeDownloadCount = remember(downloadTasks) {
+                                                    downloadTasks.sumOf { task ->
+                                                        task.items.count {
+                                                            it.state == DownloadItemState.RUNNING || it.state == DownloadItemState.ENQUEUED
+                                                        }
+                                                    }
+                                                }
+                                                Box {
+                                                    IconButton(onClick = { navController.navigate("downloads") }) {
+                                                        Icon(Icons.Default.Download, contentDescription = "下载管理")
+                                                    }
+                                                    if (activeDownloadCount > 0) {
+                                                        Badge(
+                                                            modifier = Modifier
+                                                                .align(Alignment.TopEnd)
+                                                        ) {
+                                                            Text(activeDownloadCount.toString())
+                                                        }
+                                                    }
                                                 }
                                             }
                                             if (currentRoute == "library") {

--- a/app/src/main/java/com/asmr/player/ui/hotlistening/HotListeningScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/hotlistening/HotListeningScreen.kt
@@ -71,7 +71,7 @@ fun HotListeningScreen(
     val listState = rememberSaveable(saver = LazyListState.Saver) { LazyListState(0, 0) }
     val gridState = rememberSaveable(saver = LazyStaggeredGridState.Saver) { LazyStaggeredGridState() }
 
-    val periods = listOf("day" to "日", "week" to "周", "month" to "月", "year" to "年")
+    val periods = listOf("day" to "过去一天", "week" to "过去一周", "month" to "过去一月")
     val currentPeriod = (uiState as? HotListeningUiState.Success)?.period ?: "day"
 
     fun scrollToTop() {

--- a/app/src/main/java/com/asmr/player/ui/hotlistening/HotListeningScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/hotlistening/HotListeningScreen.kt
@@ -23,6 +23,7 @@ import androidx.compose.material3.FilterChipDefaults
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.windowsizeclass.WindowSizeClass
+import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -65,6 +66,7 @@ fun HotListeningScreen(
     val viewMode by viewModel.viewMode.collectAsState()
     val colorScheme = AsmrTheme.colorScheme
     val scope = rememberCoroutineScope()
+    val isCompactWidth = windowSizeClass.widthSizeClass == WindowWidthSizeClass.Compact
 
     val listState = rememberSaveable(saver = LazyListState.Saver) { LazyListState(0, 0) }
     val gridState = rememberSaveable(saver = LazyStaggeredGridState.Saver) { LazyStaggeredGridState() }
@@ -88,12 +90,10 @@ fun HotListeningScreen(
     }
 
     Column(
-        modifier = Modifier
-            .fillMaxSize()
-            .padding(horizontal = 8.dp)
+        modifier = Modifier.fillMaxSize()
     ) {
         Row(
-            modifier = Modifier.fillMaxWidth().padding(vertical = 8.dp),
+            modifier = Modifier.fillMaxWidth().padding(horizontal = 8.dp, vertical = 8.dp),
             horizontalArrangement = Arrangement.spacedBy(12.dp, Alignment.CenterHorizontally),
             verticalAlignment = Alignment.CenterVertically
         ) {
@@ -167,13 +167,16 @@ fun HotListeningScreen(
                         }
                     }
                 } else {
+                    val adaptiveCellSize = if (isCompactWidth) 150.dp else 200.dp
                     LazyVerticalStaggeredGrid(
-                        columns = StaggeredGridCells.Adaptive(150.dp),
+                        columns = StaggeredGridCells.Adaptive(adaptiveCellSize),
                         state = gridState,
                         modifier = Modifier
                             .fillMaxSize()
                             .thinScrollbar(gridState),
                         contentPadding = PaddingValues(
+                            start = 8.dp,
+                            end = 8.dp,
                             bottom = 16.dp
                         ).withAddedBottomPadding(LocalBottomOverlayPadding.current),
                         horizontalArrangement = Arrangement.spacedBy(AlbumGridItemSpacing),

--- a/app/src/main/java/com/asmr/player/ui/library/LibraryScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/LibraryScreen.kt
@@ -690,7 +690,7 @@ fun LibraryScreen(
                                     }
                                 } else if (isGrid) {
                                     LazyVerticalStaggeredGrid(
-                                        columns = StaggeredGridCells.Adaptive(150.dp),
+                                        columns = StaggeredGridCells.Adaptive(if (isCompact) 150.dp else 200.dp),
                                         state = gridState,
                                         modifier = Modifier
                                             .fillMaxSize()

--- a/app/src/main/java/com/asmr/player/ui/search/SearchScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/search/SearchScreen.kt
@@ -476,7 +476,7 @@ fun SearchScreen(
                                     }
                                 } else {
                                     LazyVerticalStaggeredGrid(
-                                        columns = StaggeredGridCells.Adaptive(150.dp),
+                                        columns = StaggeredGridCells.Adaptive(if (isCompact) 150.dp else 200.dp),
                                         state = gridState,
                                         modifier = Modifier
                                             .fillMaxSize()


### PR DESCRIPTION
将热门收听页面的时间段筛选标签从'日/周/月/年'更新为更清晰的'过去一天/过去一周/过去一月'，并移除'年'选项。