### PR TITLE
fix: 播放队列清空后持久化未清除导致后台杀App后恢复旧队列

### DIFF
--- a/app/src/main/java/com/asmr/player/playback/PlayerConnection.kt
+++ b/app/src/main/java/com/asmr/player/playback/PlayerConnection.kt
@@ -544,7 +544,10 @@ class PlayerConnection @Inject constructor(
     private suspend fun savePlaybackState() {
         val c = controller ?: return
         val items = _queue.value.ifEmpty { (0 until c.mediaItemCount).map { idx -> c.getMediaItemAt(idx) } }
-        if (items.isEmpty()) return
+        if (items.isEmpty()) {
+            playbackStateStore.clear()
+            return
+        }
         val persistedQueue = items.mapNotNull { item ->
             val mediaId = item.mediaId.trim()
             if (mediaId.isBlank()) return@mapNotNull null


### PR DESCRIPTION
当用户手动移除播放队列中所有音频后，直接关闭 App 后台。再次打开时依旧会恢复显示上次正在播放的音频。

## 原因
`PlayerConnection.savePlaybackState()` 在队列为空时直接 `return`，不清理磁盘上的持久化状态。后台杀 App 时 `PlaybackService.onDestroy()` 未触发，下次启动时 `restorePlaybackStateIfNeeded()` 把旧队列恢复。

## 修复
队列为空时调用 `playbackStateStore.clear()` 清除持久化数据。

## 变更
- `PlayerConnection.kt`: `savePlaybackState()` 中 `items.isEmpty()` 时调用 `playbackStateStore.clear()`
