### PR TITLE
feat: add hot listening duration sorting

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -70,8 +70,8 @@ android {
         applicationId = "com.asmr.player"
         minSdk = 24
         targetSdk = 34
-        versionCode = 10102
-        versionName = "1.1.1"
+        versionCode = 10103
+        versionName = "1.1.2"
         buildConfigField("String", "UPDATE_REPO_OWNER", "\"eValDoll\"")
         buildConfigField("String", "UPDATE_REPO_NAME", "\"EaraAsmrPlayer\"")
         buildConfigField("String", "LISTEN_TOGETHER_BASE_URL", "\"$listenTogetherBaseUrl\"")

--- a/app/src/main/java/com/asmr/player/data/settings/SettingsDataStore.kt
+++ b/app/src/main/java/com/asmr/player/data/settings/SettingsDataStore.kt
@@ -19,6 +19,7 @@ object SettingsKeys {
     val LIBRARY_VIEW_MODE = intPreferencesKey("library_view_mode")
     val SEARCH_VIEW_MODE = intPreferencesKey("search_view_mode")
     val HOT_LISTENING_VIEW_MODE = intPreferencesKey("hot_listening_view_mode")
+    val HOT_LISTENING_SORT_MODE = stringPreferencesKey("hot_listening_sort_mode")
 
     val PLAY_MODE = intPreferencesKey("play_mode")
 

--- a/app/src/main/java/com/asmr/player/data/settings/SettingsRepository.kt
+++ b/app/src/main/java/com/asmr/player/data/settings/SettingsRepository.kt
@@ -2,6 +2,7 @@ package com.asmr.player.data.settings
 
 import android.content.Context
 import com.asmr.player.playback.AppVolume
+import com.asmr.player.hotlistening.HotListeningSortMode
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
@@ -40,6 +41,10 @@ class SettingsRepository @Inject constructor(
 
     val hotListeningViewMode: Flow<Int> = context.settingsDataStore.data.map { prefs ->
         prefs[SettingsKeys.HOT_LISTENING_VIEW_MODE] ?: 1
+    }
+
+    val hotListeningSortMode: Flow<HotListeningSortMode> = context.settingsDataStore.data.map { prefs ->
+        HotListeningSortMode.fromWireValue(prefs[SettingsKeys.HOT_LISTENING_SORT_MODE])
     }
 
     val playMode: Flow<Int> = context.settingsDataStore.data.map { prefs ->
@@ -352,6 +357,12 @@ class SettingsRepository @Inject constructor(
     suspend fun setHotListeningViewMode(mode: Int) {
         withContext(Dispatchers.IO) {
             context.settingsDataStore.edit { it[SettingsKeys.HOT_LISTENING_VIEW_MODE] = mode }
+        }
+    }
+
+    suspend fun setHotListeningSortMode(mode: HotListeningSortMode) {
+        withContext(Dispatchers.IO) {
+            context.settingsDataStore.edit { it[SettingsKeys.HOT_LISTENING_SORT_MODE] = mode.wireValue }
         }
     }
 

--- a/app/src/main/java/com/asmr/player/hotlistening/HotListeningApi.kt
+++ b/app/src/main/java/com/asmr/player/hotlistening/HotListeningApi.kt
@@ -4,27 +4,32 @@ import android.os.Build
 import com.asmr.player.BuildConfig
 import com.asmr.player.data.remote.NetworkHeaders
 import com.google.gson.Gson
-import com.google.gson.annotations.SerializedName
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.RequestBody.Companion.toRequestBody
-import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 import java.io.IOException
 import java.util.UUID
-import kotlin.text.Charsets.UTF_8
 import javax.inject.Inject
 import javax.inject.Singleton
+import kotlin.text.Charsets.UTF_8
 
 data class HotListeningReportRequest(
     val rj: String
 )
 
+data class HotListeningDurationReportRequest(
+    val rj: String,
+    val durationMs: Long
+)
+
 data class HotListeningReportResponse(
     val rj: String,
-    val valid: Boolean
+    val valid: Boolean,
+    val durationMs: Long = 0L
 )
 
 data class HotListeningItem(
@@ -34,13 +39,25 @@ data class HotListeningItem(
     val cv: String = "",
     val tags: String = "",
     val coverUrl: String = "",
-    val playCount: Int = 0
+    val playCount: Int = 0,
+    val listenDurationMs: Long = 0L
 ) {
     val cvList: List<String>
         get() = cv.split(",").map { it.trim() }.filter { it.isNotBlank() }
 
     val tagList: List<String>
         get() = tags.split(",").map { it.trim() }.filter { it.isNotBlank() }
+}
+
+enum class HotListeningSortMode(val wireValue: String, val label: String) {
+    PlayCount("play_count", "按播放次数"),
+    ListenDuration("listen_duration", "按收听时长");
+
+    companion object {
+        fun fromWireValue(value: String?): HotListeningSortMode {
+            return entries.firstOrNull { it.wireValue == value } ?: PlayCount
+        }
+    }
 }
 
 @Singleton
@@ -67,7 +84,21 @@ class HotListeningApi @Inject constructor(
         )
     }
 
-    suspend fun getTopListings(period: String): List<HotListeningItem>? {
+    suspend fun reportListenDuration(rj: String, durationMs: Long): HotListeningReportResponse? {
+        if (!isBackendConfigured) return null
+        val normalizedRj = rj.trim().uppercase()
+        if (normalizedRj.isBlank() || durationMs < MIN_DURATION_REPORT_MS) return null
+        return postJson(
+            path = "api/hot-listenings/report-duration",
+            body = HotListeningDurationReportRequest(rj = normalizedRj, durationMs = durationMs),
+            responseClass = HotListeningReportResponse::class.java
+        )
+    }
+
+    suspend fun getTopListings(
+        period: String,
+        sortMode: HotListeningSortMode = HotListeningSortMode.PlayCount
+    ): List<HotListeningItem>? {
         if (!isBackendConfigured) return null
         val normalizedPeriod = period.trim().lowercase()
         if (normalizedPeriod !in setOf("day", "week", "month", "year")) return null
@@ -77,7 +108,10 @@ class HotListeningApi @Inject constructor(
         ).type
         return getJson(
             path = "api/hot-listenings/top",
-            queryParameters = mapOf("period" to normalizedPeriod),
+            queryParameters = mapOf(
+                "period" to normalizedPeriod,
+                "sort" to sortMode.wireValue
+            ),
             responseType = listType
         )
     }
@@ -149,12 +183,6 @@ class HotListeningApi @Inject constructor(
         return "$root/$normalizedPath"
     }
 
-    private companion object {
-        private val JSON_MEDIA_TYPE = "application/json; charset=utf-8".toMediaType()
-        private val baseUrl: String
-            get() = BuildConfig.LISTEN_TOGETHER_BASE_URL
-    }
-
     private fun buildDeviceFingerprint(): String {
         val source = listOf(
             Build.BRAND,
@@ -176,5 +204,12 @@ class HotListeningApi @Inject constructor(
             .joinToString(separator = " ")
             .ifBlank { "Android" }
         return "EaraHotListening/${BuildConfig.VERSION_NAME} (Android ${Build.VERSION.SDK_INT}; $deviceModel)"
+    }
+
+    private companion object {
+        private val JSON_MEDIA_TYPE = "application/json; charset=utf-8".toMediaType()
+        private const val MIN_DURATION_REPORT_MS = 30_000L
+        private val baseUrl: String
+            get() = BuildConfig.LISTEN_TOGETHER_BASE_URL
     }
 }

--- a/app/src/main/java/com/asmr/player/hotlistening/ListeningTracker.kt
+++ b/app/src/main/java/com/asmr/player/hotlistening/ListeningTracker.kt
@@ -5,7 +5,9 @@ import com.asmr.player.playback.PlaybackSnapshot
 import com.asmr.player.ui.player.isOnlineMedia
 import com.asmr.player.util.DlsiteWorkNo
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.map
@@ -18,68 +20,130 @@ class ListeningTracker @Inject constructor(
     private val hotListeningApi: HotListeningApi
 ) {
     private var observationJob: Job? = null
+    private val reportScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    private var activeSession = ListenSession()
+    private var playCountReportedMediaId: String? = null
 
     fun start(scope: CoroutineScope, playback: StateFlow<PlaybackSnapshot>) {
         stop()
         observationJob = scope.launch {
-            var accumulatedMs = 0L
-            var lastPositionMs = 0L
-            var reportedForCurrentMediaId: String? = null
-            var lastMediaId: String? = null
-
             playback
                 .map { snapshot ->
                     val item = snapshot.currentMediaItem
                     val mediaId = item?.mediaId ?: ""
                     val isOnline = item.isOnlineMedia()
-                    Triple(snapshot.isPlaying, snapshot.positionMs.coerceAtLeast(0L), isOnline) to mediaId
+                    val rjCode = extractRjCode(item)
+                    TrackerSnapshot(
+                        mediaId = mediaId,
+                        rjCode = rjCode,
+                        isPlaying = snapshot.isPlaying,
+                        isOnline = isOnline,
+                        positionMs = snapshot.positionMs.coerceAtLeast(0L),
+                        observedAtMs = android.os.SystemClock.elapsedRealtime()
+                    )
                 }
                 .distinctUntilChanged { old, new ->
-                    old.first.first == new.first.first &&
-                        old.first.second == new.first.second &&
-                        old.second == new.second
+                    old.mediaId == new.mediaId &&
+                        old.rjCode == new.rjCode &&
+                        old.isPlaying == new.isPlaying &&
+                        old.isOnline == new.isOnline &&
+                        old.positionMs == new.positionMs
                 }
-                .collect { (triple, mediaId) ->
-                    val (isPlaying, positionMs, isOnline) = triple
-
-                    if (mediaId != lastMediaId) {
-                        accumulatedMs = 0L
-                        lastPositionMs = positionMs
-                        lastMediaId = mediaId
-                        reportedForCurrentMediaId = null
-                        return@collect
-                    }
-
-                    if (!isPlaying) {
-                        lastPositionMs = positionMs
-                        return@collect
-                    }
-
-                    val delta = positionMs - lastPositionMs
-                    if (delta > 0L && delta < 3_000L) {
-                        accumulatedMs = accumulatedMs + delta
-                    }
-                    lastPositionMs = positionMs
-
-                    if (accumulatedMs >= REPORT_THRESHOLD_MS && reportedForCurrentMediaId != mediaId) {
-                        reportedForCurrentMediaId = mediaId
-                        val currentItem = playback.value.currentMediaItem
-                        val rjCode = extractRjCode(item = currentItem)
-                        if (rjCode.isNotBlank() && hotListeningApi.isBackendConfigured) {
-                            scope.launch {
-                                runCatching {
-                                    hotListeningApi.reportListen(rjCode)
-                                }
-                            }
-                        }
-                    }
+                .collect { snapshot ->
+                    handleSnapshot(snapshot, scope)
                 }
         }
     }
 
     fun stop() {
+        flushDuration()
         observationJob?.cancel()
         observationJob = null
+    }
+
+    fun flushNow() {
+        flushDuration()
+    }
+
+    private fun handleSnapshot(snapshot: TrackerSnapshot, scope: CoroutineScope) {
+        val previous = activeSession
+        if (snapshot.mediaId.isBlank()) {
+            flushDuration()
+            playCountReportedMediaId = null
+            return
+        }
+
+        val mediaChanged = previous.mediaId.isNotBlank() && previous.mediaId != snapshot.mediaId
+        val rjChanged = previous.rjCode.isNotBlank() && previous.rjCode != snapshot.rjCode
+        if (mediaChanged || rjChanged) {
+            flushDuration()
+            playCountReportedMediaId = null
+            activeSession = ListenSession(
+                mediaId = snapshot.mediaId,
+                rjCode = snapshot.rjCode,
+                isOnline = snapshot.isOnline,
+                isPlaying = snapshot.isPlaying,
+                lastObservedAtMs = snapshot.observedAtMs
+            )
+            return
+        }
+
+        if (previous.mediaId.isBlank() && snapshot.mediaId.isNotBlank()) {
+            activeSession = ListenSession(
+                mediaId = snapshot.mediaId,
+                rjCode = snapshot.rjCode,
+                isOnline = snapshot.isOnline,
+                isPlaying = snapshot.isPlaying,
+                lastObservedAtMs = snapshot.observedAtMs
+            )
+            return
+        }
+
+        activeSession = previous.addElapsedUntil(snapshot.observedAtMs).copy(
+            mediaId = snapshot.mediaId,
+            rjCode = snapshot.rjCode,
+            isOnline = snapshot.isOnline,
+            isPlaying = snapshot.isPlaying,
+            lastObservedAtMs = snapshot.observedAtMs
+        )
+
+        val session = activeSession
+        if (session.playedMs >= REPORT_THRESHOLD_MS && playCountReportedMediaId != session.mediaId) {
+            playCountReportedMediaId = session.mediaId
+            reportPlayCount(session.rjCode, scope)
+        }
+
+        if (!snapshot.isPlaying && previous.isPlaying) {
+            flushDuration()
+        }
+    }
+
+    private fun flushDuration() {
+        activeSession = activeSession.addElapsedUntil(android.os.SystemClock.elapsedRealtime())
+        val session = activeSession
+        if (session.playedMs >= REPORT_THRESHOLD_MS && session.rjCode.isNotBlank() && hotListeningApi.isBackendConfigured) {
+            val durationMs = session.playedMs
+            val rjCode = session.rjCode
+            if (playCountReportedMediaId != session.mediaId) {
+                playCountReportedMediaId = session.mediaId
+                reportScope.launch {
+                    runCatching { hotListeningApi.reportListen(rjCode) }
+                }
+            }
+            reportScope.launch {
+                runCatching { hotListeningApi.reportListenDuration(rjCode, durationMs) }
+            }
+        }
+        activeSession = ListenSession()
+    }
+
+    private fun reportPlayCount(rjCode: String, scope: CoroutineScope) {
+        if (rjCode.isBlank() || !hotListeningApi.isBackendConfigured) return
+        scope.launch {
+            runCatching {
+                hotListeningApi.reportListen(rjCode)
+            }
+        }
     }
 
     private fun extractRjCode(item: MediaItem?): String {
@@ -102,5 +166,31 @@ class ListeningTracker @Inject constructor(
 
     private companion object {
         private const val REPORT_THRESHOLD_MS = 30_000L
+    }
+}
+
+private data class TrackerSnapshot(
+    val mediaId: String,
+    val rjCode: String,
+    val isPlaying: Boolean,
+    val isOnline: Boolean,
+    val positionMs: Long,
+    val observedAtMs: Long
+)
+
+private data class ListenSession(
+    val mediaId: String = "",
+    val rjCode: String = "",
+    val isOnline: Boolean = false,
+    val isPlaying: Boolean = false,
+    val lastObservedAtMs: Long = 0L,
+    val playedMs: Long = 0L
+) {
+    fun addElapsedUntil(nowMs: Long): ListenSession {
+        if (!isPlaying || lastObservedAtMs <= 0L || nowMs <= lastObservedAtMs) return this
+        return copy(
+            playedMs = playedMs + (nowMs - lastObservedAtMs),
+            lastObservedAtMs = nowMs
+        )
     }
 }

--- a/app/src/main/java/com/asmr/player/main/MainContainer.kt
+++ b/app/src/main/java/com/asmr/player/main/MainContainer.kt
@@ -187,6 +187,9 @@ import androidx.compose.foundation.border
 import androidx.compose.foundation.BorderStroke
 import androidx.media3.common.MediaItem
 import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.compose.ui.platform.LocalLifecycleOwner
 import com.asmr.player.data.settings.SettingsRepository
 import com.asmr.player.playback.AppVolume
 import com.asmr.player.ui.common.AppVolumeVerticalSlider
@@ -295,6 +298,18 @@ fun MainContainer(
     }
     LaunchedEffect(Unit) {
         listeningTracker.start(this, playerViewModel.playback)
+    }
+    val lifecycleOwner = LocalLifecycleOwner.current
+    DisposableEffect(lifecycleOwner, listeningTracker) {
+        val observer = LifecycleEventObserver { _, event ->
+            if (event == Lifecycle.Event.ON_STOP) {
+                listeningTracker.flushNow()
+            }
+        }
+        lifecycleOwner.lifecycle.addObserver(observer)
+        onDispose {
+            lifecycleOwner.lifecycle.removeObserver(observer)
+        }
     }
     LaunchedEffect(navController, startRoute, initialDestination) {
         if (startRoute.isBlank() || startRoute == initialDestination) return@LaunchedEffect

--- a/app/src/main/java/com/asmr/player/ui/hotlistening/HotListeningScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/hotlistening/HotListeningScreen.kt
@@ -14,12 +14,17 @@ import androidx.compose.foundation.lazy.items as lazyItems
 import androidx.compose.foundation.lazy.staggeredgrid.LazyStaggeredGridState
 import androidx.compose.foundation.lazy.staggeredgrid.LazyVerticalStaggeredGrid
 import androidx.compose.foundation.lazy.staggeredgrid.StaggeredGridCells
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.rounded.Search
+import androidx.compose.material.icons.rounded.AccessTime
+import androidx.compose.material.icons.rounded.FilterList
+import androidx.compose.material.icons.rounded.PlayArrow
 import androidx.compose.material.icons.rounded.Whatshot
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FilterChip
 import androidx.compose.material3.FilterChipDefaults
+import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.windowsizeclass.WindowSizeClass
@@ -28,13 +33,17 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import androidx.compose.foundation.layout.size
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.asmr.player.domain.model.Album
+import com.asmr.player.hotlistening.HotListeningSortMode
 import com.asmr.player.ui.common.EaraBrandedEmptyState
 import com.asmr.player.ui.common.EaraLogoLoadingIndicator
 import com.asmr.player.ui.common.LocalBottomOverlayPadding
@@ -42,6 +51,7 @@ import com.asmr.player.ui.common.thinScrollbar
 import com.asmr.player.ui.common.withAddedBottomPadding
 import com.asmr.player.ui.library.AlbumGridItem
 import com.asmr.player.ui.library.AlbumGridItemSpacing
+import com.asmr.player.ui.library.AlbumCoverBadge
 import com.asmr.player.ui.library.AlbumItem
 import com.asmr.player.ui.theme.AsmrTheme
 import kotlinx.coroutines.launch
@@ -64,6 +74,8 @@ fun HotListeningScreen(
 ) {
     val uiState by viewModel.uiState.collectAsState()
     val viewMode by viewModel.viewMode.collectAsState()
+    val selectedSortMode by viewModel.sortMode.collectAsState()
+    val selectedPeriod by viewModel.selectedPeriod.collectAsState()
     val colorScheme = AsmrTheme.colorScheme
     val scope = rememberCoroutineScope()
     val isCompactWidth = windowSizeClass.widthSizeClass == WindowWidthSizeClass.Compact
@@ -72,7 +84,6 @@ fun HotListeningScreen(
     val gridState = rememberSaveable(saver = LazyStaggeredGridState.Saver) { LazyStaggeredGridState() }
 
     val periods = listOf("day" to "过去一天", "week" to "过去一周", "month" to "过去一月")
-    val currentPeriod = (uiState as? HotListeningUiState.Success)?.period ?: "day"
 
     fun scrollToTop() {
         scope.launch {
@@ -94,22 +105,57 @@ fun HotListeningScreen(
     ) {
         Row(
             modifier = Modifier.fillMaxWidth().padding(horizontal = 8.dp, vertical = 8.dp),
-            horizontalArrangement = Arrangement.spacedBy(12.dp, Alignment.CenterHorizontally),
+            horizontalArrangement = Arrangement.Center,
             verticalAlignment = Alignment.CenterVertically
         ) {
-            periods.forEach { (period, label) ->
-                FilterChip(
-                    selected = currentPeriod == period,
-                    onClick = {
-                        viewModel.selectPeriod(period)
-                        scrollToTop()
-                    },
-                    label = { Text(label) },
-                    colors = FilterChipDefaults.filterChipColors(
-                        selectedContainerColor = colorScheme.primary.copy(alpha = 0.2f),
-                        selectedLabelColor = colorScheme.primary
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(12.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                periods.forEach { (period, label) ->
+                    FilterChip(
+                        selected = selectedPeriod == period,
+                        onClick = {
+                            viewModel.selectPeriod(period)
+                            scrollToTop()
+                        },
+                        label = { Text(label) },
+                        colors = FilterChipDefaults.filterChipColors(
+                            selectedContainerColor = colorScheme.primary.copy(alpha = 0.2f),
+                            selectedLabelColor = colorScheme.primary
+                        )
                     )
-                )
+                }
+            }
+            Box(modifier = Modifier.padding(start = 18.dp)) {
+                Row(
+                    modifier = Modifier
+                        .clickable(
+                            interactionSource = remember { MutableInteractionSource() },
+                            indication = null
+                        ) {
+                            viewModel.selectSortMode(selectedSortMode.nextMode)
+                            scrollToTop()
+                        }
+                        .padding(horizontal = 4.dp, vertical = 4.dp),
+                    horizontalArrangement = Arrangement.spacedBy(3.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Text(
+                        text = selectedSortMode.toggleLabel,
+                        style = androidx.compose.material3.MaterialTheme.typography.labelMedium,
+                        fontWeight = FontWeight.Medium,
+                        color = colorScheme.primary
+                    )
+                    Icon(
+                        imageVector = Icons.Rounded.FilterList,
+                        contentDescription = null,
+                        tint = colorScheme.primary,
+                        modifier = Modifier
+                            .padding(top = 1.dp)
+                            .size(14.dp)
+                    )
+                }
             }
         }
 
@@ -135,7 +181,7 @@ fun HotListeningScreen(
             )
 
             is HotListeningUiState.Success -> {
-                if (state.albums.isEmpty()) {
+                if (state.entries.isEmpty()) {
                     EaraBrandedEmptyState(
                         sectionTitle = "热门收听",
                         headline = "暂无排行数据",
@@ -153,14 +199,16 @@ fun HotListeningScreen(
                             .withAddedBottomPadding(LocalBottomOverlayPadding.current)
                     ) {
                         lazyItems(
-                            items = state.albums,
-                            key = { album -> stableAlbumKey(album) },
+                            items = state.entries,
+                            key = { entry -> stableAlbumKey(entry.album) },
                             contentType = { "album" }
-                        ) { album ->
+                        ) { entry ->
+                            val album = entry.album
                             AlbumItem(
                                 album = album,
                                 onClick = { onAlbumClick(album) },
-                                emptyCoverUseShimmer = true
+                                emptyCoverUseShimmer = true,
+                                coverBadge = entry.toCoverBadge()
                             )
                         }
                     }
@@ -181,15 +229,17 @@ fun HotListeningScreen(
                         verticalItemSpacing = AlbumGridItemSpacing
                     ) {
                         items(
-                            state.albums.size,
-                            key = { index -> stableAlbumKey(state.albums[index]) },
+                            state.entries.size,
+                            key = { index -> stableAlbumKey(state.entries[index].album) },
                             contentType = { "albumGrid" }
                         ) { index ->
-                            val album = state.albums[index]
+                            val entry = state.entries[index]
+                            val album = entry.album
                             AlbumGridItem(
                                 album = album,
                                 onClick = { onAlbumClick(album) },
-                                emptyCoverUseShimmer = true
+                                emptyCoverUseShimmer = true,
+                                coverBadge = entry.toCoverBadge()
                             )
                         }
                     }
@@ -198,3 +248,23 @@ fun HotListeningScreen(
         }
     }
 }
+
+private fun HotListeningEntry.toCoverBadge(): AlbumCoverBadge {
+    val icon = when (sortMode) {
+        HotListeningSortMode.PlayCount -> Icons.Rounded.PlayArrow
+        HotListeningSortMode.ListenDuration -> Icons.Rounded.AccessTime
+    }
+    return AlbumCoverBadge(icon = icon, text = metricLabel)
+}
+
+private val HotListeningSortMode.toggleLabel: String
+    get() = when (this) {
+        HotListeningSortMode.PlayCount -> "次数"
+        HotListeningSortMode.ListenDuration -> "时长"
+    }
+
+private val HotListeningSortMode.nextMode: HotListeningSortMode
+    get() = when (this) {
+        HotListeningSortMode.PlayCount -> HotListeningSortMode.ListenDuration
+        HotListeningSortMode.ListenDuration -> HotListeningSortMode.PlayCount
+    }

--- a/app/src/main/java/com/asmr/player/ui/hotlistening/HotListeningViewModel.kt
+++ b/app/src/main/java/com/asmr/player/ui/hotlistening/HotListeningViewModel.kt
@@ -6,11 +6,14 @@ import com.asmr.player.data.settings.SettingsRepository
 import com.asmr.player.domain.model.Album
 import com.asmr.player.hotlistening.HotListeningApi
 import com.asmr.player.hotlistening.HotListeningItem
+import com.asmr.player.hotlistening.HotListeningSortMode
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
@@ -25,19 +28,31 @@ class HotListeningViewModel @Inject constructor(
     private val _uiState = MutableStateFlow<HotListeningUiState>(HotListeningUiState.Loading)
     val uiState: StateFlow<HotListeningUiState> = _uiState.asStateFlow()
 
+    private val _selectedPeriod = MutableStateFlow("day")
+    val selectedPeriod: StateFlow<String> = _selectedPeriod.asStateFlow()
+
     val viewMode: StateFlow<Int> = settingsRepository.hotListeningViewMode
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), 1)
 
-    private var currentPeriod: String = "day"
+    val sortMode: StateFlow<HotListeningSortMode> = settingsRepository.hotListeningSortMode
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), HotListeningSortMode.PlayCount)
 
     init {
-        loadTopListings(currentPeriod)
+        viewModelScope.launch {
+            combine(_selectedPeriod, sortMode) { period, mode -> period to mode }
+                .collectLatest { (period, mode) ->
+                    loadTopListings(period, mode)
+                }
+        }
     }
 
     fun selectPeriod(period: String) {
-        if (period != currentPeriod) {
-            currentPeriod = period
-            loadTopListings(period)
+        _selectedPeriod.value = period
+    }
+
+    fun selectSortMode(mode: HotListeningSortMode) {
+        viewModelScope.launch {
+            settingsRepository.setHotListeningSortMode(mode)
         }
     }
 
@@ -48,55 +63,110 @@ class HotListeningViewModel @Inject constructor(
     }
 
     fun refresh() {
-        loadTopListings(currentPeriod)
+        val period = _selectedPeriod.value
+        val mode = sortMode.value
+        viewModelScope.launch {
+            loadTopListings(period, mode)
+        }
     }
 
-    private fun loadTopListings(period: String) {
+    private suspend fun loadTopListings(period: String, sortMode: HotListeningSortMode) {
         if (!hotListeningApi.isBackendConfigured) {
             _uiState.update { HotListeningUiState.Error("后端未配置") }
             return
         }
         _uiState.update { HotListeningUiState.Loading }
-        viewModelScope.launch {
-            runCatching {
-                val items = hotListeningApi.getTopListings(period)
-                if (items == null) {
-                    _uiState.update { HotListeningUiState.Error("请求失败") }
-                    return@launch
-                }
-                val albums = items.map { it.toAlbum() }
-                _uiState.update {
-                    HotListeningUiState.Success(
-                        albums = albums,
-                        period = period
-                    )
-                }
-            }.onFailure { error ->
-                _uiState.update {
-                    HotListeningUiState.Error(error.message ?: "加载失败")
-                }
+        runCatching {
+            val items = hotListeningApi.getTopListings(period, sortMode)
+            if (items == null) {
+                _uiState.update { HotListeningUiState.Error("请求失败") }
+                return
+            }
+            val entries = items.map { it.toEntry(sortMode) }
+            _uiState.update {
+                HotListeningUiState.Success(
+                    entries = entries,
+                    period = period,
+                    sortMode = sortMode
+                )
+            }
+        }.onFailure { error ->
+            _uiState.update {
+                HotListeningUiState.Error(error.message ?: "加载失败")
             }
         }
     }
 
-    private fun HotListeningItem.toAlbum(): Album {
-        return Album(
-            title = this.title,
-            path = "",
-            circle = this.circle,
-            cv = this.cv,
-            tags = this.tagList,
-            coverUrl = this.coverUrl,
-            rjCode = this.rj
+    private fun HotListeningItem.toEntry(sortMode: HotListeningSortMode): HotListeningEntry {
+        return HotListeningEntry(
+            album = Album(
+                title = title,
+                path = "",
+                circle = circle,
+                cv = cv,
+                tags = tagList,
+                coverUrl = coverUrl,
+                rjCode = rj
+            ),
+            playCount = playCount,
+            listenDurationMs = listenDurationMs,
+            sortMode = sortMode
         )
+    }
+}
+
+data class HotListeningEntry(
+    val album: Album,
+    val playCount: Int,
+    val listenDurationMs: Long,
+    val sortMode: HotListeningSortMode
+) {
+    val metricLabel: String
+        get() = when (sortMode) {
+            HotListeningSortMode.PlayCount -> formatCompactCount(playCount.toLong())
+            HotListeningSortMode.ListenDuration -> formatCompactDuration(listenDurationMs)
+        }
+
+    private fun formatCompactCount(value: Long): String {
+        return when {
+            value >= 100_000_000L -> formatDecimalUnit(value, 100_000_000L, "亿")
+            value >= 10_000L -> formatDecimalUnit(value, 10_000L, "万")
+            else -> value.toString()
+        }
+    }
+
+    private fun formatDecimalUnit(value: Long, unitValue: Long, unit: String): String {
+        val whole = value / unitValue
+        val decimal = (value % unitValue) / (unitValue / 10L)
+        return if (decimal > 0L && whole < 100L) {
+            "$whole.$decimal$unit"
+        } else {
+            "$whole$unit"
+        }
+    }
+
+    private fun formatCompactDuration(ms: Long): String {
+        if (ms < 60_000L) return "<1分钟"
+
+        val totalMinutes = ms / 60_000L
+        if (totalMinutes < 60L) return "${totalMinutes}分钟"
+
+        val totalHours = totalMinutes / 60L
+        val compactHours = when {
+            totalHours >= 100_000_000L -> "${totalHours / 100_000_000L}亿"
+            totalHours >= 10_000L -> "${totalHours / 10_000L}万"
+            else -> totalHours.toString()
+        }
+        return "${compactHours}小时"
     }
 }
 
 sealed class HotListeningUiState {
     data object Loading : HotListeningUiState()
     data class Success(
-        val albums: List<Album>,
-        val period: String
+        val entries: List<HotListeningEntry>,
+        val period: String,
+        val sortMode: HotListeningSortMode
     ) : HotListeningUiState()
     data class Error(val message: String) : HotListeningUiState()
 }

--- a/app/src/main/java/com/asmr/player/ui/library/AlbumItem.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/AlbumItem.kt
@@ -19,8 +19,10 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.background
 import androidx.compose.ui.graphics.Color
+import androidx.compose.material3.Icon as MaterialIcon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
@@ -67,6 +69,7 @@ fun AlbumItem(
     onCircleClick: ((String) -> Unit)? = null,
     onCvClick: ((String) -> Unit)? = null,
     onTagClick: ((String) -> Unit)? = null,
+    coverBadge: AlbumCoverBadge? = null,
 ) {
     val colorScheme = AsmrTheme.colorScheme
     val shape = remember { RoundedCornerShape(AlbumListItemCornerRadius) }
@@ -130,6 +133,14 @@ fun AlbumItem(
                             contentScale = ContentScale.Crop,
                             placeholderCornerRadius = 0,
                             modifier = Modifier.fillMaxSize().clip(coverShape),
+                        )
+                    }
+                    coverBadge?.let { badge ->
+                        AlbumCoverMetricBadge(
+                            badge = badge,
+                            modifier = Modifier
+                                .align(Alignment.BottomEnd)
+                                .padding(6.dp)
                         )
                     }
                 }
@@ -266,6 +277,7 @@ fun AlbumGridItem(
     onCircleClick: ((String) -> Unit)? = null,
     onCvClick: ((String) -> Unit)? = null,
     onTagClick: ((String) -> Unit)? = null,
+    coverBadge: AlbumCoverBadge? = null,
 ) {
     val colorScheme = AsmrTheme.colorScheme
     val shape = remember { RoundedCornerShape(AlbumGridItemCornerRadius) }
@@ -349,6 +361,15 @@ fun AlbumGridItem(
                 )
             }
 
+            coverBadge?.let { badge ->
+                AlbumCoverMetricBadge(
+                    badge = badge,
+                    modifier = Modifier
+                        .align(Alignment.BottomEnd)
+                        .padding(8.dp)
+                )
+            }
+
             if (album.hasAsmrOne) {
                 CollectedStamp(
                     modifier = Modifier
@@ -416,6 +437,40 @@ fun AlbumGridItem(
                 )
             }
         }
+    }
+}
+
+data class AlbumCoverBadge(
+    val icon: ImageVector,
+    val text: String
+)
+
+@Composable
+private fun AlbumCoverMetricBadge(
+    badge: AlbumCoverBadge,
+    modifier: Modifier = Modifier
+) {
+    if (badge.text.isBlank()) return
+    Row(
+        modifier = modifier
+            .background(Color.Black.copy(alpha = 0.58f), RoundedCornerShape(4.dp))
+            .padding(horizontal = 5.dp, vertical = 3.dp),
+        horizontalArrangement = Arrangement.spacedBy(3.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        MaterialIcon(
+            imageVector = badge.icon,
+            contentDescription = null,
+            tint = Color.White,
+            modifier = Modifier.size(12.dp)
+        )
+        Text(
+            text = badge.text,
+            style = MaterialTheme.typography.labelSmall,
+            color = Color.White,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis
+        )
     }
 }
 


### PR DESCRIPTION
## Summary
- add hot listening sort mode support for play count and listen duration
- show compact metric badges on hot listening album covers
- report listen duration after 30 seconds and persist hot listening sort mode
- bump Android version to 1.1.2 / versionCode 10103

## Test Plan
- .\\gradlew.bat :app:compileDebugKotlin