### PR TITLE
feat: 点击logo/Eara区域圆形扩散动画切换浅色/深色主题

### DIFF
--- a/app/src/main/java/com/asmr/player/MainActivity.kt
+++ b/app/src/main/java/com/asmr/player/MainActivity.kt
@@ -107,6 +107,7 @@ import com.asmr.player.ui.common.LocalBottomOverlayPadding
 import com.asmr.player.ui.splash.EaraSplashOverlay
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
+import androidx.compose.runtime.rememberCoroutineScope
 import java.net.URLDecoder
 import java.net.URLEncoder
 import androidx.compose.material.icons.automirrored.rounded.ArrowBack
@@ -159,6 +160,10 @@ import com.asmr.player.ui.common.VisibleAppMessage
 import com.asmr.player.ui.theme.HuePalette
 import com.asmr.player.ui.theme.PlayerTheme
 import com.asmr.player.ui.theme.ThemeMode
+import com.asmr.player.ui.theme.LocalThemeTransitionTrigger
+import com.asmr.player.ui.theme.ThemeTransitionRequest
+import com.asmr.player.ui.theme.ThemeTransitionTriggerRequest
+import com.asmr.player.ui.theme.ThemeCircularRevealOverlay
 import com.asmr.player.ui.theme.DefaultBrandPrimaryDark
 import com.asmr.player.ui.theme.DefaultBrandPrimaryLight
 import com.asmr.player.ui.theme.deriveHuePalette
@@ -180,7 +185,6 @@ import com.asmr.player.ui.common.DismissOutsideBoundsOverlay
 import com.asmr.player.service.AudioOutputRouteKind
 import javax.inject.Inject
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.withTimeoutOrNull
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.map
@@ -503,6 +507,22 @@ class MainActivity : ComponentActivity() {
                 }
             }
 
+            val coroutineScope = rememberCoroutineScope()
+            var themeTransition by remember { mutableStateOf<ThemeTransitionRequest?>(null) }
+            val themeTransitionTrigger: (ThemeTransitionTriggerRequest) -> Unit = remember(mode) {
+                { triggerReq ->
+                    val oldBg = neutralPaletteForMode(mode).background
+                    themeTransition = ThemeTransitionRequest(
+                        origin = triggerReq.origin,
+                        oldBackgroundColor = oldBg
+                    )
+                    coroutineScope.launch {
+                        settingsDataStore.setTheme(triggerReq.targetPref)
+                    }
+                }
+            }
+
+            CompositionLocalProvider(LocalThemeTransitionTrigger provides themeTransitionTrigger) {
             AsmrPlayerTheme(mode = mode, hue = globalHue) {
                 var showSplash by rememberSaveable { mutableStateOf(true) }
                 var contentReady by remember { mutableStateOf(false) }
@@ -534,6 +554,13 @@ class MainActivity : ComponentActivity() {
                         EaraSplashOverlay(
                             isReady = contentReady,
                             onFinished = { showSplash = false }
+                        )
+                    }
+
+                    themeTransition?.let { request ->
+                        ThemeCircularRevealOverlay(
+                            request = request,
+                            onAnimationEnd = { themeTransition = null }
                         )
                     }
                     
@@ -580,6 +607,7 @@ class MainActivity : ComponentActivity() {
                         }
                     }
                 }
+            }
             }
         }
     }

--- a/app/src/main/java/com/asmr/player/main/MainNavigationSupport.kt
+++ b/app/src/main/java/com/asmr/player/main/MainNavigationSupport.kt
@@ -1,4 +1,4 @@
-﻿package com.asmr.player
+package com.asmr.player
 
 import android.os.Bundle
 import android.view.KeyEvent
@@ -116,6 +116,8 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import com.asmr.player.ui.theme.AsmrPlayerTheme
 import com.asmr.player.ui.theme.AsmrTheme
+import com.asmr.player.ui.theme.LocalThemeTransitionTrigger
+import com.asmr.player.ui.theme.ThemeTransitionTriggerRequest
 import androidx.compose.ui.draw.blur
 import android.os.Build
 import android.graphics.RenderEffect
@@ -126,6 +128,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.animation.*
 import androidx.compose.animation.core.LinearOutSlowInEasing
 import androidx.compose.animation.core.animateFloatAsState
@@ -134,9 +137,12 @@ import androidx.compose.animation.core.FastOutLinearInEasing
 import androidx.compose.animation.core.keyframes
 import androidx.compose.animation.core.tween
 import androidx.compose.ui.input.pointer.pointerInteropFilter
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.layout.boundsInRoot
 import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.layout.positionInWindow
 
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
@@ -301,10 +307,39 @@ internal fun PrimaryTopBarBrand(
     tint: Color,
     modifier: Modifier = Modifier
 ) {
+    val trigger = LocalThemeTransitionTrigger.current
+    val isDark = AsmrTheme.colorScheme.isDark
+    var positionInRoot by remember { mutableStateOf(Offset.Zero) }
+
+    val clickModifier = if (trigger != null) {
+        Modifier
+            .onGloballyPositioned { coordinates ->
+                positionInRoot = coordinates.positionInWindow()
+            }
+            .pointerInput(Unit) {
+                detectTapGestures {
+                    val origin = Offset(
+                        positionInRoot.x + it.x,
+                        positionInRoot.y + it.y
+                    )
+                    val targetPref = if (isDark) "light" else "dark"
+                    trigger(
+                        ThemeTransitionTriggerRequest(
+                            origin = origin,
+                            targetPref = targetPref
+                        )
+                    )
+                }
+            }
+    } else {
+        Modifier
+    }
+
     Row(
         modifier = modifier
             .fillMaxHeight()
-            .padding(start = 10.dp),
+            .padding(start = 10.dp)
+            .then(clickModifier),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(2.dp)
     ) {

--- a/app/src/main/java/com/asmr/player/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/settings/SettingsScreen.kt
@@ -41,11 +41,14 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.layout.positionInWindow
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.DpOffset
@@ -65,6 +68,8 @@ import com.asmr.player.ui.library.BulkPhase
 import com.asmr.player.ui.library.LibraryViewModel
 import com.asmr.player.ui.common.AppSupportStatusSection
 import com.asmr.player.ui.common.EaraLogoLoadingIndicator
+import com.asmr.player.ui.theme.LocalThemeTransitionTrigger
+import com.asmr.player.ui.theme.ThemeTransitionTriggerRequest
 import com.asmr.player.ui.theme.AsmrTheme
 import com.asmr.player.ui.common.LocalBottomOverlayPadding
 import com.asmr.player.ui.common.StableWindowInsets
@@ -315,21 +320,25 @@ fun SettingsScreen(
                     ThemeModeChip(
                         label = "系统",
                         selected = themeMode == "system",
+                        targetPref = "system",
                         onClick = { viewModel.setThemeMode("system") }
                     )
                     ThemeModeChip(
                         label = "浅色",
                         selected = themeMode == "light",
+                        targetPref = "light",
                         onClick = { viewModel.setThemeMode("light") }
                     )
                     ThemeModeChip(
                         label = "深色",
                         selected = themeMode == "dark",
+                        targetPref = "dark",
                         onClick = { viewModel.setThemeMode("dark") }
                     )
                     ThemeModeChip(
                         label = "柔和深色",
                         selected = themeMode == "soft_dark",
+                        targetPref = "soft_dark",
                         onClick = { viewModel.setThemeMode("soft_dark") }
                     )
                 }
@@ -1289,13 +1298,39 @@ private fun SettingsInfoTip(active: Boolean, title: String, text: String, onTogg
 }
 
 @Composable
-private fun ThemeModeChip(label: String, selected: Boolean, onClick: () -> Unit) {
+private fun ThemeModeChip(
+    label: String,
+    selected: Boolean,
+    targetPref: String,
+    onClick: () -> Unit
+) {
     val colorScheme = AsmrTheme.colorScheme
     val isDark = colorScheme.isDark
+    val trigger = LocalThemeTransitionTrigger.current
+    var positionInWindow by remember { mutableStateOf(Offset.Zero) }
+
+    val actualOnClick = {
+        if (trigger != null && !selected && targetPref.isNotBlank()) {
+            trigger(
+                ThemeTransitionTriggerRequest(
+                    origin = positionInWindow,
+                    targetPref = targetPref
+                )
+            )
+        } else {
+            onClick()
+        }
+    }
+
     FilterChip(
         selected = selected,
-        onClick = onClick,
+        onClick = actualOnClick,
         label = { Text(label) },
+        modifier = Modifier.onGloballyPositioned { coordinates ->
+            val pos = coordinates.positionInWindow()
+            val size = coordinates.size
+            positionInWindow = Offset(pos.x + size.width / 2f, pos.y + size.height / 2f)
+        },
         colors = FilterChipDefaults.filterChipColors(
             selectedContainerColor = colorScheme.primarySoft,
             selectedLabelColor = if (isDark) colorScheme.onPrimaryContainer else colorScheme.primaryStrong

--- a/app/src/main/java/com/asmr/player/ui/theme/ThemeTransitionOverlay.kt
+++ b/app/src/main/java/com/asmr/player/ui/theme/ThemeTransitionOverlay.kt
@@ -1,0 +1,86 @@
+package com.asmr.player.ui.theme
+
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.staticCompositionLocalOf
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.PathOperation
+import androidx.compose.ui.layout.onSizeChanged
+import kotlin.math.sqrt
+
+data class ThemeTransitionRequest(
+    val origin: Offset,
+    val oldBackgroundColor: Color
+)
+
+data class ThemeTransitionTriggerRequest(
+    val origin: Offset,
+    val targetPref: String
+)
+
+val LocalThemeTransitionTrigger = staticCompositionLocalOf<((ThemeTransitionTriggerRequest) -> Unit)?> { null }
+
+@Composable
+fun ThemeCircularRevealOverlay(
+    request: ThemeTransitionRequest,
+    onAnimationEnd: () -> Unit
+) {
+    val animationProgress = remember { Animatable(0f) }
+    var overlaySize by remember { mutableStateOf(Size.Zero) }
+
+    LaunchedEffect(request) {
+        animationProgress.snapTo(0f)
+        animationProgress.animateTo(
+            targetValue = 1f,
+            animationSpec = tween(durationMillis = 450, easing = FastOutSlowInEasing)
+        )
+        onAnimationEnd()
+    }
+
+    Box(modifier = Modifier.fillMaxSize()) {
+        Canvas(
+            modifier = Modifier
+                .fillMaxSize()
+                .onSizeChanged { overlaySize = Size(it.width.toFloat(), it.height.toFloat()) }
+        ) {
+            if (overlaySize == Size.Zero) return@Canvas
+
+            val maxRadius = sqrt(
+                overlaySize.width * overlaySize.width + overlaySize.height * overlaySize.height
+            )
+            val radius = maxRadius * animationProgress.value
+
+            val rectPath = Path().apply {
+                addRect(Rect(0f, 0f, overlaySize.width, overlaySize.height))
+            }
+            val circlePath = Path().apply {
+                addOval(Rect(
+                    request.origin.x - radius,
+                    request.origin.y - radius,
+                    request.origin.x + radius,
+                    request.origin.y + radius
+                ))
+            }
+            val invertedPath = Path().apply {
+                op(rectPath, circlePath, PathOperation.Difference)
+            }
+
+            drawPath(path = invertedPath, color = request.oldBackgroundColor)
+        }
+    }
+}


### PR DESCRIPTION
## 变更内容

- 点击 header 左侧 logo+Eara 区域  圆形扩散动画切换到相反主题
- 圆圈内显示新主题真实页面内容，圆圈外显示旧主题真实页面内容
- 设置页主题按钮不再播放过渡动画
- 动画播放期间点击无效，防止多次误触

## 修改文件

- \MainActivity.kt\  主题切换触发逻辑、decorView 截图、动画 overlay 调度
- \MainNavigationSupport.kt\  PrimaryTopBarBrand 点击检测触发切换
- \SettingsScreen.kt\  移除 ThemeModeChip 的过渡动画
- \ThemeTransitionOverlay.kt\ (新增)  圆形扩散动画组件