### PR TITLE
fix: 空白占位取消描述文字、收藏页header加下载按钮、水平切换header平滑过渡

### DIFF
--- a/app/src/main/java/com/asmr/player/main/MainContainer.kt
+++ b/app/src/main/java/com/asmr/player/main/MainContainer.kt
@@ -917,46 +917,62 @@ fun MainContainer(
                                         modifier = Modifier.height(if (compactTopBar) 48.dp else 64.dp),
                                         title = {
                                             val entry = navBackStackEntry
-                                            val groupName = if (currentRoute == "group/{groupId}/{groupName}") {
+                                            val resolvedTitleRoute = if (currentScreenIsPrimary) visualPrimaryRoute else currentRoute
+                                            val groupName = if (resolvedTitleRoute == "group/{groupId}/{groupName}") {
                                                 decodeRouteArg(entry?.arguments?.getString("groupName").orEmpty())
                                             } else ""
-                                            val playlistName = if (currentRoute == "playlist/{playlistId}/{playlistName}") {
+                                            val playlistName = if (resolvedTitleRoute == "playlist/{playlistId}/{playlistName}") {
                                                 decodeRouteArg(entry?.arguments?.getString("playlistName").orEmpty())
                                             } else ""
-                                            val systemPlaylistType = if (currentRoute == "playlist_system/{type}") {
+                                            val systemPlaylistType = if (resolvedTitleRoute == "playlist_system/{type}") {
                                                 entry?.arguments?.getString("type").orEmpty()
                                             } else ""
                                             val appName = stringResource(R.string.app_name)
+                                            val titleText = when {
+                                                resolvedTitleRoute == "library" -> "本地库"
+                                                resolvedTitleRoute == "library_filter" -> "筛选"
+                                                resolvedTitleRoute == "search" -> "在线搜索"
+                                                resolvedTitleRoute == Routes.HotListening -> "热门收听"
+                                                resolvedTitleRoute == "playlists" -> "我的列表"
+                                                resolvedTitleRoute == "playlist/{playlistId}/{playlistName}" ->
+                                                    playlistName.ifBlank { "我的列表" }
+                                                resolvedTitleRoute == "playlist_system/favorites" -> "我的收藏"
+                                                resolvedTitleRoute == "playlist_system/{type}" -> when (systemPlaylistType) {
+                                                    "favorites" -> "我的收藏"
+                                                    else -> "我的收藏"
+                                                }
+                                                resolvedTitleRoute == "groups" -> "我的分组"
+                                                resolvedTitleRoute == "group/{groupId}/{groupName}" ->
+                                                    groupName.ifBlank { "我的分组" }
+                                                resolvedTitleRoute == "settings" -> "设置"
+                                                resolvedTitleRoute == "downloads" -> "下载管理"
+                                                resolvedTitleRoute == "dlsite_login" -> "DLsite 登录"
+                                                resolvedTitleRoute?.startsWith("playlist_picker") == true -> "添加到我的列表"
+                                                resolvedTitleRoute?.startsWith("album_detail") == true -> "专辑详情"
+                                                else -> appName
+                                            }
                                             Box(modifier = Modifier.fillMaxHeight(), contentAlignment = Alignment.Center) {
-                                                Text(
-                                                    when {
-                                                        currentRoute == "library" -> "本地库"
-                                                        currentRoute == "library_filter" -> "筛选"
-                                                        currentRoute == "search" -> "在线搜索"
-                                                        currentRoute == Routes.HotListening -> "热门收听"
-                                                        currentRoute == "playlists" -> "我的列表"
-                                                        currentRoute == "playlist/{playlistId}/{playlistName}" ->
-                                                            playlistName.ifBlank { "我的列表" }
-                                                        currentRoute == "playlist_system/{type}" -> when (systemPlaylistType) {
-                                                            "favorites" -> "我的收藏"
-                                                            else -> "我的收藏"
-                                                        }
-                                                        currentRoute == "groups" -> "我的分组"
-                                                        currentRoute == "group/{groupId}/{groupName}" ->
-                                                            groupName.ifBlank { "我的分组" }
-                                                        currentRoute == "settings" -> "设置"
-                                                        currentRoute == "downloads" -> "下载管理"
-                                                        currentRoute == "dlsite_login" -> "DLsite 登录"
-                                                        currentRoute?.startsWith("playlist_picker") == true -> "添加到我的列表"
-                                                        currentRoute?.startsWith("album_detail") == true -> "专辑详情"
-                                                        else -> appName
+                                                AnimatedContent(
+                                                    targetState = titleText,
+                                                    transitionSpec = {
+                                                        (fadeIn(animationSpec = tween(220, easing = LinearOutSlowInEasing))
+                                                            + slideInHorizontally(animationSpec = tween(220, easing = LinearOutSlowInEasing)) { it / 4 })
+                                                            .togetherWith(
+                                                                fadeOut(animationSpec = tween(180, easing = FastOutLinearInEasing))
+                                                                    + slideOutHorizontally(animationSpec = tween(180, easing = FastOutLinearInEasing)) { -it / 4 }
+                                                            )
                                                     },
-                                                    style = if (compactTopBar) {
-                                                        MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.SemiBold)
-                                                    } else {
-                                                        MaterialTheme.typography.titleLarge.copy(fontWeight = FontWeight.Bold)
-                                                    }
-                                                )
+                                                    label = "headerTitle"
+                                                ) { targetText ->
+                                                    Text(
+                                                        targetText,
+                                                        style = if (compactTopBar) {
+                                                            MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.SemiBold)
+                                                        } else {
+                                                            MaterialTheme.typography.titleLarge.copy(fontWeight = FontWeight.Bold)
+                                                        }
+                                                    )
+                                                }
                                             }
                                         },
                                         windowInsets = WindowInsets(0, 0, 0, 0),
@@ -980,7 +996,7 @@ fun MainContainer(
                                         },
                                         actions = {
                                             val entry = navBackStackEntry
-                                            if (currentRoute != null && isPrimaryRoute(currentRoute)) {
+                                            if (currentRoute != null && (isPrimaryRoute(currentRoute) || currentRoute == "playlist_system/{type}")) {
                                                 val downloadTasks by downloadsViewModel.tasks.collectAsState()
                                                 val activeDownloadCount = remember(downloadTasks) {
                                                     downloadTasks.sumOf { task ->

--- a/app/src/main/java/com/asmr/player/ui/common/EaraBrandedEmptyState.kt
+++ b/app/src/main/java/com/asmr/player/ui/common/EaraBrandedEmptyState.kt
@@ -29,7 +29,6 @@ internal const val EARA_EMPTY_STATE_TAG = "earaEmptyState"
 fun EaraBrandedEmptyState(
     sectionTitle: String,
     headline: String,
-    description: String,
     sectionIcon: ImageVector,
     modifier: Modifier = Modifier,
     contentPadding: PaddingValues = PaddingValues(0.dp),
@@ -91,13 +90,6 @@ fun EaraBrandedEmptyState(
                 )
 
                 Spacer(modifier = Modifier.size(8.dp))
-
-                Text(
-                    text = description,
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = colorScheme.textSecondary,
-                    textAlign = TextAlign.Center
-                )
 
                 if (footer != null) {
                     Spacer(modifier = Modifier.size(24.dp))

--- a/app/src/main/java/com/asmr/player/ui/groups/AlbumGroupDetailScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/groups/AlbumGroupDetailScreen.kt
@@ -1,4 +1,4 @@
-﻿package com.asmr.player.ui.groups
+package com.asmr.player.ui.groups
 
 import android.net.Uri
 import androidx.compose.foundation.ExperimentalFoundationApi
@@ -229,7 +229,6 @@ internal fun AlbumGroupDetailContent(
                 EaraBrandedEmptyState(
                     sectionTitle = title.ifBlank { "我的分组" },
                     headline = "这个分组还没有内容",
-                    description = "把专辑加入分组后，它们会按专辑整理展示在这里。",
                     sectionIcon = Icons.Rounded.Folder,
                     modifier = Modifier.fillMaxSize(),
                     contentPadding = PaddingValues(bottom = LocalBottomOverlayPadding.current + 88.dp)

--- a/app/src/main/java/com/asmr/player/ui/groups/AlbumGroupsScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/groups/AlbumGroupsScreen.kt
@@ -1,4 +1,4 @@
-﻿package com.asmr.player.ui.groups
+package com.asmr.player.ui.groups
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -108,7 +108,6 @@ fun AlbumGroupsScreen(
                     EaraBrandedEmptyState(
                         sectionTitle = "我的分组",
                         headline = "还没有创建分组",
-                        description = "按主题或场景建立分组，让收藏的专辑更容易整理和回看。",
                         sectionIcon = Icons.Rounded.Folder,
                         modifier = Modifier.fillMaxSize(),
                         contentPadding = PaddingValues(bottom = LocalBottomOverlayPadding.current + 88.dp)

--- a/app/src/main/java/com/asmr/player/ui/hotlistening/HotListeningScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/hotlistening/HotListeningScreen.kt
@@ -124,7 +124,6 @@ fun HotListeningScreen(
             is HotListeningUiState.Error -> EaraBrandedEmptyState(
                 sectionTitle = "热门收听",
                 headline = "数据加载失败",
-                description = state.message,
                 sectionIcon = Icons.Rounded.Whatshot,
                 modifier = Modifier.fillMaxSize(),
                 contentPadding = PaddingValues(bottom = LocalBottomOverlayPadding.current + 24.dp),
@@ -140,7 +139,6 @@ fun HotListeningScreen(
                     EaraBrandedEmptyState(
                         sectionTitle = "热门收听",
                         headline = "暂无排行数据",
-                        description = "热门收听排行数据正在统计中，请稍后再来查看。",
                         sectionIcon = Icons.Rounded.Whatshot,
                         modifier = Modifier.fillMaxSize(),
                         contentPadding = PaddingValues(bottom = LocalBottomOverlayPadding.current + 24.dp)

--- a/app/src/main/java/com/asmr/player/ui/library/LibraryScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/LibraryScreen.kt
@@ -492,11 +492,6 @@ fun LibraryScreen(
                                     EaraBrandedEmptyState(
                                         sectionTitle = if (hasAnyQuery) "本地库结果" else "本地库",
                                         headline = if (hasAnyQuery) "没有匹配的本地内容" else "还没有扫描到本地专辑",
-                                        description = if (hasAnyQuery) {
-                                            "可以调整关键词或筛选条件，也可以直接重置后重新查看全部内容。"
-                                        } else {
-                                            "到设置里的本地库添加目录后，再执行同步或刷新，这里就会出现内容。"
-                                        },
                                         sectionIcon = if (hasAnyQuery) Icons.Rounded.Search else Icons.Rounded.FolderOpen,
                                         modifier = Modifier.fillMaxSize(),
                                         contentPadding = PaddingValues(

--- a/app/src/main/java/com/asmr/player/ui/playlists/PlaylistDetailScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/playlists/PlaylistDetailScreen.kt
@@ -1,4 +1,4 @@
-﻿package com.asmr.player.ui.playlists
+package com.asmr.player.ui.playlists
 
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
@@ -167,11 +167,6 @@ internal fun PlaylistDetailContent(
     } else {
         "这个列表还没有内容"
     }
-    val emptyDescription = if (isFavorites) {
-        "看到喜欢的专辑或音轨时点一下收藏，它们就会回到这里。"
-    } else {
-        "把常听内容添加进来，后续就能从这里快速播放。"
-    }
     val emptySectionTitle = if (isFavorites) "我的收藏" else title.ifBlank { "我的列表" }
 
     Scaffold(
@@ -197,7 +192,6 @@ internal fun PlaylistDetailContent(
                 EaraBrandedEmptyState(
                     sectionTitle = emptySectionTitle,
                     headline = emptyHeadline,
-                    description = emptyDescription,
                     sectionIcon = if (isFavorites) Icons.Rounded.Favorite else Icons.AutoMirrored.Rounded.QueueMusic,
                     modifier = contentModifier,
                     contentPadding = PaddingValues(bottom = LocalBottomOverlayPadding.current + 88.dp)

--- a/app/src/main/java/com/asmr/player/ui/playlists/PlaylistsScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/playlists/PlaylistsScreen.kt
@@ -107,7 +107,6 @@ fun PlaylistsScreen(
                     EaraBrandedEmptyState(
                         sectionTitle = "我的列表",
                         headline = "还没有创建列表",
-                        description = "从右下角新建一个列表，把常听内容整理成自己的播放集合。",
                         sectionIcon = Icons.AutoMirrored.Rounded.QueueMusic,
                         modifier = Modifier.fillMaxSize(),
                         contentPadding = PaddingValues(bottom = LocalBottomOverlayPadding.current + 88.dp)

--- a/app/src/main/java/com/asmr/player/ui/search/SearchScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/search/SearchScreen.kt
@@ -436,11 +436,6 @@ fun SearchScreen(
                                     EaraBrandedEmptyState(
                                         sectionTitle = "在线搜索",
                                         headline = if (state.keyword.isBlank()) "还没有搜索结果" else "没有找到匹配结果",
-                                        description = if (state.keyword.isBlank()) {
-                                            "输入作品号、社团或 CV 后，匹配结果会显示在这里。"
-                                        } else {
-                                            "没有找到和当前关键词相关的内容，试试更换关键词、语言或排序方式。"
-                                        },
                                         sectionIcon = Icons.Rounded.Search,
                                         modifier = Modifier.fillMaxSize(),
                                         contentPadding = PaddingValues(
@@ -514,7 +509,6 @@ fun SearchScreen(
                             is SearchUiState.Error -> EaraBrandedEmptyState(
                                 sectionTitle = "在线搜索",
                                 headline = "网络连接出了点问题",
-                                description = state.message,
                                 sectionIcon = Icons.Rounded.WifiOff,
                                 modifier = Modifier.fillMaxSize(),
                                 contentPadding = PaddingValues(


### PR DESCRIPTION
## 变更内容

### 1. 空白页面占位组件取消最下方小字描述
- 移除 \EaraBrandedEmptyState\ 的 \description\ 参数及对应的 Text 渲染
- 清理所有 9 处调用点的 \description\ 实参

### 2. 我的收藏页面 header 右侧添加下载管理按钮
- 将下载按钮的显示条件从 \isPrimaryRoute(currentRoute)\ 扩展为同时匹配 \playlist_system/{type}\ 路由模式

### 3. 页面水平滚动切换时 header 增加平滑过渡
- header 标题使用 \AnimatedContent\ 包裹，fade + 水平滑动过渡（进入 220ms / 退出 180ms）
- 标题路由解析改用 \isualPrimaryRoute\，在滚动开始时即触发标题切换，而非等滚动完成后