### PR TITLE
fix: optimize library album list row spacing

### DIFF
--- a/app/src/main/java/com/asmr/player/ui/common/AudioItemRow.kt
+++ b/app/src/main/java/com/asmr/player/ui/common/AudioItemRow.kt
@@ -4,7 +4,9 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.Arrangement
@@ -73,11 +75,12 @@ internal fun AudioItemRow(
     titleColor: Color = Unspecified,
     subtitleColor: Color = Unspecified,
     fixedTrailingSubtitle: String = "",
-    showClickIndication: Boolean = true
+    showClickIndication: Boolean = true,
+    compact: Boolean = false,
+    compactContentPadding: PaddingValues = PaddingValues(horizontal = 16.dp, vertical = 6.dp),
+    titleMaxLines: Int = 2
 ) {
     val colorScheme = AsmrTheme.colorScheme
-    val materialColorScheme = MaterialTheme.colorScheme
-    val dynamicContainerColor = dynamicPageContainerColor(colorScheme)
     val interactionSource = remember { MutableInteractionSource() }
     val resolvedTitleStyle = titleTextStyle ?: MaterialTheme.typography.bodyLarge
     val resolvedSubtitleStyle = subtitleTextStyle ?: MaterialTheme.typography.bodySmall
@@ -94,154 +97,240 @@ internal fun AudioItemRow(
         )
     }
 
+    if (compact) {
+        Row(
+            modifier = modifier
+                .then(clickableModifier)
+                .fillMaxWidth()
+                .padding(compactContentPadding),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            leadingContent?.let { content ->
+                Box(
+                    modifier = Modifier.padding(end = 12.dp),
+                    contentAlignment = Alignment.Center
+                ) {
+                    content()
+                }
+            }
+
+            Column(
+                modifier = Modifier.weight(1f),
+                verticalArrangement = Arrangement.spacedBy(1.dp)
+            ) {
+                Text(
+                    text = title,
+                    maxLines = titleMaxLines,
+                    overflow = TextOverflow.Ellipsis,
+                    style = resolvedTitleStyle,
+                    color = resolvedTitleColor
+                )
+                AudioItemSupportingText(
+                    subtitle = subtitle,
+                    fixedTrailingSubtitle = fixedTrailingSubtitle,
+                    textStyle = resolvedSubtitleStyle,
+                    textColor = resolvedSubtitleColor
+                )
+            }
+
+            AudioItemTrailingContent(
+                showSubtitleStamp = showSubtitleStamp,
+                subtitleStampModifier = subtitleStampModifier,
+                subtitleStampTestTag = subtitleStampTestTag,
+                menuButtonTestTag = menuButtonTestTag,
+                actions = actions,
+                trailingContent = trailingContent
+            )
+        }
+        return
+    }
+
     ListItem(
         headlineContent = {
             Text(
                 text = title,
-                maxLines = 2,
+                maxLines = titleMaxLines,
                 overflow = TextOverflow.Ellipsis,
                 style = resolvedTitleStyle,
                 color = resolvedTitleColor
             )
         },
         supportingContent = {
-            when {
-                subtitle.isNotBlank() && fixedTrailingSubtitle.isNotBlank() -> {
-                    Row(modifier = Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
-                        Text(
-                            text = subtitle,
-                            maxLines = 1,
-                            overflow = TextOverflow.Ellipsis,
-                            style = resolvedSubtitleStyle,
-                            color = resolvedSubtitleColor,
-                            modifier = Modifier.weight(1f, fill = false)
-                        )
-                        Text(
-                            text = fixedTrailingSubtitle,
-                            maxLines = 1,
-                            overflow = TextOverflow.Clip,
-                            textAlign = TextAlign.End,
-                            style = resolvedSubtitleStyle,
-                            color = resolvedSubtitleColor,
-                            modifier = Modifier.padding(start = 8.dp)
-                        )
-                    }
-                }
-                subtitle.isNotBlank() -> {
-                    Text(
-                        text = subtitle,
-                        maxLines = 1,
-                        overflow = TextOverflow.Ellipsis,
-                        style = resolvedSubtitleStyle,
-                        color = resolvedSubtitleColor
-                    )
-                }
-                fixedTrailingSubtitle.isNotBlank() -> {
-                    Text(
-                        text = fixedTrailingSubtitle,
-                        maxLines = 1,
-                        overflow = TextOverflow.Clip,
-                        style = resolvedSubtitleStyle,
-                        color = resolvedSubtitleColor
-                    )
-                }
-            }
+            AudioItemSupportingText(
+                subtitle = subtitle,
+                fixedTrailingSubtitle = fixedTrailingSubtitle,
+                textStyle = resolvedSubtitleStyle,
+                textColor = resolvedSubtitleColor
+            )
         },
         leadingContent = leadingContent,
         trailingContent = {
-            val showMenu = actions.isNotEmpty()
-            val showTrailing = showSubtitleStamp || trailingContent != null || showMenu
-            if (!showTrailing) return@ListItem
-
-            var expanded by remember { mutableStateOf(false) }
-            Row(
-                modifier = Modifier.offset(x = AudioItemTrailingRightOffset),
-                verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.spacedBy(AudioItemTrailingSpacing)
-            ) {
-                if (showSubtitleStamp) {
-                    val stampModifier = if (subtitleStampTestTag != null) {
-                        subtitleStampModifier.testTag(subtitleStampTestTag)
-                    } else {
-                        subtitleStampModifier
-                    }
-                    SubtitleStamp(modifier = stampModifier)
-                }
-
-                trailingContent?.invoke(this)
-
-                if (showMenu) {
-                    Box {
-                        IconButton(
-                            onClick = { expanded = true },
-                            modifier = if (menuButtonTestTag != null) {
-                                Modifier
-                                    .size(AudioItemMenuButtonSize)
-                                    .testTag(menuButtonTestTag)
-                            } else {
-                                Modifier.size(AudioItemMenuButtonSize)
-                            }
-                        ) {
-                            Icon(
-                                imageVector = Icons.Rounded.MoreVert,
-                                contentDescription = null,
-                                tint = colorScheme.onSurfaceVariant,
-                                modifier = Modifier.size(AudioItemMenuIconSize)
-                            )
-                        }
-                        MaterialTheme(
-                            colorScheme = materialColorScheme.copy(
-                                surface = dynamicContainerColor,
-                                surfaceContainer = dynamicContainerColor
-                            )
-                        ) {
-                            DropdownMenu(
-                                expanded = expanded,
-                                onDismissRequest = { expanded = false },
-                                modifier = Modifier.background(dynamicContainerColor)
-                            ) {
-                                actions.forEach { action ->
-                                    if (action.showDividerBefore) {
-                                        HorizontalDivider(
-                                            modifier = Modifier.padding(horizontal = 8.dp),
-                                            thickness = 0.5.dp,
-                                            color = materialColorScheme.outlineVariant.copy(alpha = 0.3f)
-                                        )
-                                    }
-
-                                    DropdownMenuItem(
-                                        text = { Text(action.label) },
-                                        modifier = if (action.testTag != null) {
-                                            Modifier.testTag(action.testTag)
-                                        } else {
-                                            Modifier
-                                        },
-                                        onClick = {
-                                            expanded = false
-                                            action.onClick()
-                                        },
-                                        leadingIcon = action.icon?.let { icon ->
-                                            {
-                                                Icon(
-                                                    imageVector = icon,
-                                                    contentDescription = null,
-                                                    tint = if (action.iconTint != Unspecified) {
-                                                        action.iconTint
-                                                    } else {
-                                                        colorScheme.onSurfaceVariant
-                                                    }
-                                                )
-                                            }
-                                        }
-                                    )
-                                }
-                            }
-                        }
-                    }
-                }
-            }
+            AudioItemTrailingContent(
+                showSubtitleStamp = showSubtitleStamp,
+                subtitleStampModifier = subtitleStampModifier,
+                subtitleStampTestTag = subtitleStampTestTag,
+                menuButtonTestTag = menuButtonTestTag,
+                actions = actions,
+                trailingContent = trailingContent
+            )
         },
         colors = ListItemDefaults.colors(containerColor = Color.Transparent),
         modifier = modifier.then(clickableModifier)
     )
+}
+
+@Composable
+private fun AudioItemSupportingText(
+    subtitle: String,
+    fixedTrailingSubtitle: String,
+    textStyle: TextStyle,
+    textColor: Color
+) {
+    when {
+        subtitle.isNotBlank() && fixedTrailingSubtitle.isNotBlank() -> {
+            Row(modifier = Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
+                Text(
+                    text = subtitle,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    style = textStyle,
+                    color = textColor,
+                    modifier = Modifier.weight(1f, fill = false)
+                )
+                Text(
+                    text = fixedTrailingSubtitle,
+                    maxLines = 1,
+                    overflow = TextOverflow.Clip,
+                    textAlign = TextAlign.End,
+                    style = textStyle,
+                    color = textColor,
+                    modifier = Modifier.padding(start = 8.dp)
+                )
+            }
+        }
+        subtitle.isNotBlank() -> {
+            Text(
+                text = subtitle,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                style = textStyle,
+                color = textColor
+            )
+        }
+        fixedTrailingSubtitle.isNotBlank() -> {
+            Text(
+                text = fixedTrailingSubtitle,
+                maxLines = 1,
+                overflow = TextOverflow.Clip,
+                style = textStyle,
+                color = textColor
+            )
+        }
+    }
+}
+
+@Composable
+private fun AudioItemTrailingContent(
+    showSubtitleStamp: Boolean,
+    subtitleStampModifier: Modifier,
+    subtitleStampTestTag: String?,
+    menuButtonTestTag: String?,
+    actions: List<AudioItemMenuAction>,
+    trailingContent: (@Composable (RowScope.() -> Unit))?
+) {
+    val showMenu = actions.isNotEmpty()
+    val showTrailing = showSubtitleStamp || trailingContent != null || showMenu
+    if (!showTrailing) return
+
+    val colorScheme = AsmrTheme.colorScheme
+    val materialColorScheme = MaterialTheme.colorScheme
+    val dynamicContainerColor = dynamicPageContainerColor(colorScheme)
+    var expanded by remember { mutableStateOf(false) }
+
+    Row(
+        modifier = Modifier.offset(x = AudioItemTrailingRightOffset),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(AudioItemTrailingSpacing)
+    ) {
+        if (showSubtitleStamp) {
+            val stampModifier = if (subtitleStampTestTag != null) {
+                subtitleStampModifier.testTag(subtitleStampTestTag)
+            } else {
+                subtitleStampModifier
+            }
+            SubtitleStamp(modifier = stampModifier)
+        }
+
+        trailingContent?.invoke(this)
+
+        if (showMenu) {
+            Box {
+                IconButton(
+                    onClick = { expanded = true },
+                    modifier = if (menuButtonTestTag != null) {
+                        Modifier
+                            .size(AudioItemMenuButtonSize)
+                            .testTag(menuButtonTestTag)
+                    } else {
+                        Modifier.size(AudioItemMenuButtonSize)
+                    }
+                ) {
+                    Icon(
+                        imageVector = Icons.Rounded.MoreVert,
+                        contentDescription = null,
+                        tint = colorScheme.onSurfaceVariant,
+                        modifier = Modifier.size(AudioItemMenuIconSize)
+                    )
+                }
+                MaterialTheme(
+                    colorScheme = materialColorScheme.copy(
+                        surface = dynamicContainerColor,
+                        surfaceContainer = dynamicContainerColor
+                    )
+                ) {
+                    DropdownMenu(
+                        expanded = expanded,
+                        onDismissRequest = { expanded = false },
+                        modifier = Modifier.background(dynamicContainerColor)
+                    ) {
+                        actions.forEach { action ->
+                            if (action.showDividerBefore) {
+                                HorizontalDivider(
+                                    modifier = Modifier.padding(horizontal = 8.dp),
+                                    thickness = 0.5.dp,
+                                    color = materialColorScheme.outlineVariant.copy(alpha = 0.3f)
+                                )
+                            }
+
+                            DropdownMenuItem(
+                                text = { Text(action.label) },
+                                modifier = if (action.testTag != null) {
+                                    Modifier.testTag(action.testTag)
+                                } else {
+                                    Modifier
+                                },
+                                onClick = {
+                                    expanded = false
+                                    action.onClick()
+                                },
+                                leadingIcon = action.icon?.let { icon ->
+                                    {
+                                        Icon(
+                                            imageVector = icon,
+                                            contentDescription = null,
+                                            tint = if (action.iconTint != Unspecified) {
+                                                action.iconTint
+                                            } else {
+                                                colorScheme.onSurfaceVariant
+                                            }
+                                        )
+                                    }
+                                }
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
 }

--- a/app/src/main/java/com/asmr/player/ui/common/CoverContentRow.kt
+++ b/app/src/main/java/com/asmr/player/ui/common/CoverContentRow.kt
@@ -14,6 +14,7 @@ fun CoverContentRow(
     minHeight: Dp,
     modifier: Modifier = Modifier,
     spacing: Dp = 16.dp,
+    fillContentHeight: Boolean = false,
     cover: @Composable () -> Unit,
     content: @Composable () -> Unit,
 ) {
@@ -27,6 +28,11 @@ fun CoverContentRow(
         val coverWidthPx = coverWidth.roundToPx()
         val spacingPx = spacing.roundToPx()
         val minHeightPx = minHeight.roundToPx()
+        val contentMinHeight = if (fillContentHeight) {
+            max(minHeightPx, coverWidthPx).coerceAtMost(constraints.maxHeight)
+        } else {
+            0
+        }
 
         val maxWidth = constraints.maxWidth
         val contentMaxWidth = (maxWidth - coverWidthPx - spacingPx).coerceAtLeast(0)
@@ -34,7 +40,7 @@ fun CoverContentRow(
         val contentConstraints = Constraints(
             minWidth = 0,
             maxWidth = contentMaxWidth,
-            minHeight = 0,
+            minHeight = contentMinHeight,
             maxHeight = constraints.maxHeight,
         )
         var contentPlaceable = measurables[1].measure(contentConstraints)
@@ -42,8 +48,13 @@ fun CoverContentRow(
         val desiredHeight = max(minHeightPx, max(coverWidthPx, contentPlaceable.height))
         val finalHeight = desiredHeight.coerceIn(constraints.minHeight, constraints.maxHeight)
 
-        if (finalHeight != desiredHeight) {
-            contentPlaceable = measurables[1].measure(contentConstraints.copy(maxHeight = finalHeight))
+        if (finalHeight != desiredHeight || (fillContentHeight && contentPlaceable.height != finalHeight)) {
+            contentPlaceable = measurables[1].measure(
+                contentConstraints.copy(
+                    minHeight = if (fillContentHeight) finalHeight else contentConstraints.minHeight,
+                    maxHeight = finalHeight
+                )
+            )
         }
 
         val coverPlaceable = measurables[0].measure(Constraints.fixed(coverWidthPx, coverWidthPx))

--- a/app/src/main/java/com/asmr/player/ui/library/AlbumItem.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/AlbumItem.kt
@@ -30,10 +30,13 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.layout.Layout
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.Constraints
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.asmr.player.domain.model.Album
 import com.asmr.player.cache.CacheImageModel
@@ -50,7 +53,6 @@ internal val AlbumGridItemCornerRadius = 6.dp
 internal val AlbumGridItemSpacing = 6.dp
 private val AlbumItemHorizontalPadding = 8.dp
 private val AlbumItemVerticalPadding = 2.dp
-private val AlbumItemMetaLineVerticalPadding = 1.dp
 private val AlbumItemCoverContentSpacing = 8.dp
 private val AlbumGridInfoHorizontalPadding = 6.dp
 private val AlbumGridInfoVerticalPadding = 8.dp
@@ -109,6 +111,7 @@ fun AlbumItem(
             coverWidth = coverSize,
             minHeight = coverSize,
             spacing = AlbumItemCoverContentSpacing,
+            fillContentHeight = true,
             modifier = Modifier
                 .fillMaxWidth()
                 .heightIn(min = listItemHeight),
@@ -146,10 +149,40 @@ fun AlbumItem(
                 }
             },
             content = {
-                Column(
+                val statsText = remember(
+                    album.ratingValue,
+                    album.ratingCount,
+                    album.dlCount,
+                    album.priceJpy,
+                    album.releaseDate
+                ) {
+                    buildString {
+                        val rv = album.ratingValue
+                        if (rv != null && rv > 0.0) {
+                            append("★")
+                            append(String.format("%.1f", rv))
+                            if (album.ratingCount > 0) append("(${album.ratingCount})")
+                        }
+                        if (album.dlCount > 0) {
+                            if (isNotEmpty()) append(" · ")
+                            append("DL ${album.dlCount}")
+                        }
+                        if (album.priceJpy > 0) {
+                            if (isNotEmpty()) append(" · ")
+                            append("¥${album.priceJpy}")
+                        }
+                        if (album.releaseDate.isNotBlank()) {
+                            if (isNotEmpty()) append(" · ")
+                            append(album.releaseDate)
+                        }
+                    }
+                }
+
+                BalancedColumn(
                     modifier = Modifier
-                        .padding(top = 3.dp, bottom = 3.dp, end = 12.dp),
-                    verticalArrangement = Arrangement.spacedBy(2.dp, Alignment.CenterVertically)
+                        .padding(top = 4.dp, bottom = 4.dp, end = 12.dp),
+                    minGap = 4.dp,
+                    maxGap = 12.dp,
                 ) {
                     val rj = album.rjCode.ifBlank { album.workId }
                     Text(
@@ -160,81 +193,44 @@ fun AlbumItem(
                         overflow = TextOverflow.Ellipsis
                     )
 
-                    AlbumItemMetaLine {
-                        AlbumPrimaryMetaRow(
-                            rjCode = rj,
-                            circle = album.circle,
+                    AlbumPrimaryMetaRow(
+                        rjCode = rj,
+                        circle = album.circle,
+                        modifier = Modifier.fillMaxWidth(),
+                        rjOnClick = onRjClick?.let { click -> { click(rj) } },
+                        circleOnClick = onCircleClick?.let { click -> { click(album.circle) } },
+                        leadingVisual = Icon,
+                        order = AlbumPrimaryMetaOrder.CircleThenRj,
+                    )
+
+                    if (album.cv.isNotBlank()) {
+                        AlbumCvChipsSingleLine(
+                            cvText = album.cv,
                             modifier = Modifier.fillMaxWidth(),
-                            rjOnClick = onRjClick?.let { click -> { click(rj) } },
-                            circleOnClick = onCircleClick?.let { click -> { click(album.circle) } },
+                            onCvClick = onCvClick,
                             leadingVisual = Icon,
-                            order = AlbumPrimaryMetaOrder.CircleThenRj,
+                        )
+                    }
+                    if (album.tags.isNotEmpty()) {
+                        AlbumTagsSingleLine(
+                            tags = album.tags,
+                            modifier = Modifier.fillMaxWidth(),
+                            onTagClick = onTagClick,
+                            leadingVisual = Icon,
                         )
                     }
 
-                    if (album.cv.isNotBlank()) {
-                        AlbumItemMetaLine {
-                            AlbumCvChipsSingleLine(
-                                cvText = album.cv,
-                                modifier = Modifier.fillMaxWidth(),
-                                onCvClick = onCvClick,
-                                leadingVisual = Icon,
-                            )
-                        }
-                    }
-
-                    val statsText = remember(
-                        album.ratingValue,
-                        album.ratingCount,
-                        album.dlCount,
-                        album.priceJpy,
-                        album.releaseDate
-                    ) {
-                        buildString {
-                            val rv = album.ratingValue
-                            if (rv != null && rv > 0.0) {
-                                append("★")
-                                append(String.format("%.1f", rv))
-                                if (album.ratingCount > 0) append("(${album.ratingCount})")
-                            }
-                            if (album.dlCount > 0) {
-                                if (isNotEmpty()) append(" · ")
-                                append("DL ${album.dlCount}")
-                            }
-                            if (album.priceJpy > 0) {
-                                if (isNotEmpty()) append(" · ")
-                                append("¥${album.priceJpy}")
-                            }
-                            if (album.releaseDate.isNotBlank()) {
-                                if (isNotEmpty()) append(" · ")
-                                append(album.releaseDate)
-                            }
-                        }
-                    }
-                    if (album.tags.isNotEmpty()) {
-                        AlbumItemMetaLine {
-                            AlbumTagsSingleLine(
-                                tags = album.tags,
-                                modifier = Modifier.fillMaxWidth(),
-                                onTagClick = onTagClick,
-                                leadingVisual = Icon,
-                            )
-                        }
-                    }
-
                     if (statsText.isNotBlank()) {
-                        AlbumItemMetaLine {
-                            Text(
-                                text = statsText,
-                                style = MaterialTheme.typography.labelSmall,
-                                color = colorScheme.textTertiary,
-                                maxLines = 1,
-                                overflow = TextOverflow.Ellipsis,
-                                modifier = Modifier
-                                    .fillMaxWidth()
-                                    .testTag(ALBUM_ITEM_STATS_TAG)
-                            )
-                        }
+                        Text(
+                            text = statsText,
+                            style = MaterialTheme.typography.labelSmall,
+                            color = colorScheme.textTertiary,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis,
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .testTag(ALBUM_ITEM_STATS_TAG)
+                        )
                     }
                 }
             },
@@ -251,17 +247,44 @@ fun AlbumItem(
 }
 
 @Composable
-private fun AlbumItemMetaLine(
+internal fun BalancedColumn(
     modifier: Modifier = Modifier,
-    content: @Composable () -> Unit
+    minGap: Dp = 4.dp,
+    maxGap: Dp = 12.dp,
+    content: @Composable () -> Unit,
 ) {
-    Box(
-        modifier = modifier
-            .fillMaxWidth()
-            .padding(vertical = AlbumItemMetaLineVerticalPadding),
-        contentAlignment = Alignment.CenterStart
-    ) {
-        content()
+    Layout(content = content, modifier = modifier) { measurables, constraints ->
+        val placeables = measurables.map { measurable ->
+            measurable.measure(constraints.copy(minHeight = 0))
+        }
+
+        val layoutWidth = if (constraints.maxWidth != Constraints.Infinity) {
+            constraints.maxWidth
+        } else {
+            maxOf(constraints.minWidth, placeables.maxOfOrNull { it.width } ?: 0)
+        }
+
+        val childrenHeight = placeables.sumOf { it.height }
+        val layoutHeight = if (constraints.maxHeight != Constraints.Infinity) {
+            maxOf(constraints.minHeight, constraints.maxHeight, childrenHeight)
+        } else {
+            maxOf(constraints.minHeight, childrenHeight)
+        }
+
+        val remaining = (layoutHeight - childrenHeight).coerceAtLeast(0)
+        val gapCount = placeables.size + 1
+        val idealGap = if (gapCount > 0) remaining / gapCount else 0
+        val gap = idealGap.coerceIn(minGap.roundToPx(), maxGap.roundToPx())
+        val used = gap * gapCount
+        val extra = remaining - used
+
+        layout(layoutWidth, layoutHeight) {
+            var y = (extra / 2) + gap
+            placeables.forEach { placeable ->
+                placeable.placeRelative(0, y)
+                y += placeable.height + gap
+            }
+        }
     }
 }
 

--- a/app/src/main/java/com/asmr/player/ui/library/LibraryScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/LibraryScreen.kt
@@ -104,6 +104,7 @@ import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import androidx.compose.ui.platform.LocalContext
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.asmr.player.domain.model.Album
@@ -1257,6 +1258,11 @@ private fun TrackListRow(
         fixedTrailingSubtitle = fixedTrailingSubtitle,
         showSubtitleStamp = showSubtitleStamp,
         onClick = onClick,
+        compact = true,
+        compactContentPadding = PaddingValues(horizontal = 16.dp, vertical = 5.dp),
+        titleMaxLines = 1,
+        titleTextStyle = MaterialTheme.typography.bodyMedium,
+        subtitleTextStyle = MaterialTheme.typography.labelSmall.copy(lineHeight = 14.sp),
         modifier = Modifier
             .fillMaxWidth()
             .clip(rowShape)

--- a/app/src/main/java/com/asmr/player/ui/library/LibraryScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/LibraryScreen.kt
@@ -99,12 +99,9 @@ import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.layout.Layout
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalDensity
-import androidx.compose.ui.unit.Constraints
-import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.platform.LocalContext
@@ -1511,6 +1508,7 @@ private fun AlbumItem(
             coverWidth = coverSize,
             minHeight = coverSize,
             spacing = 8.dp,
+            fillContentHeight = true,
             modifier = Modifier
                 .fillMaxWidth()
                 .heightIn(min = listItemHeight),
@@ -1640,47 +1638,5 @@ private fun AlbumItem(
                 }
             },
         )
-    }
-}
-
-@Composable
-private fun BalancedColumn(
-    modifier: Modifier = Modifier,
-    minGap: Dp = 4.dp,
-    maxGap: Dp = 12.dp,
-    content: @Composable () -> Unit,
-) {
-    Layout(content = content, modifier = modifier) { measurables, constraints ->
-        val placeables = measurables.map { measurable ->
-            measurable.measure(constraints.copy(minHeight = 0))
-        }
-
-        val layoutWidth = if (constraints.maxWidth != Constraints.Infinity) {
-            constraints.maxWidth
-        } else {
-            maxOf(constraints.minWidth, placeables.maxOfOrNull { it.width } ?: 0)
-        }
-
-        val childrenHeight = placeables.sumOf { it.height }
-        val layoutHeight = if (constraints.maxHeight != Constraints.Infinity) {
-            maxOf(constraints.minHeight, constraints.maxHeight, childrenHeight)
-        } else {
-            maxOf(constraints.minHeight, childrenHeight)
-        }
-
-        val remaining = (layoutHeight - childrenHeight).coerceAtLeast(0)
-        val gapCount = placeables.size + 1
-        val idealGap = if (gapCount > 0) remaining / gapCount else 0
-        val gap = idealGap.coerceIn(minGap.roundToPx(), maxGap.roundToPx())
-        val used = gap * gapCount
-        val extra = remaining - used
-
-        layout(layoutWidth, layoutHeight) {
-            var y = (extra / 2) + gap
-            placeables.forEach { placeable ->
-                placeable.placeRelative(0, y)
-                y += placeable.height + gap
-            }
-        }
     }
 }


### PR DESCRIPTION
## Summary
- balance album list metadata rows so missing stats do not leave the content vertically centered
- add a compact AudioItemRow mode and use it for expanded local library track rows
- reduce local track row title/subtitle sizing and vertical padding

## Verification
- .\\gradlew.bat :app:compileDebugKotlin
- git diff --check

Note: targeted unit test compilation was previously blocked by existing SearchScreenChromeTest onFirstPage argument errors.