### PR TITLE
Fix app volume syncing with system volume

### DIFF
--- a/app/src/main/java/com/asmr/player/MainActivity.kt
+++ b/app/src/main/java/com/asmr/player/MainActivity.kt
@@ -25,6 +25,7 @@ import android.content.Context
 import android.content.ContextWrapper
 import android.content.pm.ActivityInfo
 import android.content.res.Configuration
+import android.media.AudioManager
 import android.net.Uri
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.core.view.WindowCompat
@@ -649,5 +650,23 @@ class MainActivity : ComponentActivity() {
             volumeKeyEventTick.value = volumeKeyEventSeq
         }
         return true
+    }
+
+    override fun onResume() {
+        super.onResume()
+        syncAppVolumePercentFromSystem()
+    }
+
+    private fun syncAppVolumePercentFromSystem() {
+        val audioManager = getSystemService(AUDIO_SERVICE) as AudioManager
+        val maxSystemVolume = audioManager.getStreamMaxVolume(AudioManager.STREAM_MUSIC)
+        val currentSystemVolume = audioManager.getStreamVolume(AudioManager.STREAM_MUSIC)
+        val currentAppVolumePercent = AppVolume.percentFromSystemVolume(
+            systemVolume = currentSystemVolume,
+            maxSystemVolume = maxSystemVolume
+        )
+        lifecycleScope.launch {
+            settingsRepository.syncAppVolumePercentFromSystem(currentAppVolumePercent)
+        }
     }
 }

--- a/app/src/main/java/com/asmr/player/data/settings/SettingsRepository.kt
+++ b/app/src/main/java/com/asmr/player/data/settings/SettingsRepository.kt
@@ -27,6 +27,9 @@ data class PlaybackRuntimeSettings(
 class SettingsRepository @Inject constructor(
     @ApplicationContext private val context: Context
 ) {
+    private val systemVolumeSyncLock = Any()
+    private var pendingSystemVolumeSyncPercent: Int? = null
+
     val appVolumePercent: Flow<Int> = context.settingsDataStore.data.map { prefs ->
         AppVolume.clampPercent(prefs[SettingsKeys.APP_VOLUME_PERCENT] ?: AppVolume.DefaultPercent)
     }
@@ -373,6 +376,7 @@ class SettingsRepository @Inject constructor(
     }
 
     suspend fun setAppVolumePercent(percent: Int) {
+        clearPendingSystemVolumeSync()
         withContext(Dispatchers.IO) {
             context.settingsDataStore.edit {
                 it[SettingsKeys.APP_VOLUME_PERCENT] = AppVolume.clampPercent(percent)
@@ -380,24 +384,35 @@ class SettingsRepository @Inject constructor(
         }
     }
 
-    suspend fun ensureAppVolumePercentInitialized(defaultPercent: Int): Int {
-        return withContext(Dispatchers.IO) {
-            var resolved = AppVolume.clampPercent(defaultPercent)
+    suspend fun syncAppVolumePercentFromSystem(percent: Int) {
+        val clampedPercent = AppVolume.clampPercent(percent)
+        withContext(Dispatchers.IO) {
             context.settingsDataStore.edit { prefs ->
-                val stored = prefs[SettingsKeys.APP_VOLUME_PERCENT]
-                resolved = if (stored == null) {
-                    AppVolume.clampPercent(defaultPercent).also {
-                        prefs[SettingsKeys.APP_VOLUME_PERCENT] = it
-                    }
-                } else {
-                    AppVolume.clampPercent(stored)
+                val currentPercent = AppVolume.clampPercent(
+                    prefs[SettingsKeys.APP_VOLUME_PERCENT] ?: AppVolume.DefaultPercent
+                )
+                if (currentPercent != clampedPercent) {
+                    markPendingSystemVolumeSync(clampedPercent)
                 }
+                prefs[SettingsKeys.APP_VOLUME_PERCENT] = clampedPercent
             }
-            resolved
+        }
+    }
+
+    fun consumePendingSystemVolumeSync(percent: Int): Boolean {
+        val clampedPercent = AppVolume.clampPercent(percent)
+        return synchronized(systemVolumeSyncLock) {
+            if (pendingSystemVolumeSyncPercent != clampedPercent) {
+                false
+            } else {
+                pendingSystemVolumeSyncPercent = null
+                true
+            }
         }
     }
 
     suspend fun adjustAppVolumePercent(deltaPercent: Int): Int {
+        clearPendingSystemVolumeSync()
         return withContext(Dispatchers.IO) {
             var updated = AppVolume.DefaultPercent
             context.settingsDataStore.edit {
@@ -412,6 +427,18 @@ class SettingsRepository @Inject constructor(
     suspend fun setAsmrOneSite(site: Int) {
         withContext(Dispatchers.IO) {
             context.settingsDataStore.edit { it[SettingsKeys.ASMR_ONE_SITE] = site }
+        }
+    }
+
+    private fun markPendingSystemVolumeSync(percent: Int) {
+        synchronized(systemVolumeSyncLock) {
+            pendingSystemVolumeSyncPercent = AppVolume.clampPercent(percent)
+        }
+    }
+
+    private fun clearPendingSystemVolumeSync() {
+        synchronized(systemVolumeSyncLock) {
+            pendingSystemVolumeSyncPercent = null
         }
     }
 

--- a/app/src/main/java/com/asmr/player/playback/AppVolume.kt
+++ b/app/src/main/java/com/asmr/player/playback/AppVolume.kt
@@ -1,7 +1,6 @@
 package com.asmr.player.playback
 
 import kotlin.math.ceil
-import kotlin.math.roundToInt
 
 object AppVolume {
     const val MinPercent = 0
@@ -38,8 +37,9 @@ object AppVolume {
 
     fun percentFromSystemVolume(systemVolume: Int, maxSystemVolume: Int): Int {
         if (maxSystemVolume <= 0 || systemVolume <= 0) return 0
-        val percent = (systemVolume.toFloat() / maxSystemVolume.toFloat() * MaxPercent).roundToInt()
-        return clampPercent(percent)
+        val boundedSystemVolume = systemVolume.coerceAtMost(maxSystemVolume)
+        val percent = (boundedSystemVolume.toFloat() / maxSystemVolume.toFloat() * MaxPercent).toInt()
+        return (percent / StepPercent * StepPercent).coerceIn(MinPercent, MaxPercent)
     }
 
     fun visualFraction(percent: Int): Float {

--- a/app/src/main/java/com/asmr/player/service/PlaybackService.kt
+++ b/app/src/main/java/com/asmr/player/service/PlaybackService.kt
@@ -93,6 +93,7 @@ class PlaybackService : MediaSessionService() {
     private lateinit var exoPlayer: ExoPlayer
     private lateinit var sessionPlayer: FadingPlayer
     private lateinit var appVolumeBoostController: AppVolumeBoostController
+    private var startupAppVolumePercent: Int? = null
     private val graphicEqualizerAudioProcessor = GraphicEqualizerAudioProcessor()
     private val gainAudioProcessor = GainAudioProcessor()
     private val balanceAudioProcessor = BalanceAudioProcessor()
@@ -218,10 +219,10 @@ class PlaybackService : MediaSessionService() {
             settingsRepository.loadPlaybackRuntimeSettings()
         }
         applyPlaybackRuntimeSettings(runtimeSettings)
+        val currentAppVolumePercent = appVolumeBoostController.currentVolumePercent()
+        startupAppVolumePercent = currentAppVolumePercent
         runBlocking {
-            settingsRepository.ensureAppVolumePercentInitialized(
-                appVolumeBoostController.currentVolumePercent()
-            )
+            settingsRepository.syncAppVolumePercentFromSystem(currentAppVolumePercent)
         }
         runCatching {
             val audioManager = getSystemService(AUDIO_SERVICE) as AudioManager
@@ -1037,9 +1038,19 @@ class PlaybackService : MediaSessionService() {
             }
         }
         serviceScope.launch {
+            var skipStartupApplyPercent = startupAppVolumePercent
             settingsRepository.appVolumePercent
                 .distinctUntilChanged()
                 .collect { appVolumePercent ->
+                    if (
+                        skipStartupApplyPercent == appVolumePercent ||
+                        settingsRepository.consumePendingSystemVolumeSync(appVolumePercent)
+                    ) {
+                        skipStartupApplyPercent = null
+                        sessionPlayer.setBaseVolume(1f)
+                        return@collect
+                    }
+                    skipStartupApplyPercent = null
                     sessionPlayer.setBaseVolume(
                         appVolumeBoostController.applyVolumePercent(appVolumePercent)
                     )

--- a/app/src/test/java/com/asmr/player/data/settings/SettingsRepositoryTest.kt
+++ b/app/src/test/java/com/asmr/player/data/settings/SettingsRepositoryTest.kt
@@ -59,21 +59,38 @@ class SettingsRepositoryTest {
     }
 
     @Test
-    fun ensureAppVolumePercentInitialized_seedsWhenUnset() = runBlocking {
-        val resolved = repository.ensureAppVolumePercentInitialized(46)
+    fun setAppVolumePercent_storesClampedPercent() = runBlocking {
+        repository.setAppVolumePercent(47)
 
-        assertEquals(46, resolved)
-        assertEquals(46, repository.appVolumePercentValue())
+        assertEquals(48, repository.appVolumePercentValue())
     }
 
     @Test
-    fun ensureAppVolumePercentInitialized_keepsStoredValue() = runBlocking {
+    fun setAppVolumePercent_overwritesStoredValue() = runBlocking {
+        repository.setAppVolumePercent(72)
+        repository.setAppVolumePercent(32)
+
+        assertEquals(32, repository.appVolumePercentValue())
+    }
+
+    @Test
+    fun syncAppVolumePercentFromSystem_marksNextMatchingValueAsSystemSync() = runBlocking {
         repository.setAppVolumePercent(72)
 
-        val resolved = repository.ensureAppVolumePercentInitialized(32)
+        repository.syncAppVolumePercentFromSystem(32)
 
-        assertEquals(72, resolved)
-        assertEquals(72, repository.appVolumePercentValue())
+        assertEquals(32, repository.appVolumePercentValue())
+        assertEquals(true, repository.consumePendingSystemVolumeSync(32))
+        assertEquals(false, repository.consumePendingSystemVolumeSync(32))
+    }
+
+    @Test
+    fun setAppVolumePercent_clearsPendingSystemSync() = runBlocking {
+        repository.syncAppVolumePercentFromSystem(32)
+
+        repository.setAppVolumePercent(48)
+
+        assertEquals(false, repository.consumePendingSystemVolumeSync(32))
     }
 
     @Test

--- a/app/src/test/java/com/asmr/player/playback/AppVolumeTest.kt
+++ b/app/src/test/java/com/asmr/player/playback/AppVolumeTest.kt
@@ -33,4 +33,13 @@ class AppVolumeTest {
         assertEquals(8, systemVolume)
         assertEquals(0.9375f, playerVolume, 0.0001f)
     }
+
+    @Test
+    fun percentFromSystemVolumeDoesNotRoundIntoHigherSystemStep() {
+        val percent = AppVolume.percentFromSystemVolume(systemVolume = 5, maxSystemVolume = 15)
+
+        val (systemVolume, playerVolume) = AppVolume.resolveSystemVolume(percent, maxSystemVolume = 15)
+        assertEquals(5, systemVolume)
+        assertEquals(0.96f, playerVolume, 0.0001f)
+    }
 }


### PR DESCRIPTION
## Summary
- sync app volume state from the current system media volume on service startup and activity resume
- skip writing system-sourced volume syncs back to AudioManager
- avoid rounding system volume steps into a higher media volume level

## Verification
- .\\gradlew.bat :app:compileDebugKotlin :app:compileDebugUnitTestKotlin