### PR TITLE
fix: preserve hot listening scroll position

### DIFF
--- a/app/src/main/java/com/asmr/player/ui/hotlistening/HotListeningScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/hotlistening/HotListeningScreen.kt
@@ -36,6 +36,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
@@ -80,20 +81,47 @@ fun HotListeningScreen(
     val scope = rememberCoroutineScope()
     val isCompactWidth = windowSizeClass.widthSizeClass == WindowWidthSizeClass.Compact
 
-    val listState = rememberSaveable(saver = LazyListState.Saver) { LazyListState(0, 0) }
-    val gridState = rememberSaveable(saver = LazyStaggeredGridState.Saver) { LazyStaggeredGridState() }
+    val savedScrollPosition = viewModel.scrollPosition
+    val listState = rememberSaveable(saver = LazyListState.Saver) {
+        LazyListState(
+            savedScrollPosition.listFirstVisibleItemIndex,
+            savedScrollPosition.listFirstVisibleItemScrollOffset
+        )
+    }
+    val gridState = rememberSaveable(saver = LazyStaggeredGridState.Saver) {
+        LazyStaggeredGridState(
+            savedScrollPosition.gridFirstVisibleItemIndex,
+            savedScrollPosition.gridFirstVisibleItemScrollOffset
+        )
+    }
 
     val periods = listOf("day" to "过去一天", "week" to "过去一周", "month" to "过去一月")
 
     fun scrollToTop() {
+        viewModel.resetScrollPosition()
         scope.launch {
             runCatching { listState.scrollToItem(0) }
             runCatching { gridState.scrollToItem(0) }
         }
     }
 
+    LaunchedEffect(listState) {
+        snapshotFlow { listState.firstVisibleItemIndex to listState.firstVisibleItemScrollOffset }
+            .collect { (index, offset) ->
+                viewModel.updateListScrollPosition(index, offset)
+            }
+    }
+
+    LaunchedEffect(gridState) {
+        snapshotFlow { gridState.firstVisibleItemIndex to gridState.firstVisibleItemScrollOffset }
+            .collect { (index, offset) ->
+                viewModel.updateGridScrollPosition(index, offset)
+            }
+    }
+
     LaunchedEffect(scrollToTopSignal) {
         if (scrollToTopSignal == 0L) return@LaunchedEffect
+        viewModel.resetScrollPosition()
         when (viewMode) {
             0 -> runCatching { listState.animateScrollToItem(0) }
             else -> runCatching { gridState.animateScrollToItem(0) }

--- a/app/src/main/java/com/asmr/player/ui/hotlistening/HotListeningViewModel.kt
+++ b/app/src/main/java/com/asmr/player/ui/hotlistening/HotListeningViewModel.kt
@@ -31,6 +31,9 @@ class HotListeningViewModel @Inject constructor(
     private val _selectedPeriod = MutableStateFlow("day")
     val selectedPeriod: StateFlow<String> = _selectedPeriod.asStateFlow()
 
+    var scrollPosition: HotListeningScrollPosition = HotListeningScrollPosition()
+        private set
+
     val viewMode: StateFlow<Int> = settingsRepository.hotListeningViewMode
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), 1)
 
@@ -60,6 +63,24 @@ class HotListeningViewModel @Inject constructor(
         viewModelScope.launch {
             settingsRepository.setHotListeningViewMode(mode.coerceIn(0, 1))
         }
+    }
+
+    fun updateListScrollPosition(firstVisibleItemIndex: Int, firstVisibleItemScrollOffset: Int) {
+        scrollPosition = scrollPosition.copy(
+            listFirstVisibleItemIndex = firstVisibleItemIndex.coerceAtLeast(0),
+            listFirstVisibleItemScrollOffset = firstVisibleItemScrollOffset.coerceAtLeast(0)
+        )
+    }
+
+    fun updateGridScrollPosition(firstVisibleItemIndex: Int, firstVisibleItemScrollOffset: Int) {
+        scrollPosition = scrollPosition.copy(
+            gridFirstVisibleItemIndex = firstVisibleItemIndex.coerceAtLeast(0),
+            gridFirstVisibleItemScrollOffset = firstVisibleItemScrollOffset.coerceAtLeast(0)
+        )
+    }
+
+    fun resetScrollPosition() {
+        scrollPosition = HotListeningScrollPosition()
     }
 
     fun refresh() {
@@ -114,6 +135,13 @@ class HotListeningViewModel @Inject constructor(
         )
     }
 }
+
+data class HotListeningScrollPosition(
+    val listFirstVisibleItemIndex: Int = 0,
+    val listFirstVisibleItemScrollOffset: Int = 0,
+    val gridFirstVisibleItemIndex: Int = 0,
+    val gridFirstVisibleItemScrollOffset: Int = 0
+)
 
 data class HotListeningEntry(
     val album: Album,

--- a/app/src/main/java/com/asmr/player/ui/nav/AppNavigator.kt
+++ b/app/src/main/java/com/asmr/player/ui/nav/AppNavigator.kt
@@ -26,6 +26,15 @@ object Routes {
     }
 }
 
+internal fun resolveAlbumDetailPopUpToRoute(currentRoute: String?): String {
+    return when (currentRoute) {
+        Routes.Search -> Routes.Search
+        Routes.Library -> Routes.Library
+        Routes.HotListening -> Routes.HotListening
+        else -> currentRoute ?: Routes.Library
+    }
+}
+
 class AppNavigator(
     private val navController: NavHostController
 ) {
@@ -44,11 +53,7 @@ class AppNavigator(
         }
         val refreshToken = System.currentTimeMillis()
         val currentRoute = navController.currentBackStackEntry?.destination?.route
-        val popToRoute = when {
-            currentRoute == Routes.Search -> Routes.Search
-            currentRoute == Routes.Library -> Routes.Library
-            else -> currentRoute ?: Routes.Library
-        }
+        val popToRoute = resolveAlbumDetailPopUpToRoute(currentRoute)
         navController.navigate(route) {
             launchSingleTop = true
             restoreState = false
@@ -70,11 +75,7 @@ class AppNavigator(
         )
         val refreshToken = System.currentTimeMillis()
         val currentRoute = navController.currentBackStackEntry?.destination?.route
-        val popToRoute = when {
-            currentRoute == Routes.Search -> Routes.Search
-            currentRoute == Routes.Library -> Routes.Library
-            else -> currentRoute ?: Routes.Library
-        }
+        val popToRoute = resolveAlbumDetailPopUpToRoute(currentRoute)
         navController.navigate(route) {
             launchSingleTop = true
             restoreState = false

--- a/app/src/main/java/com/asmr/player/ui/search/SearchScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/search/SearchScreen.kt
@@ -178,7 +178,7 @@ fun SearchScreen(
     var purchasedOnly by rememberSaveable { mutableStateOf(false) }
     var presaleOnly by rememberSaveable { mutableStateOf(false) }
     var chineseTranslatedOnly by rememberSaveable { mutableStateOf(false) }
-    var collectedOnly by rememberSaveable { mutableStateOf(false) }
+    var collectedOnly by rememberSaveable { mutableStateOf(true) }
     var selectedLocale by rememberSaveable { mutableStateOf("ja_JP") }
     var selectedOrderName by rememberSaveable { mutableStateOf(SearchSortOption.Trend.name) }
     val selectedOrder = remember(selectedOrderName) {
@@ -212,7 +212,12 @@ fun SearchScreen(
     var optionsSyncedFromState by rememberSaveable { mutableStateOf(false) }
 
     LaunchedEffect(Unit) {
-        viewModel.bootstrap(keyword, purchasedOnly, selectedLocale)
+        viewModel.bootstrap(
+            initialKeyword = keyword,
+            initialPurchasedOnly = purchasedOnly,
+            initialLocale = selectedLocale,
+            initialCollectedOnly = collectedOnly
+        )
     }
 
     LaunchedEffect(success?.keyword) {

--- a/app/src/main/java/com/asmr/player/ui/search/SearchViewModel.kt
+++ b/app/src/main/java/com/asmr/player/ui/search/SearchViewModel.kt
@@ -64,7 +64,7 @@ class SearchViewModel @Inject constructor(
     private var purchasedOnly: Boolean = false
     private var presaleOnly: Boolean = false
     private var chineseTranslatedOnly: Boolean = false
-    private var collectedOnly: Boolean = false
+    private var collectedOnly: Boolean = true
     private var enrichJob: Job? = null
     private var asmrOneJob: Job? = null
     private var cacheWriteJob: Job? = null
@@ -88,7 +88,12 @@ class SearchViewModel @Inject constructor(
         }
     }
 
-    fun bootstrap(initialKeyword: String, initialPurchasedOnly: Boolean, initialLocale: String?) {
+    fun bootstrap(
+        initialKeyword: String,
+        initialPurchasedOnly: Boolean,
+        initialLocale: String?,
+        initialCollectedOnly: Boolean = true
+    ) {
         if (!bootstrapped.compareAndSet(false, true)) return
         viewModelScope.launch {
             val cached = runCatching { searchCacheStore.readLast() }.getOrNull()
@@ -99,7 +104,7 @@ class SearchViewModel @Inject constructor(
                 purchasedOnly = initialPurchasedOnly
                 presaleOnly = false
                 chineseTranslatedOnly = false
-                collectedOnly = false
+                collectedOnly = initialCollectedOnly
                 currentLocale = initialLocale
                 lastRequestedKeyword = initialKeyword.trim()
                 requestPage(lastRequestedKeyword, 1, SearchPendingRequestKind.Search)

--- a/app/src/test/java/com/asmr/player/ui/nav/AppNavigatorTest.kt
+++ b/app/src/test/java/com/asmr/player/ui/nav/AppNavigatorTest.kt
@@ -1,0 +1,13 @@
+package com.asmr.player.ui.nav
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class AppNavigatorTest {
+    @Test
+    fun resolveAlbumDetailPopUpToRoute_keepsHotListeningAsDetailSource() {
+        assertEquals(Routes.HotListening, resolveAlbumDetailPopUpToRoute(Routes.HotListening))
+        assertEquals(Routes.Search, resolveAlbumDetailPopUpToRoute(Routes.Search))
+        assertEquals(Routes.Library, resolveAlbumDetailPopUpToRoute(null))
+    }
+}


### PR DESCRIPTION
## Summary
- Preserve Hot Listening list/grid scroll position when returning from album detail
- Keep Hot Listening album detail navigation anchored to the Hot Listening route
- Default the online search filter to 已收录 on first launch without cached search state

## Verification
- ./gradlew.bat --no-daemon :app:compileDebugKotlin --stacktrace
- ./gradlew.bat --no-daemon :app:testDebugUnitTest --tests com.asmr.player.ui.nav.AppNavigatorTest --stacktrace was blocked by local Gradle Test Executor worker classpath failure (GradleWorkerMain / pipe closed), after source and unit-test Kotlin compilation completed