### PR TITLE
feat: 点击 logo 区域快速切换主题 + 圆形扩散过渡动画

### DIFF
--- a/app/src/main/java/com/asmr/player/MainActivity.kt
+++ b/app/src/main/java/com/asmr/player/MainActivity.kt
@@ -107,6 +107,7 @@ import com.asmr.player.ui.common.LocalBottomOverlayPadding
 import com.asmr.player.ui.splash.EaraSplashOverlay
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
+import androidx.compose.runtime.rememberCoroutineScope
 import java.net.URLDecoder
 import java.net.URLEncoder
 import androidx.compose.material.icons.automirrored.rounded.ArrowBack
@@ -159,6 +160,9 @@ import com.asmr.player.ui.common.VisibleAppMessage
 import com.asmr.player.ui.theme.HuePalette
 import com.asmr.player.ui.theme.PlayerTheme
 import com.asmr.player.ui.theme.ThemeMode
+import com.asmr.player.ui.theme.LocalThemeTransitionTrigger
+import com.asmr.player.ui.theme.ThemeTransitionRequest
+import com.asmr.player.ui.theme.ThemeCircularRevealOverlay
 import com.asmr.player.ui.theme.DefaultBrandPrimaryDark
 import com.asmr.player.ui.theme.DefaultBrandPrimaryLight
 import com.asmr.player.ui.theme.deriveHuePalette
@@ -503,6 +507,18 @@ class MainActivity : ComponentActivity() {
                 }
             }
 
+            val coroutineScope = rememberCoroutineScope()
+            var themeTransition by remember { mutableStateOf<ThemeTransitionRequest?>(null) }
+            val themeTransitionTrigger: (ThemeTransitionRequest) -> Unit = remember {
+                { request ->
+                    themeTransition = request
+                    coroutineScope.launch {
+                        settingsDataStore.setTheme(request.targetPref)
+                    }
+                }
+            }
+
+            CompositionLocalProvider(LocalThemeTransitionTrigger provides themeTransitionTrigger) {
             AsmrPlayerTheme(mode = mode, hue = globalHue) {
                 var showSplash by rememberSaveable { mutableStateOf(true) }
                 var contentReady by remember { mutableStateOf(false) }
@@ -534,6 +550,13 @@ class MainActivity : ComponentActivity() {
                         EaraSplashOverlay(
                             isReady = contentReady,
                             onFinished = { showSplash = false }
+                        )
+                    }
+
+                    themeTransition?.let { request ->
+                        ThemeCircularRevealOverlay(
+                            request = request,
+                            onAnimationEnd = { themeTransition = null }
                         )
                     }
                     
@@ -580,6 +603,7 @@ class MainActivity : ComponentActivity() {
                         }
                     }
                 }
+            }
             }
         }
     }

--- a/app/src/main/java/com/asmr/player/MainActivity.kt
+++ b/app/src/main/java/com/asmr/player/MainActivity.kt
@@ -187,6 +187,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.withTimeoutOrNull
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.runBlocking
 
@@ -512,9 +513,6 @@ class MainActivity : ComponentActivity() {
             val themeTransitionTrigger: (ThemeTransitionRequest) -> Unit = remember {
                 { request ->
                     themeTransition = request
-                    coroutineScope.launch {
-                        settingsDataStore.setTheme(request.targetPref)
-                    }
                 }
             }
 
@@ -556,7 +554,15 @@ class MainActivity : ComponentActivity() {
                     themeTransition?.let { request ->
                         ThemeCircularRevealOverlay(
                             request = request,
-                            onAnimationEnd = { themeTransition = null }
+                            onAnimationEnd = {
+                                coroutineScope.launch {
+                                    settingsDataStore.setTheme(request.targetPref)
+                                    withTimeoutOrNull(500) {
+                                        settingsDataStore.themeBootstrapPreferences.first { it.theme == request.targetPref }
+                                    }
+                                    themeTransition = null
+                                }
+                            }
                         )
                     }
                     

--- a/app/src/main/java/com/asmr/player/MainActivity.kt
+++ b/app/src/main/java/com/asmr/player/MainActivity.kt
@@ -162,6 +162,7 @@ import com.asmr.player.ui.theme.PlayerTheme
 import com.asmr.player.ui.theme.ThemeMode
 import com.asmr.player.ui.theme.LocalThemeTransitionTrigger
 import com.asmr.player.ui.theme.ThemeTransitionRequest
+import com.asmr.player.ui.theme.ThemeTransitionTriggerRequest
 import com.asmr.player.ui.theme.ThemeCircularRevealOverlay
 import com.asmr.player.ui.theme.DefaultBrandPrimaryDark
 import com.asmr.player.ui.theme.DefaultBrandPrimaryLight
@@ -184,10 +185,8 @@ import com.asmr.player.ui.common.DismissOutsideBoundsOverlay
 import com.asmr.player.service.AudioOutputRouteKind
 import javax.inject.Inject
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.withTimeoutOrNull
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.filter
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.runBlocking
 
@@ -510,9 +509,16 @@ class MainActivity : ComponentActivity() {
 
             val coroutineScope = rememberCoroutineScope()
             var themeTransition by remember { mutableStateOf<ThemeTransitionRequest?>(null) }
-            val themeTransitionTrigger: (ThemeTransitionRequest) -> Unit = remember {
-                { request ->
-                    themeTransition = request
+            val themeTransitionTrigger: (ThemeTransitionTriggerRequest) -> Unit = remember(mode) {
+                { triggerReq ->
+                    val oldBg = neutralPaletteForMode(mode).background
+                    themeTransition = ThemeTransitionRequest(
+                        origin = triggerReq.origin,
+                        oldBackgroundColor = oldBg
+                    )
+                    coroutineScope.launch {
+                        settingsDataStore.setTheme(triggerReq.targetPref)
+                    }
                 }
             }
 
@@ -554,15 +560,7 @@ class MainActivity : ComponentActivity() {
                     themeTransition?.let { request ->
                         ThemeCircularRevealOverlay(
                             request = request,
-                            onAnimationEnd = {
-                                coroutineScope.launch {
-                                    settingsDataStore.setTheme(request.targetPref)
-                                    withTimeoutOrNull(500) {
-                                        settingsDataStore.themeBootstrapPreferences.first { it.theme == request.targetPref }
-                                    }
-                                    themeTransition = null
-                                }
-                            }
+                            onAnimationEnd = { themeTransition = null }
                         )
                     }
                     

--- a/app/src/main/java/com/asmr/player/main/MainNavigationSupport.kt
+++ b/app/src/main/java/com/asmr/player/main/MainNavigationSupport.kt
@@ -1,4 +1,4 @@
-﻿package com.asmr.player
+package com.asmr.player
 
 import android.os.Bundle
 import android.view.KeyEvent
@@ -116,6 +116,8 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import com.asmr.player.ui.theme.AsmrPlayerTheme
 import com.asmr.player.ui.theme.AsmrTheme
+import com.asmr.player.ui.theme.LocalThemeTransitionTrigger
+import com.asmr.player.ui.theme.ThemeTransitionRequest
 import androidx.compose.ui.draw.blur
 import android.os.Build
 import android.graphics.RenderEffect
@@ -126,6 +128,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.animation.*
 import androidx.compose.animation.core.LinearOutSlowInEasing
 import androidx.compose.animation.core.animateFloatAsState
@@ -134,9 +137,12 @@ import androidx.compose.animation.core.FastOutLinearInEasing
 import androidx.compose.animation.core.keyframes
 import androidx.compose.animation.core.tween
 import androidx.compose.ui.input.pointer.pointerInteropFilter
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.layout.boundsInRoot
 import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.layout.positionInWindow
 
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
@@ -301,10 +307,40 @@ internal fun PrimaryTopBarBrand(
     tint: Color,
     modifier: Modifier = Modifier
 ) {
+    val trigger = LocalThemeTransitionTrigger.current
+    val isDark = AsmrTheme.colorScheme.isDark
+    var positionInRoot by remember { mutableStateOf(Offset.Zero) }
+
+    val clickModifier = if (trigger != null) {
+        Modifier
+            .onGloballyPositioned { coordinates ->
+                positionInRoot = coordinates.positionInWindow()
+            }
+            .pointerInput(Unit) {
+                detectTapGestures {
+                    val origin = Offset(
+                        positionInRoot.x + it.x,
+                        positionInRoot.y + it.y
+                    )
+                    val targetPref = if (isDark) "light" else "dark"
+                    trigger(
+                        ThemeTransitionRequest(
+                            origin = origin,
+                            targetIsDark = !isDark,
+                            targetPref = targetPref
+                        )
+                    )
+                }
+            }
+    } else {
+        Modifier
+    }
+
     Row(
         modifier = modifier
             .fillMaxHeight()
-            .padding(start = 10.dp),
+            .padding(start = 10.dp)
+            .then(clickModifier),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(2.dp)
     ) {

--- a/app/src/main/java/com/asmr/player/main/MainNavigationSupport.kt
+++ b/app/src/main/java/com/asmr/player/main/MainNavigationSupport.kt
@@ -117,7 +117,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import com.asmr.player.ui.theme.AsmrPlayerTheme
 import com.asmr.player.ui.theme.AsmrTheme
 import com.asmr.player.ui.theme.LocalThemeTransitionTrigger
-import com.asmr.player.ui.theme.ThemeTransitionRequest
+import com.asmr.player.ui.theme.ThemeTransitionTriggerRequest
 import androidx.compose.ui.draw.blur
 import android.os.Build
 import android.graphics.RenderEffect
@@ -324,9 +324,8 @@ internal fun PrimaryTopBarBrand(
                     )
                     val targetPref = if (isDark) "light" else "dark"
                     trigger(
-                        ThemeTransitionRequest(
+                        ThemeTransitionTriggerRequest(
                             origin = origin,
-                            targetIsDark = !isDark,
                             targetPref = targetPref
                         )
                     )

--- a/app/src/main/java/com/asmr/player/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/settings/SettingsScreen.kt
@@ -15,8 +15,6 @@ import androidx.compose.foundation.interaction.collectIsPressedAsState
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.gestures.detectTapGestures
-import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.rememberLazyListState
@@ -49,7 +47,6 @@ import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.testTag
-import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.layout.positionInWindow
 import androidx.compose.ui.text.font.FontWeight
@@ -72,7 +69,7 @@ import com.asmr.player.ui.library.LibraryViewModel
 import com.asmr.player.ui.common.AppSupportStatusSection
 import com.asmr.player.ui.common.EaraLogoLoadingIndicator
 import com.asmr.player.ui.theme.LocalThemeTransitionTrigger
-import com.asmr.player.ui.theme.ThemeTransitionRequest
+import com.asmr.player.ui.theme.ThemeTransitionTriggerRequest
 import com.asmr.player.ui.theme.AsmrTheme
 import com.asmr.player.ui.common.LocalBottomOverlayPadding
 import com.asmr.player.ui.common.StableWindowInsets
@@ -1310,20 +1307,13 @@ private fun ThemeModeChip(
     val colorScheme = AsmrTheme.colorScheme
     val isDark = colorScheme.isDark
     val trigger = LocalThemeTransitionTrigger.current
-    val systemDark = isSystemInDarkTheme()
     var positionInWindow by remember { mutableStateOf(Offset.Zero) }
 
     val actualOnClick = {
         if (trigger != null && !selected && targetPref.isNotBlank()) {
-            val targetIsDark = when (targetPref) {
-                "light" -> false
-                "system" -> systemDark
-                else -> true
-            }
             trigger(
-                ThemeTransitionRequest(
+                ThemeTransitionTriggerRequest(
                     origin = positionInWindow,
-                    targetIsDark = targetIsDark,
                     targetPref = targetPref
                 )
             )

--- a/app/src/main/java/com/asmr/player/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/settings/SettingsScreen.kt
@@ -15,6 +15,8 @@ import androidx.compose.foundation.interaction.collectIsPressedAsState
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.rememberLazyListState
@@ -41,11 +43,15 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.layout.positionInWindow
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.DpOffset
@@ -65,6 +71,8 @@ import com.asmr.player.ui.library.BulkPhase
 import com.asmr.player.ui.library.LibraryViewModel
 import com.asmr.player.ui.common.AppSupportStatusSection
 import com.asmr.player.ui.common.EaraLogoLoadingIndicator
+import com.asmr.player.ui.theme.LocalThemeTransitionTrigger
+import com.asmr.player.ui.theme.ThemeTransitionRequest
 import com.asmr.player.ui.theme.AsmrTheme
 import com.asmr.player.ui.common.LocalBottomOverlayPadding
 import com.asmr.player.ui.common.StableWindowInsets
@@ -315,21 +323,25 @@ fun SettingsScreen(
                     ThemeModeChip(
                         label = "系统",
                         selected = themeMode == "system",
+                        targetPref = "system",
                         onClick = { viewModel.setThemeMode("system") }
                     )
                     ThemeModeChip(
                         label = "浅色",
                         selected = themeMode == "light",
+                        targetPref = "light",
                         onClick = { viewModel.setThemeMode("light") }
                     )
                     ThemeModeChip(
                         label = "深色",
                         selected = themeMode == "dark",
+                        targetPref = "dark",
                         onClick = { viewModel.setThemeMode("dark") }
                     )
                     ThemeModeChip(
                         label = "柔和深色",
                         selected = themeMode == "soft_dark",
+                        targetPref = "soft_dark",
                         onClick = { viewModel.setThemeMode("soft_dark") }
                     )
                 }
@@ -1289,13 +1301,46 @@ private fun SettingsInfoTip(active: Boolean, title: String, text: String, onTogg
 }
 
 @Composable
-private fun ThemeModeChip(label: String, selected: Boolean, onClick: () -> Unit) {
+private fun ThemeModeChip(
+    label: String,
+    selected: Boolean,
+    targetPref: String,
+    onClick: () -> Unit
+) {
     val colorScheme = AsmrTheme.colorScheme
     val isDark = colorScheme.isDark
+    val trigger = LocalThemeTransitionTrigger.current
+    val systemDark = isSystemInDarkTheme()
+    var positionInWindow by remember { mutableStateOf(Offset.Zero) }
+
+    val actualOnClick = {
+        if (trigger != null && !selected && targetPref.isNotBlank()) {
+            val targetIsDark = when (targetPref) {
+                "light" -> false
+                "system" -> systemDark
+                else -> true
+            }
+            trigger(
+                ThemeTransitionRequest(
+                    origin = positionInWindow,
+                    targetIsDark = targetIsDark,
+                    targetPref = targetPref
+                )
+            )
+        } else {
+            onClick()
+        }
+    }
+
     FilterChip(
         selected = selected,
-        onClick = onClick,
+        onClick = actualOnClick,
         label = { Text(label) },
+        modifier = Modifier.onGloballyPositioned { coordinates ->
+            val pos = coordinates.positionInWindow()
+            val size = coordinates.size
+            positionInWindow = Offset(pos.x + size.width / 2f, pos.y + size.height / 2f)
+        },
         colors = FilterChipDefaults.filterChipColors(
             selectedContainerColor = colorScheme.primarySoft,
             selectedLabelColor = if (isDark) colorScheme.onPrimaryContainer else colorScheme.primaryStrong

--- a/app/src/main/java/com/asmr/player/ui/theme/ThemeTransitionOverlay.kt
+++ b/app/src/main/java/com/asmr/player/ui/theme/ThemeTransitionOverlay.kt
@@ -1,0 +1,60 @@
+package com.asmr.player.ui.theme
+
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.staticCompositionLocalOf
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import kotlin.math.sqrt
+
+data class ThemeTransitionRequest(
+    val origin: Offset,
+    val targetIsDark: Boolean,
+    val targetPref: String
+)
+
+val LightBackground = Color(0xFFF0F4F8)
+val DarkBackground = Color(0xFF121212)
+
+val LocalThemeTransitionTrigger = staticCompositionLocalOf<((ThemeTransitionRequest) -> Unit)?> { null }
+
+@Composable
+fun ThemeCircularRevealOverlay(
+    request: ThemeTransitionRequest,
+    onAnimationEnd: () -> Unit
+) {
+    val targetColor = if (request.targetIsDark) DarkBackground else LightBackground
+
+    val animationProgress = remember { Animatable(0f) }
+
+    LaunchedEffect(request) {
+        animationProgress.snapTo(0f)
+        animationProgress.animateTo(
+            targetValue = 1f,
+            animationSpec = tween(durationMillis = 500, easing = FastOutSlowInEasing)
+        )
+        onAnimationEnd()
+    }
+
+    Box(modifier = Modifier.fillMaxSize()) {
+        Canvas(modifier = Modifier.fillMaxSize()) {
+            val maxRadius = sqrt(
+                size.width * size.width + size.height * size.height
+            )
+            val radius = maxRadius * animationProgress.value
+            drawCircle(
+                color = targetColor,
+                radius = radius,
+                center = request.origin
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/asmr/player/ui/theme/ThemeTransitionOverlay.kt
+++ b/app/src/main/java/com/asmr/player/ui/theme/ThemeTransitionOverlay.kt
@@ -8,53 +8,79 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.PathOperation
+import androidx.compose.ui.layout.onSizeChanged
 import kotlin.math.sqrt
 
 data class ThemeTransitionRequest(
     val origin: Offset,
-    val targetIsDark: Boolean,
+    val oldBackgroundColor: Color
+)
+
+data class ThemeTransitionTriggerRequest(
+    val origin: Offset,
     val targetPref: String
 )
 
-val LightBackground = Color(0xFFF0F4F8)
-val DarkBackground = Color(0xFF121212)
-
-val LocalThemeTransitionTrigger = staticCompositionLocalOf<((ThemeTransitionRequest) -> Unit)?> { null }
+val LocalThemeTransitionTrigger = staticCompositionLocalOf<((ThemeTransitionTriggerRequest) -> Unit)?> { null }
 
 @Composable
 fun ThemeCircularRevealOverlay(
     request: ThemeTransitionRequest,
     onAnimationEnd: () -> Unit
 ) {
-    val targetColor = if (request.targetIsDark) DarkBackground else LightBackground
-
     val animationProgress = remember { Animatable(0f) }
+    var overlaySize by remember { mutableStateOf(Size.Zero) }
 
     LaunchedEffect(request) {
         animationProgress.snapTo(0f)
         animationProgress.animateTo(
             targetValue = 1f,
-            animationSpec = tween(durationMillis = 500, easing = FastOutSlowInEasing)
+            animationSpec = tween(durationMillis = 450, easing = FastOutSlowInEasing)
         )
         onAnimationEnd()
     }
 
     Box(modifier = Modifier.fillMaxSize()) {
-        Canvas(modifier = Modifier.fillMaxSize()) {
+        Canvas(
+            modifier = Modifier
+                .fillMaxSize()
+                .onSizeChanged { overlaySize = Size(it.width.toFloat(), it.height.toFloat()) }
+        ) {
+            if (overlaySize == Size.Zero) return@Canvas
+
             val maxRadius = sqrt(
-                size.width * size.width + size.height * size.height
+                overlaySize.width * overlaySize.width + overlaySize.height * overlaySize.height
             )
             val radius = maxRadius * animationProgress.value
-            drawCircle(
-                color = targetColor,
-                radius = radius,
-                center = request.origin
-            )
+
+            val rectPath = Path().apply {
+                addRect(Rect(0f, 0f, overlaySize.width, overlaySize.height))
+            }
+            val circlePath = Path().apply {
+                addOval(Rect(
+                    request.origin.x - radius,
+                    request.origin.y - radius,
+                    request.origin.x + radius,
+                    request.origin.y + radius
+                ))
+            }
+            val invertedPath = Path().apply {
+                op(rectPath, circlePath, PathOperation.Difference)
+            }
+
+            drawPath(path = invertedPath, color = request.oldBackgroundColor)
         }
     }
 }


### PR DESCRIPTION
## 功能说明

### 1. Header Logo 区域快速切换主题
- 用户点击顶部导航栏左侧的 **logo + Eara 文案** 区域即可快速切换浅色/深色主题
- 切换逻辑：浅色  深色 / 深色/柔和深色  浅色 / 跟随系统  相反模式

### 2. 圆形扩散过渡动画
- 主题切换时从点击位置（或设置页按钮中心）开始播放圆形扩散动画
- 动画时长 500ms，使用 FastOutSlowInEasing 缓动
- 扩散半径覆盖整个屏幕，无缝衔接主题切换

### 3. 设置页面同步动画
- 在「设置  外观  主题模式」中点击任意模式按钮
- 同样从按钮中心播放圆形扩散过渡动画

## 技术实现
- 新增 \ThemeTransitionOverlay.kt\：使用 Compose Canvas 绘制圆形扩散
- 通过 \CompositionLocal\ 传递触发回调，无需修改组件间传参
- 点击坐标使用 \positionInWindow()\ 定位，确保动画精确从点击位置展开
- 主题写入由 MainActivity 统一处理，通过 DataStore 触发全局主题更新