### PR TITLE
fix: 目录树音频为网络资源时不显示标签管理菜单

### DIFF
--- a/app/src/main/java/com/asmr/player/ui/library/LibraryScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/LibraryScreen.kt
@@ -50,6 +50,7 @@ import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.ElevatedCard
 import androidx.compose.foundation.layout.fillMaxHeight
 import com.asmr.player.util.Formatting
+import com.asmr.player.util.isOnlineTrackPath
 import com.asmr.player.ui.common.SubtitleStamp
 import com.asmr.player.ui.common.DiscPlaceholder
 import com.asmr.player.ui.common.LocalBottomOverlayPadding
@@ -653,7 +654,7 @@ fun LibraryScreen(
                                                             onAddToPlaylist = {
                                                                 onOpenPlaylistPicker(MediaItemFactory.fromTrack(album, track))
                                                             },
-                                                            onManageTags = {
+                                                            onManageTags = if (!isOnlineTrackPath(track.path)) {{
                                                                 scope.launch {
                                                                     val inherited = withContext(Dispatchers.IO) {
                                                                         viewModel.loadInheritedTagsForAlbum(album.id)
@@ -666,7 +667,7 @@ fun LibraryScreen(
                                                                         userTags = user
                                                                     )
                                                                 }
-                                                            },
+                                                            }} else null,
                                                             onRemove = {
                                                                 viewModel.removeTrackFromAlbum(track.id)
                                                             }
@@ -1238,7 +1239,7 @@ private fun TrackListRow(
     onClick: () -> Unit,
     onAddToQueue: () -> Unit,
     onAddToPlaylist: () -> Unit,
-    onManageTags: () -> Unit,
+    onManageTags: (() -> Unit)? = null,
     onRemove: () -> Unit
 ) {
     val colorScheme = AsmrTheme.colorScheme
@@ -1263,31 +1264,41 @@ private fun TrackListRow(
             .fillMaxWidth()
             .clip(rowShape)
             .background(colorScheme.surface),
-        actions = listOf(
-            AudioItemMenuAction(
-                label = "添加到播放队列",
-                onClick = onAddToQueue,
-                icon = Icons.AutoMirrored.Rounded.QueueMusic
-            ),
-            AudioItemMenuAction(
-                label = "添加到播放列表",
-                onClick = onAddToPlaylist,
-                icon = Icons.AutoMirrored.Rounded.PlaylistAdd,
-                showDividerBefore = true
-            ),
-            AudioItemMenuAction(
-                label = "标签管理",
-                onClick = onManageTags,
-                icon = Icons.AutoMirrored.Rounded.Label,
-                showDividerBefore = true
-            ),
-            AudioItemMenuAction(
-                label = "从专辑移除",
-                onClick = onRemove,
-                icon = Icons.Rounded.Delete,
-                showDividerBefore = true
+        actions = buildList {
+            add(
+                AudioItemMenuAction(
+                    label = "添加到播放队列",
+                    onClick = onAddToQueue,
+                    icon = Icons.AutoMirrored.Rounded.QueueMusic
+                )
             )
-        )
+            add(
+                AudioItemMenuAction(
+                    label = "添加到播放列表",
+                    onClick = onAddToPlaylist,
+                    icon = Icons.AutoMirrored.Rounded.PlaylistAdd,
+                    showDividerBefore = true
+                )
+            )
+            if (onManageTags != null) {
+                add(
+                    AudioItemMenuAction(
+                        label = "标签管理",
+                        onClick = onManageTags,
+                        icon = Icons.AutoMirrored.Rounded.Label,
+                        showDividerBefore = true
+                    )
+                )
+            }
+            add(
+                AudioItemMenuAction(
+                    label = "从专辑移除",
+                    onClick = onRemove,
+                    icon = Icons.Rounded.Delete,
+                    showDividerBefore = true
+                )
+            )
+        }
     )
 }
 

--- a/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailLocalTab.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailLocalTab.kt
@@ -136,6 +136,7 @@ import com.asmr.player.ui.theme.dynamicPageContainerColor
 import com.asmr.player.util.Formatting
 import com.asmr.player.util.MessageManager
 import com.asmr.player.util.RemoteSubtitleSource
+import com.asmr.player.util.isOnlineTrackPath
 
 @Composable
 internal fun AlbumLocalBreadcrumbTabV2(
@@ -377,7 +378,7 @@ internal fun AlbumLocalBreadcrumbTabV2(
                             onDownload = null,
                             onAddToQueue = track?.let { { onAddToQueue(it); Unit } },
                             onAddToPlaylist = track?.let { { onAddToPlaylist(it) } },
-                            onManageTags = track?.let { { onManageTrackTags(it) } },
+                            onManageTags = track?.let { if (!isOnlineTrackPath(it.path)) { { onManageTrackTags(it) } } else null },
                             onRemoveFromAlbum = track?.let { { onRemoveTrack(it) } }
                         )
                     }


### PR DESCRIPTION
## 问题

目录树中音频条目右侧的 "..." 菜单中，"标签管理"选项对网络资源音频也显示，但网络资源不支持标签管理。

## 修复

1. **AlbumDetailLocalTab.kt**: 在本地目录树的 `DirectoryFileRow` 调用处，通过 `isOnlineTrackPath(it.path)` 判断 track 路径，网络资源时将 `onManageTags` 设为 `null`，从而不显示标签管理菜单项。

2. **LibraryScreen.kt TrackListRow**: 将 `onManageTags` 参数改为可空类型 `(() -> Unit)? = null`，并使用 `buildList` 仅在回调非空时添加"标签管理"菜单项。调用处同样通过 `isOnlineTrackPath` 判断。

## 影响范围

- 本地专辑详情页目录树视图（Local Tab）
- 曲库列表中的曲目行

网络在线专辑（Dlsite Tab）本身未传 `onManageTags`，行为不受影响。
