### PR TITLE
feat: 迁移全部 Material Icons 至 Rounded 圆润风格

### DIFF
--- a/app/src/main/java/com/asmr/player/MainActivity.kt
+++ b/app/src/main/java/com/asmr/player/MainActivity.kt
@@ -1,4 +1,4 @@
-package com.asmr.player
+﻿package com.asmr.player
 
 import android.os.Bundle
 import android.view.KeyEvent
@@ -16,10 +16,10 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.*
-import androidx.compose.material.icons.filled.AccessTime
-import androidx.compose.material.icons.filled.Audiotrack
-import androidx.compose.material.icons.filled.CloudDownload
+import androidx.compose.material.icons.rounded.*
+import androidx.compose.material.icons.rounded.AccessTime
+import androidx.compose.material.icons.rounded.Audiotrack
+import androidx.compose.material.icons.rounded.CloudDownload
 import android.app.Activity
 import android.content.Context
 import android.content.ContextWrapper
@@ -109,7 +109,7 @@ import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
 import java.net.URLDecoder
 import java.net.URLEncoder
-import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.automirrored.rounded.ArrowBack
 
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
@@ -143,7 +143,7 @@ import androidx.compose.ui.layout.onGloballyPositioned
 
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
-import androidx.compose.material.icons.automirrored.filled.QueueMusic
+import androidx.compose.material.icons.automirrored.rounded.QueueMusic
 import com.asmr.player.ui.player.QueueSheetContent
 import com.asmr.player.ui.player.SleepTimerSheetContent
 import com.asmr.player.ui.player.MiniPlayerDisplayMode

--- a/app/src/main/java/com/asmr/player/main/MainChromeUi.kt
+++ b/app/src/main/java/com/asmr/player/main/MainChromeUi.kt
@@ -1,4 +1,4 @@
-package com.asmr.player
+﻿package com.asmr.player
 
 import android.os.Bundle
 import android.view.KeyEvent
@@ -16,10 +16,10 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.*
-import androidx.compose.material.icons.filled.AccessTime
-import androidx.compose.material.icons.filled.Audiotrack
-import androidx.compose.material.icons.filled.CloudDownload
+import androidx.compose.material.icons.rounded.*
+import androidx.compose.material.icons.rounded.AccessTime
+import androidx.compose.material.icons.rounded.Audiotrack
+import androidx.compose.material.icons.rounded.CloudDownload
 import android.app.Activity
 import android.content.Context
 import android.content.ContextWrapper
@@ -108,7 +108,7 @@ import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
 import java.net.URLDecoder
 import java.net.URLEncoder
-import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.automirrored.rounded.ArrowBack
 
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
@@ -140,7 +140,7 @@ import androidx.compose.ui.layout.onGloballyPositioned
 
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
-import androidx.compose.material.icons.automirrored.filled.QueueMusic
+import androidx.compose.material.icons.automirrored.rounded.QueueMusic
 import com.asmr.player.ui.player.QueueSheetContent
 import com.asmr.player.ui.player.SleepTimerSheetContent
 import com.asmr.player.ui.player.MiniPlayerDisplayMode
@@ -386,7 +386,7 @@ internal fun DrawerSiteStatusFooter(
                             maxLines = 1
                         )
                         Icon(
-                            imageVector = Icons.Default.ArrowDropDown,
+                            imageVector = Icons.Rounded.ArrowDropDown,
                             contentDescription = null,
                             modifier = Modifier.size(18.dp),
                             tint = colorScheme.textSecondary
@@ -408,7 +408,7 @@ internal fun DrawerSiteStatusFooter(
                                 leadingIcon = {
                                     if (selected) {
                                         Icon(
-                                            imageVector = Icons.Default.Check,
+                                            imageVector = Icons.Rounded.Check,
                                             contentDescription = null,
                                             modifier = Modifier.size(18.dp),
                                             tint = colorScheme.primary
@@ -443,9 +443,9 @@ private fun DrawerSiteRow(
         SiteStatusType.Unknown -> colorScheme.onSurface.copy(alpha = 0.35f)
     }
     val statusIcon = when (status.type) {
-        SiteStatusType.Ok -> Icons.Default.Check
-        SiteStatusType.Fail -> Icons.Default.Close
-        SiteStatusType.Testing -> Icons.Default.Refresh
+        SiteStatusType.Ok -> Icons.Rounded.Check
+        SiteStatusType.Fail -> Icons.Rounded.Close
+        SiteStatusType.Testing -> Icons.Rounded.Refresh
         SiteStatusType.Unknown -> null
     }
     
@@ -584,17 +584,17 @@ internal fun DailyStatisticsFooter(
                 horizontalArrangement = Arrangement.SpaceAround
             ) {
                 StatItem(
-                    icon = Icons.Default.AccessTime,
+                    icon = Icons.Rounded.AccessTime,
                     label = "时长",
                     value = formatStatsDuration(stats?.listeningDurationMs ?: 0L)
                 )
                 StatItem(
-                    icon = Icons.Default.Audiotrack,
+                    icon = Icons.Rounded.Audiotrack,
                     label = "音轨",
                     value = "${stats?.trackCount ?: 0}"
                 )
                 StatItem(
-                    icon = Icons.Default.CloudDownload,
+                    icon = Icons.Rounded.CloudDownload,
                     label = "流量",
                     value = formatStatsTraffic(stats?.networkTrafficBytes ?: 0L)
                 )

--- a/app/src/main/java/com/asmr/player/main/MainContainer.kt
+++ b/app/src/main/java/com/asmr/player/main/MainContainer.kt
@@ -1,4 +1,4 @@
-package com.asmr.player
+﻿package com.asmr.player
 
 import android.os.Bundle
 import android.view.KeyEvent
@@ -16,11 +16,11 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.ViewList
-import androidx.compose.material.icons.filled.*
-import androidx.compose.material.icons.filled.AccessTime
-import androidx.compose.material.icons.filled.Audiotrack
-import androidx.compose.material.icons.filled.CloudDownload
+import androidx.compose.material.icons.automirrored.rounded.ViewList
+import androidx.compose.material.icons.rounded.*
+import androidx.compose.material.icons.rounded.AccessTime
+import androidx.compose.material.icons.rounded.Audiotrack
+import androidx.compose.material.icons.rounded.CloudDownload
 import android.app.Activity
 import android.content.Context
 import android.content.ContextWrapper
@@ -113,7 +113,7 @@ import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
 import java.net.URLDecoder
 import java.net.URLEncoder
-import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.automirrored.rounded.ArrowBack
 
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
@@ -145,7 +145,7 @@ import androidx.compose.ui.layout.onGloballyPositioned
 
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
-import androidx.compose.material.icons.automirrored.filled.QueueMusic
+import androidx.compose.material.icons.automirrored.rounded.QueueMusic
 import com.asmr.player.ui.player.QueueSheetContent
 import com.asmr.player.ui.player.SleepTimerSheetContent
 import com.asmr.player.ui.player.MiniPlayerDisplayMode
@@ -754,14 +754,14 @@ fun MainContainer(
                     modifier = Modifier.fillMaxSize()
                 ) {
                     val navItems = listOf(
-                        Triple(Icons.Default.Home, "本地库", "library"),
-                        Triple(Icons.Default.Search, "在线搜索", "search"),
-                        Triple(Icons.Default.Favorite, "我的收藏", "playlist_system/favorites"),
-                        Triple(Icons.AutoMirrored.Filled.QueueMusic, "我的列表", "playlists"),
-                        Triple(Icons.Default.Folder, "我的分组", "groups"),
-                        Triple(Icons.Default.Download, "下载管理", "downloads"),
-                        Triple(Icons.Default.Settings, "设置", "settings"),
-                        Triple(Icons.Default.Person, "DLsite 登录", "dlsite_login")
+                        Triple(Icons.Rounded.Home, "本地库", "library"),
+                        Triple(Icons.Rounded.Search, "在线搜索", "search"),
+                        Triple(Icons.Rounded.Favorite, "我的收藏", "playlist_system/favorites"),
+                        Triple(Icons.AutoMirrored.Rounded.QueueMusic, "我的列表", "playlists"),
+                        Triple(Icons.Rounded.Folder, "我的分组", "groups"),
+                        Triple(Icons.Rounded.Download, "下载管理", "downloads"),
+                        Triple(Icons.Rounded.Settings, "设置", "settings"),
+                        Triple(Icons.Rounded.Person, "DLsite 登录", "dlsite_login")
                     )
 
                     Column(modifier = Modifier.fillMaxSize()) {
@@ -969,7 +969,7 @@ fun MainContainer(
                                         navigationIcon = {
                                             if (showBackButton && hasPreviousBackStackEntry) {
                                                 IconButton(onClick = { navController.popBackStack() }) {
-                                                    Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = null)
+                                                    Icon(Icons.AutoMirrored.Rounded.ArrowBack, contentDescription = null)
                                                 }
                                             } else if (showPrimaryBrand) {
                                                 PrimaryTopBarBrand(
@@ -991,7 +991,7 @@ fun MainContainer(
                                                 }
                                                 Box {
                                                     IconButton(onClick = { navController.navigate("downloads") }) {
-                                                        Icon(Icons.Default.Download, contentDescription = "下载管理")
+                                                        Icon(Icons.Rounded.Download, contentDescription = "下载管理")
                                                     }
                                                     if (activeDownloadCount > 0) {
                                                         Badge(
@@ -1010,9 +1010,9 @@ fun MainContainer(
                                                     Box {
                                                         val normalized = (viewMode ?: 0).coerceIn(0, 2)
                                                         val icon = when (normalized) {
-                                                            1 -> Icons.Default.GridView
-                                                            2 -> Icons.Default.Audiotrack
-                                                            else -> Icons.AutoMirrored.Filled.ViewList
+                                                            1 -> Icons.Rounded.GridView
+                                                            2 -> Icons.Rounded.Audiotrack
+                                                            else -> Icons.AutoMirrored.Rounded.ViewList
                                                         }
                                                         IconButton(onClick = { viewMenuExpanded = true }) {
                                                             Icon(imageVector = icon, contentDescription = "切换视图")
@@ -1031,7 +1031,7 @@ fun MainContainer(
                                                             DropdownMenuItem(
                                                                 text = { Text("专辑列表") },
                                                                 leadingIcon = {
-                                                                    Icon(Icons.AutoMirrored.Filled.ViewList, contentDescription = null)
+                                                                    Icon(Icons.AutoMirrored.Rounded.ViewList, contentDescription = null)
                                                                 },
                                                                 onClick = {
                                                                     viewMenuExpanded = false
@@ -1046,7 +1046,7 @@ fun MainContainer(
                                                             DropdownMenuItem(
                                                                 text = { Text("专辑卡片") },
                                                                 leadingIcon = {
-                                                                    Icon(Icons.Default.GridView, contentDescription = null)
+                                                                    Icon(Icons.Rounded.GridView, contentDescription = null)
                                                                 },
                                                                 onClick = {
                                                                     viewMenuExpanded = false
@@ -1061,7 +1061,7 @@ fun MainContainer(
                                                             DropdownMenuItem(
                                                                 text = { Text("音轨列表") },
                                                                 leadingIcon = {
-                                                                    Icon(Icons.Default.Audiotrack, contentDescription = null)
+                                                                    Icon(Icons.Rounded.Audiotrack, contentDescription = null)
                                                                 },
                                                                 onClick = {
                                                                     viewMenuExpanded = false
@@ -1076,7 +1076,7 @@ fun MainContainer(
                                                 val viewMode by searchViewModel.viewMode.collectAsState()
                                                 IconButton(onClick = { searchViewModel.setViewMode(if (viewMode == 1) 0 else 1) }) {
                                                     Icon(
-                                                        imageVector = if (viewMode == 1) Icons.AutoMirrored.Filled.ViewList else Icons.Default.ViewModule,
+                                                        imageVector = if (viewMode == 1) Icons.AutoMirrored.Rounded.ViewList else Icons.Rounded.ViewModule,
                                                         contentDescription = null
                                                     )
                                                 }
@@ -1084,7 +1084,7 @@ fun MainContainer(
                                                 val viewMode by hotListeningViewModel.viewMode.collectAsState()
                                                 IconButton(onClick = { hotListeningViewModel.setViewMode(if (viewMode == 1) 0 else 1) }) {
                                                     Icon(
-                                                        imageVector = if (viewMode == 1) Icons.AutoMirrored.Filled.ViewList else Icons.Default.ViewModule,
+                                                        imageVector = if (viewMode == 1) Icons.AutoMirrored.Rounded.ViewList else Icons.Rounded.ViewModule,
                                                         contentDescription = null
                                                     )
                                                 }
@@ -1136,7 +1136,7 @@ fun MainContainer(
                                                             showManualRjDialog = true
                                                         }
                                                     ) {
-                                                        Icon(Icons.Default.Edit, contentDescription = "手动输入RJ号")
+                                                        Icon(Icons.Rounded.Edit, contentDescription = "手动输入RJ号")
                                                     }
                                                 }
                                             }

--- a/app/src/main/java/com/asmr/player/main/MainNavigationSupport.kt
+++ b/app/src/main/java/com/asmr/player/main/MainNavigationSupport.kt
@@ -1,4 +1,4 @@
-package com.asmr.player
+﻿package com.asmr.player
 
 import android.os.Bundle
 import android.view.KeyEvent
@@ -16,10 +16,10 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.*
-import androidx.compose.material.icons.filled.AccessTime
-import androidx.compose.material.icons.filled.Audiotrack
-import androidx.compose.material.icons.filled.CloudDownload
+import androidx.compose.material.icons.rounded.*
+import androidx.compose.material.icons.rounded.AccessTime
+import androidx.compose.material.icons.rounded.Audiotrack
+import androidx.compose.material.icons.rounded.CloudDownload
 import android.app.Activity
 import android.content.Context
 import android.content.ContextWrapper
@@ -108,7 +108,7 @@ import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
 import java.net.URLDecoder
 import java.net.URLEncoder
-import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.automirrored.rounded.ArrowBack
 
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
@@ -140,7 +140,7 @@ import androidx.compose.ui.layout.onGloballyPositioned
 
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
-import androidx.compose.material.icons.automirrored.filled.QueueMusic
+import androidx.compose.material.icons.automirrored.rounded.QueueMusic
 import com.asmr.player.ui.player.QueueSheetContent
 import com.asmr.player.ui.player.SleepTimerSheetContent
 import com.asmr.player.ui.player.MiniPlayerDisplayMode

--- a/app/src/main/java/com/asmr/player/ui/common/AppSnackbar.kt
+++ b/app/src/main/java/com/asmr/player/ui/common/AppSnackbar.kt
@@ -1,4 +1,4 @@
-package com.asmr.player.ui.common
+﻿package com.asmr.player.ui.common
 
 import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.LinearEasing
@@ -13,10 +13,10 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.CheckCircle
-import androidx.compose.material.icons.filled.Error
-import androidx.compose.material.icons.filled.Info
-import androidx.compose.material.icons.filled.Warning
+import androidx.compose.material.icons.rounded.CheckCircle
+import androidx.compose.material.icons.rounded.Error
+import androidx.compose.material.icons.rounded.Info
+import androidx.compose.material.icons.rounded.Warning
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.SnackbarHost
@@ -51,10 +51,10 @@ fun AppSnackbar(
 ) {
     val appColors = AsmrTheme.colorScheme
     val (icon, accentColor) = when (type) {
-        MessageType.Success -> Icons.Default.CheckCircle to Color(0xFF3E9B63)
-        MessageType.Error -> Icons.Default.Error to Color(0xFFD95C4F)
-        MessageType.Warning -> Icons.Default.Warning to Color(0xFFD6942A)
-        MessageType.Info -> Icons.Default.Info to Color(0xFF2F7FB6)
+        MessageType.Success -> Icons.Rounded.CheckCircle to Color(0xFF3E9B63)
+        MessageType.Error -> Icons.Rounded.Error to Color(0xFFD95C4F)
+        MessageType.Warning -> Icons.Rounded.Warning to Color(0xFFD6942A)
+        MessageType.Info -> Icons.Rounded.Info to Color(0xFF2F7FB6)
     }
     val shape = RoundedCornerShape(16.dp)
     val containerColor = MaterialTheme.colorScheme.surface

--- a/app/src/main/java/com/asmr/player/ui/common/AppSupportStatusSection.kt
+++ b/app/src/main/java/com/asmr/player/ui/common/AppSupportStatusSection.kt
@@ -1,4 +1,4 @@
-package com.asmr.player.ui.common
+﻿package com.asmr.player.ui.common
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.BorderStroke
@@ -19,13 +19,13 @@ import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.AccessTime
-import androidx.compose.material.icons.filled.ArrowDropDown
-import androidx.compose.material.icons.filled.Audiotrack
-import androidx.compose.material.icons.filled.Check
-import androidx.compose.material.icons.filled.CloudDownload
-import androidx.compose.material.icons.filled.Close
-import androidx.compose.material.icons.filled.Refresh
+import androidx.compose.material.icons.rounded.AccessTime
+import androidx.compose.material.icons.rounded.ArrowDropDown
+import androidx.compose.material.icons.rounded.Audiotrack
+import androidx.compose.material.icons.rounded.Check
+import androidx.compose.material.icons.rounded.CloudDownload
+import androidx.compose.material.icons.rounded.Close
+import androidx.compose.material.icons.rounded.Refresh
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
@@ -116,17 +116,17 @@ fun DailyStatisticsSection(
                 horizontalArrangement = Arrangement.SpaceAround
             ) {
                 StatItem(
-                    icon = Icons.Default.AccessTime,
+                    icon = Icons.Rounded.AccessTime,
                     label = "时长",
                     value = formatStatsDuration(stats?.listeningDurationMs ?: 0L)
                 )
                 StatItem(
-                    icon = Icons.Default.Audiotrack,
+                    icon = Icons.Rounded.Audiotrack,
                     label = "音轨",
                     value = "${stats?.trackCount ?: 0}"
                 )
                 StatItem(
-                    icon = Icons.Default.CloudDownload,
+                    icon = Icons.Rounded.CloudDownload,
                     label = "流量",
                     value = formatStatsTraffic(stats?.networkTrafficBytes ?: 0L)
                 )
@@ -177,7 +177,7 @@ fun SiteStatusSection(
                             maxLines = 1
                         )
                         Icon(
-                            imageVector = Icons.Default.ArrowDropDown,
+                            imageVector = Icons.Rounded.ArrowDropDown,
                             contentDescription = null,
                             modifier = Modifier.size(18.dp),
                             tint = colorScheme.textSecondary
@@ -199,7 +199,7 @@ fun SiteStatusSection(
                                 leadingIcon = {
                                     if (selected) {
                                         Icon(
-                                            imageVector = Icons.Default.Check,
+                                            imageVector = Icons.Rounded.Check,
                                             contentDescription = null,
                                             modifier = Modifier.size(18.dp),
                                             tint = colorScheme.primary
@@ -231,9 +231,9 @@ private fun SiteStatusRow(
         SiteStatusType.Unknown -> colorScheme.onSurface.copy(alpha = 0.35f)
     }
     val statusIcon = when (status.type) {
-        SiteStatusType.Ok -> Icons.Default.Check
-        SiteStatusType.Fail -> Icons.Default.Close
-        SiteStatusType.Testing -> Icons.Default.Refresh
+        SiteStatusType.Ok -> Icons.Rounded.Check
+        SiteStatusType.Fail -> Icons.Rounded.Close
+        SiteStatusType.Testing -> Icons.Rounded.Refresh
         SiteStatusType.Unknown -> null
     }
 

--- a/app/src/main/java/com/asmr/player/ui/common/AudioItemRow.kt
+++ b/app/src/main/java/com/asmr/player/ui/common/AudioItemRow.kt
@@ -1,4 +1,4 @@
-package com.asmr.player.ui.common
+﻿package com.asmr.player.ui.common
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -12,7 +12,7 @@ import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.MoreVert
+import androidx.compose.material.icons.rounded.MoreVert
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.HorizontalDivider
@@ -183,7 +183,7 @@ internal fun AudioItemRow(
                             }
                         ) {
                             Icon(
-                                imageVector = Icons.Default.MoreVert,
+                                imageVector = Icons.Rounded.MoreVert,
                                 contentDescription = null,
                                 tint = colorScheme.onSurfaceVariant,
                                 modifier = Modifier.size(AudioItemMenuIconSize)

--- a/app/src/main/java/com/asmr/player/ui/common/AudioOutputRouteUi.kt
+++ b/app/src/main/java/com/asmr/player/ui/common/AudioOutputRouteUi.kt
@@ -1,4 +1,4 @@
-package com.asmr.player.ui.common
+﻿package com.asmr.player.ui.common
 
 import android.content.Context
 import android.media.AudioDeviceCallback
@@ -7,8 +7,8 @@ import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.VolumeUp
-import androidx.compose.material.icons.filled.Headset
+import androidx.compose.material.icons.automirrored.rounded.VolumeUp
+import androidx.compose.material.icons.rounded.Headset
 import androidx.compose.material3.Icon
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
@@ -58,9 +58,9 @@ internal fun rememberCurrentAudioOutputRouteKind(): AudioOutputRouteKind {
 
 internal fun volumeRouteIcon(routeKind: AudioOutputRouteKind): ImageVector {
     return if (routeKind == AudioOutputRouteKind.Headphones) {
-        Icons.Default.Headset
+        Icons.Rounded.Headset
     } else {
-        Icons.AutoMirrored.Filled.VolumeUp
+        Icons.AutoMirrored.Rounded.VolumeUp
     }
 }
 

--- a/app/src/main/java/com/asmr/player/ui/common/EqualizerPanel.kt
+++ b/app/src/main/java/com/asmr/player/ui/common/EqualizerPanel.kt
@@ -1,4 +1,4 @@
-package com.asmr.player.ui.common
+﻿package com.asmr.player.ui.common
 
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
@@ -13,12 +13,12 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.KeyboardArrowLeft
-import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
-import androidx.compose.material.icons.filled.Delete
-import androidx.compose.material.icons.filled.Info
-import androidx.compose.material.icons.filled.KeyboardArrowDown
-import androidx.compose.material.icons.filled.Save
+import androidx.compose.material.icons.automirrored.rounded.KeyboardArrowLeft
+import androidx.compose.material.icons.automirrored.rounded.KeyboardArrowRight
+import androidx.compose.material.icons.rounded.Delete
+import androidx.compose.material.icons.rounded.Info
+import androidx.compose.material.icons.rounded.KeyboardArrowDown
+import androidx.compose.material.icons.rounded.Save
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
@@ -142,7 +142,7 @@ fun EqualizerPanel(
                     modifier = Modifier.size(22.dp)
                 ) {
                     Icon(
-                        imageVector = Icons.Default.Info,
+                        imageVector = Icons.Rounded.Info,
                         contentDescription = null,
                         tint = MaterialTheme.colorScheme.onSurfaceVariant,
                         modifier = Modifier.size(14.dp)
@@ -383,7 +383,7 @@ fun EqualizerPanel(
                     TextButton(onClick = onReset, enabled = resetEnabled) { Text("重置") }
                     IconButton(onClick = { onExpandedChange(!expanded) }, modifier = Modifier.size(28.dp)) {
                         Icon(
-                            imageVector = if (expanded) Icons.Default.KeyboardArrowDown else Icons.AutoMirrored.Filled.KeyboardArrowRight,
+                            imageVector = if (expanded) Icons.Rounded.KeyboardArrowDown else Icons.AutoMirrored.Rounded.KeyboardArrowRight,
                             contentDescription = null
                         )
                     }
@@ -1024,7 +1024,7 @@ fun EqualizerPanel(
                                         if (preset.isCustom) {
                                             Spacer(modifier = Modifier.weight(1f))
                                             IconButton(onClick = { onDeletePreset(preset) }) {
-                                                Icon(Icons.Default.Delete, contentDescription = null, modifier = Modifier.size(18.dp))
+                                                Icon(Icons.Rounded.Delete, contentDescription = null, modifier = Modifier.size(18.dp))
                                             }
                                         }
                                     }
@@ -1123,7 +1123,7 @@ fun EqualizerPanel(
                         contentAlignment = Alignment.Center
                     ) {
                         Icon(
-                            imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight,
+                            imageVector = Icons.AutoMirrored.Rounded.KeyboardArrowRight,
                             contentDescription = null,
                             tint = materialColorScheme.onSurfaceVariant.copy(alpha = 0.65f)
                         )
@@ -1146,7 +1146,7 @@ fun EqualizerPanel(
                         contentAlignment = Alignment.Center
                     ) {
                         Icon(
-                            imageVector = Icons.AutoMirrored.Filled.KeyboardArrowLeft,
+                            imageVector = Icons.AutoMirrored.Rounded.KeyboardArrowLeft,
                             contentDescription = null,
                             tint = materialColorScheme.onSurfaceVariant.copy(alpha = 0.65f)
                         )
@@ -1160,7 +1160,7 @@ fun EqualizerPanel(
                 shape = RoundedCornerShape(12.dp),
                 enabled = eqEnabled
             ) {
-                Icon(Icons.Default.Save, contentDescription = null)
+                Icon(Icons.Rounded.Save, contentDescription = null)
                 Spacer(modifier = Modifier.width(8.dp))
                 Text("保存为自定义预设")
             }

--- a/app/src/main/java/com/asmr/player/ui/common/ImagePreviewDialog.kt
+++ b/app/src/main/java/com/asmr/player/ui/common/ImagePreviewDialog.kt
@@ -1,4 +1,4 @@
-package com.asmr.player.ui.common
+﻿package com.asmr.player.ui.common
 
 import android.content.Intent
 import android.net.Uri
@@ -25,11 +25,11 @@ import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.OpenInNew
-import androidx.compose.material.icons.filled.ChevronLeft
-import androidx.compose.material.icons.filled.ChevronRight
-import androidx.compose.material.icons.filled.Close
-import androidx.compose.material.icons.filled.ImageNotSupported
+import androidx.compose.material.icons.automirrored.rounded.OpenInNew
+import androidx.compose.material.icons.rounded.ChevronLeft
+import androidx.compose.material.icons.rounded.ChevronRight
+import androidx.compose.material.icons.rounded.Close
+import androidx.compose.material.icons.rounded.ImageNotSupported
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.HorizontalDivider
@@ -247,13 +247,13 @@ internal fun ImagePreviewDialog(
                             onClick = ::openCurrentWithOtherApp,
                             modifier = Modifier.testTag(IMAGE_PREVIEW_OPEN_EXTERNAL_TAG)
                         ) {
-                            Icon(Icons.AutoMirrored.Filled.OpenInNew, contentDescription = "打开")
+                            Icon(Icons.AutoMirrored.Rounded.OpenInNew, contentDescription = "打开")
                         }
                         IconButton(
                             onClick = onDismiss,
                             modifier = Modifier.testTag(IMAGE_PREVIEW_CLOSE_TAG)
                         ) {
-                            Icon(Icons.Default.Close, contentDescription = "关闭")
+                            Icon(Icons.Rounded.Close, contentDescription = "关闭")
                         }
                     }
 
@@ -303,7 +303,7 @@ internal fun ImagePreviewDialog(
                                         }
                                     }
                                 },
-                                icon = Icons.Default.ChevronLeft,
+                                icon = Icons.Rounded.ChevronLeft,
                                 enabled = pagerState.currentPage > 0
                             )
                             PreviewNavButton(
@@ -319,7 +319,7 @@ internal fun ImagePreviewDialog(
                                         }
                                     }
                                 },
-                                icon = Icons.Default.ChevronRight,
+                                icon = Icons.Rounded.ChevronRight,
                                 enabled = pagerState.currentPage < items.lastIndex
                             )
                         }
@@ -505,7 +505,7 @@ private fun PreviewImageFallback(
             verticalArrangement = Arrangement.Center
         ) {
             Icon(
-                imageVector = Icons.Default.ImageNotSupported,
+                imageVector = Icons.Rounded.ImageNotSupported,
                 contentDescription = null,
                 tint = colorScheme.textTertiary,
                 modifier = Modifier.size(40.dp)

--- a/app/src/main/java/com/asmr/player/ui/common/ManualReorderDialog.kt
+++ b/app/src/main/java/com/asmr/player/ui/common/ManualReorderDialog.kt
@@ -1,4 +1,4 @@
-package com.asmr.player.ui.common
+﻿package com.asmr.player.ui.common
 
 import androidx.compose.animation.animateColorAsState
 import androidx.compose.animation.core.animateDpAsState
@@ -23,7 +23,7 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.automirrored.rounded.ArrowBack
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -138,7 +138,7 @@ internal fun ManualReorderDialog(
                 ) {
                     IconButton(onClick = onDismiss) {
                         Icon(
-                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            imageVector = Icons.AutoMirrored.Rounded.ArrowBack,
                             contentDescription = null
                         )
                     }

--- a/app/src/main/java/com/asmr/player/ui/dlsite/DlsiteLoginScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/dlsite/DlsiteLoginScreen.kt
@@ -1,11 +1,11 @@
-package com.asmr.player.ui.dlsite
+﻿package com.asmr.player.ui.dlsite
 
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Visibility
-import androidx.compose.material.icons.filled.VisibilityOff
+import androidx.compose.material.icons.rounded.Visibility
+import androidx.compose.material.icons.rounded.VisibilityOff
 import androidx.compose.material3.*
 import androidx.compose.material3.windowsizeclass.WindowSizeClass
 import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
@@ -177,7 +177,7 @@ private fun CredentialBlock(
                     trailingIcon = {
                         IconButton(onClick = onToggleRevealed, enabled = value.isNotBlank()) {
                             Icon(
-                                imageVector = if (revealed) Icons.Filled.VisibilityOff else Icons.Filled.Visibility,
+                                imageVector = if (revealed) Icons.Rounded.VisibilityOff else Icons.Rounded.Visibility,
                                 contentDescription = if (revealed) "隐藏" else "显示"
                             )
                         }

--- a/app/src/main/java/com/asmr/player/ui/downloads/DownloadsScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/downloads/DownloadsScreen.kt
@@ -1,4 +1,4 @@
-package com.asmr.player.ui.downloads
+﻿package com.asmr.player.ui.downloads
 
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.tween
@@ -25,19 +25,19 @@ import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.InsertDriveFile
-import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
-import androidx.compose.material.icons.filled.Close
-import androidx.compose.material.icons.filled.Delete
-import androidx.compose.material.icons.filled.Folder
-import androidx.compose.material.icons.filled.Image
-import androidx.compose.material.icons.filled.KeyboardArrowDown
-import androidx.compose.material.icons.filled.Movie
-import androidx.compose.material.icons.filled.MusicNote
-import androidx.compose.material.icons.filled.Pause
-import androidx.compose.material.icons.filled.PlayArrow
-import androidx.compose.material.icons.filled.Refresh
-import androidx.compose.material.icons.filled.Subtitles
+import androidx.compose.material.icons.automirrored.rounded.InsertDriveFile
+import androidx.compose.material.icons.automirrored.rounded.KeyboardArrowRight
+import androidx.compose.material.icons.rounded.Close
+import androidx.compose.material.icons.rounded.Delete
+import androidx.compose.material.icons.rounded.Folder
+import androidx.compose.material.icons.rounded.Image
+import androidx.compose.material.icons.rounded.KeyboardArrowDown
+import androidx.compose.material.icons.rounded.Movie
+import androidx.compose.material.icons.rounded.MusicNote
+import androidx.compose.material.icons.rounded.Pause
+import androidx.compose.material.icons.rounded.PlayArrow
+import androidx.compose.material.icons.rounded.Refresh
+import androidx.compose.material.icons.rounded.Subtitles
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
@@ -327,7 +327,7 @@ private fun DownloadTaskCard(
                         horizontalArrangement = Arrangement.spacedBy(8.dp)
                     ) {
                         Icon(
-                            imageVector = if (expanded) Icons.Default.KeyboardArrowDown else Icons.AutoMirrored.Filled.KeyboardArrowRight,
+                            imageVector = if (expanded) Icons.Rounded.KeyboardArrowDown else Icons.AutoMirrored.Rounded.KeyboardArrowRight,
                             contentDescription = null,
                             tint = colors.primary,
                             modifier = Modifier.size(22.dp)
@@ -358,7 +358,7 @@ private fun DownloadTaskCard(
                                     modifier = Modifier.size(36.dp)
                                 ) {
                                     Icon(
-                                        Icons.Default.Refresh,
+                                        Icons.Rounded.Refresh,
                                         contentDescription = null,
                                         tint = colors.primary,
                                         modifier = Modifier.size(18.dp)
@@ -371,7 +371,7 @@ private fun DownloadTaskCard(
                                     modifier = Modifier.size(36.dp)
                                 ) {
                                     Icon(
-                                        Icons.Default.Pause,
+                                        Icons.Rounded.Pause,
                                         contentDescription = null,
                                         tint = colors.primary,
                                         modifier = Modifier.size(18.dp)
@@ -383,7 +383,7 @@ private fun DownloadTaskCard(
                                     modifier = Modifier.size(36.dp)
                                 ) {
                                     Icon(
-                                        Icons.Default.PlayArrow,
+                                        Icons.Rounded.PlayArrow,
                                         contentDescription = null,
                                         tint = colors.primary,
                                         modifier = Modifier.size(18.dp)
@@ -425,7 +425,7 @@ private fun DownloadTaskCard(
                             modifier = Modifier.size(36.dp)
                         ) {
                             Icon(
-                                Icons.Default.Close,
+                                Icons.Rounded.Close,
                                 contentDescription = null,
                                 tint = colors.textSecondary,
                                 modifier = Modifier.size(18.dp)
@@ -574,7 +574,7 @@ private fun DownloadFolderRow(
         verticalAlignment = Alignment.CenterVertically
     ) {
         Icon(
-            Icons.Default.Folder,
+            Icons.Rounded.Folder,
             contentDescription = null,
             tint = colors.primary.copy(alpha = 0.8f),
             modifier = Modifier.size(20.dp)
@@ -589,7 +589,7 @@ private fun DownloadFolderRow(
             modifier = Modifier.weight(1f)
         )
         Icon(
-            imageVector = if (expanded) Icons.Default.KeyboardArrowDown else Icons.AutoMirrored.Filled.KeyboardArrowRight,
+            imageVector = if (expanded) Icons.Rounded.KeyboardArrowDown else Icons.AutoMirrored.Rounded.KeyboardArrowRight,
             contentDescription = null,
             tint = colors.textSecondary,
             modifier = Modifier.size(20.dp)
@@ -731,7 +731,7 @@ private fun DownloadFileRow(
                             modifier = Modifier.size(32.dp)
                         ) {
                             Icon(
-                                Icons.Default.Pause,
+                                Icons.Rounded.Pause,
                                 contentDescription = null,
                                 tint = colors.primary,
                                 modifier = Modifier.size(16.dp)
@@ -745,7 +745,7 @@ private fun DownloadFileRow(
                             modifier = Modifier.size(32.dp)
                         ) {
                             Icon(
-                                Icons.Default.PlayArrow,
+                                Icons.Rounded.PlayArrow,
                                 contentDescription = null,
                                 tint = colors.primary,
                                 modifier = Modifier.size(16.dp)
@@ -759,7 +759,7 @@ private fun DownloadFileRow(
                             modifier = Modifier.size(32.dp)
                         ) {
                             Icon(
-                                Icons.Default.Refresh,
+                                Icons.Rounded.Refresh,
                                 contentDescription = null,
                                 tint = colors.danger,
                                 modifier = Modifier.size(16.dp)
@@ -775,7 +775,7 @@ private fun DownloadFileRow(
                     modifier = Modifier.size(32.dp)
                 ) {
                     Icon(
-                        Icons.Default.Delete,
+                        Icons.Rounded.Delete,
                         contentDescription = null,
                         tint = colors.textSecondary,
                         modifier = Modifier.size(16.dp)
@@ -932,11 +932,11 @@ private fun downloadItemStateLabel(state: DownloadItemState): String {
 private fun pickFileIcon(fileName: String): androidx.compose.ui.graphics.vector.ImageVector {
     val ext = fileName.substringAfterLast('.', "").lowercase()
     return when {
-        ext in setOf("mp3", "flac", "wav", "m4a", "ogg", "aac", "opus") -> Icons.Default.MusicNote
-        ext in setOf("lrc", "srt", "vtt") -> Icons.Default.Subtitles
-        ext in setOf("jpg", "jpeg", "png", "webp") -> Icons.Default.Image
-        ext in setOf("mp4", "m4v", "webm", "mkv", "mov") -> Icons.Default.Movie
-        else -> Icons.AutoMirrored.Filled.InsertDriveFile
+        ext in setOf("mp3", "flac", "wav", "m4a", "ogg", "aac", "opus") -> Icons.Rounded.MusicNote
+        ext in setOf("lrc", "srt", "vtt") -> Icons.Rounded.Subtitles
+        ext in setOf("jpg", "jpeg", "png", "webp") -> Icons.Rounded.Image
+        ext in setOf("mp4", "m4v", "webm", "mkv", "mov") -> Icons.Rounded.Movie
+        else -> Icons.AutoMirrored.Rounded.InsertDriveFile
     }
 }
 

--- a/app/src/main/java/com/asmr/player/ui/groups/AlbumGroupDetailScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/groups/AlbumGroupDetailScreen.kt
@@ -1,4 +1,4 @@
-package com.asmr.player.ui.groups
+﻿package com.asmr.player.ui.groups
 
 import android.net.Uri
 import androidx.compose.foundation.ExperimentalFoundationApi
@@ -27,9 +27,9 @@ import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Delete
-import androidx.compose.material.icons.filled.Folder
-import androidx.compose.material.icons.filled.MoreVert
+import androidx.compose.material.icons.rounded.Delete
+import androidx.compose.material.icons.rounded.Folder
+import androidx.compose.material.icons.rounded.MoreVert
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
@@ -230,7 +230,7 @@ internal fun AlbumGroupDetailContent(
                     sectionTitle = title.ifBlank { "我的分组" },
                     headline = "这个分组还没有内容",
                     description = "把专辑加入分组后，它们会按专辑整理展示在这里。",
-                    sectionIcon = Icons.Default.Folder,
+                    sectionIcon = Icons.Rounded.Folder,
                     modifier = Modifier.fillMaxSize(),
                     contentPadding = PaddingValues(bottom = LocalBottomOverlayPadding.current + 88.dp)
                 )
@@ -413,7 +413,7 @@ private fun AlbumSectionHeader(
         }
         IconButton(onClick = onRemoveAlbum, modifier = Modifier.size(GroupActionButtonSize)) {
             Icon(
-                imageVector = Icons.Default.Delete,
+                imageVector = Icons.Rounded.Delete,
                 contentDescription = null,
                 tint = colorScheme.danger.copy(alpha = 0.7f),
                 modifier = Modifier.size(GroupActionIconSize)

--- a/app/src/main/java/com/asmr/player/ui/groups/AlbumGroupsScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/groups/AlbumGroupsScreen.kt
@@ -1,4 +1,4 @@
-package com.asmr.player.ui.groups
+﻿package com.asmr.player.ui.groups
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -22,10 +22,10 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Add
-import androidx.compose.material.icons.filled.Delete
-import androidx.compose.material.icons.filled.Edit
-import androidx.compose.material.icons.filled.Folder
+import androidx.compose.material.icons.rounded.Add
+import androidx.compose.material.icons.rounded.Delete
+import androidx.compose.material.icons.rounded.Edit
+import androidx.compose.material.icons.rounded.Folder
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.FloatingActionButton
@@ -109,7 +109,7 @@ fun AlbumGroupsScreen(
                         sectionTitle = "我的分组",
                         headline = "还没有创建分组",
                         description = "按主题或场景建立分组，让收藏的专辑更容易整理和回看。",
-                        sectionIcon = Icons.Default.Folder,
+                        sectionIcon = Icons.Rounded.Folder,
                         modifier = Modifier.fillMaxSize(),
                         contentPadding = PaddingValues(bottom = LocalBottomOverlayPadding.current + 88.dp)
                     )
@@ -147,7 +147,7 @@ fun AlbumGroupsScreen(
                         .align(Alignment.BottomEnd)
                         .padding(end = AlbumGroupsPageHorizontalPadding, bottom = LocalBottomOverlayPadding.current + 16.dp)
                 ) {
-                    Icon(Icons.Default.Add, contentDescription = null)
+                    Icon(Icons.Rounded.Add, contentDescription = null)
                 }
             }
         }
@@ -211,7 +211,7 @@ private fun AlbumGroupRow(
             }
             IconButton(onClick = { showRename = true }, modifier = Modifier.size(AlbumGroupRowActionButtonSize)) {
                 Icon(
-                    Icons.Default.Edit,
+                    Icons.Rounded.Edit,
                     contentDescription = null,
                     tint = colorScheme.textSecondary,
                     modifier = Modifier.size(AlbumGroupRowActionIconSize)
@@ -219,7 +219,7 @@ private fun AlbumGroupRow(
             }
             IconButton(onClick = { showDeleteConfirm = true }, modifier = Modifier.size(AlbumGroupRowActionButtonSize)) {
                 Icon(
-                    Icons.Default.Delete,
+                    Icons.Rounded.Delete,
                     contentDescription = null,
                     tint = colorScheme.danger.copy(alpha = 0.7f),
                     modifier = Modifier.size(AlbumGroupRowActionIconSize)

--- a/app/src/main/java/com/asmr/player/ui/hotlistening/HotListeningScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/hotlistening/HotListeningScreen.kt
@@ -1,4 +1,4 @@
-package com.asmr.player.ui.hotlistening
+﻿package com.asmr.player.ui.hotlistening
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -15,8 +15,8 @@ import androidx.compose.foundation.lazy.staggeredgrid.LazyStaggeredGridState
 import androidx.compose.foundation.lazy.staggeredgrid.LazyVerticalStaggeredGrid
 import androidx.compose.foundation.lazy.staggeredgrid.StaggeredGridCells
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Search
-import androidx.compose.material.icons.filled.Whatshot
+import androidx.compose.material.icons.rounded.Search
+import androidx.compose.material.icons.rounded.Whatshot
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FilterChip
 import androidx.compose.material3.FilterChipDefaults
@@ -125,7 +125,7 @@ fun HotListeningScreen(
                 sectionTitle = "热门收听",
                 headline = "数据加载失败",
                 description = state.message,
-                sectionIcon = Icons.Default.Whatshot,
+                sectionIcon = Icons.Rounded.Whatshot,
                 modifier = Modifier.fillMaxSize(),
                 contentPadding = PaddingValues(bottom = LocalBottomOverlayPadding.current + 24.dp),
                 footer = {
@@ -141,7 +141,7 @@ fun HotListeningScreen(
                         sectionTitle = "热门收听",
                         headline = "暂无排行数据",
                         description = "热门收听排行数据正在统计中，请稍后再来查看。",
-                        sectionIcon = Icons.Default.Whatshot,
+                        sectionIcon = Icons.Rounded.Whatshot,
                         modifier = Modifier.fillMaxSize(),
                         contentPadding = PaddingValues(bottom = LocalBottomOverlayPadding.current + 24.dp)
                     )

--- a/app/src/main/java/com/asmr/player/ui/library/AlbumDetailScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/AlbumDetailScreen.kt
@@ -1,4 +1,4 @@
-package com.asmr.player.ui.library
+﻿package com.asmr.player.ui.library
 
 import android.content.Intent
 import android.net.Uri
@@ -37,9 +37,9 @@ import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.ArrowBack
-import androidx.compose.material.icons.automirrored.filled.OpenInNew
-import androidx.compose.material.icons.filled.*
+import androidx.compose.material.icons.automirrored.rounded.ArrowBack
+import androidx.compose.material.icons.automirrored.rounded.OpenInNew
+import androidx.compose.material.icons.rounded.*
 import androidx.compose.material3.*
 import androidx.compose.material3.windowsizeclass.WindowSizeClass
 import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
@@ -104,10 +104,10 @@ import android.webkit.WebChromeClient
 import android.webkit.WebSettings
 import android.webkit.WebView
 import android.webkit.WebViewClient
-import androidx.compose.material.icons.automirrored.filled.Label
-import androidx.compose.material.icons.automirrored.filled.PlaylistAdd
-import androidx.compose.material.icons.automirrored.filled.PlaylistPlay
-import androidx.compose.material.icons.automirrored.filled.QueueMusic
+import androidx.compose.material.icons.automirrored.rounded.Label
+import androidx.compose.material.icons.automirrored.rounded.PlaylistAdd
+import androidx.compose.material.icons.automirrored.rounded.PlaylistPlay
+import androidx.compose.material.icons.automirrored.rounded.QueueMusic
 import java.io.File
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
@@ -1007,7 +1007,7 @@ private fun AlbumHeader(
                             .size(36.dp)
                     ) {
                         Icon(
-                            imageVector = Icons.Default.Photo,
+                            imageVector = Icons.Rounded.Photo,
                             contentDescription = "閫夋嫨灏侀潰",
                             tint = Color.White,
                             modifier = Modifier.size(18.dp)
@@ -1217,7 +1217,7 @@ private fun AlbumHeader(
                                     contentPadding = PaddingValues(horizontal = primaryButtonPadding, vertical = 0.dp),
                                     colors = ButtonDefaults.buttonColors(containerColor = colorScheme.primary)
                                 ) {
-                                    Icon(Icons.Default.Download, contentDescription = null, modifier = Modifier.size(primaryIconSize))
+                                    Icon(Icons.Rounded.Download, contentDescription = null, modifier = Modifier.size(primaryIconSize))
                                     Spacer(modifier = Modifier.width(primaryIconGap))
                                     Text("下载", style = MaterialTheme.typography.labelMedium, maxLines = 1)
                                 }
@@ -1236,7 +1236,7 @@ private fun AlbumHeader(
                                             contentColor = colorScheme.primary
                                         )
                                     ) {
-                                        Icon(Icons.Default.LibraryMusic, contentDescription = null, modifier = Modifier.size(primaryIconSize))
+                                        Icon(Icons.Rounded.LibraryMusic, contentDescription = null, modifier = Modifier.size(primaryIconSize))
                                         Spacer(modifier = Modifier.width(primaryIconGap))
                                         Text("无损下载", style = MaterialTheme.typography.labelMedium, maxLines = 1)
                                     }
@@ -1254,7 +1254,7 @@ private fun AlbumHeader(
                                             contentColor = colorScheme.primary
                                         )
                                     ) {
-                                        Icon(Icons.Default.Bookmark, contentDescription = null, modifier = Modifier.size(primaryIconSize))
+                                        Icon(Icons.Rounded.Bookmark, contentDescription = null, modifier = Modifier.size(primaryIconSize))
                                         Spacer(modifier = Modifier.width(primaryIconGap))
                                         Text("保存", style = MaterialTheme.typography.labelMedium, maxLines = 1)
                                     }
@@ -1276,7 +1276,7 @@ private fun AlbumHeader(
                                     border = androidx.compose.foundation.BorderStroke(1.dp, colorScheme.primary.copy(alpha = 0.3f))
                                 ) {
                                     Icon(
-                                        Icons.Default.CreateNewFolder,
+                                        Icons.Rounded.CreateNewFolder,
                                         contentDescription = null,
                                         tint = colorScheme.primary,
                                         modifier = Modifier.size(primaryIconSize)
@@ -1305,7 +1305,7 @@ private fun AlbumHeader(
                                         )
                                         Spacer(modifier = Modifier.width(if (compact) 2.dp else 4.dp))
                                         Icon(
-                                            imageVector = Icons.Default.ArrowDropDown,
+                                            imageVector = Icons.Rounded.ArrowDropDown,
                                             contentDescription = null,
                                             tint = colorScheme.primary,
                                             modifier = Modifier.size(primaryIconSize)

--- a/app/src/main/java/com/asmr/player/ui/library/LibraryFilterSheet.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/LibraryFilterSheet.kt
@@ -1,4 +1,4 @@
-package com.asmr.player.ui.library
+﻿package com.asmr.player.ui.library
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
@@ -23,13 +23,13 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.ManageSearch
-import androidx.compose.material.icons.filled.Bookmark
-import androidx.compose.material.icons.filled.Close
-import androidx.compose.material.icons.filled.Delete
-import androidx.compose.material.icons.filled.FilterList
-import androidx.compose.material.icons.filled.Restore
-import androidx.compose.material.icons.filled.Search
+import androidx.compose.material.icons.automirrored.rounded.ManageSearch
+import androidx.compose.material.icons.rounded.Bookmark
+import androidx.compose.material.icons.rounded.Close
+import androidx.compose.material.icons.rounded.Delete
+import androidx.compose.material.icons.rounded.FilterList
+import androidx.compose.material.icons.rounded.Restore
+import androidx.compose.material.icons.rounded.Search
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.ElevatedCard
 import androidx.compose.material3.FilterChip
@@ -84,14 +84,14 @@ fun LibraryFilterScreen(
         ) {
             IconButton(onClick = { showTagManager = true }) {
                 Icon(
-                    imageVector = Icons.AutoMirrored.Filled.ManageSearch,
+                    imageVector = Icons.AutoMirrored.Rounded.ManageSearch,
                     contentDescription = "管理标签",
                     tint = colorScheme.primary
                 )
             }
             IconButton(onClick = { viewModel.clearFilters() }) {
                 Icon(
-                    imageVector = Icons.Default.Restore,
+                    imageVector = Icons.Rounded.Restore,
                     contentDescription = "重置筛选",
                     tint = colorScheme.primary
                 )
@@ -176,18 +176,18 @@ fun LibraryFilterSheet(
                 verticalAlignment = Alignment.CenterVertically
             ) {
                 Row(modifier = Modifier.weight(1f), verticalAlignment = Alignment.CenterVertically) {
-                    Icon(imageVector = Icons.Default.FilterList, contentDescription = null, tint = colorScheme.primary)
+                    Icon(imageVector = Icons.Rounded.FilterList, contentDescription = null, tint = colorScheme.primary)
                     Spacer(modifier = Modifier.width(8.dp))
                     Text(text = "筛选", maxLines = 1, overflow = TextOverflow.Ellipsis)
                 }
                 IconButton(onClick = onOpenTagManager) {
-                    Icon(imageVector = Icons.AutoMirrored.Filled.ManageSearch, contentDescription = null)
+                    Icon(imageVector = Icons.AutoMirrored.Rounded.ManageSearch, contentDescription = null)
                 }
                 IconButton(onClick = onClear) {
-                    Icon(imageVector = Icons.Default.Restore, contentDescription = null)
+                    Icon(imageVector = Icons.Rounded.Restore, contentDescription = null)
                 }
                 IconButton(onClick = onClose) {
-                    Icon(imageVector = Icons.Default.Close, contentDescription = null)
+                    Icon(imageVector = Icons.Rounded.Close, contentDescription = null)
                 }
             }
         }
@@ -218,7 +218,7 @@ fun LibraryFilterSheet(
                             .heightIn(min = 30.dp),
                         singleLine = true,
                         textStyle = MaterialTheme.typography.bodySmall,
-                        leadingIcon = { Icon(imageVector = Icons.Default.Search, contentDescription = null) },
+                        leadingIcon = { Icon(imageVector = Icons.Rounded.Search, contentDescription = null) },
                         placeholder = { Text("搜索标签", style = MaterialTheme.typography.bodySmall) }
                     )
 
@@ -307,7 +307,7 @@ fun LibraryFilterSheet(
                     verticalAlignment = Alignment.CenterVertically
                 ) {
                     Row(modifier = Modifier.weight(1f), verticalAlignment = Alignment.CenterVertically) {
-                        Icon(imageVector = Icons.Default.Bookmark, contentDescription = null, tint = colorScheme.primary)
+                        Icon(imageVector = Icons.Rounded.Bookmark, contentDescription = null, tint = colorScheme.primary)
                         Spacer(modifier = Modifier.width(8.dp))
                         Text(text = "预设")
                     }
@@ -331,7 +331,7 @@ fun LibraryFilterSheet(
                         },
                         trailingContent = {
                             IconButton(onClick = { onDeletePreset(preset.id) }) {
-                                Icon(imageVector = Icons.Default.Delete, contentDescription = null)
+                                Icon(imageVector = Icons.Rounded.Delete, contentDescription = null)
                             }
                         }
                     )

--- a/app/src/main/java/com/asmr/player/ui/library/LibraryScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/LibraryScreen.kt
@@ -1,4 +1,4 @@
-package com.asmr.player.ui.library
+﻿package com.asmr.player.ui.library
 
 import android.content.Intent
 import androidx.activity.compose.BackHandler
@@ -28,21 +28,21 @@ import androidx.compose.foundation.lazy.staggeredgrid.LazyVerticalStaggeredGrid
 import androidx.compose.foundation.lazy.staggeredgrid.StaggeredGridCells
 import androidx.compose.foundation.lazy.staggeredgrid.items as staggeredItems
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Add
-import androidx.compose.material.icons.filled.CloudSync
-import androidx.compose.material.icons.filled.Delete
-import androidx.compose.material.icons.filled.Close
-import androidx.compose.material.icons.filled.CreateNewFolder
-import androidx.compose.material.icons.filled.FolderOpen
-import androidx.compose.material.icons.filled.FilterList
-import androidx.compose.material.icons.filled.GridView
-import androidx.compose.material.icons.filled.Refresh
-import androidx.compose.material.icons.filled.Search
-import androidx.compose.material.icons.filled.SwapVert
-import androidx.compose.material.icons.filled.Sync
-import androidx.compose.material.icons.filled.MoreVert
-import androidx.compose.material.icons.filled.ViewList
-import androidx.compose.material.icons.filled.Audiotrack
+import androidx.compose.material.icons.rounded.Add
+import androidx.compose.material.icons.rounded.CloudSync
+import androidx.compose.material.icons.rounded.Delete
+import androidx.compose.material.icons.rounded.Close
+import androidx.compose.material.icons.rounded.CreateNewFolder
+import androidx.compose.material.icons.rounded.FolderOpen
+import androidx.compose.material.icons.rounded.FilterList
+import androidx.compose.material.icons.rounded.GridView
+import androidx.compose.material.icons.rounded.Refresh
+import androidx.compose.material.icons.rounded.Search
+import androidx.compose.material.icons.rounded.SwapVert
+import androidx.compose.material.icons.rounded.Sync
+import androidx.compose.material.icons.rounded.MoreVert
+import androidx.compose.material.icons.rounded.ViewList
+import androidx.compose.material.icons.rounded.Audiotrack
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -136,11 +136,11 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.staggeredgrid.rememberLazyStaggeredGridState
-import androidx.compose.material.icons.automirrored.filled.Label
-import androidx.compose.material.icons.automirrored.filled.PlaylistAdd
-import androidx.compose.material.icons.automirrored.filled.QueueMusic
-import androidx.compose.material.icons.filled.ErrorOutline
-import androidx.compose.material.icons.filled.Label
+import androidx.compose.material.icons.automirrored.rounded.Label
+import androidx.compose.material.icons.automirrored.rounded.PlaylistAdd
+import androidx.compose.material.icons.automirrored.rounded.QueueMusic
+import androidx.compose.material.icons.rounded.ErrorOutline
+import androidx.compose.material.icons.rounded.Label
 import androidx.compose.material3.Card
 import androidx.compose.ui.draw.blur
 import androidx.compose.ui.graphics.vector.ImageVector
@@ -497,7 +497,7 @@ fun LibraryScreen(
                                         } else {
                                             "到设置里的本地库添加目录后，再执行同步或刷新，这里就会出现内容。"
                                         },
-                                        sectionIcon = if (hasAnyQuery) Icons.Default.Search else Icons.Default.FolderOpen,
+                                        sectionIcon = if (hasAnyQuery) Icons.Rounded.Search else Icons.Rounded.FolderOpen,
                                         modifier = Modifier.fillMaxSize(),
                                         contentPadding = PaddingValues(
                                             top = topPadding,
@@ -847,7 +847,7 @@ fun LibraryScreen(
                 val hasLocalPaths = remember(album) { album.getAllLocalPaths().isNotEmpty() }
                 ListItem(
                     headlineContent = { Text("删除") },
-                    leadingContent = { Icon(Icons.Default.Delete, contentDescription = null) },
+                    leadingContent = { Icon(Icons.Rounded.Delete, contentDescription = null) },
                     modifier = Modifier
                         .fillMaxWidth()
                         .padding(horizontal = 8.dp)
@@ -858,7 +858,7 @@ fun LibraryScreen(
                 )
                 ListItem(
                     headlineContent = { Text("标签管理") },
-                    leadingContent = { Icon(Icons.AutoMirrored.Filled.Label, contentDescription = null) },
+                    leadingContent = { Icon(Icons.AutoMirrored.Rounded.Label, contentDescription = null) },
                     modifier = Modifier
                         .fillMaxWidth()
                         .padding(horizontal = 8.dp)
@@ -876,7 +876,7 @@ fun LibraryScreen(
                 )
                 ListItem(
                     headlineContent = { Text("添加到分组") },
-                    leadingContent = { Icon(Icons.Default.CreateNewFolder, contentDescription = null) },
+                    leadingContent = { Icon(Icons.Rounded.CreateNewFolder, contentDescription = null) },
                     modifier = Modifier
                         .fillMaxWidth()
                         .padding(horizontal = 8.dp)
@@ -887,7 +887,7 @@ fun LibraryScreen(
                 )
                 ListItem(
                     headlineContent = { Text("本地同步") },
-                    leadingContent = { Icon(Icons.Default.Sync, contentDescription = null) },
+                    leadingContent = { Icon(Icons.Rounded.Sync, contentDescription = null) },
                     modifier = Modifier
                         .fillMaxWidth()
                         .padding(horizontal = 8.dp)
@@ -898,7 +898,7 @@ fun LibraryScreen(
                 )
                 ListItem(
                     headlineContent = { Text("云同步") },
-                    leadingContent = { Icon(Icons.Default.CloudSync, contentDescription = null) },
+                    leadingContent = { Icon(Icons.Rounded.CloudSync, contentDescription = null) },
                     modifier = Modifier
                         .fillMaxWidth()
                         .padding(horizontal = 8.dp)
@@ -910,7 +910,7 @@ fun LibraryScreen(
                 if (isSyncing) {
                     ListItem(
                         headlineContent = { Text("取消同步") },
-                        leadingContent = { Icon(Icons.Default.Close, contentDescription = null) },
+                        leadingContent = { Icon(Icons.Rounded.Close, contentDescription = null) },
                         modifier = Modifier
                             .fillMaxWidth()
                             .padding(horizontal = 8.dp)
@@ -1038,7 +1038,7 @@ internal fun LibraryChrome(
                 .testTag(LIBRARY_SEARCH_INPUT_TAG),
             leadingIcon = {
                 Icon(
-                    imageVector = Icons.Default.Search,
+                    imageVector = Icons.Rounded.Search,
                     contentDescription = null,
                     tint = colorScheme.onSurfaceVariant
                 )
@@ -1050,7 +1050,7 @@ internal fun LibraryChrome(
                         modifier = Modifier.size(20.dp)
                     ) {
                         Icon(
-                            imageVector = Icons.Default.Close,
+                            imageVector = Icons.Rounded.Close,
                             contentDescription = null,
                             tint = colorScheme.onSurfaceVariant,
                             modifier = Modifier.size(14.dp)
@@ -1064,7 +1064,7 @@ internal fun LibraryChrome(
         Spacer(modifier = Modifier.width(12.dp))
         Box {
             ActionButton(
-                icon = Icons.Default.SwapVert,
+                icon = Icons.Rounded.SwapVert,
                 onClick = { onSortMenuExpandedChange(true) },
                 modifier = Modifier.testTag(LIBRARY_SORT_BUTTON_TAG)
             )
@@ -1116,7 +1116,7 @@ internal fun LibraryChrome(
         }
         Spacer(modifier = Modifier.width(8.dp))
         ActionButton(
-            icon = Icons.Default.FilterList,
+            icon = Icons.Rounded.FilterList,
             onClick = onOpenFilterScreen,
             modifier = Modifier.testTag(LIBRARY_FILTER_BUTTON_TAG)
         )
@@ -1272,24 +1272,24 @@ private fun TrackListRow(
             AudioItemMenuAction(
                 label = "添加到播放队列",
                 onClick = onAddToQueue,
-                icon = Icons.AutoMirrored.Filled.QueueMusic
+                icon = Icons.AutoMirrored.Rounded.QueueMusic
             ),
             AudioItemMenuAction(
                 label = "添加到播放列表",
                 onClick = onAddToPlaylist,
-                icon = Icons.AutoMirrored.Filled.PlaylistAdd,
+                icon = Icons.AutoMirrored.Rounded.PlaylistAdd,
                 showDividerBefore = true
             ),
             AudioItemMenuAction(
                 label = "标签管理",
                 onClick = onManageTags,
-                icon = Icons.AutoMirrored.Filled.Label,
+                icon = Icons.AutoMirrored.Rounded.Label,
                 showDividerBefore = true
             ),
             AudioItemMenuAction(
                 label = "从专辑移除",
                 onClick = onRemove,
-                icon = Icons.Default.Delete,
+                icon = Icons.Rounded.Delete,
                 showDividerBefore = true
             )
         )
@@ -1363,7 +1363,7 @@ private fun AlbumGridItem(
                     contentAlignment = Alignment.Center
                 ) {
                     Icon(
-                        imageVector = Icons.Default.ErrorOutline,
+                        imageVector = Icons.Rounded.ErrorOutline,
                         contentDescription = null,
                         tint = Color.White,
                         modifier = Modifier.size(24.dp)
@@ -1548,7 +1548,7 @@ private fun AlbumItem(
                             contentAlignment = Alignment.Center
                         ) {
                             Icon(
-                                imageVector = Icons.Default.ErrorOutline,
+                                imageVector = Icons.Rounded.ErrorOutline,
                                 contentDescription = null,
                                 tint = Color.White,
                                 modifier = Modifier.size(16.dp)

--- a/app/src/main/java/com/asmr/player/ui/library/TagAssignDialog.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/TagAssignDialog.kt
@@ -1,4 +1,4 @@
-package com.asmr.player.ui.library
+﻿package com.asmr.player.ui.library
 
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.rememberScrollState
@@ -15,10 +15,10 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.ArrowBack
-import androidx.compose.material.icons.filled.Add
-import androidx.compose.material.icons.filled.Close
-import androidx.compose.material.icons.filled.Search
+import androidx.compose.material.icons.automirrored.rounded.ArrowBack
+import androidx.compose.material.icons.rounded.Add
+import androidx.compose.material.icons.rounded.Close
+import androidx.compose.material.icons.rounded.Search
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -90,7 +90,7 @@ fun TagAssignDialog(
                     verticalAlignment = Alignment.CenterVertically
                 ) {
                     IconButton(onClick = onDismiss) {
-                        Icon(imageVector = Icons.AutoMirrored.Filled.ArrowBack, contentDescription = null)
+                        Icon(imageVector = Icons.AutoMirrored.Rounded.ArrowBack, contentDescription = null)
                     }
                     Text(
                         text = title,
@@ -155,11 +155,11 @@ fun TagAssignDialog(
                         onValueChange = { query = it },
                         modifier = Modifier.fillMaxWidth(),
                         singleLine = true,
-                        leadingIcon = { Icon(imageVector = Icons.Default.Search, contentDescription = null) },
+                        leadingIcon = { Icon(imageVector = Icons.Rounded.Search, contentDescription = null) },
                         trailingIcon = {
                             if (query.isNotBlank()) {
                                 IconButton(onClick = { query = "" }) {
-                                    Icon(imageVector = Icons.Default.Close, contentDescription = null)
+                                    Icon(imageVector = Icons.Rounded.Close, contentDescription = null)
                                 }
                             }
                         },
@@ -203,7 +203,7 @@ fun TagAssignDialog(
                                 customInput = ""
                             }
                         ) {
-                            Icon(imageVector = Icons.Default.Add, contentDescription = null, tint = colorScheme.primary)
+                            Icon(imageVector = Icons.Rounded.Add, contentDescription = null, tint = colorScheme.primary)
                         }
                         if (onOpenTagManager != null) {
                             Spacer(modifier = Modifier.width(6.dp))

--- a/app/src/main/java/com/asmr/player/ui/library/TagManagerSheet.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/TagManagerSheet.kt
@@ -1,4 +1,4 @@
-package com.asmr.player.ui.library
+﻿package com.asmr.player.ui.library
 
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.clickable
@@ -14,7 +14,7 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.automirrored.rounded.ArrowBack
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -64,7 +64,7 @@ fun TagManagerSheet(
     Column(modifier = Modifier.fillMaxSize()) {
         Row(modifier = Modifier.fillMaxWidth().padding(horizontal = 6.dp, vertical = 8.dp)) {
             IconButton(onClick = onClose) {
-                Icon(imageVector = Icons.AutoMirrored.Filled.ArrowBack, contentDescription = null)
+                Icon(imageVector = Icons.AutoMirrored.Rounded.ArrowBack, contentDescription = null)
             }
             Text(text = "标签管理", modifier = Modifier.weight(1f))
             TextButton(onClick = onClose) { Text("完成") }

--- a/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailDialogs.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailDialogs.kt
@@ -1,4 +1,4 @@
-package com.asmr.player.ui.library
+﻿package com.asmr.player.ui.library
 
 import android.content.Intent
 import android.net.Uri
@@ -35,11 +35,11 @@ import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.ArrowBack
-import androidx.compose.material.icons.automirrored.filled.KeyboardArrowLeft
-import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
-import androidx.compose.material.icons.automirrored.filled.OpenInNew
-import androidx.compose.material.icons.filled.*
+import androidx.compose.material.icons.automirrored.rounded.ArrowBack
+import androidx.compose.material.icons.automirrored.rounded.KeyboardArrowLeft
+import androidx.compose.material.icons.automirrored.rounded.KeyboardArrowRight
+import androidx.compose.material.icons.automirrored.rounded.OpenInNew
+import androidx.compose.material.icons.rounded.*
 import androidx.compose.material3.*
 import androidx.compose.material3.windowsizeclass.WindowSizeClass
 import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
@@ -104,10 +104,10 @@ import android.webkit.WebChromeClient
 import android.webkit.WebSettings
 import android.webkit.WebView
 import android.webkit.WebViewClient
-import androidx.compose.material.icons.automirrored.filled.Label
-import androidx.compose.material.icons.automirrored.filled.PlaylistAdd
-import androidx.compose.material.icons.automirrored.filled.PlaylistPlay
-import androidx.compose.material.icons.automirrored.filled.QueueMusic
+import androidx.compose.material.icons.automirrored.rounded.Label
+import androidx.compose.material.icons.automirrored.rounded.PlaylistAdd
+import androidx.compose.material.icons.automirrored.rounded.PlaylistPlay
+import androidx.compose.material.icons.automirrored.rounded.QueueMusic
 import java.io.File
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -164,7 +164,7 @@ internal fun AsmrOneDownloadDialog(
                     verticalAlignment = Alignment.CenterVertically
                 ) {
                     IconButton(onClick = onDismiss) {
-                        Icon(imageVector = Icons.AutoMirrored.Filled.ArrowBack, contentDescription = null)
+                        Icon(imageVector = Icons.AutoMirrored.Rounded.ArrowBack, contentDescription = null)
                     }
                     Text(
                         text = "选择要下载的文件",
@@ -425,7 +425,7 @@ internal fun OnlineSaveDialog(
                     verticalAlignment = Alignment.CenterVertically
                 ) {
                     IconButton(onClick = onDismiss) {
-                        Icon(imageVector = Icons.AutoMirrored.Filled.ArrowBack, contentDescription = null)
+                        Icon(imageVector = Icons.AutoMirrored.Rounded.ArrowBack, contentDescription = null)
                     }
                     Text(
                         text = "选择要保存的文件",
@@ -556,7 +556,7 @@ private fun AsmrTreeFolderCheckboxRow(
             Spacer(modifier = Modifier.width(4.dp))
             IconButton(onClick = onToggleExpand, modifier = Modifier.size(32.dp)) {
                 Icon(
-                    imageVector = if (expanded) Icons.Default.KeyboardArrowDown else Icons.AutoMirrored.Filled.KeyboardArrowRight,
+                    imageVector = if (expanded) Icons.Rounded.KeyboardArrowDown else Icons.AutoMirrored.Rounded.KeyboardArrowRight,
                     contentDescription = null,
                     tint = MaterialTheme.colorScheme.onSurfaceVariant
                 )
@@ -836,10 +836,10 @@ internal fun FilePreviewDialog(
                     )
                     if (canNavigate) {
                         IconButton(onClick = { currentIndex = (currentIndex - 1 + initialCandidates.size) % initialCandidates.size }) {
-                            Icon(Icons.AutoMirrored.Filled.KeyboardArrowLeft, contentDescription = "上一项")
+                            Icon(Icons.AutoMirrored.Rounded.KeyboardArrowLeft, contentDescription = "上一项")
                         }
                         IconButton(onClick = { currentIndex = (currentIndex + 1) % initialCandidates.size }) {
-                            Icon(Icons.AutoMirrored.Filled.KeyboardArrowRight, contentDescription = "下一项")
+                            Icon(Icons.AutoMirrored.Rounded.KeyboardArrowRight, contentDescription = "下一项")
                         }
                     }
                     if (canFullscreen) {
@@ -848,10 +848,10 @@ internal fun FilePreviewDialog(
                         }
                     }
                     IconButton(onClick = ::openWithOtherApp) {
-                        Icon(Icons.AutoMirrored.Filled.OpenInNew, contentDescription = "打开")
+                        Icon(Icons.AutoMirrored.Rounded.OpenInNew, contentDescription = "打开")
                     }
                     IconButton(onClick = onDismiss) {
-                        Icon(Icons.Default.Close, contentDescription = "关闭")
+                        Icon(Icons.Rounded.Close, contentDescription = "关闭")
                     }
                 }
                 
@@ -902,7 +902,7 @@ internal fun FilePreviewDialog(
                         TreeFileType.Pdf -> {
                             Column(horizontalAlignment = Alignment.CenterHorizontally) {
                                 Icon(
-                                    imageVector = Icons.Default.PictureAsPdf,
+                                    imageVector = Icons.Rounded.PictureAsPdf,
                                     contentDescription = null,
                                     modifier = Modifier.size(64.dp),
                                     tint = colorScheme.danger

--- a/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailDirectorySupport.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailDirectorySupport.kt
@@ -1,4 +1,4 @@
-package com.asmr.player.ui.library
+﻿package com.asmr.player.ui.library
 
 import android.content.Intent
 import android.net.Uri
@@ -36,9 +36,9 @@ import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.ArrowBack
-import androidx.compose.material.icons.automirrored.filled.OpenInNew
-import androidx.compose.material.icons.filled.*
+import androidx.compose.material.icons.automirrored.rounded.ArrowBack
+import androidx.compose.material.icons.automirrored.rounded.OpenInNew
+import androidx.compose.material.icons.rounded.*
 import androidx.compose.material3.*
 import androidx.compose.material3.windowsizeclass.WindowSizeClass
 import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
@@ -107,12 +107,12 @@ import android.webkit.WebChromeClient
 import android.webkit.WebSettings
 import android.webkit.WebView
 import android.webkit.WebViewClient
-import androidx.compose.material.icons.automirrored.filled.InsertDriveFile
-import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
-import androidx.compose.material.icons.automirrored.filled.Label
-import androidx.compose.material.icons.automirrored.filled.PlaylistAdd
-import androidx.compose.material.icons.automirrored.filled.PlaylistPlay
-import androidx.compose.material.icons.automirrored.filled.QueueMusic
+import androidx.compose.material.icons.automirrored.rounded.InsertDriveFile
+import androidx.compose.material.icons.automirrored.rounded.KeyboardArrowRight
+import androidx.compose.material.icons.automirrored.rounded.Label
+import androidx.compose.material.icons.automirrored.rounded.PlaylistAdd
+import androidx.compose.material.icons.automirrored.rounded.PlaylistPlay
+import androidx.compose.material.icons.automirrored.rounded.QueueMusic
 import java.io.File
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -1454,7 +1454,7 @@ internal fun DirectoryBreadcrumbBar(
                 label = { Text("根目录") },
                 leadingIcon = {
                     Icon(
-                        imageVector = Icons.Default.Home,
+                        imageVector = Icons.Rounded.Home,
                         contentDescription = null,
                         modifier = Modifier.size(18.dp)
                     )
@@ -1516,7 +1516,7 @@ internal fun CompactDirectoryBreadcrumbBar(
             CompactBreadcrumbNode(
                 text = "根目录",
                 selected = currentPath.isBlank(),
-                icon = Icons.Default.Home,
+                icon = Icons.Rounded.Home,
                 onClick = { onNavigate("") }
             )
             displayedCrumbs.forEach { crumb ->
@@ -1610,7 +1610,7 @@ internal fun CompactDirectoryBreadcrumbContent(
         CompactBreadcrumbNode(
             text = "根目录",
             selected = currentPath.isBlank(),
-            icon = Icons.Default.Home,
+            icon = Icons.Rounded.Home,
             onClick = { onNavigate("") }
         )
         displayedCrumbs.forEach { crumb ->
@@ -1817,7 +1817,7 @@ internal fun DirectoryBatchBarEmbeddedV2(
                 contentPadding = PaddingValues(horizontal = 10.dp, vertical = 0.dp),
                 modifier = Modifier.height(30.dp)
             ) {
-                Icon(Icons.Default.FavoriteBorder, contentDescription = null, modifier = Modifier.size(14.dp))
+                Icon(Icons.Rounded.FavoriteBorder, contentDescription = null, modifier = Modifier.size(14.dp))
                 Spacer(modifier = Modifier.width(4.dp))
                 Text("收藏", style = MaterialTheme.typography.labelMedium)
             }
@@ -1827,7 +1827,7 @@ internal fun DirectoryBatchBarEmbeddedV2(
                 contentPadding = PaddingValues(horizontal = 10.dp, vertical = 0.dp),
                 modifier = Modifier.height(30.dp)
             ) {
-                Icon(Icons.AutoMirrored.Filled.PlaylistAdd, contentDescription = null, modifier = Modifier.size(14.dp))
+                Icon(Icons.AutoMirrored.Rounded.PlaylistAdd, contentDescription = null, modifier = Modifier.size(14.dp))
                 Spacer(modifier = Modifier.width(4.dp))
                 Text("列表", style = MaterialTheme.typography.labelMedium)
             }
@@ -1837,7 +1837,7 @@ internal fun DirectoryBatchBarEmbeddedV2(
                 contentPadding = PaddingValues(horizontal = 10.dp, vertical = 0.dp),
                 modifier = Modifier.height(30.dp)
             ) {
-                Icon(Icons.AutoMirrored.Filled.PlaylistPlay, contentDescription = null, modifier = Modifier.size(14.dp))
+                Icon(Icons.AutoMirrored.Rounded.PlaylistPlay, contentDescription = null, modifier = Modifier.size(14.dp))
                 Spacer(modifier = Modifier.width(4.dp))
                 Text("队列", style = MaterialTheme.typography.labelMedium)
             }
@@ -1872,7 +1872,7 @@ internal fun CompactDirectoryBreadcrumbContentV2(
         CompactBreadcrumbNode(
             text = "根目录",
             selected = currentPath.isBlank(),
-            icon = Icons.Default.Home,
+            icon = Icons.Rounded.Home,
             onClick = { onNavigate("") }
         )
         displayedCrumbs.forEach { crumb ->
@@ -1914,7 +1914,7 @@ internal fun DirectoryFolderRowV2(
         verticalAlignment = Alignment.CenterVertically
     ) {
         Icon(
-            imageVector = Icons.Default.Folder,
+            imageVector = Icons.Rounded.Folder,
             contentDescription = null,
             tint = colorScheme.primary,
             modifier = Modifier.size(18.dp)
@@ -1929,7 +1929,7 @@ internal fun DirectoryFolderRowV2(
             color = colorScheme.textPrimary
         )
         Icon(
-            imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight,
+            imageVector = Icons.AutoMirrored.Rounded.KeyboardArrowRight,
             contentDescription = null,
             tint = colorScheme.textSecondary,
             modifier = Modifier.size(18.dp)
@@ -2000,7 +2000,7 @@ internal fun DirectoryBatchBarEmbeddedV3(
             Row(verticalAlignment = Alignment.CenterVertically) {
                 DirectoryActionGroupButton(
                     text = "收藏",
-                    icon = Icons.Default.FavoriteBorder,
+                    icon = Icons.Rounded.FavoriteBorder,
                     enabled = hasMediaItems,
                     onClick = { onAddToFavorites(mediaItems) }
                 )
@@ -2011,7 +2011,7 @@ internal fun DirectoryBatchBarEmbeddedV3(
                 )
                 DirectoryActionGroupButton(
                     text = "列表",
-                    icon = Icons.AutoMirrored.Filled.PlaylistAdd,
+                    icon = Icons.AutoMirrored.Rounded.PlaylistAdd,
                     enabled = hasMediaItems,
                     onClick = { onOpenBatchPlaylistPicker(mediaItems) }
                 )
@@ -2022,7 +2022,7 @@ internal fun DirectoryBatchBarEmbeddedV3(
                 )
                 DirectoryActionGroupButton(
                     text = "队列",
-                    icon = Icons.AutoMirrored.Filled.PlaylistPlay,
+                    icon = Icons.AutoMirrored.Rounded.PlaylistPlay,
                     enabled = hasMediaItems,
                     onClick = { onAddMediaItemsToQueue(mediaItems) }
                 )
@@ -2203,7 +2203,7 @@ internal fun DirectoryFolderRow(
             verticalAlignment = Alignment.CenterVertically
         ) {
             Icon(
-                imageVector = Icons.Default.Folder,
+                imageVector = Icons.Rounded.Folder,
                 contentDescription = null,
                 tint = colorScheme.primary,
                 modifier = Modifier.size(22.dp)
@@ -2218,7 +2218,7 @@ internal fun DirectoryFolderRow(
                 color = colorScheme.textPrimary
             )
             Icon(
-                imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight,
+                imageVector = Icons.AutoMirrored.Rounded.KeyboardArrowRight,
                 contentDescription = null,
                 tint = colorScheme.textSecondary
             )
@@ -2253,7 +2253,7 @@ internal fun CompactDirectoryBreadcrumbContentV3(
         CompactBreadcrumbNode(
             text = "根目录",
             selected = currentPath.isBlank(),
-            icon = Icons.Default.Home,
+            icon = Icons.Rounded.Home,
             onClick = { onNavigate("") }
         )
         displayedCrumbs.forEach { crumb ->
@@ -2298,7 +2298,7 @@ internal fun DirectoryFolderRowV3(
         verticalAlignment = Alignment.CenterVertically
     ) {
         Icon(
-            imageVector = Icons.Default.Folder,
+            imageVector = Icons.Rounded.Folder,
             contentDescription = null,
             tint = colorScheme.primary,
             modifier = Modifier.size(18.dp)
@@ -2313,7 +2313,7 @@ internal fun DirectoryFolderRowV3(
             color = colorScheme.textPrimary
         )
         Icon(
-            imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight,
+            imageVector = Icons.AutoMirrored.Rounded.KeyboardArrowRight,
             contentDescription = null,
             tint = colorScheme.textSecondary,
             modifier = Modifier.size(18.dp)
@@ -2363,21 +2363,21 @@ internal fun DirectoryBatchBarEmbeddedV4(
             Row(verticalAlignment = Alignment.CenterVertically) {
                 DirectoryActionGroupButton(
                     text = "收藏",
-                    icon = Icons.Default.FavoriteBorder,
+                    icon = Icons.Rounded.FavoriteBorder,
                     enabled = hasMediaItems,
                     onClick = { onAddToFavorites(mediaItems) }
                 )
                 Text("|", color = AsmrTheme.colorScheme.textTertiary, style = MaterialTheme.typography.labelMedium)
                 DirectoryActionGroupButton(
                     text = "列表",
-                    icon = Icons.AutoMirrored.Filled.PlaylistAdd,
+                    icon = Icons.AutoMirrored.Rounded.PlaylistAdd,
                     enabled = hasMediaItems,
                     onClick = { onOpenBatchPlaylistPicker(mediaItems) }
                 )
                 Text("|", color = AsmrTheme.colorScheme.textTertiary, style = MaterialTheme.typography.labelMedium)
                 DirectoryActionGroupButton(
                     text = "队列",
-                    icon = Icons.AutoMirrored.Filled.PlaylistPlay,
+                    icon = Icons.AutoMirrored.Rounded.PlaylistPlay,
                     enabled = hasMediaItems,
                     onClick = { onAddMediaItemsToQueue(mediaItems) }
                 )
@@ -2429,14 +2429,14 @@ internal fun DirectoryBatchBarEmbeddedV5(
             Row(verticalAlignment = Alignment.CenterVertically) {
                 DirectoryActionGroupButton(
                     text = "收藏",
-                    icon = Icons.Default.FavoriteBorder,
+                    icon = Icons.Rounded.FavoriteBorder,
                     enabled = hasMediaItems,
                     onClick = { onAddToFavorites(mediaItems) }
                 )
                 Text("|", color = AsmrTheme.colorScheme.textTertiary, style = MaterialTheme.typography.labelMedium)
                 DirectoryActionGroupButton(
                     text = "列表",
-                    icon = Icons.AutoMirrored.Filled.PlaylistAdd,
+                    icon = Icons.AutoMirrored.Rounded.PlaylistAdd,
                     enabled = hasMediaItems,
                     onClick = {
                         if (hasMediaItems) {
@@ -2447,7 +2447,7 @@ internal fun DirectoryBatchBarEmbeddedV5(
                 Text("|", color = AsmrTheme.colorScheme.textTertiary, style = MaterialTheme.typography.labelMedium)
                 DirectoryActionGroupButton(
                     text = "队列",
-                    icon = Icons.AutoMirrored.Filled.PlaylistPlay,
+                    icon = Icons.AutoMirrored.Rounded.PlaylistPlay,
                     enabled = hasMediaItems,
                     onClick = { onAddMediaItemsToQueue(mediaItems) }
                 )
@@ -2587,7 +2587,7 @@ internal fun DirectoryBrowserPanelV4(
                     onAddMediaItemsToQueue = onAddMediaItemsToQueue
                 )
                 if (onTogglePreferredPath != null && !selectionMode) {
-                    val preferredIcon = if (isPreferredPath) Icons.Default.Bookmark else Icons.Default.BookmarkBorder
+                    val preferredIcon = if (isPreferredPath) Icons.Rounded.Bookmark else Icons.Rounded.BookmarkBorder
                     val preferredTextColor = if (isPreferredPath) AsmrTheme.colorScheme.primary else AsmrTheme.colorScheme.textSecondary
                     val preferredContainerColor = AsmrTheme.colorScheme.primary.copy(alpha = if (AsmrTheme.colorScheme.isDark) 0.24f else 0.14f)
                     val preferredButton: @Composable (@Composable () -> Unit) -> Unit = { content ->
@@ -2737,13 +2737,13 @@ internal fun DirectoryFileRow(
     val dynamicContainerColor = dynamicPageContainerColor(colorScheme)
     val context = LocalContext.current
     val icon = when (file.fileType) {
-        TreeFileType.Audio -> Icons.Default.Audiotrack
-        TreeFileType.Video -> Icons.Default.Movie
-        TreeFileType.Image -> Icons.Default.Image
-        TreeFileType.Subtitle -> Icons.Default.Subtitles
-        TreeFileType.Text -> Icons.Default.Description
-        TreeFileType.Pdf -> Icons.Default.PictureAsPdf
-        TreeFileType.Other -> Icons.AutoMirrored.Filled.InsertDriveFile
+        TreeFileType.Audio -> Icons.Rounded.Audiotrack
+        TreeFileType.Video -> Icons.Rounded.Movie
+        TreeFileType.Image -> Icons.Rounded.Image
+        TreeFileType.Subtitle -> Icons.Rounded.Subtitles
+        TreeFileType.Text -> Icons.Rounded.Description
+        TreeFileType.Pdf -> Icons.Rounded.PictureAsPdf
+        TreeFileType.Other -> Icons.AutoMirrored.Rounded.InsertDriveFile
     }
     val iconTint = when (file.fileType) {
         TreeFileType.Audio -> colorScheme.primary
@@ -2851,7 +2851,7 @@ internal fun DirectoryFileRow(
                                 modifier = Modifier.size(32.dp)
                             ) {
                                 Icon(
-                                    imageVector = Icons.Default.Photo,
+                                    imageVector = Icons.Rounded.Photo,
                                     contentDescription = "设为封面",
                                     tint = colorScheme.textSecondary,
                                     modifier = Modifier.size(20.dp)
@@ -2866,7 +2866,7 @@ internal fun DirectoryFileRow(
                                     modifier = Modifier.size(AudioItemMenuButtonSize)
                                 ) {
                                     Icon(
-                                        imageVector = Icons.Default.MoreVert,
+                                        imageVector = Icons.Rounded.MoreVert,
                                         contentDescription = "更多操作",
                                         tint = colorScheme.textSecondary,
                                         modifier = Modifier.size(20.dp)
@@ -2891,7 +2891,7 @@ internal fun DirectoryFileRow(
                                                     showMenuExpanded = false
                                                 },
                                                 leadingIcon = {
-                                                    Icon(Icons.Default.PlayArrow, contentDescription = null, tint = colorScheme.primary)
+                                                    Icon(Icons.Rounded.PlayArrow, contentDescription = null, tint = colorScheme.primary)
                                                 }
                                             )
                                         }
@@ -2903,7 +2903,7 @@ internal fun DirectoryFileRow(
                                                     showMenuExpanded = false
                                                 },
                                                 leadingIcon = {
-                                                    Icon(Icons.Default.Download, contentDescription = null, tint = colorScheme.textSecondary)
+                                                    Icon(Icons.Rounded.Download, contentDescription = null, tint = colorScheme.textSecondary)
                                                 }
                                             )
                                         }
@@ -2915,7 +2915,7 @@ internal fun DirectoryFileRow(
                                                     showMenuExpanded = false
                                                 },
                                                 leadingIcon = {
-                                                    Icon(Icons.AutoMirrored.Filled.PlaylistPlay, contentDescription = null, tint = colorScheme.textSecondary)
+                                                    Icon(Icons.AutoMirrored.Rounded.PlaylistPlay, contentDescription = null, tint = colorScheme.textSecondary)
                                                 }
                                             )
                                         }
@@ -2927,7 +2927,7 @@ internal fun DirectoryFileRow(
                                                     showMenuExpanded = false
                                                 },
                                                 leadingIcon = {
-                                                    Icon(Icons.AutoMirrored.Filled.PlaylistAdd, contentDescription = null, tint = colorScheme.textSecondary)
+                                                    Icon(Icons.AutoMirrored.Rounded.PlaylistAdd, contentDescription = null, tint = colorScheme.textSecondary)
                                                 }
                                             )
                                         }
@@ -2939,7 +2939,7 @@ internal fun DirectoryFileRow(
                                                     showMenuExpanded = false
                                                 },
                                                 leadingIcon = {
-                                                    Icon(Icons.AutoMirrored.Filled.Label, contentDescription = null, tint = colorScheme.textSecondary)
+                                                    Icon(Icons.AutoMirrored.Rounded.Label, contentDescription = null, tint = colorScheme.textSecondary)
                                                 }
                                             )
                                         }
@@ -2951,7 +2951,7 @@ internal fun DirectoryFileRow(
                                                     showMenuExpanded = false
                                                 },
                                                 leadingIcon = {
-                                                    Icon(Icons.Default.Delete, contentDescription = null, tint = colorScheme.textSecondary)
+                                                    Icon(Icons.Rounded.Delete, contentDescription = null, tint = colorScheme.textSecondary)
                                                 }
                                             )
                                         }
@@ -2995,7 +2995,7 @@ internal fun TreeFolderRow(
                 Row(verticalAlignment = Alignment.CenterVertically) {
                     if (depth > 0) Spacer(modifier = Modifier.width((depth * 12).dp))
                     Icon(
-                        imageVector = Icons.Default.Folder,
+                        imageVector = Icons.Rounded.Folder,
                         contentDescription = null,
                         tint = colorScheme.primary,
                         modifier = Modifier.size(24.dp)
@@ -3004,7 +3004,7 @@ internal fun TreeFolderRow(
             },
             trailingContent = {
                 Icon(
-                    imageVector = if (expanded) Icons.Default.KeyboardArrowDown else Icons.AutoMirrored.Filled.KeyboardArrowRight,
+                    imageVector = if (expanded) Icons.Rounded.KeyboardArrowDown else Icons.AutoMirrored.Rounded.KeyboardArrowRight,
                     contentDescription = null,
                     tint = colorScheme.textTertiary,
                     modifier = Modifier.size(20.dp)
@@ -3035,13 +3035,13 @@ internal fun TreeFileRow(
     val materialColorScheme = MaterialTheme.colorScheme
     val dynamicContainerColor = dynamicPageContainerColor(colorScheme)
     val icon = when (fileType) {
-        TreeFileType.Audio -> Icons.Default.Audiotrack
-        TreeFileType.Video -> Icons.Default.Movie
-        TreeFileType.Image -> Icons.Default.Image
-        TreeFileType.Subtitle -> Icons.Default.Subtitles
-        TreeFileType.Text -> Icons.Default.Description
-        TreeFileType.Pdf -> Icons.Default.PictureAsPdf
-        TreeFileType.Other -> Icons.AutoMirrored.Filled.InsertDriveFile
+        TreeFileType.Audio -> Icons.Rounded.Audiotrack
+        TreeFileType.Video -> Icons.Rounded.Movie
+        TreeFileType.Image -> Icons.Rounded.Image
+        TreeFileType.Subtitle -> Icons.Rounded.Subtitles
+        TreeFileType.Text -> Icons.Rounded.Description
+        TreeFileType.Pdf -> Icons.Rounded.PictureAsPdf
+        TreeFileType.Other -> Icons.AutoMirrored.Rounded.InsertDriveFile
     }
     val iconTint = when (fileType) {
         TreeFileType.Audio -> colorScheme.primary
@@ -3107,7 +3107,7 @@ internal fun TreeFileRow(
                                 modifier = Modifier.size(32.dp)
                             ) {
                                 Icon(
-                                    imageVector = Icons.Default.Photo,
+                                    imageVector = Icons.Rounded.Photo,
                                     contentDescription = "设为封面",
                                     tint = colorScheme.textSecondary,
                                     modifier = Modifier.size(20.dp)
@@ -3122,7 +3122,7 @@ internal fun TreeFileRow(
                                     modifier = Modifier.size(AudioItemMenuButtonSize)
                                 ) {
                                     Icon(
-                                        imageVector = Icons.Default.MoreVert,
+                                        imageVector = Icons.Rounded.MoreVert,
                                         contentDescription = "更多操作",
                                         tint = colorScheme.textSecondary,
                                         modifier = Modifier.size(20.dp)
@@ -3163,7 +3163,7 @@ internal fun TreeFileRow(
                                                 },
                                                 leadingIcon = {
                                                     Icon(
-                                                        Icons.Default.PlayArrow,
+                                                        Icons.Rounded.PlayArrow,
                                                         contentDescription = null,
                                                         tint = colorScheme.primary
                                                     )
@@ -3180,7 +3180,7 @@ internal fun TreeFileRow(
                                                 },
                                                 leadingIcon = {
                                                     Icon(
-                                                        Icons.Default.Download,
+                                                        Icons.Rounded.Download,
                                                         contentDescription = null,
                                                         tint = colorScheme.textSecondary
                                                     )
@@ -3197,7 +3197,7 @@ internal fun TreeFileRow(
                                                 },
                                                 leadingIcon = {
                                                     Icon(
-                                                        Icons.AutoMirrored.Filled.PlaylistPlay,
+                                                        Icons.AutoMirrored.Rounded.PlaylistPlay,
                                                         contentDescription = null,
                                                         tint = colorScheme.textSecondary
                                                     )
@@ -3214,7 +3214,7 @@ internal fun TreeFileRow(
                                                 },
                                                 leadingIcon = {
                                                     Icon(
-                                                        Icons.AutoMirrored.Filled.PlaylistAdd,
+                                                        Icons.AutoMirrored.Rounded.PlaylistAdd,
                                                         contentDescription = null,
                                                         tint = colorScheme.textSecondary
                                                     )
@@ -3231,7 +3231,7 @@ internal fun TreeFileRow(
                                                 },
                                                 leadingIcon = {
                                                     Icon(
-                                                        Icons.AutoMirrored.Filled.Label,
+                                                        Icons.AutoMirrored.Rounded.Label,
                                                         contentDescription = null,
                                                         tint = colorScheme.textSecondary
                                                     )
@@ -3248,7 +3248,7 @@ internal fun TreeFileRow(
                                                 },
                                                 leadingIcon = {
                                                     Icon(
-                                                        Icons.Default.Delete,
+                                                        Icons.Rounded.Delete,
                                                         contentDescription = null,
                                                         tint = colorScheme.textSecondary
                                                     )

--- a/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailDlsiteTabs.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailDlsiteTabs.kt
@@ -1,4 +1,4 @@
-package com.asmr.player.ui.library
+﻿package com.asmr.player.ui.library
 
 import android.content.Intent
 import android.net.Uri
@@ -37,9 +37,9 @@ import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.ArrowBack
-import androidx.compose.material.icons.automirrored.filled.OpenInNew
-import androidx.compose.material.icons.filled.*
+import androidx.compose.material.icons.automirrored.rounded.ArrowBack
+import androidx.compose.material.icons.automirrored.rounded.OpenInNew
+import androidx.compose.material.icons.rounded.*
 import androidx.compose.material3.*
 import androidx.compose.material3.windowsizeclass.WindowSizeClass
 import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
@@ -107,10 +107,10 @@ import android.webkit.WebChromeClient
 import android.webkit.WebSettings
 import android.webkit.WebView
 import android.webkit.WebViewClient
-import androidx.compose.material.icons.automirrored.filled.Label
-import androidx.compose.material.icons.automirrored.filled.PlaylistAdd
-import androidx.compose.material.icons.automirrored.filled.PlaylistPlay
-import androidx.compose.material.icons.automirrored.filled.QueueMusic
+import androidx.compose.material.icons.automirrored.rounded.Label
+import androidx.compose.material.icons.automirrored.rounded.PlaylistAdd
+import androidx.compose.material.icons.automirrored.rounded.PlaylistPlay
+import androidx.compose.material.icons.automirrored.rounded.QueueMusic
 import java.io.File
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -326,7 +326,7 @@ private fun DlsiteTrialAudioItem(
         horizontalArrangement = Arrangement.spacedBy(10.dp)
     ) {
         Icon(
-            imageVector = Icons.Default.PlayArrow,
+            imageVector = Icons.Rounded.PlayArrow,
             contentDescription = null,
             tint = colorScheme.primary
         )
@@ -355,7 +355,7 @@ private fun DlsiteTrialAudioItem(
                 modifier = Modifier.size(AudioItemMenuButtonSize)
             ) {
                 Icon(
-                    imageVector = Icons.AutoMirrored.Filled.PlaylistAdd,
+                    imageVector = Icons.AutoMirrored.Rounded.PlaylistAdd,
                     contentDescription = null,
                     tint = colorScheme.onSurfaceVariant
                 )
@@ -906,7 +906,7 @@ internal fun AlbumDlsiteInfoBreadcrumbTabV2(
                 )
                 Spacer(modifier = Modifier.weight(1f))
                 IconButton(onClick = onRefreshAsmrOne, enabled = !isLoadingAsmrOne) {
-                    Icon(Icons.Default.Refresh, contentDescription = "刷新")
+                    Icon(Icons.Rounded.Refresh, contentDescription = "刷新")
                 }
             }
         }
@@ -1062,10 +1062,10 @@ internal fun AlbumDlsiteInfoBreadcrumbTabV2(
                 )
                 Spacer(modifier = Modifier.weight(1f))
                 IconButton(onClick = onRefreshTrial, enabled = !isLoading && !isLoadingTrial) {
-                    Icon(Icons.Default.Refresh, contentDescription = "刷新")
+                    Icon(Icons.Rounded.Refresh, contentDescription = "刷新")
                 }
                 IconButton(onClick = onDownloadTrial, enabled = trialDownloadEnabled) {
-                    Icon(Icons.Default.Download, contentDescription = "下载")
+                    Icon(Icons.Rounded.Download, contentDescription = "下载")
                 }
             }
         }

--- a/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailLocalTab.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailLocalTab.kt
@@ -1,4 +1,4 @@
-package com.asmr.player.ui.library
+﻿package com.asmr.player.ui.library
 
 import android.content.Intent
 import android.net.Uri
@@ -35,9 +35,9 @@ import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.ArrowBack
-import androidx.compose.material.icons.automirrored.filled.OpenInNew
-import androidx.compose.material.icons.filled.*
+import androidx.compose.material.icons.automirrored.rounded.ArrowBack
+import androidx.compose.material.icons.automirrored.rounded.OpenInNew
+import androidx.compose.material.icons.rounded.*
 import androidx.compose.material3.*
 import androidx.compose.material3.windowsizeclass.WindowSizeClass
 import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
@@ -102,10 +102,10 @@ import android.webkit.WebChromeClient
 import android.webkit.WebSettings
 import android.webkit.WebView
 import android.webkit.WebViewClient
-import androidx.compose.material.icons.automirrored.filled.Label
-import androidx.compose.material.icons.automirrored.filled.PlaylistAdd
-import androidx.compose.material.icons.automirrored.filled.PlaylistPlay
-import androidx.compose.material.icons.automirrored.filled.QueueMusic
+import androidx.compose.material.icons.automirrored.rounded.Label
+import androidx.compose.material.icons.automirrored.rounded.PlaylistAdd
+import androidx.compose.material.icons.automirrored.rounded.PlaylistPlay
+import androidx.compose.material.icons.automirrored.rounded.QueueMusic
 import java.io.File
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext

--- a/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailSharedSections.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailSharedSections.kt
@@ -1,4 +1,4 @@
-package com.asmr.player.ui.library
+﻿package com.asmr.player.ui.library
 
 import android.content.Intent
 import android.net.Uri
@@ -35,9 +35,9 @@ import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.ArrowBack
-import androidx.compose.material.icons.automirrored.filled.OpenInNew
-import androidx.compose.material.icons.filled.*
+import androidx.compose.material.icons.automirrored.rounded.ArrowBack
+import androidx.compose.material.icons.automirrored.rounded.OpenInNew
+import androidx.compose.material.icons.rounded.*
 import androidx.compose.material3.*
 import androidx.compose.material3.windowsizeclass.WindowSizeClass
 import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
@@ -102,10 +102,10 @@ import android.webkit.WebChromeClient
 import android.webkit.WebSettings
 import android.webkit.WebView
 import android.webkit.WebViewClient
-import androidx.compose.material.icons.automirrored.filled.Label
-import androidx.compose.material.icons.automirrored.filled.PlaylistAdd
-import androidx.compose.material.icons.automirrored.filled.PlaylistPlay
-import androidx.compose.material.icons.automirrored.filled.QueueMusic
+import androidx.compose.material.icons.automirrored.rounded.Label
+import androidx.compose.material.icons.automirrored.rounded.PlaylistAdd
+import androidx.compose.material.icons.automirrored.rounded.PlaylistPlay
+import androidx.compose.material.icons.automirrored.rounded.QueueMusic
 import java.io.File
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -341,7 +341,7 @@ private fun DlsiteRecommendedWorkCard(
                             contentAlignment = Alignment.Center
                         ) {
                             Icon(
-                                imageVector = Icons.Default.Image,
+                                imageVector = Icons.Rounded.Image,
                                 contentDescription = null,
                                 tint = colorScheme.textTertiary,
                                 modifier = Modifier.size(28.dp)
@@ -509,7 +509,7 @@ internal fun TrackItem(
             )
         },
         leadingContent = {
-            Icon(Icons.Default.PlayArrow, contentDescription = null, tint = colorScheme.primary)
+            Icon(Icons.Rounded.PlayArrow, contentDescription = null, tint = colorScheme.primary)
         },
         trailingContent = {
             if (showSubtitleStamp) {
@@ -517,7 +517,7 @@ internal fun TrackItem(
             }
             if (onAddToPlaylist != null) {
                 IconButton(onClick = onAddToPlaylist, modifier = Modifier.size(AudioItemMenuButtonSize)) {
-                    Icon(Icons.AutoMirrored.Filled.PlaylistAdd, contentDescription = null, tint = colorScheme.onSurfaceVariant)
+                    Icon(Icons.AutoMirrored.Rounded.PlaylistAdd, contentDescription = null, tint = colorScheme.onSurfaceVariant)
                 }
             }
         },
@@ -556,7 +556,7 @@ private fun OnlineTrackRow(
             )
         },
         leadingContent = {
-            Icon(Icons.Default.PlayArrow, contentDescription = null, tint = colorScheme.primary)
+            Icon(Icons.Rounded.PlayArrow, contentDescription = null, tint = colorScheme.primary)
         },
         trailingContent = {
             val showMenu = onAddToQueue != null || onAddToPlaylist != null || onManageTags != null
@@ -564,7 +564,7 @@ private fun OnlineTrackRow(
             var expanded by rememberSaveable { mutableStateOf(false) }
             Box {
                 IconButton(onClick = { expanded = true }) {
-                    Icon(Icons.Default.MoreVert, contentDescription = null, tint = colorScheme.onSurfaceVariant)
+                    Icon(Icons.Rounded.MoreVert, contentDescription = null, tint = colorScheme.onSurfaceVariant)
                 }
                 MaterialTheme(
                     colorScheme = materialColorScheme.copy(
@@ -584,7 +584,7 @@ private fun OnlineTrackRow(
                                 expanded = false
                             },
                             leadingIcon = {
-                                Icon(Icons.Default.PlayArrow, contentDescription = null, tint = colorScheme.primary)
+                                Icon(Icons.Rounded.PlayArrow, contentDescription = null, tint = colorScheme.primary)
                             }
                         )
                         if (onAddToQueue != null) {
@@ -600,7 +600,7 @@ private fun OnlineTrackRow(
                                     expanded = false
                                 },
                                 leadingIcon = {
-                                    Icon(Icons.AutoMirrored.Filled.QueueMusic, contentDescription = null, tint = colorScheme.onSurfaceVariant)
+                                    Icon(Icons.AutoMirrored.Rounded.QueueMusic, contentDescription = null, tint = colorScheme.onSurfaceVariant)
                                 }
                             )
                         }
@@ -617,7 +617,7 @@ private fun OnlineTrackRow(
                                     expanded = false
                                 },
                                 leadingIcon = {
-                                    Icon(Icons.AutoMirrored.Filled.PlaylistAdd, contentDescription = null, tint = colorScheme.onSurfaceVariant)
+                                    Icon(Icons.AutoMirrored.Rounded.PlaylistAdd, contentDescription = null, tint = colorScheme.onSurfaceVariant)
                                 }
                             )
                         }
@@ -634,7 +634,7 @@ private fun OnlineTrackRow(
                                     expanded = false
                                 },
                                 leadingIcon = {
-                                    Icon(Icons.AutoMirrored.Filled.Label, contentDescription = null, tint = colorScheme.onSurfaceVariant)
+                                    Icon(Icons.AutoMirrored.Rounded.Label, contentDescription = null, tint = colorScheme.onSurfaceVariant)
                                 }
                             )
                         }

--- a/app/src/main/java/com/asmr/player/ui/nav/BottomChrome.kt
+++ b/app/src/main/java/com/asmr/player/ui/nav/BottomChrome.kt
@@ -1,4 +1,4 @@
-package com.asmr.player.ui.nav
+﻿package com.asmr.player.ui.nav
 
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.SizeTransform
@@ -30,17 +30,17 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.QueueMusic
-import androidx.compose.material.icons.filled.Download
-import androidx.compose.material.icons.filled.Favorite
-import androidx.compose.material.icons.filled.Folder
-import androidx.compose.material.icons.filled.Home
-import androidx.compose.material.icons.filled.MoreHoriz
-import androidx.compose.material.icons.filled.Person
-import androidx.compose.material.icons.filled.Search
-import androidx.compose.material.icons.filled.Settings
-import androidx.compose.material.icons.filled.SwapHoriz
-import androidx.compose.material.icons.filled.Whatshot
+import androidx.compose.material.icons.automirrored.rounded.QueueMusic
+import androidx.compose.material.icons.rounded.Download
+import androidx.compose.material.icons.rounded.Favorite
+import androidx.compose.material.icons.rounded.Folder
+import androidx.compose.material.icons.rounded.Home
+import androidx.compose.material.icons.rounded.MoreHoriz
+import androidx.compose.material.icons.rounded.Person
+import androidx.compose.material.icons.rounded.Search
+import androidx.compose.material.icons.rounded.Settings
+import androidx.compose.material.icons.rounded.SwapHoriz
+import androidx.compose.material.icons.rounded.Whatshot
 import androidx.compose.material3.Icon
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -255,14 +255,14 @@ private fun bottomChromeMetrics(largeLayout: Boolean): BottomChromeMetrics =
     }
 
 fun bottomChromeNavItems(): List<BottomChromeNavItem> = listOf(
-    BottomChromeNavItem(Icons.Default.Home, "本地库", Routes.Library),
-    BottomChromeNavItem(Icons.Default.Search, "在线搜索", Routes.Search),
-    BottomChromeNavItem(Icons.Default.Whatshot, "热门收听", Routes.HotListening),
-    BottomChromeNavItem(Icons.Default.Favorite, "我的收藏", "playlist_system/favorites"),
-    BottomChromeNavItem(Icons.AutoMirrored.Filled.QueueMusic, "我的列表", "playlists"),
-    BottomChromeNavItem(Icons.Default.Folder, "我的分组", "groups"),
-    BottomChromeNavItem(Icons.Default.Settings, "设置", "settings"),
-    BottomChromeNavItem(Icons.Default.Person, "DLsite 登录", "dlsite_login")
+    BottomChromeNavItem(Icons.Rounded.Home, "本地库", Routes.Library),
+    BottomChromeNavItem(Icons.Rounded.Search, "在线搜索", Routes.Search),
+    BottomChromeNavItem(Icons.Rounded.Whatshot, "热门收听", Routes.HotListening),
+    BottomChromeNavItem(Icons.Rounded.Favorite, "我的收藏", "playlist_system/favorites"),
+    BottomChromeNavItem(Icons.AutoMirrored.Rounded.QueueMusic, "我的列表", "playlists"),
+    BottomChromeNavItem(Icons.Rounded.Folder, "我的分组", "groups"),
+    BottomChromeNavItem(Icons.Rounded.Settings, "设置", "settings"),
+    BottomChromeNavItem(Icons.Rounded.Person, "DLsite 登录", "dlsite_login")
 )
 
 fun isPrimaryRoute(route: String?): Boolean {
@@ -465,7 +465,7 @@ private fun buildBottomNavRailEntries(
 
     if (layout.showsOverflow) {
         entries += BottomNavRailEntry(
-            item = BottomChromeNavItem(Icons.Default.SwapHoriz, "切换", BottomNavOverflowTag),
+            item = BottomChromeNavItem(Icons.Rounded.SwapHoriz, "切换", BottomNavOverflowTag),
             width = metrics.itemSlotWidth,
             isOverflow = true
         )

--- a/app/src/main/java/com/asmr/player/ui/player/LyricsPage.kt
+++ b/app/src/main/java/com/asmr/player/ui/player/LyricsPage.kt
@@ -1,4 +1,4 @@
-package com.asmr.player.ui.player
+﻿package com.asmr.player.ui.player
 
 import androidx.compose.foundation.layout.size
 import androidx.compose.ui.text.style.TextOverflow
@@ -12,7 +12,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.KeyboardArrowDown
+import androidx.compose.material.icons.rounded.KeyboardArrowDown
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -117,7 +117,7 @@ internal fun LyricsPage(
             ) {
                 IconButton(onClick = onBack) {
                     Icon(
-                        Icons.Default.KeyboardArrowDown, 
+                        Icons.Rounded.KeyboardArrowDown, 
                         contentDescription = null,
                         modifier = Modifier.size(if (isLandscape) 24.dp else 28.dp)
                     )

--- a/app/src/main/java/com/asmr/player/ui/player/MiniPlayer.kt
+++ b/app/src/main/java/com/asmr/player/ui/player/MiniPlayer.kt
@@ -1,4 +1,4 @@
-package com.asmr.player.ui.player
+﻿package com.asmr.player.ui.player
 
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.SizeTransform
@@ -33,11 +33,11 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.border
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.PlaylistPlay
-import androidx.compose.material.icons.filled.Favorite
-import androidx.compose.material.icons.filled.FavoriteBorder
-import androidx.compose.material.icons.filled.Pause
-import androidx.compose.material.icons.filled.PlayArrow
+import androidx.compose.material.icons.automirrored.rounded.PlaylistPlay
+import androidx.compose.material.icons.rounded.Favorite
+import androidx.compose.material.icons.rounded.FavoriteBorder
+import androidx.compose.material.icons.rounded.Pause
+import androidx.compose.material.icons.rounded.PlayArrow
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.ElevatedCard
 import androidx.compose.material3.Icon
@@ -240,7 +240,7 @@ fun MiniPlayer(
                                         modifier = Modifier.size(controlsButtonSize)
                                     ) {
                                         Icon(
-                                        imageVector = if (isFavorite) Icons.Default.Favorite else Icons.Default.FavoriteBorder,
+                                        imageVector = if (isFavorite) Icons.Rounded.Favorite else Icons.Rounded.FavoriteBorder,
                                         contentDescription = null,
                                         tint = if (isFavorite) Color.Red else colorScheme.onSurface.copy(alpha = 0.6f),
                                         modifier = Modifier.size(favoriteIconSize)
@@ -254,7 +254,7 @@ fun MiniPlayer(
                                         modifier = Modifier.size(controlsButtonSize)
                                     ) {
                                         Icon(
-                                        imageVector = if (isPlayingEffective) Icons.Default.Pause else Icons.Default.PlayArrow,
+                                        imageVector = if (isPlayingEffective) Icons.Rounded.Pause else Icons.Rounded.PlayArrow,
                                         contentDescription = null,
                                         tint = colorScheme.primary,
                                         modifier = Modifier.size(playbackIconSize)
@@ -265,7 +265,7 @@ fun MiniPlayer(
                                         modifier = Modifier.size(controlsButtonSize)
                                     ) {
                                         Icon(
-                                        imageVector = Icons.AutoMirrored.Filled.PlaylistPlay,
+                                        imageVector = Icons.AutoMirrored.Rounded.PlaylistPlay,
                                         contentDescription = null,
                                         tint = colorScheme.onSurface,
                                         modifier = Modifier.size(queueIconSize)

--- a/app/src/main/java/com/asmr/player/ui/player/NowPlayingScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/player/NowPlayingScreen.kt
@@ -1,4 +1,4 @@
-package com.asmr.player.ui.player
+﻿package com.asmr.player.ui.player
 
 import android.app.Activity
 import android.content.Context
@@ -26,8 +26,8 @@ import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.PlaylistPlay
-import androidx.compose.material.icons.filled.*
+import androidx.compose.material.icons.automirrored.rounded.PlaylistPlay
+import androidx.compose.material.icons.rounded.*
 import androidx.compose.material.icons.outlined.*
 import androidx.compose.material3.*
 import androidx.compose.material3.windowsizeclass.WindowHeightSizeClass
@@ -765,7 +765,7 @@ internal fun NowPlayingScreen(
                     Row(verticalAlignment = Alignment.CenterVertically, modifier = Modifier.weight(1f)) {
                         IconButton(onClick = requestClose, enabled = !pendingRouteExit) {
                             Icon(
-                                Icons.Default.KeyboardArrowDown,
+                                Icons.Rounded.KeyboardArrowDown,
                                 contentDescription = null,
                                 tint = colorScheme.onSurface,
                                 modifier = Modifier.size(36.dp)
@@ -784,7 +784,7 @@ internal fun NowPlayingScreen(
                     Row(verticalAlignment = Alignment.CenterVertically) {
                         IconButton(onClick = onShowSleepTimer) {
                             Icon(
-                                Icons.Default.Timer,
+                                Icons.Rounded.Timer,
                                 contentDescription = null,
                                 tint = colorScheme.onSurface,
                                 modifier = Modifier.size(28.dp)
@@ -792,7 +792,7 @@ internal fun NowPlayingScreen(
                         }
                         IconButton(onClick = onShowQueue) {
                             Icon(
-                                Icons.AutoMirrored.Filled.PlaylistPlay,
+                                Icons.AutoMirrored.Rounded.PlaylistPlay,
                                 contentDescription = null,
                                 tint = colorScheme.onSurface,
                                 modifier = Modifier.size(32.dp)
@@ -990,7 +990,7 @@ internal fun NowPlayingScreen(
                     Row(verticalAlignment = Alignment.CenterVertically, modifier = Modifier.weight(1f)) {
                         IconButton(onClick = requestClose, enabled = !pendingRouteExit) {
                             Icon(
-                                Icons.Default.KeyboardArrowDown,
+                                Icons.Rounded.KeyboardArrowDown,
                                 contentDescription = null,
                                 tint = colorScheme.onSurface,
                                 modifier = Modifier.size(28.dp)
@@ -1008,7 +1008,7 @@ internal fun NowPlayingScreen(
                     Row(verticalAlignment = Alignment.CenterVertically) {
                         IconButton(onClick = onShowSleepTimer) {
                             Icon(
-                                Icons.Default.Timer,
+                                Icons.Rounded.Timer,
                                 contentDescription = null,
                                 tint = colorScheme.onSurface,
                                 modifier = Modifier.size(22.dp)
@@ -1016,7 +1016,7 @@ internal fun NowPlayingScreen(
                         }
                         IconButton(onClick = onShowQueue) {
                             Icon(
-                                Icons.AutoMirrored.Filled.PlaylistPlay,
+                                Icons.AutoMirrored.Rounded.PlaylistPlay,
                                 contentDescription = null,
                                 tint = colorScheme.onSurface,
                                 modifier = Modifier.size(24.dp)
@@ -1213,7 +1213,7 @@ internal fun NowPlayingScreen(
                     ) {
                         IconButton(onClick = requestClose, enabled = !pendingRouteExit) {
                             Icon(
-                                Icons.Default.KeyboardArrowDown,
+                                Icons.Rounded.KeyboardArrowDown,
                                 contentDescription = null,
                                 tint = colorScheme.onSurface,
                                 modifier = Modifier.size(32.dp)
@@ -1241,7 +1241,7 @@ internal fun NowPlayingScreen(
                         Row(verticalAlignment = Alignment.CenterVertically) {
                             IconButton(onClick = onShowSleepTimer) {
                                 Icon(
-                                    Icons.Default.Timer,
+                                    Icons.Rounded.Timer,
                                     contentDescription = null,
                                     tint = colorScheme.onSurface,
                                     modifier = Modifier.size(26.dp)
@@ -1249,7 +1249,7 @@ internal fun NowPlayingScreen(
                             }
                             IconButton(onClick = onShowQueue) {
                                 Icon(
-                                    Icons.AutoMirrored.Filled.PlaylistPlay,
+                                    Icons.AutoMirrored.Rounded.PlaylistPlay,
                                     contentDescription = null,
                                     tint = colorScheme.onSurface,
                                     modifier = Modifier.size(28.dp)
@@ -1543,7 +1543,7 @@ internal fun NowPlayingScreen(
 
                                         IconButton(onClick = { viewModel.playSlicePreview(slice) }) {
                                             Icon(
-                                                imageVector = Icons.Default.PlayArrow,
+                                                imageVector = Icons.Rounded.PlayArrow,
                                                 contentDescription = "播放切片",
                                                 tint = colorScheme.onSurface
                                             )

--- a/app/src/main/java/com/asmr/player/ui/player/QueueSheet.kt
+++ b/app/src/main/java/com/asmr/player/ui/player/QueueSheet.kt
@@ -1,4 +1,4 @@
-package com.asmr.player.ui.player
+﻿package com.asmr.player.ui.player
 
 import androidx.compose.animation.core.FastOutSlowInEasing
 import androidx.compose.animation.core.RepeatMode
@@ -22,7 +22,7 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.rounded.Close
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
@@ -123,7 +123,7 @@ fun QueueSheetContent(
                         }
                         IconButton(onClick = { viewModel.removeFromQueue(index) }) {
                             Icon(
-                                imageVector = Icons.Default.Close,
+                                imageVector = Icons.Rounded.Close,
                                 contentDescription = "移除",
                                 tint = colorScheme.textSecondary,
                                 modifier = Modifier.size(20.dp)

--- a/app/src/main/java/com/asmr/player/ui/player/nowplaying/NowPlayingControls.kt
+++ b/app/src/main/java/com/asmr/player/ui/player/nowplaying/NowPlayingControls.kt
@@ -1,4 +1,4 @@
-package com.asmr.player.ui.player
+﻿package com.asmr.player.ui.player
 
 import android.app.Activity
 import android.content.Context
@@ -21,10 +21,10 @@ import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.Label
+import androidx.compose.material.icons.automirrored.rounded.Label
 import androidx.compose.material.icons.automirrored.outlined.LabelOff
 import androidx.compose.material.icons.automirrored.outlined.PlaylistAdd
-import androidx.compose.material.icons.filled.*
+import androidx.compose.material.icons.rounded.*
 import androidx.compose.material.icons.outlined.*
 import androidx.compose.material3.*
 import androidx.compose.material3.windowsizeclass.WindowHeightSizeClass
@@ -163,7 +163,7 @@ internal fun PlaybackControls(
             ) {
                 IconButton(onClick = { viewModel.toggleFavorite() }) {
                     Icon(
-                        imageVector = if (isFavorite) Icons.Default.Favorite else Icons.Outlined.FavoriteBorder,
+                        imageVector = if (isFavorite) Icons.Rounded.Favorite else Icons.Outlined.FavoriteBorder,
                         contentDescription = "喜欢",
                         tint = if (isFavorite) Color.Red else colorScheme.onSurface.copy(alpha = 0.8f),
                         modifier = Modifier.size(24.dp)
@@ -182,7 +182,7 @@ internal fun PlaybackControls(
                 val floatingEnabled by viewModel.floatingLyricsEnabled.collectAsState()
                 IconButton(onClick = { viewModel.toggleFloatingLyrics() }) {
                     Icon(
-                        imageVector = Icons.Default.Subtitles,
+                        imageVector = Icons.Rounded.Subtitles,
                         contentDescription = "悬浮歌词",
                         tint = if (floatingEnabled) primaryColor else colorScheme.onSurface.copy(alpha = 0.8f),
                         modifier = Modifier.size(24.dp)
@@ -196,7 +196,7 @@ internal fun PlaybackControls(
                     }
                 ) {
                     Icon(
-                        imageVector = if (isOnlineMedia) Icons.AutoMirrored.Outlined.LabelOff else Icons.AutoMirrored.Filled.Label,
+                        imageVector = if (isOnlineMedia) Icons.AutoMirrored.Outlined.LabelOff else Icons.AutoMirrored.Rounded.Label,
                         contentDescription = "标签管理",
                         tint = colorScheme.onSurface.copy(alpha = if (isOnlineMedia) 0.38f else 0.8f),
                         modifier = Modifier.size(24.dp)
@@ -205,7 +205,7 @@ internal fun PlaybackControls(
 
                 IconButton(onClick = onShowEqualizer) {
                     Icon(
-                        imageVector = Icons.Default.Tune,
+                        imageVector = Icons.Rounded.Tune,
                         contentDescription = "均衡器",
                         tint = colorScheme.onSurface.copy(alpha = 0.8f),
                         modifier = Modifier.size(24.dp)
@@ -246,9 +246,9 @@ internal fun PlaybackControls(
         ) {
             IconButton(onClick = { viewModel.cyclePlayMode() }) {
                 val icon = when {
-                    playback.shuffleEnabled -> Icons.Default.Shuffle
-                    playback.repeatMode == Player.REPEAT_MODE_ONE -> Icons.Default.RepeatOne
-                    else -> Icons.Default.Repeat
+                    playback.shuffleEnabled -> Icons.Rounded.Shuffle
+                    playback.repeatMode == Player.REPEAT_MODE_ONE -> Icons.Rounded.RepeatOne
+                    else -> Icons.Rounded.Repeat
                 }
                 Icon(
                     icon,
@@ -260,7 +260,7 @@ internal fun PlaybackControls(
 
             IconButton(onClick = { viewModel.previous() }) {
                 Icon(
-                    Icons.Default.SkipPrevious,
+                    Icons.Rounded.SkipPrevious,
                     contentDescription = "上一首",
                     tint = colorScheme.onSurface,
                     modifier = Modifier.size(36.dp)
@@ -300,7 +300,7 @@ internal fun PlaybackControls(
                         label = "play_pause_icon"
                     ) { playing ->
                         Icon(
-                            imageVector = if (playing) Icons.Default.Pause else Icons.Default.PlayArrow,
+                            imageVector = if (playing) Icons.Rounded.Pause else Icons.Rounded.PlayArrow,
                             contentDescription = "播放/暂停",
                             modifier = Modifier.size(36.dp)
                         )
@@ -310,7 +310,7 @@ internal fun PlaybackControls(
 
             IconButton(onClick = { viewModel.next() }) {
                 Icon(
-                    Icons.Default.SkipNext,
+                    Icons.Rounded.SkipNext,
                     contentDescription = "下一首",
                     tint = colorScheme.onSurface,
                     modifier = Modifier.size(36.dp)
@@ -319,7 +319,7 @@ internal fun PlaybackControls(
 
             IconButton(onClick = { viewModel.seekForward10s() }) {
                 Icon(
-                    Icons.Default.FastForward,
+                    Icons.Rounded.FastForward,
                     contentDescription = "快进10秒",
                     tint = colorScheme.onSurface,
                     modifier = Modifier.size(28.dp)

--- a/app/src/main/java/com/asmr/player/ui/player/nowplaying/NowPlayingProgress.kt
+++ b/app/src/main/java/com/asmr/player/ui/player/nowplaying/NowPlayingProgress.kt
@@ -1,4 +1,4 @@
-package com.asmr.player.ui.player
+﻿package com.asmr.player.ui.player
 
 import android.app.Activity
 import android.content.Context
@@ -21,7 +21,7 @@ import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.*
+import androidx.compose.material.icons.rounded.*
 import androidx.compose.material.icons.outlined.*
 import androidx.compose.material3.*
 import androidx.compose.material3.windowsizeclass.WindowHeightSizeClass

--- a/app/src/main/java/com/asmr/player/ui/player/nowplaying/NowPlayingSurfaceComponents.kt
+++ b/app/src/main/java/com/asmr/player/ui/player/nowplaying/NowPlayingSurfaceComponents.kt
@@ -1,4 +1,4 @@
-package com.asmr.player.ui.player
+﻿package com.asmr.player.ui.player
 
 import android.app.Activity
 import android.content.Context
@@ -21,8 +21,8 @@ import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.PlaylistPlay
-import androidx.compose.material.icons.filled.*
+import androidx.compose.material.icons.automirrored.rounded.PlaylistPlay
+import androidx.compose.material.icons.rounded.*
 import androidx.compose.material.icons.outlined.*
 import androidx.compose.material3.*
 import androidx.compose.material3.windowsizeclass.WindowHeightSizeClass
@@ -133,7 +133,7 @@ internal fun PlayerSurfaceHeader(
         ) {
         IconButton(onClick = onNavigateUp, enabled = navigationEnabled) {
             Icon(
-                Icons.Default.KeyboardArrowDown,
+                Icons.Rounded.KeyboardArrowDown,
                 contentDescription = null,
                 modifier = Modifier.size(if (isLandscape) 24.dp else 28.dp),
                 tint = colorScheme.onSurface
@@ -165,7 +165,7 @@ internal fun PlayerSurfaceHeader(
             }
             IconButton(onClick = onShowSleepTimer) {
                 Icon(
-                    Icons.Default.Timer,
+                    Icons.Rounded.Timer,
                     contentDescription = null,
                     modifier = Modifier.size(if (isLandscape) 20.dp else 22.dp),
                     tint = colorScheme.onSurface
@@ -173,7 +173,7 @@ internal fun PlayerSurfaceHeader(
             }
             IconButton(onClick = onShowQueue) {
                 Icon(
-                    Icons.AutoMirrored.Filled.PlaylistPlay,
+                    Icons.AutoMirrored.Rounded.PlaylistPlay,
                     contentDescription = null,
                     modifier = Modifier.size(if (isLandscape) 22.dp else 24.dp),
                     tint = colorScheme.onSurface
@@ -382,7 +382,7 @@ private fun NowPlayingVideoPlayer(
                 .background(Color.Black.copy(alpha = 0.35f), RoundedCornerShape(10.dp))
         ) {
             Icon(
-                imageVector = if (fullscreen) Icons.Default.FullscreenExit else Icons.Default.Fullscreen,
+                imageVector = if (fullscreen) Icons.Rounded.FullscreenExit else Icons.Rounded.Fullscreen,
                 contentDescription = if (fullscreen) "退出全屏" else "全屏",
                 tint = Color.White
             )

--- a/app/src/main/java/com/asmr/player/ui/playlists/PlaylistDetailScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/playlists/PlaylistDetailScreen.kt
@@ -1,4 +1,4 @@
-package com.asmr.player.ui.playlists
+﻿package com.asmr.player.ui.playlists
 
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
@@ -22,9 +22,9 @@ import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.QueueMusic
-import androidx.compose.material.icons.filled.Favorite
-import androidx.compose.material.icons.filled.MoreVert
+import androidx.compose.material.icons.automirrored.rounded.QueueMusic
+import androidx.compose.material.icons.rounded.Favorite
+import androidx.compose.material.icons.rounded.MoreVert
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
@@ -198,7 +198,7 @@ internal fun PlaylistDetailContent(
                     sectionTitle = emptySectionTitle,
                     headline = emptyHeadline,
                     description = emptyDescription,
-                    sectionIcon = if (isFavorites) Icons.Default.Favorite else Icons.AutoMirrored.Filled.QueueMusic,
+                    sectionIcon = if (isFavorites) Icons.Rounded.Favorite else Icons.AutoMirrored.Rounded.QueueMusic,
                     modifier = contentModifier,
                     contentPadding = PaddingValues(bottom = LocalBottomOverlayPadding.current + 88.dp)
                 )

--- a/app/src/main/java/com/asmr/player/ui/playlists/PlaylistsScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/playlists/PlaylistsScreen.kt
@@ -1,4 +1,4 @@
-package com.asmr.player.ui.playlists
+﻿package com.asmr.player.ui.playlists
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -20,10 +20,10 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.clickable
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.QueueMusic
-import androidx.compose.material.icons.filled.Add
-import androidx.compose.material.icons.filled.Delete
-import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material.icons.automirrored.rounded.QueueMusic
+import androidx.compose.material.icons.rounded.Add
+import androidx.compose.material.icons.rounded.Delete
+import androidx.compose.material.icons.rounded.Edit
 import androidx.compose.material3.*
 import androidx.compose.material3.windowsizeclass.WindowSizeClass
 import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
@@ -108,7 +108,7 @@ fun PlaylistsScreen(
                         sectionTitle = "我的列表",
                         headline = "还没有创建列表",
                         description = "从右下角新建一个列表，把常听内容整理成自己的播放集合。",
-                        sectionIcon = Icons.AutoMirrored.Filled.QueueMusic,
+                        sectionIcon = Icons.AutoMirrored.Rounded.QueueMusic,
                         modifier = Modifier.fillMaxSize(),
                         contentPadding = PaddingValues(bottom = LocalBottomOverlayPadding.current + 88.dp)
                     )
@@ -147,7 +147,7 @@ fun PlaylistsScreen(
                         .align(Alignment.BottomEnd)
                         .padding(end = PlaylistsPageHorizontalPadding, bottom = LocalBottomOverlayPadding.current + 16.dp)
                 ) {
-                    Icon(Icons.Default.Add, contentDescription = null)
+                    Icon(Icons.Rounded.Add, contentDescription = null)
                 }
             }
         }
@@ -214,7 +214,7 @@ private fun PlaylistRow(
                 modifier = Modifier.size(PlaylistRowActionButtonSize)
             ) {
                 Icon(
-                    Icons.Default.Edit,
+                    Icons.Rounded.Edit,
                     contentDescription = null,
                     tint = if (playlist.category != "system") colorScheme.textSecondary else colorScheme.textTertiary,
                     modifier = Modifier.size(PlaylistRowActionIconSize)
@@ -226,7 +226,7 @@ private fun PlaylistRow(
                 modifier = Modifier.size(PlaylistRowActionButtonSize)
             ) {
                 Icon(
-                    Icons.Default.Delete, 
+                    Icons.Rounded.Delete, 
                     contentDescription = null, 
                     tint = if (playlist.category != "system") colorScheme.danger.copy(alpha = 0.7f) else colorScheme.textTertiary,
                     modifier = Modifier.size(PlaylistRowActionIconSize)

--- a/app/src/main/java/com/asmr/player/ui/search/SearchFilterOption.kt
+++ b/app/src/main/java/com/asmr/player/ui/search/SearchFilterOption.kt
@@ -1,12 +1,12 @@
-package com.asmr.player.ui.search
+﻿package com.asmr.player.ui.search
 
 import androidx.annotation.DrawableRes
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.AutoStories
-import androidx.compose.material.icons.filled.CalendarMonth
-import androidx.compose.material.icons.filled.EmojiEvents
-import androidx.compose.material.icons.filled.LocalFireDepartment
-import androidx.compose.material.icons.filled.ShoppingBag
+import androidx.compose.material.icons.rounded.AutoStories
+import androidx.compose.material.icons.rounded.CalendarMonth
+import androidx.compose.material.icons.rounded.EmojiEvents
+import androidx.compose.material.icons.rounded.LocalFireDepartment
+import androidx.compose.material.icons.rounded.ShoppingBag
 import androidx.compose.ui.graphics.vector.ImageVector
 import com.asmr.player.R
 
@@ -24,22 +24,22 @@ enum class SearchFilterOption(
 ) {
     PurchasedOnly(
         label = "已购",
-        icon = SearchFilterIcon.Vector(Icons.Default.ShoppingBag),
+        icon = SearchFilterIcon.Vector(Icons.Rounded.ShoppingBag),
         mode = SearchFilterMode.PurchasedOnly
     ),
     ChineseTranslated(
         label = "中文作品",
-        icon = SearchFilterIcon.Vector(Icons.Default.AutoStories),
+        icon = SearchFilterIcon.Vector(Icons.Rounded.AutoStories),
         mode = SearchFilterMode.ChineseTranslated
     ),
     Presale(
         label = "预售",
-        icon = SearchFilterIcon.Vector(Icons.Default.CalendarMonth),
+        icon = SearchFilterIcon.Vector(Icons.Rounded.CalendarMonth),
         mode = SearchFilterMode.PresaleOnly
     ),
     Trend(
         label = SearchSortOption.Trend.label,
-        icon = SearchFilterIcon.Vector(Icons.Default.LocalFireDepartment),
+        icon = SearchFilterIcon.Vector(Icons.Rounded.LocalFireDepartment),
         mode = SearchFilterMode.Standard,
         sortOption = SearchSortOption.Trend
     ),
@@ -51,7 +51,7 @@ enum class SearchFilterOption(
     ),
     DLCount(
         label = SearchSortOption.DLCount.label,
-        icon = SearchFilterIcon.Vector(Icons.Default.EmojiEvents),
+        icon = SearchFilterIcon.Vector(Icons.Rounded.EmojiEvents),
         mode = SearchFilterMode.Standard,
         sortOption = SearchSortOption.DLCount
     ),

--- a/app/src/main/java/com/asmr/player/ui/search/SearchScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/search/SearchScreen.kt
@@ -1,4 +1,4 @@
-package com.asmr.player.ui.search
+﻿package com.asmr.player.ui.search
 
 import androidx.compose.animation.core.FastOutSlowInEasing
 import androidx.compose.animation.core.animateFloatAsState
@@ -36,12 +36,12 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.ArrowBack
-import androidx.compose.material.icons.automirrored.filled.ArrowForward
-import androidx.compose.material.icons.filled.Close
-import androidx.compose.material.icons.filled.Search
-import androidx.compose.material.icons.filled.SkipPrevious
-import androidx.compose.material.icons.filled.WifiOff
+import androidx.compose.material.icons.automirrored.rounded.ArrowBack
+import androidx.compose.material.icons.automirrored.rounded.ArrowForward
+import androidx.compose.material.icons.rounded.Close
+import androidx.compose.material.icons.rounded.Search
+import androidx.compose.material.icons.rounded.SkipPrevious
+import androidx.compose.material.icons.rounded.WifiOff
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
@@ -441,7 +441,7 @@ fun SearchScreen(
                                         } else {
                                             "没有找到和当前关键词相关的内容，试试更换关键词、语言或排序方式。"
                                         },
-                                        sectionIcon = Icons.Default.Search,
+                                        sectionIcon = Icons.Rounded.Search,
                                         modifier = Modifier.fillMaxSize(),
                                         contentPadding = PaddingValues(
                                             top = topPadding,
@@ -515,7 +515,7 @@ fun SearchScreen(
                                 sectionTitle = "在线搜索",
                                 headline = "网络连接出了点问题",
                                 description = state.message,
-                                sectionIcon = Icons.Filled.WifiOff,
+                                sectionIcon = Icons.Rounded.WifiOff,
                                 modifier = Modifier.fillMaxSize(),
                                 contentPadding = PaddingValues(
                                     top = topPadding,
@@ -541,7 +541,7 @@ fun SearchScreen(
                                 verticalArrangement = Arrangement.Center
                             ) {
                                 Icon(
-                                    imageVector = Icons.Filled.WifiOff,
+                                    imageVector = Icons.Rounded.WifiOff,
                                     contentDescription = null,
                                     tint = colorScheme.textSecondary.copy(alpha = 0.6f),
                                     modifier = Modifier.size(92.dp)
@@ -891,7 +891,7 @@ internal fun SearchToolbar(
                                 .testTag(SEARCH_CLEAR_BUTTON_TAG)
                         ) {
                             Icon(
-                                imageVector = Icons.Default.Close,
+                                imageVector = Icons.Rounded.Close,
                                 contentDescription = null,
                                 tint = colorScheme.primary,
                                 modifier = Modifier.size(16.dp)
@@ -961,7 +961,7 @@ internal fun SearchToolbar(
                             )
                         } else {
                             Icon(
-                                imageVector = Icons.Default.Search,
+                                imageVector = Icons.Rounded.Search,
                                 contentDescription = null,
                                 tint = colorScheme.primary,
                                 modifier = Modifier.size(17.dp)
@@ -1057,14 +1057,14 @@ internal fun SearchPaginationHeader(
                         SearchPaginationIconButton(
                             onClick = onFirstPage,
                             enabled = canGoFirst && !controlsLocked,
-                            imageVector = Icons.Default.SkipPrevious,
+                            imageVector = Icons.Rounded.SkipPrevious,
                             contentDescription = "回到第一页",
                             modifier = Modifier.testTag(SEARCH_FIRST_PAGE_BUTTON_TAG)
                         )
                         SearchPaginationIconButton(
                             onClick = onPrev,
                             enabled = canGoPrev && !controlsLocked,
-                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            imageVector = Icons.AutoMirrored.Rounded.ArrowBack,
                             contentDescription = "上一页",
                             modifier = Modifier.testTag(SEARCH_PREV_BUTTON_TAG)
                         )
@@ -1089,7 +1089,7 @@ internal fun SearchPaginationHeader(
                     SearchPaginationIconButton(
                         onClick = onNext,
                         enabled = canGoNext && !controlsLocked,
-                        imageVector = Icons.AutoMirrored.Filled.ArrowForward,
+                        imageVector = Icons.AutoMirrored.Rounded.ArrowForward,
                         contentDescription = "下一页",
                         modifier = Modifier.testTag(SEARCH_NEXT_BUTTON_TAG)
                     )

--- a/app/src/main/java/com/asmr/player/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/settings/SettingsScreen.kt
@@ -1,4 +1,4 @@
-package com.asmr.player.ui.settings
+﻿package com.asmr.player.ui.settings
 
 import android.Manifest
 import android.content.Intent
@@ -21,17 +21,17 @@ import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.FormatAlignLeft
-import androidx.compose.material.icons.automirrored.filled.FormatAlignRight
-import androidx.compose.material.icons.filled.CloudSync
-import androidx.compose.material.icons.filled.Delete
-import androidx.compose.material.icons.filled.FolderOpen
-import androidx.compose.material.icons.filled.FormatAlignCenter
-import androidx.compose.material.icons.filled.FormatAlignLeft
-import androidx.compose.material.icons.filled.FormatAlignRight
-import androidx.compose.material.icons.filled.Info
-import androidx.compose.material.icons.filled.Refresh
-import androidx.compose.material.icons.filled.Sync
+import androidx.compose.material.icons.automirrored.rounded.FormatAlignLeft
+import androidx.compose.material.icons.automirrored.rounded.FormatAlignRight
+import androidx.compose.material.icons.rounded.CloudSync
+import androidx.compose.material.icons.rounded.Delete
+import androidx.compose.material.icons.rounded.FolderOpen
+import androidx.compose.material.icons.rounded.FormatAlignCenter
+import androidx.compose.material.icons.rounded.FormatAlignLeft
+import androidx.compose.material.icons.rounded.FormatAlignRight
+import androidx.compose.material.icons.rounded.Info
+import androidx.compose.material.icons.rounded.Refresh
+import androidx.compose.material.icons.rounded.Sync
 import androidx.compose.material3.*
 import androidx.compose.material3.windowsizeclass.WindowSizeClass
 import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
@@ -195,7 +195,7 @@ fun SettingsScreen(
                         colors = buttonColors,
                         enabled = !isGlobalSyncRunning
                     ) {
-                        Icon(Icons.Default.Refresh, contentDescription = null, tint = buttonColors.contentColor)
+                        Icon(Icons.Rounded.Refresh, contentDescription = null, tint = buttonColors.contentColor)
                         Spacer(modifier = Modifier.width(8.dp))
                         Text("刷新本地")
                     }
@@ -205,7 +205,7 @@ fun SettingsScreen(
                         colors = buttonColors,
                         enabled = !isGlobalSyncRunning
                     ) {
-                        Icon(Icons.Default.CloudSync, contentDescription = null, tint = buttonColors.contentColor)
+                        Icon(Icons.Rounded.CloudSync, contentDescription = null, tint = buttonColors.contentColor)
                         Spacer(modifier = Modifier.width(8.dp))
                         Text("云同步")
                     }
@@ -216,7 +216,7 @@ fun SettingsScreen(
                     modifier = Modifier.fillMaxWidth(),
                     colors = buttonColors
                 ) {
-                    Icon(Icons.Default.FolderOpen, contentDescription = null, tint = buttonColors.contentColor)
+                    Icon(Icons.Rounded.FolderOpen, contentDescription = null, tint = buttonColors.contentColor)
                     Spacer(modifier = Modifier.width(8.dp))
                     Text("添加目录")
                 }
@@ -293,13 +293,13 @@ fun SettingsScreen(
                                     Text(root, style = MaterialTheme.typography.bodySmall, color = colorScheme.textSecondary, maxLines = 1)
                                 }
                                 IconButton(onClick = { libraryViewModel.scanSingleRoot(root) }, enabled = !isGlobalSyncRunning) {
-                                    Icon(Icons.Default.Refresh, contentDescription = null, tint = colorScheme.onSurface)
+                                    Icon(Icons.Rounded.Refresh, contentDescription = null, tint = colorScheme.onSurface)
                                 }
                                 IconButton(onClick = { libraryViewModel.syncMetadataForRoot(root) }, enabled = !isGlobalSyncRunning) {
-                                    Icon(Icons.Default.CloudSync, contentDescription = null, tint = colorScheme.onSurface)
+                                    Icon(Icons.Rounded.CloudSync, contentDescription = null, tint = colorScheme.onSurface)
                                 }
                                 IconButton(onClick = { pendingRemoveRoot = root }) {
-                                    Icon(Icons.Default.Delete, contentDescription = null, tint = colorScheme.onSurface)
+                                    Icon(Icons.Rounded.Delete, contentDescription = null, tint = colorScheme.onSurface)
                                 }
                             }
                             }
@@ -606,7 +606,7 @@ fun SettingsScreen(
                                         shape = SegmentedButtonDefaults.itemShape(index = 0, count = 3),
                                         colors = segmentedButtonColors,
                                         icon = {},
-                                        label = { Icon(Icons.AutoMirrored.Filled.FormatAlignLeft, null) }
+                                        label = { Icon(Icons.AutoMirrored.Rounded.FormatAlignLeft, null) }
                                     )
                                     SegmentedButton(
                                         selected = floatingSettings.align == 1,
@@ -614,7 +614,7 @@ fun SettingsScreen(
                                         shape = SegmentedButtonDefaults.itemShape(index = 1, count = 3),
                                         colors = segmentedButtonColors,
                                         icon = {},
-                                        label = { Icon(Icons.Default.FormatAlignCenter, null) }
+                                        label = { Icon(Icons.Rounded.FormatAlignCenter, null) }
                                     )
                                     SegmentedButton(
                                         selected = floatingSettings.align == 2,
@@ -622,7 +622,7 @@ fun SettingsScreen(
                                         shape = SegmentedButtonDefaults.itemShape(index = 2, count = 3),
                                         colors = segmentedButtonColors,
                                         icon = {},
-                                        label = { Icon(Icons.AutoMirrored.Filled.FormatAlignRight, null) }
+                                        label = { Icon(Icons.AutoMirrored.Rounded.FormatAlignRight, null) }
                                     )
                                 }
                             }
@@ -924,7 +924,7 @@ private fun LyricsPageSettingsSection(
                 shape = SegmentedButtonDefaults.itemShape(index = 0, count = 3),
                 colors = segmentedButtonColors,
                 icon = {},
-                label = { Icon(Icons.AutoMirrored.Filled.FormatAlignLeft, null) }
+                label = { Icon(Icons.AutoMirrored.Rounded.FormatAlignLeft, null) }
             )
             SegmentedButton(
                 selected = settings.align == 1,
@@ -932,7 +932,7 @@ private fun LyricsPageSettingsSection(
                 shape = SegmentedButtonDefaults.itemShape(index = 1, count = 3),
                 colors = segmentedButtonColors,
                 icon = {},
-                label = { Icon(Icons.Default.FormatAlignCenter, null) }
+                label = { Icon(Icons.Rounded.FormatAlignCenter, null) }
             )
             SegmentedButton(
                 selected = settings.align == 2,
@@ -940,7 +940,7 @@ private fun LyricsPageSettingsSection(
                 shape = SegmentedButtonDefaults.itemShape(index = 2, count = 3),
                 colors = segmentedButtonColors,
                 icon = {},
-                label = { Icon(Icons.AutoMirrored.Filled.FormatAlignRight, null) }
+                label = { Icon(Icons.AutoMirrored.Rounded.FormatAlignRight, null) }
             )
         }
     }
@@ -1240,7 +1240,7 @@ private fun SettingsInfoTip(active: Boolean, title: String, text: String, onTogg
                 modifier = Modifier.size(22.dp)
             ) {
                 Icon(
-                    imageVector = Icons.Default.Info,
+                    imageVector = Icons.Rounded.Info,
                     contentDescription = null,
                     tint = MaterialTheme.colorScheme.onSurfaceVariant,
                     modifier = Modifier.size(14.dp)
@@ -1351,7 +1351,7 @@ private fun PreviewModeInfoTip(active: Boolean, onToggle: () -> Unit) {
                 modifier = Modifier.size(22.dp)
             ) {
                 Icon(
-                    imageVector = Icons.Default.Info,
+                    imageVector = Icons.Rounded.Info,
                     contentDescription = null,
                     tint = MaterialTheme.colorScheme.onSurfaceVariant,
                     modifier = Modifier.size(14.dp)

--- a/app/src/main/java/com/asmr/player/ui/sidepanel/landscaperightpanelhost.kt
+++ b/app/src/main/java/com/asmr/player/ui/sidepanel/landscaperightpanelhost.kt
@@ -1,4 +1,4 @@
-package com.asmr.player.ui.sidepanel
+﻿package com.asmr.player.ui.sidepanel
 
 import android.content.res.Configuration
 import androidx.compose.animation.*
@@ -31,8 +31,8 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.material3.windowsizeclass.WindowSizeClass
 import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.KeyboardArrowLeft
-import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
+import androidx.compose.material.icons.automirrored.rounded.KeyboardArrowLeft
+import androidx.compose.material.icons.automirrored.rounded.KeyboardArrowRight
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -91,7 +91,7 @@ fun LandscapeRightPanelHost(
         val keepPanelSpace = panelVisibilityState.currentState || panelVisibilityState.targetState
         val toggle: @Composable (Modifier) -> Unit = { modifier ->
             ActionButton(
-                icon = if (expanded) Icons.AutoMirrored.Filled.KeyboardArrowRight else Icons.AutoMirrored.Filled.KeyboardArrowLeft,
+                icon = if (expanded) Icons.AutoMirrored.Rounded.KeyboardArrowRight else Icons.AutoMirrored.Rounded.KeyboardArrowLeft,
                 onClick = { setExpanded(!expanded) },
                 modifier = modifier
             )

--- a/app/src/main/java/com/asmr/player/ui/sidepanel/recentalbumspanel.kt
+++ b/app/src/main/java/com/asmr/player/ui/sidepanel/recentalbumspanel.kt
@@ -1,4 +1,4 @@
-package com.asmr.player.ui.sidepanel
+﻿package com.asmr.player.ui.sidepanel
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
@@ -17,7 +17,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.PlayArrow
+import androidx.compose.material.icons.rounded.PlayArrow
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
@@ -493,7 +493,7 @@ private fun RecentAlbumRow(
                 contentAlignment = Alignment.Center
             ) {
                 Icon(
-                    imageVector = Icons.Filled.PlayArrow,
+                    imageVector = Icons.Rounded.PlayArrow,
                     contentDescription = null,
                     tint = textColor
                 )

--- a/app/src/main/java/com/asmr/player/ui/theme/AppIcons.kt
+++ b/app/src/main/java/com/asmr/player/ui/theme/AppIcons.kt
@@ -1,0 +1,161 @@
+package com.asmr.player.ui.theme
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.rounded.ArrowBack
+import androidx.compose.material.icons.automirrored.rounded.ArrowForward
+import androidx.compose.material.icons.automirrored.rounded.FormatAlignLeft
+import androidx.compose.material.icons.automirrored.rounded.FormatAlignRight
+import androidx.compose.material.icons.automirrored.rounded.Label
+import androidx.compose.material.icons.automirrored.rounded.OpenInNew
+import androidx.compose.material.icons.automirrored.rounded.PlaylistAdd
+import androidx.compose.material.icons.automirrored.rounded.PlaylistPlay
+import androidx.compose.material.icons.automirrored.rounded.QueueMusic
+import androidx.compose.material.icons.automirrored.rounded.VolumeUp
+import androidx.compose.material.icons.outlined.FavoriteBorder
+import androidx.compose.material.icons.rounded.AccessTime
+import androidx.compose.material.icons.rounded.Add
+import androidx.compose.material.icons.rounded.ArrowDropDown
+import androidx.compose.material.icons.rounded.Audiotrack
+import androidx.compose.material.icons.rounded.AutoStories
+import androidx.compose.material.icons.rounded.CalendarMonth
+import androidx.compose.material.icons.rounded.Check
+import androidx.compose.material.icons.rounded.CheckCircle
+import androidx.compose.material.icons.rounded.Close
+import androidx.compose.material.icons.rounded.CloudDownload
+import androidx.compose.material.icons.rounded.CloudSync
+import androidx.compose.material.icons.rounded.ContentCut
+import androidx.compose.material.icons.rounded.Delete
+import androidx.compose.material.icons.rounded.DeleteOutline
+import androidx.compose.material.icons.rounded.Download
+import androidx.compose.material.icons.rounded.Edit
+import androidx.compose.material.icons.rounded.EmojiEvents
+import androidx.compose.material.icons.rounded.Error
+import androidx.compose.material.icons.rounded.FastForward
+import androidx.compose.material.icons.rounded.Favorite
+import androidx.compose.material.icons.rounded.FavoriteBorder
+import androidx.compose.material.icons.rounded.FilterList
+import androidx.compose.material.icons.rounded.Folder
+import androidx.compose.material.icons.rounded.FormatAlignCenter
+import androidx.compose.material.icons.rounded.Fullscreen
+import androidx.compose.material.icons.rounded.FullscreenExit
+import androidx.compose.material.icons.rounded.GridView
+import androidx.compose.material.icons.rounded.Headset
+import androidx.compose.material.icons.rounded.Home
+import androidx.compose.material.icons.rounded.Image
+import androidx.compose.material.icons.rounded.ImageNotSupported
+import androidx.compose.material.icons.rounded.Info
+import androidx.compose.material.icons.rounded.KeyboardArrowDown
+import androidx.compose.material.icons.rounded.LocalFireDepartment
+import androidx.compose.material.icons.rounded.MoreHoriz
+import androidx.compose.material.icons.rounded.Movie
+import androidx.compose.material.icons.rounded.MusicNote
+import androidx.compose.material.icons.rounded.Pause
+import androidx.compose.material.icons.rounded.Person
+import androidx.compose.material.icons.rounded.PlayArrow
+import androidx.compose.material.icons.rounded.Refresh
+import androidx.compose.material.icons.rounded.Repeat
+import androidx.compose.material.icons.rounded.RepeatOne
+import androidx.compose.material.icons.rounded.Search
+import androidx.compose.material.icons.rounded.Settings
+import androidx.compose.material.icons.rounded.ShoppingBag
+import androidx.compose.material.icons.rounded.Shuffle
+import androidx.compose.material.icons.rounded.SkipNext
+import androidx.compose.material.icons.rounded.SkipPrevious
+import androidx.compose.material.icons.rounded.Subtitles
+import androidx.compose.material.icons.rounded.SwapHoriz
+import androidx.compose.material.icons.rounded.SwapVert
+import androidx.compose.material.icons.rounded.Sync
+import androidx.compose.material.icons.rounded.Timer
+import androidx.compose.material.icons.rounded.Tune
+import androidx.compose.material.icons.rounded.ViewModule
+import androidx.compose.material.icons.rounded.Visibility
+import androidx.compose.material.icons.rounded.VisibilityOff
+import androidx.compose.material.icons.rounded.Warning
+import androidx.compose.material.icons.rounded.Whatshot
+import androidx.compose.material.icons.rounded.WifiOff
+import androidx.compose.ui.graphics.vector.ImageVector
+
+object AppIcons {
+    val Home: ImageVector = Icons.Rounded.Home
+    val Search: ImageVector = Icons.Rounded.Search
+    val Whatshot: ImageVector = Icons.Rounded.Whatshot
+    val Favorite: ImageVector = Icons.Rounded.Favorite
+    val QueueMusic: ImageVector = Icons.AutoMirrored.Rounded.QueueMusic
+    val Folder: ImageVector = Icons.Rounded.Folder
+    val Settings: ImageVector = Icons.Rounded.Settings
+    val Person: ImageVector = Icons.Rounded.Person
+
+    val PlayArrow: ImageVector = Icons.Rounded.PlayArrow
+    val Pause: ImageVector = Icons.Rounded.Pause
+    val SkipNext: ImageVector = Icons.Rounded.SkipNext
+    val SkipPrevious: ImageVector = Icons.Rounded.SkipPrevious
+    val FastForward: ImageVector = Icons.Rounded.FastForward
+    val Shuffle: ImageVector = Icons.Rounded.Shuffle
+    val Repeat: ImageVector = Icons.Rounded.Repeat
+    val RepeatOne: ImageVector = Icons.Rounded.RepeatOne
+    val FavoriteBorder: ImageVector = Icons.Rounded.FavoriteBorder
+
+    val Add: ImageVector = Icons.Rounded.Add
+    val Delete: ImageVector = Icons.Rounded.Delete
+    val Edit: ImageVector = Icons.Rounded.Edit
+    val Close: ImageVector = Icons.Rounded.Close
+    val Info: ImageVector = Icons.Rounded.Info
+    val Refresh: ImageVector = Icons.Rounded.Refresh
+    val Sync: ImageVector = Icons.Rounded.Sync
+    val MoreHoriz: ImageVector = Icons.Rounded.MoreHoriz
+    val SwapHoriz: ImageVector = Icons.Rounded.SwapHoriz
+    val Check: ImageVector = Icons.Rounded.Check
+
+    val KeyboardArrowDown: ImageVector = Icons.Rounded.KeyboardArrowDown
+    val ArrowBack: ImageVector = Icons.AutoMirrored.Rounded.ArrowBack
+    val ArrowForward: ImageVector = Icons.AutoMirrored.Rounded.ArrowForward
+    val ArrowDropDown: ImageVector = Icons.Rounded.ArrowDropDown
+
+    val Timer: ImageVector = Icons.Rounded.Timer
+    val Tune: ImageVector = Icons.Rounded.Tune
+    val Subtitles: ImageVector = Icons.Rounded.Subtitles
+    val Fullscreen: ImageVector = Icons.Rounded.Fullscreen
+    val FullscreenExit: ImageVector = Icons.Rounded.FullscreenExit
+    val PlaylistPlay: ImageVector = Icons.AutoMirrored.Rounded.PlaylistPlay
+    val PlaylistAdd: ImageVector = Icons.AutoMirrored.Rounded.PlaylistAdd
+    val LabelIcon: ImageVector = Icons.AutoMirrored.Rounded.Label
+    val OpenInNew: ImageVector = Icons.AutoMirrored.Rounded.OpenInNew
+    val VolumeUp: ImageVector = Icons.AutoMirrored.Rounded.VolumeUp
+
+    val CloudDownload: ImageVector = Icons.Rounded.CloudDownload
+    val Audiotrack: ImageVector = Icons.Rounded.Audiotrack
+    val AccessTime: ImageVector = Icons.Rounded.AccessTime
+    val Headset: ImageVector = Icons.Rounded.Headset
+    val CheckCircle: ImageVector = Icons.Rounded.CheckCircle
+    val Error: ImageVector = Icons.Rounded.Error
+    val Warning: ImageVector = Icons.Rounded.Warning
+    val CloudSync: ImageVector = Icons.Rounded.CloudSync
+
+    val Image: ImageVector = Icons.Rounded.Image
+    val ImageNotSupported: ImageVector = Icons.Rounded.ImageNotSupported
+    val MusicNote: ImageVector = Icons.Rounded.MusicNote
+    val Movie: ImageVector = Icons.Rounded.Movie
+
+    val ShoppingBag: ImageVector = Icons.Rounded.ShoppingBag
+    val AutoStories: ImageVector = Icons.Rounded.AutoStories
+    val CalendarMonth: ImageVector = Icons.Rounded.CalendarMonth
+    val LocalFireDepartment: ImageVector = Icons.Rounded.LocalFireDepartment
+    val EmojiEvents: ImageVector = Icons.Rounded.EmojiEvents
+    val FilterList: ImageVector = Icons.Rounded.FilterList
+    val SwapVert: ImageVector = Icons.Rounded.SwapVert
+    val WifiOff: ImageVector = Icons.Rounded.WifiOff
+
+    val FormatAlignLeft: ImageVector = Icons.AutoMirrored.Rounded.FormatAlignLeft
+    val FormatAlignCenter: ImageVector = Icons.Rounded.FormatAlignCenter
+    val FormatAlignRight: ImageVector = Icons.AutoMirrored.Rounded.FormatAlignRight
+
+    val Visibility: ImageVector = Icons.Rounded.Visibility
+    val VisibilityOff: ImageVector = Icons.Rounded.VisibilityOff
+
+    val ContentCut: ImageVector = Icons.Rounded.ContentCut
+    val DeleteOutline: ImageVector = Icons.Rounded.DeleteOutline
+    val FavoriteBorderToggle: ImageVector = Icons.Outlined.FavoriteBorder
+    val Download: ImageVector = Icons.Rounded.Download
+    val GridView: ImageVector = Icons.Rounded.GridView
+    val ViewModule: ImageVector = Icons.Rounded.ViewModule
+}


### PR DESCRIPTION
## 改动概要

将所有 Material Icons 从默认的尖角/直角风格（Icons.Default / Icons.Filled）迁移为圆润风格（Icons.Rounded），提升 App 整体视觉质感。

## 改动内容

- **40 个 Kotlin 文件**：图标引用和 import 路径全部从 filled.* 迁移至 rounded.*
- **1 个新文件**：AppIcons.kt  统一的图标抽象层
- **Toggle 状态保留**：Icons.Outlined.FavoriteBorder / Icons.AutoMirrored.Outlined.LabelOff
- **无需新依赖**：material-icons-extended 内置 Icons.Rounded 变体

## 验证

- assembleDebug 编译通过