### PR TITLE
feat: add search assist suggestions

### DIFF
--- a/app/src/main/java/com/asmr/player/data/local/datastore/SearchCacheStore.kt
+++ b/app/src/main/java/com/asmr/player/data/local/datastore/SearchCacheStore.kt
@@ -7,12 +7,14 @@ import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
 import com.asmr.player.domain.model.Album
 import com.google.gson.Gson
+import com.google.gson.reflect.TypeToken
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.flow.first
 import javax.inject.Inject
 import javax.inject.Singleton
 
 private val Context.searchCacheDataStore by preferencesDataStore(name = "search_cache")
+private const val SearchHistoryLimit = 50
 
 data class LastSearchStateV1(
     val savedAtMs: Long,
@@ -33,7 +35,9 @@ class SearchCacheStore @Inject constructor(
     @ApplicationContext private val context: Context
 ) {
     private val key: Preferences.Key<String> = stringPreferencesKey("last_search_state_v1")
+    private val historyKey: Preferences.Key<String> = stringPreferencesKey("search_history_keywords_v1")
     private val gson = Gson()
+    private val historyListType = object : TypeToken<List<String>>() {}.type
 
     suspend fun readLast(): LastSearchStateV1? {
         val raw = context.searchCacheDataStore.data.first()[key].orEmpty()
@@ -49,9 +53,50 @@ class SearchCacheStore @Inject constructor(
         }
     }
 
+    suspend fun readHistory(): List<String> {
+        val raw = context.searchCacheDataStore.data.first()[historyKey].orEmpty()
+        if (raw.isBlank()) return emptyList()
+        return runCatching {
+            val parsed: List<String> = gson.fromJson(raw, historyListType)
+            mergeSearchHistory("", parsed)
+        }.getOrDefault(emptyList())
+    }
+
+    suspend fun addHistory(keyword: String) {
+        val current = readHistory()
+        val next = mergeSearchHistory(keyword, current)
+        context.searchCacheDataStore.edit { prefs ->
+            prefs[historyKey] = gson.toJson(next)
+        }
+    }
+
+    suspend fun clearHistory() {
+        context.searchCacheDataStore.edit { prefs ->
+            prefs.remove(historyKey)
+        }
+    }
+
     suspend fun clear() {
         context.searchCacheDataStore.edit { prefs ->
             prefs.remove(key)
         }
     }
+}
+
+internal fun mergeSearchHistory(
+    keyword: String,
+    existing: List<String>,
+    limit: Int = SearchHistoryLimit
+): List<String> {
+    val normalizedKeyword = keyword.trim()
+    val merged = buildList {
+        if (normalizedKeyword.isNotBlank()) add(normalizedKeyword)
+        existing.forEach { item ->
+            val normalized = item.trim()
+            if (normalized.isNotBlank()) add(normalized)
+        }
+    }
+    return merged
+        .distinctBy { it.lowercase() }
+        .take(limit.coerceAtLeast(0))
 }

--- a/app/src/main/java/com/asmr/player/hotlistening/HotListeningApi.kt
+++ b/app/src/main/java/com/asmr/player/hotlistening/HotListeningApi.kt
@@ -49,6 +49,19 @@ data class HotListeningItem(
         get() = tags.split(",").map { it.trim() }.filter { it.isNotBlank() }
 }
 
+data class SearchSuggestionTerm(
+    val value: String = "",
+    val count: Int = 0,
+    val rank: Int = 0
+)
+
+data class SearchSuggestionsResponse(
+    val hotCvs: List<SearchSuggestionTerm> = emptyList(),
+    val hotTags: List<SearchSuggestionTerm> = emptyList(),
+    val hotWorks: List<HotListeningItem> = emptyList(),
+    val serverTimeEpochMs: Long = 0L
+)
+
 enum class HotListeningSortMode(val wireValue: String, val label: String) {
     PlayCount("play_count", "按播放次数"),
     ListenDuration("listen_duration", "按收听时长");
@@ -116,9 +129,17 @@ class HotListeningApi @Inject constructor(
         )
     }
 
+    suspend fun getSearchSuggestions(): SearchSuggestionsResponse? {
+        if (!isBackendConfigured) return null
+        return getJson(
+            path = "api/search-suggestions",
+            responseType = SearchSuggestionsResponse::class.java
+        )
+    }
+
     private suspend fun <T> getJson(
         path: String,
-        queryParameters: Map<String, String>,
+        queryParameters: Map<String, String> = emptyMap(),
         responseType: java.lang.reflect.Type
     ): T? {
         return withContext(Dispatchers.IO) {

--- a/app/src/main/java/com/asmr/player/main/MainContainer.kt
+++ b/app/src/main/java/com/asmr/player/main/MainContainer.kt
@@ -90,6 +90,16 @@ import com.asmr.player.ui.playlists.PlaylistPickerScreen
 import com.asmr.player.ui.playlists.PlaylistsScreen
 import com.asmr.player.ui.playlists.PlaylistsViewModel
 import com.asmr.player.ui.playlists.SystemPlaylistScreen
+import com.asmr.player.ui.search.SEARCH_ASSIST_RESULT_CHINESE_TRANSLATED_ONLY_KEY
+import com.asmr.player.ui.search.SEARCH_ASSIST_RESULT_COLLECTED_ONLY_KEY
+import com.asmr.player.ui.search.SEARCH_ASSIST_RESULT_KEY
+import com.asmr.player.ui.search.SEARCH_ASSIST_RESULT_LOCALE_KEY
+import com.asmr.player.ui.search.SEARCH_ASSIST_RESULT_ORDER_KEY
+import com.asmr.player.ui.search.SEARCH_ASSIST_RESULT_PRESALE_ONLY_KEY
+import com.asmr.player.ui.search.SEARCH_ASSIST_RESULT_PURCHASED_ONLY_KEY
+import com.asmr.player.ui.search.SEARCH_ASSIST_RESULT_SIGNAL_KEY
+import com.asmr.player.ui.search.SearchAssistSearchRequest
+import com.asmr.player.ui.search.SearchAssistScreen
 import com.asmr.player.ui.search.SearchScreen
 import com.asmr.player.ui.search.SearchViewModel
 import com.asmr.player.domain.model.SearchSource
@@ -359,6 +369,17 @@ fun MainContainer(
     var hardwareVolumeOverlayBounds by remember { mutableStateOf<Rect?>(null) }
     var libraryScrollToTopSignal by remember { mutableLongStateOf(0L) }
     var searchScrollToTopSignal by remember { mutableLongStateOf(0L) }
+    var submittedSearchKeyword by rememberSaveable { mutableStateOf("") }
+    var submittedSearchOrderName by rememberSaveable { mutableStateOf(SearchAssistSearchRequest().orderName) }
+    var submittedSearchPurchasedOnly by rememberSaveable { mutableStateOf(SearchAssistSearchRequest().purchasedOnly) }
+    var submittedSearchPresaleOnly by rememberSaveable { mutableStateOf(SearchAssistSearchRequest().presaleOnly) }
+    var submittedSearchChineseTranslatedOnly by rememberSaveable {
+        mutableStateOf(SearchAssistSearchRequest().chineseTranslatedOnly)
+    }
+    var submittedSearchCollectedOnly by rememberSaveable { mutableStateOf(SearchAssistSearchRequest().collectedOnly) }
+    var submittedSearchLocale by rememberSaveable { mutableStateOf(SearchAssistSearchRequest().locale) }
+    var submittedSearchSignal by rememberSaveable { mutableLongStateOf(0L) }
+    var searchAssistInitialRequest by remember { mutableStateOf(SearchAssistSearchRequest()) }
     var favoritesScrollToTopSignal by remember { mutableLongStateOf(0L) }
     var playlistsScrollToTopSignal by remember { mutableLongStateOf(0L) }
     var groupsScrollToTopSignal by remember { mutableLongStateOf(0L) }
@@ -492,6 +513,27 @@ fun MainContainer(
                 pendingDetailNavigation = false
             }
         }
+    }
+
+    fun submitSearchAssistRequest(request: SearchAssistSearchRequest) {
+        val targetEntry = runCatching {
+            navController.getBackStackEntry(Routes.Search)
+        }.getOrNull() ?: navController.previousBackStackEntry
+        targetEntry?.savedStateHandle?.set(SEARCH_ASSIST_RESULT_KEY, request.keyword)
+        targetEntry?.savedStateHandle?.set(SEARCH_ASSIST_RESULT_ORDER_KEY, request.orderName)
+        targetEntry?.savedStateHandle?.set(SEARCH_ASSIST_RESULT_PURCHASED_ONLY_KEY, request.purchasedOnly)
+        targetEntry?.savedStateHandle?.set(SEARCH_ASSIST_RESULT_PRESALE_ONLY_KEY, request.presaleOnly)
+        targetEntry?.savedStateHandle?.set(
+            SEARCH_ASSIST_RESULT_CHINESE_TRANSLATED_ONLY_KEY,
+            request.chineseTranslatedOnly
+        )
+        targetEntry?.savedStateHandle?.set(SEARCH_ASSIST_RESULT_COLLECTED_ONLY_KEY, request.collectedOnly)
+        targetEntry?.savedStateHandle?.set(SEARCH_ASSIST_RESULT_LOCALE_KEY, request.locale)
+        targetEntry?.savedStateHandle?.set(
+            SEARCH_ASSIST_RESULT_SIGNAL_KEY,
+            System.currentTimeMillis()
+        )
+        navController.popBackStack(Routes.Search, false)
     }
 
     LaunchedEffect(currentPrimaryRoute, primaryPagerRoutes, pendingPrimaryNavigationRoute) {
@@ -917,6 +959,8 @@ fun MainContainer(
                                         currentRoute == "library" ||
                                             currentRoute == "library_filter" ||
                                             currentRoute == "search" ||
+                                            currentRoute == Routes.SearchAssist ||
+                                            currentRoute == Routes.SearchAssistPattern ||
                                             currentRoute == Routes.HotListening ||
                                             currentRoute == "playlists" ||
                                             currentRoute == "playlist/{playlistId}/{playlistName}" ||
@@ -947,6 +991,8 @@ fun MainContainer(
                                                 resolvedTitleRoute == "library" -> "本地库"
                                                 resolvedTitleRoute == "library_filter" -> "筛选"
                                                 resolvedTitleRoute == "search" -> "在线搜索"
+                                                resolvedTitleRoute == Routes.SearchAssist -> "在线搜索"
+                                                resolvedTitleRoute == Routes.SearchAssistPattern -> "在线搜索"
                                                 resolvedTitleRoute == Routes.HotListening -> "热门收听"
                                                 resolvedTitleRoute == "playlists" -> "我的列表"
                                                 resolvedTitleRoute == "playlist/{playlistId}/{playlistName}" ->
@@ -1241,6 +1287,18 @@ fun MainContainer(
                                             SearchScreen(
                                                 windowSizeClass = windowSizeClass,
                                                 scrollToTopSignal = searchScrollToTopSignal,
+                                                submittedSearchKeyword = submittedSearchKeyword,
+                                                submittedSearchOrderName = submittedSearchOrderName,
+                                                submittedSearchPurchasedOnly = submittedSearchPurchasedOnly,
+                                                submittedSearchPresaleOnly = submittedSearchPresaleOnly,
+                                                submittedSearchChineseTranslatedOnly = submittedSearchChineseTranslatedOnly,
+                                                submittedSearchCollectedOnly = submittedSearchCollectedOnly,
+                                                submittedSearchLocale = submittedSearchLocale,
+                                                submittedSearchSignal = submittedSearchSignal,
+                                                onOpenSearchAssist = { request ->
+                                                    searchAssistInitialRequest = request
+                                                    navController.navigateSingleTop(Routes.searchAssist(request.keyword))
+                                                },
                                                 onAlbumClick = { album, fromPurchasedOnly ->
                                                     openAlbumDetailFromSearch(
                                                         albumId = album.id,
@@ -1343,8 +1401,110 @@ fun MainContainer(
                         viewModel = libraryViewModel
                     )
                 }
-                                composable("search") {
+                composable("search") { backStackEntry ->
+                    val submittedKeyword by backStackEntry.savedStateHandle
+                        .getStateFlow(SEARCH_ASSIST_RESULT_KEY, "")
+                        .collectAsState()
+                    val submittedOrderName by backStackEntry.savedStateHandle
+                        .getStateFlow(SEARCH_ASSIST_RESULT_ORDER_KEY, SearchAssistSearchRequest().orderName)
+                        .collectAsState()
+                    val submittedPurchasedOnly by backStackEntry.savedStateHandle
+                        .getStateFlow(SEARCH_ASSIST_RESULT_PURCHASED_ONLY_KEY, SearchAssistSearchRequest().purchasedOnly)
+                        .collectAsState()
+                    val submittedPresaleOnly by backStackEntry.savedStateHandle
+                        .getStateFlow(SEARCH_ASSIST_RESULT_PRESALE_ONLY_KEY, SearchAssistSearchRequest().presaleOnly)
+                        .collectAsState()
+                    val submittedChineseTranslatedOnly by backStackEntry.savedStateHandle
+                        .getStateFlow(
+                            SEARCH_ASSIST_RESULT_CHINESE_TRANSLATED_ONLY_KEY,
+                            SearchAssistSearchRequest().chineseTranslatedOnly
+                        )
+                        .collectAsState()
+                    val submittedCollectedOnly by backStackEntry.savedStateHandle
+                        .getStateFlow(SEARCH_ASSIST_RESULT_COLLECTED_ONLY_KEY, SearchAssistSearchRequest().collectedOnly)
+                        .collectAsState()
+                    val submittedLocale by backStackEntry.savedStateHandle
+                        .getStateFlow(SEARCH_ASSIST_RESULT_LOCALE_KEY, SearchAssistSearchRequest().locale)
+                        .collectAsState()
+                    val submittedSignal by backStackEntry.savedStateHandle
+                        .getStateFlow(SEARCH_ASSIST_RESULT_SIGNAL_KEY, 0L)
+                        .collectAsState()
+
+                    LaunchedEffect(
+                        submittedSignal,
+                        submittedKeyword,
+                        submittedOrderName,
+                        submittedPurchasedOnly,
+                        submittedPresaleOnly,
+                        submittedChineseTranslatedOnly,
+                        submittedCollectedOnly,
+                        submittedLocale
+                    ) {
+                        if (submittedSignal <= 0L || submittedKeyword.isBlank()) return@LaunchedEffect
+                        submittedSearchKeyword = submittedKeyword
+                        submittedSearchOrderName = submittedOrderName
+                        submittedSearchPurchasedOnly = submittedPurchasedOnly
+                        submittedSearchPresaleOnly = submittedPresaleOnly
+                        submittedSearchChineseTranslatedOnly = submittedChineseTranslatedOnly
+                        submittedSearchCollectedOnly = submittedCollectedOnly
+                        submittedSearchLocale = submittedLocale
+                        submittedSearchSignal = submittedSignal
+                        backStackEntry.savedStateHandle[SEARCH_ASSIST_RESULT_KEY] = ""
+                        backStackEntry.savedStateHandle[SEARCH_ASSIST_RESULT_ORDER_KEY] =
+                            SearchAssistSearchRequest().orderName
+                        backStackEntry.savedStateHandle[SEARCH_ASSIST_RESULT_PURCHASED_ONLY_KEY] =
+                            SearchAssistSearchRequest().purchasedOnly
+                        backStackEntry.savedStateHandle[SEARCH_ASSIST_RESULT_PRESALE_ONLY_KEY] =
+                            SearchAssistSearchRequest().presaleOnly
+                        backStackEntry.savedStateHandle[SEARCH_ASSIST_RESULT_CHINESE_TRANSLATED_ONLY_KEY] =
+                            SearchAssistSearchRequest().chineseTranslatedOnly
+                        backStackEntry.savedStateHandle[SEARCH_ASSIST_RESULT_COLLECTED_ONLY_KEY] =
+                            SearchAssistSearchRequest().collectedOnly
+                        backStackEntry.savedStateHandle[SEARCH_ASSIST_RESULT_LOCALE_KEY] =
+                            SearchAssistSearchRequest().locale
+                        backStackEntry.savedStateHandle[SEARCH_ASSIST_RESULT_SIGNAL_KEY] = 0L
+                    }
+
                     Box(modifier = Modifier.fillMaxSize())
+                }
+                composable(route = Routes.SearchAssist) {
+                    SearchAssistScreen(
+                        windowSizeClass = windowSizeClass,
+                        initialRequest = searchAssistInitialRequest,
+                        onSubmitSearch = ::submitSearchAssistRequest,
+                        onOpenFullRanking = {
+                            navController.popBackStack(Routes.Search, false)
+                            openPrimaryRoute(Routes.HotListening)
+                        }
+                    )
+                }
+                composable(
+                    route = Routes.SearchAssistPattern,
+                    arguments = listOf(
+                        navArgument("keyword") {
+                            type = NavType.StringType
+                            defaultValue = ""
+                        }
+                    )
+                ) { backStackEntry ->
+                    val initialKeyword = Uri.decode(
+                        backStackEntry.arguments?.getString("keyword").orEmpty()
+                    )
+                    val initialRequest = if (initialKeyword.isBlank()) {
+                        searchAssistInitialRequest
+                    } else {
+                        searchAssistInitialRequest.copy(keyword = initialKeyword)
+                    }
+
+                    SearchAssistScreen(
+                        windowSizeClass = windowSizeClass,
+                        initialRequest = initialRequest,
+                        onSubmitSearch = ::submitSearchAssistRequest,
+                        onOpenFullRanking = {
+                            navController.popBackStack(Routes.Search, false)
+                            openPrimaryRoute(Routes.HotListening)
+                        }
+                    )
                 }
                 composable("hot_listening") {
                     Box(modifier = Modifier.fillMaxSize())

--- a/app/src/main/java/com/asmr/player/ui/common/Modifiers.kt
+++ b/app/src/main/java/com/asmr/player/ui/common/Modifiers.kt
@@ -2,6 +2,9 @@ package com.asmr.player.ui.common
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
+import androidx.compose.foundation.gestures.awaitEachGesture
+import androidx.compose.foundation.gestures.awaitFirstDown
+import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.blur
 import androidx.compose.ui.draw.clip
@@ -12,6 +15,10 @@ import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.input.pointer.PointerEventPass
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 
 import android.os.Build
 import android.graphics.RenderEffect
@@ -51,3 +58,31 @@ fun Modifier.glassMenu(
     )
     .background(color = baseColor, shape = shape)
     .clip(shape)
+
+@Composable
+fun Modifier.clearFocusOnTapOutside(): Modifier {
+    val focusManager = LocalFocusManager.current
+    val keyboardController = LocalSoftwareKeyboardController.current
+    return pointerInput(focusManager, keyboardController) {
+        awaitEachGesture {
+            val down = awaitFirstDown(requireUnconsumed = false, pass = PointerEventPass.Final)
+            val start = down.position
+            val touchSlop = viewConfiguration.touchSlop
+            val touchSlopSquared = touchSlop * touchSlop
+            var isTap = true
+            do {
+                val event = awaitPointerEvent(PointerEventPass.Final)
+                if (isTap) {
+                    isTap = event.changes.none { change ->
+                        val delta = change.position - start
+                        delta.x * delta.x + delta.y * delta.y > touchSlopSquared
+                    }
+                }
+            } while (event.changes.any { it.pressed })
+            if (isTap) {
+                focusManager.clearFocus()
+                keyboardController?.hide()
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/asmr/player/ui/common/SearchBar.kt
+++ b/app/src/main/java/com/asmr/player/ui/common/SearchBar.kt
@@ -1,40 +1,61 @@
 package com.asmr.player.ui.common
 
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.SizeTransform
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.slideInVertically
+import androidx.compose.animation.slideOutVertically
+import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
-import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.clipToBounds
+import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.compositeOver
+import androidx.compose.ui.graphics.lerp
 import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.onClick
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.TextRange
+import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.asmr.player.ui.theme.AsmrTheme
-
-import androidx.compose.ui.draw.shadow
-import androidx.compose.ui.graphics.Color
-import androidx.compose.foundation.border
-import androidx.compose.ui.graphics.compositeOver
-import androidx.compose.ui.graphics.lerp
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -47,6 +68,10 @@ fun CustomSearchBar(
     trailingIcon: @Composable (() -> Unit)? = null,
     keyboardOptions: KeyboardOptions = KeyboardOptions.Default,
     keyboardActions: KeyboardActions = KeyboardActions.Default,
+    focusRequester: FocusRequester? = null,
+    readOnly: Boolean = false,
+    onFieldClick: (() -> Unit)? = null,
+    inputTestTag: String? = null,
 ) {
     val colorScheme = AsmrTheme.colorScheme
     val interactionSource = remember { MutableInteractionSource() }
@@ -64,11 +89,18 @@ fun CustomSearchBar(
         colorScheme.primaryStrong.copy(alpha = 0.14f)
     }
     val textColor = colorScheme.textPrimary
-    val placeholderColor = colorScheme.textSecondary.copy(alpha = if (isDark) 0.72f else 0.82f)
+    val placeholderColor = colorScheme.textTertiary.copy(alpha = if (isDark) 0.74f else 0.68f)
+    var textFieldValue by remember {
+        mutableStateOf(TextFieldValue(text = value, selection = TextRange(value.length)))
+    }
+
+    LaunchedEffect(value) {
+        if (value != textFieldValue.text) {
+            textFieldValue = TextFieldValue(text = value, selection = TextRange(value.length))
+        }
+    }
     
-    BasicTextField(
-        value = value,
-        onValueChange = onValueChange,
+    Box(
         modifier = modifier
             .height(48.dp)
             .shadow(
@@ -87,43 +119,124 @@ fun CustomSearchBar(
             .background(
                 color = containerColor,
                 shape = CircleShape
-            ),
-        textStyle = MaterialTheme.typography.bodyLarge.copy(color = textColor),
-        singleLine = true,
-        cursorBrush = SolidColor(colorScheme.primary),
-        interactionSource = interactionSource,
-        keyboardOptions = keyboardOptions,
-        keyboardActions = keyboardActions,
-        decorationBox = { innerTextField ->
-            Row(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .padding(horizontal = 14.dp),
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                if (leadingIcon != null) {
-                    leadingIcon()
-                    Spacer(modifier = Modifier.width(6.dp))
+            )
+            .then(
+                if (onFieldClick != null) {
+                    Modifier.semantics {
+                        onClick {
+                            onFieldClick()
+                            true
+                        }
+                    }
+                } else {
+                    Modifier
                 }
-                Box(modifier = Modifier.weight(1f), contentAlignment = Alignment.CenterStart) {
-                    if (value.isEmpty()) {
+            )
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(horizontal = 14.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            if (leadingIcon != null) {
+                leadingIcon()
+                Spacer(modifier = Modifier.width(6.dp))
+            }
+            Box(
+                modifier = Modifier
+                    .weight(1f)
+                    .fillMaxHeight()
+                    .clipToBounds(),
+                contentAlignment = Alignment.CenterStart
+            ) {
+                if (textFieldValue.text.isEmpty()) {
+                    AnimatedContent(
+                        targetState = placeholder,
+                        transitionSpec = {
+                            (
+                                fadeIn(animationSpec = tween(durationMillis = 260)) +
+                                    slideInVertically(
+                                        animationSpec = tween(durationMillis = 260),
+                                        initialOffsetY = { height -> height / 2 }
+                                    )
+                                ) togetherWith (
+                                fadeOut(animationSpec = tween(durationMillis = 220)) +
+                                    slideOutVertically(
+                                        animationSpec = tween(durationMillis = 220),
+                                        targetOffsetY = { height -> -height / 2 }
+                                    )
+                                ) using SizeTransform(clip = false)
+                        },
+                        label = "searchPlaceholder"
+                    ) { animatedPlaceholder ->
                         Text(
-                            text = placeholder,
+                            text = animatedPlaceholder,
                             style = MaterialTheme.typography.bodyLarge,
                             color = placeholderColor,
                             maxLines = 1,
                             overflow = TextOverflow.Ellipsis
                         )
                     }
-                    innerTextField()
                 }
-                if (trailingIcon != null) {
-                    Spacer(modifier = Modifier.width(6.dp))
-                    trailingIcon()
+                BasicTextField(
+                    value = textFieldValue,
+                    onValueChange = { nextValue ->
+                        textFieldValue = nextValue
+                        if (nextValue.text != value) {
+                            onValueChange(nextValue.text)
+                        }
+                    },
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .then(
+                            if (focusRequester != null) {
+                                Modifier.focusRequester(focusRequester)
+                            } else {
+                                Modifier
+                            }
+                        )
+                        .then(
+                            if (inputTestTag != null) {
+                                Modifier.testTag(inputTestTag)
+                            } else {
+                                Modifier
+                            }
+                        )
+                        .then(
+                            if (onFieldClick != null) {
+                                Modifier.semantics {
+                                    onClick {
+                                        onFieldClick()
+                                        true
+                                    }
+                                }
+                            } else {
+                                Modifier
+                            }
+                        ),
+                    textStyle = MaterialTheme.typography.bodyLarge.copy(color = textColor),
+                    singleLine = true,
+                    readOnly = readOnly,
+                    cursorBrush = SolidColor(colorScheme.primary),
+                    interactionSource = interactionSource,
+                    keyboardOptions = keyboardOptions,
+                    keyboardActions = keyboardActions
+                )
+                if (readOnly && onFieldClick != null) {
+                    Box(
+                        modifier = Modifier
+                            .matchParentSize()
+                            .clickable(onClick = onFieldClick)
+                    )
                 }
             }
+            if (trailingIcon != null) {
+                Spacer(modifier = Modifier.width(6.dp))
+                trailingIcon()
+            }
         }
-    )
+    }
 }
 
 @Composable

--- a/app/src/main/java/com/asmr/player/ui/library/LibraryScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/LibraryScreen.kt
@@ -161,6 +161,7 @@ import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.stateDescription
 import com.asmr.player.ui.common.CustomSearchBar
 import com.asmr.player.ui.common.ActionButton
+import com.asmr.player.ui.common.clearFocusOnTapOutside
 import com.asmr.player.ui.common.collapsibleHeaderUiState
 import com.asmr.player.ui.common.rememberCollapsibleHeaderState
 import com.asmr.player.ui.common.thinScrollbar
@@ -395,7 +396,12 @@ fun LibraryScreen(
                 ) {
                     when (val state = uiState) {
                     is LibraryUiState.Loading -> {
-                        Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                        Box(
+                            modifier = Modifier
+                                .fillMaxSize()
+                                .clearFocusOnTapOutside(),
+                            contentAlignment = Alignment.Center
+                        ) {
                             EaraLogoLoadingIndicator(tint = colorScheme.primary)
                         }
                     }
@@ -457,7 +463,12 @@ fun LibraryScreen(
                     }
                     is LibraryUiState.Success -> {
                         if (viewMode == null) {
-                            Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                            Box(
+                                modifier = Modifier
+                                    .fillMaxSize()
+                                    .clearFocusOnTapOutside(),
+                                contentAlignment = Alignment.Center
+                            ) {
                                 EaraLogoLoadingIndicator(tint = colorScheme.primary)
                             }
                         } else {
@@ -476,7 +487,12 @@ fun LibraryScreen(
                                     (pagedAlbums.loadState.refresh is LoadState.NotLoading) && pagedAlbums.itemCount == 0
                                 }
                                 if (isLoading) {
-                                    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                                    Box(
+                                        modifier = Modifier
+                                            .fillMaxSize()
+                                            .clearFocusOnTapOutside(),
+                                        contentAlignment = Alignment.Center
+                                    ) {
                                         EaraLogoLoadingIndicator(tint = colorScheme.primary)
                                     }
                                 } else if (isEmpty) {
@@ -492,7 +508,9 @@ fun LibraryScreen(
                                         sectionTitle = if (hasAnyQuery) "本地库结果" else "本地库",
                                         headline = if (hasAnyQuery) "没有匹配的本地内容" else "还没有扫描到本地专辑",
                                         sectionIcon = if (hasAnyQuery) Icons.Rounded.Search else Icons.Rounded.FolderOpen,
-                                        modifier = Modifier.fillMaxSize(),
+                                        modifier = Modifier
+                                            .fillMaxSize()
+                                            .clearFocusOnTapOutside(),
                                         contentPadding = PaddingValues(
                                             top = topPadding,
                                             bottom = LocalBottomOverlayPadding.current + 24.dp
@@ -522,6 +540,7 @@ fun LibraryScreen(
                                         state = listState,
                                         modifier = Modifier
                                             .fillMaxSize()
+                                            .clearFocusOnTapOutside()
                                             .nestedScroll(chromeState.nestedScrollConnection)
                                             .thinScrollbar(listState),
                                         contentPadding = PaddingValues(top = topPadding, bottom = 8.dp)
@@ -688,6 +707,7 @@ fun LibraryScreen(
                                         state = gridState,
                                         modifier = Modifier
                                             .fillMaxSize()
+                                            .clearFocusOnTapOutside()
                                             .nestedScroll(chromeState.nestedScrollConnection)
                                             .thinScrollbar(gridState),
                                         contentPadding = PaddingValues(top = topPadding, start = LibraryPageHorizontalPadding, end = LibraryPageHorizontalPadding, bottom = 16.dp)
@@ -748,6 +768,7 @@ fun LibraryScreen(
                                         state = listState,
                                         modifier = Modifier
                                             .fillMaxSize()
+                                            .clearFocusOnTapOutside()
                                             .nestedScroll(chromeState.nestedScrollConnection)
                                             .thinScrollbar(listState),
                                         contentPadding = PaddingValues(top = topPadding, bottom = 8.dp)
@@ -1028,8 +1049,8 @@ internal fun LibraryChrome(
             onValueChange = onSearchTextChange,
             placeholder = "社团 / CV / 标签...",
             modifier = Modifier
-                .weight(1f)
-                .testTag(LIBRARY_SEARCH_INPUT_TAG),
+                .weight(1f),
+            inputTestTag = LIBRARY_SEARCH_INPUT_TAG,
             leadingIcon = {
                 Icon(
                     imageVector = Icons.Rounded.Search,

--- a/app/src/main/java/com/asmr/player/ui/nav/AppNavigator.kt
+++ b/app/src/main/java/com/asmr/player/ui/nav/AppNavigator.kt
@@ -1,11 +1,14 @@
 package com.asmr.player.ui.nav
 
+import android.net.Uri
 import androidx.navigation.NavHostController
 import java.net.URLEncoder
 
 object Routes {
     const val Library = "library"
     const val Search = "search"
+    const val SearchAssist = "search_assist"
+    const val SearchAssistPattern = "search_assist?keyword={keyword}"
     const val HotListening = "hot_listening"
     const val NowPlaying = "now_playing"
 
@@ -13,6 +16,13 @@ object Routes {
     const val AlbumDetailOnlineByRjPattern = "album_detail_online/{rj}"
 
     const val AlbumDetailByRjPattern = "album_detail_rj/{rj}?initialTab={initialTab}"
+    fun searchAssist(keyword: String = ""): String {
+        val normalized = keyword.trim()
+        if (normalized.isBlank()) return SearchAssist
+        val encoded = Uri.encode(normalized)
+        return "search_assist?keyword=$encoded"
+    }
+
     fun albumDetailByRj(rj: String, initialTab: String? = null): String {
         val encoded = URLEncoder.encode(rj, "UTF-8")
         return buildString {
@@ -28,6 +38,8 @@ object Routes {
 
 internal fun resolveAlbumDetailPopUpToRoute(currentRoute: String?): String {
     return when (currentRoute) {
+        Routes.SearchAssistPattern -> Routes.Search
+        Routes.SearchAssist -> Routes.Search
         Routes.Search -> Routes.Search
         Routes.Library -> Routes.Library
         Routes.HotListening -> Routes.HotListening

--- a/app/src/main/java/com/asmr/player/ui/nav/BottomChrome.kt
+++ b/app/src/main/java/com/asmr/player/ui/nav/BottomChrome.kt
@@ -287,6 +287,8 @@ fun resolvePrimaryRoute(
     return when {
         currentRoute == Routes.Library -> Routes.Library
         currentRoute == Routes.Search -> Routes.Search
+        currentRoute == Routes.SearchAssist -> Routes.Search
+        currentRoute == Routes.SearchAssistPattern -> Routes.Search
         currentRoute == Routes.HotListening -> Routes.HotListening
         currentRoute == "playlists" -> "playlists"
         currentRoute == "groups" -> "groups"

--- a/app/src/main/java/com/asmr/player/ui/search/SearchAssistScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/search/SearchAssistScreen.kt
@@ -1,0 +1,723 @@
+package com.asmr.player.ui.search
+
+import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.automirrored.rounded.KeyboardArrowRight
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.Delete
+import androidx.compose.material.icons.rounded.KeyboardArrowDown
+import androidx.compose.material.icons.rounded.Leaderboard
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.windowsizeclass.WindowSizeClass
+import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.withFrameNanos
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.compositeOver
+import androidx.compose.ui.graphics.lerp
+import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.layout.Layout
+import androidx.compose.ui.layout.Placeable
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalSoftwareKeyboardController
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.asmr.player.cache.CacheImageModel
+import com.asmr.player.hotlistening.SearchSuggestionTerm
+import com.asmr.player.ui.common.AsmrAsyncImage
+import com.asmr.player.ui.common.EaraLogoLoadingIndicator
+import com.asmr.player.ui.common.LocalBottomOverlayPadding
+import com.asmr.player.ui.common.clearFocusOnTapOutside
+import com.asmr.player.ui.common.rememberCollapsibleHeaderState
+import com.asmr.player.ui.common.thinScrollbar
+import com.asmr.player.ui.common.withAddedBottomPadding
+import com.asmr.player.ui.theme.AsmrTheme
+import com.asmr.player.util.DlsiteAntiHotlink
+
+internal const val SEARCH_ASSIST_INPUT_TAG = "search_assist_input"
+internal const val SEARCH_ASSIST_SUBMIT_TAG = "search_assist_submit"
+internal const val SEARCH_ASSIST_CLEAR_TAG = "search_assist_clear"
+internal const val SEARCH_ASSIST_HISTORY_CLEAR_TAG = "search_assist_history_clear"
+internal const val SEARCH_ASSIST_HOT_WORK_CARD_TAG = "search_assist_hot_work_card"
+internal const val SEARCH_ASSIST_FULL_RANKING_TAG = "search_assist_full_ranking"
+internal const val SEARCH_ASSIST_CHROME_TAG = "search_assist_chrome"
+private const val SearchAssistCollapsedRows = 2
+private val SearchAssistChromeContentGap = 8.dp
+
+@Composable
+fun SearchAssistScreen(
+    windowSizeClass: WindowSizeClass,
+    initialRequest: SearchAssistSearchRequest,
+    onSubmitSearch: (SearchAssistSearchRequest) -> Unit,
+    onOpenFullRanking: () -> Unit,
+    viewModel: SearchAssistViewModel = hiltViewModel()
+) {
+    val uiState by viewModel.uiState.collectAsState()
+
+    Surface(
+        modifier = Modifier.fillMaxSize(),
+        color = Color.Transparent,
+        contentColor = AsmrTheme.colorScheme.onBackground
+    ) {
+        SearchAssistContent(
+            windowSizeClass = windowSizeClass,
+            initialRequest = initialRequest,
+            uiState = uiState,
+            onSubmitSearch = { request -> viewModel.submitSearch(request, onSubmitSearch) },
+            onClearHistory = viewModel::clearHistory,
+            onOpenFullRanking = onOpenFullRanking
+        )
+    }
+}
+
+@Composable
+internal fun SearchAssistContent(
+    windowSizeClass: WindowSizeClass,
+    initialRequest: SearchAssistSearchRequest,
+    uiState: SearchAssistUiState,
+    onSubmitSearch: (SearchAssistSearchRequest) -> Unit,
+    onClearHistory: () -> Unit,
+    onOpenFullRanking: () -> Unit
+) {
+    val colorScheme = AsmrTheme.colorScheme
+    val keyboardController = LocalSoftwareKeyboardController.current
+    val inputFocusRequester = remember { FocusRequester() }
+    var keyword by rememberSaveable(initialRequest.keyword) { mutableStateOf(initialRequest.keyword) }
+    var purchasedOnly by rememberSaveable(initialRequest.purchasedOnly) {
+        mutableStateOf(initialRequest.purchasedOnly)
+    }
+    var presaleOnly by rememberSaveable(initialRequest.presaleOnly) {
+        mutableStateOf(initialRequest.presaleOnly)
+    }
+    var chineseTranslatedOnly by rememberSaveable(initialRequest.chineseTranslatedOnly) {
+        mutableStateOf(initialRequest.chineseTranslatedOnly)
+    }
+    var collectedOnly by rememberSaveable(initialRequest.collectedOnly) {
+        mutableStateOf(initialRequest.collectedOnly)
+    }
+    var selectedLocale by rememberSaveable(initialRequest.locale) { mutableStateOf(initialRequest.locale) }
+    var selectedOrderName by rememberSaveable(initialRequest.orderName) {
+        mutableStateOf(initialRequest.orderName)
+    }
+    val selectedOrder = remember(selectedOrderName) {
+        SearchSortOption.values().firstOrNull { it.name == selectedOrderName } ?: SearchSortOption.Trend
+    }
+    val selectedFilter = remember(
+        selectedOrderName,
+        purchasedOnly,
+        presaleOnly,
+        chineseTranslatedOnly,
+        collectedOnly
+    ) {
+        SearchFilterOption.fromState(
+            order = selectedOrder,
+            purchasedOnly = purchasedOnly,
+            presaleOnly = presaleOnly,
+            chineseTranslatedOnly = chineseTranslatedOnly,
+            collectedOnly = collectedOnly
+        )
+    }
+    val listState = androidx.compose.foundation.lazy.rememberLazyListState()
+    val isCompact = windowSizeClass.widthSizeClass == WindowWidthSizeClass.Compact
+    var historyExpanded by rememberSaveable { mutableStateOf(false) }
+    var showClearHistoryDialog by rememberSaveable { mutableStateOf(false) }
+    var hotCvsExpanded by rememberSaveable { mutableStateOf(false) }
+    var hotTagsExpanded by rememberSaveable { mutableStateOf(false) }
+    val hotKeywordTerms = remember(uiState.suggestions.hotCvs, uiState.suggestions.hotTags) {
+        buildSearchHotKeywordTerms(
+            hotCvs = uiState.suggestions.hotCvs,
+            hotTags = uiState.suggestions.hotTags
+        )
+    }
+    val hotKeywordCarouselItem = rememberSearchHotKeywordCarouselItem(
+        terms = hotKeywordTerms,
+        showFallback = !uiState.isLoadingSuggestions
+    )
+    val chromeState = rememberCollapsibleHeaderState()
+    val density = LocalDensity.current
+    val animatedChromeOffsetPx by animateFloatAsState(
+        targetValue = chromeState.offsetPx,
+        animationSpec = tween(durationMillis = 220, easing = FastOutSlowInEasing),
+        label = "searchAssistChromeOffset"
+    )
+    val chromeReservedHeightPx = if (chromeState.heightPx > 0f) {
+        chromeState.heightPx
+    } else {
+        with(density) { 64.dp.toPx() }
+    }
+    val topPadding = with(density) { chromeReservedHeightPx.toDp() } + SearchAssistChromeContentGap
+
+    fun submit(value: String = keyword) {
+        val normalized = value.trim()
+            .ifBlank { hotKeywordCarouselItem.keyword.orEmpty() }
+        if (normalized.isBlank()) return
+        keyword = normalized
+        keyboardController?.hide()
+        onSubmitSearch(
+            SearchAssistSearchRequest(
+                keyword = normalized,
+                orderName = selectedOrder.name,
+                purchasedOnly = purchasedOnly,
+                presaleOnly = presaleOnly,
+                chineseTranslatedOnly = chineseTranslatedOnly,
+                collectedOnly = collectedOnly,
+                locale = selectedLocale
+            )
+        )
+    }
+
+    LaunchedEffect(listState.firstVisibleItemIndex, listState.firstVisibleItemScrollOffset) {
+        if (listState.firstVisibleItemIndex == 0 && listState.firstVisibleItemScrollOffset == 0) {
+            chromeState.expand()
+        }
+    }
+
+    LaunchedEffect(inputFocusRequester) {
+        withFrameNanos { }
+        inputFocusRequester.requestFocus()
+        keyboardController?.show()
+    }
+
+    Box(modifier = Modifier.fillMaxSize()) {
+        LazyColumn(
+            state = listState,
+            modifier = Modifier
+                .fillMaxSize()
+                .clearFocusOnTapOutside()
+                .nestedScroll(chromeState.nestedScrollConnection)
+                .thinScrollbar(listState),
+            contentPadding = PaddingValues(
+                top = topPadding,
+                bottom = 24.dp
+            ).withAddedBottomPadding(LocalBottomOverlayPadding.current),
+            verticalArrangement = Arrangement.spacedBy(14.dp)
+        ) {
+            item(contentType = "history") {
+                SearchAssistSection(
+                    title = "搜索历史",
+                    trailing = {
+                        if (uiState.history.isNotEmpty()) {
+                            Row(
+                                horizontalArrangement = Arrangement.spacedBy(2.dp),
+                                verticalAlignment = Alignment.CenterVertically
+                            ) {
+                                HeaderIconButton(
+                                    icon = Icons.Rounded.Delete,
+                                    contentDescription = "清空搜索历史",
+                                    onClick = { showClearHistoryDialog = true },
+                                    modifier = Modifier.testTag(SEARCH_ASSIST_HISTORY_CLEAR_TAG)
+                                )
+                                ExpandCollapseIconButton(
+                                    expanded = historyExpanded,
+                                    onClick = { historyExpanded = !historyExpanded }
+                                )
+                            }
+                        }
+                    }
+                ) {
+                    if (uiState.history.isEmpty()) {
+                        AssistMutedText("还没有搜索记录")
+                    } else {
+                        SearchAssistHistoryChips(
+                            history = uiState.history,
+                            expanded = historyExpanded,
+                            onHistoryClick = { submit(it) }
+                        )
+                    }
+                }
+            }
+
+            if (uiState.suggestions.hotCvs.isNotEmpty()) {
+                item(contentType = "hotCvs") {
+                    SearchAssistTermSection(
+                        title = "热门 CV",
+                        terms = uiState.suggestions.hotCvs,
+                        expanded = hotCvsExpanded,
+                        onExpandedChange = { hotCvsExpanded = it },
+                        onTermClick = { submit(it) }
+                    )
+                }
+            }
+
+            if (uiState.suggestions.hotTags.isNotEmpty()) {
+                item(contentType = "hotTags") {
+                    SearchAssistTermSection(
+                        title = "热门 tags",
+                        terms = uiState.suggestions.hotTags,
+                        expanded = hotTagsExpanded,
+                        onExpandedChange = { hotTagsExpanded = it },
+                        onTermClick = { submit(it) }
+                    )
+                }
+            }
+
+            if (uiState.suggestions.hotWorks.isNotEmpty()) {
+                item(contentType = "hotWorks") {
+                    SearchAssistSection(
+                        title = "热门作品",
+                        trailing = {
+                            TextButton(
+                                onClick = onOpenFullRanking,
+                                modifier = Modifier.testTag(SEARCH_ASSIST_FULL_RANKING_TAG)
+                            ) {
+                                Icon(
+                                    imageVector = Icons.Rounded.Leaderboard,
+                                    contentDescription = null,
+                                    modifier = Modifier.size(16.dp)
+                                )
+                                Text("查看完整榜单")
+                            }
+                        }
+                    ) {
+                        val rows = uiState.suggestions.hotWorks.chunked(2)
+                        Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                            rows.forEach { row ->
+                                Row(
+                                    modifier = Modifier.fillMaxWidth(),
+                                    horizontalArrangement = Arrangement.spacedBy(8.dp)
+                                ) {
+                                    row.forEach { work ->
+                                        SearchAssistWorkChip(
+                                            work = work,
+                                            modifier = Modifier.weight(1f),
+                                            compact = isCompact,
+                                            onClick = {
+                                                val rj = work.album.rjCode.ifBlank { work.album.workId }
+                                                submit(rj)
+                                            }
+                                        )
+                                    }
+                                    if (row.size == 1) {
+                                        Spacer(modifier = Modifier.weight(1f))
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            } else if (uiState.isLoadingSuggestions) {
+                item(contentType = "loadingSuggestions") {
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(top = 12.dp),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        EaraLogoLoadingIndicator(size = 28.dp, tint = colorScheme.primary)
+                    }
+                }
+            }
+        }
+
+        SearchChrome(
+            modifier = Modifier.align(Alignment.TopCenter),
+            keyword = keyword,
+            onKeywordChange = { keyword = it },
+            placeholder = hotKeywordCarouselItem.placeholder,
+            selectedFilter = selectedFilter,
+            selectedLocale = selectedLocale,
+            filterControlsLocked = false,
+            searchSubmitLocked = false,
+            showSearchSpinner = false,
+            showPagination = false,
+            page = 1,
+            canGoPrev = false,
+            canGoNext = false,
+            controlsLocked = false,
+            rightPanelToggle = null,
+            animatedOffsetPx = animatedChromeOffsetPx,
+            collapseFraction = chromeState.collapseFraction,
+            chromeTestTag = SEARCH_ASSIST_CHROME_TAG,
+            inputTestTag = SEARCH_ASSIST_INPUT_TAG,
+            clearButtonTestTag = SEARCH_ASSIST_CLEAR_TAG,
+            submitButtonTestTag = SEARCH_ASSIST_SUBMIT_TAG,
+            inputFocusRequester = inputFocusRequester,
+            onMeasured = { size -> chromeState.updateHeight(size.height.toFloat()) },
+            onSearchSubmit = { submit() },
+            onFilterSelected = { option ->
+                val nextOrder = option.sortOption ?: selectedOrder
+                selectedOrderName = nextOrder.name
+                purchasedOnly = option.isPurchasedOnly
+                presaleOnly = option.isPresaleOnly
+                chineseTranslatedOnly = option.isChineseTranslated
+                collectedOnly = option.isCollectedOnly
+            },
+            onLocaleSelected = { locale -> selectedLocale = locale },
+            onFirstPage = {},
+            onPrev = {},
+            onNext = {}
+        )
+
+        if (showClearHistoryDialog) {
+            AlertDialog(
+                onDismissRequest = { showClearHistoryDialog = false },
+                title = { Text("清空历史搜索") },
+                text = { Text("是否清空历史搜索记录？") },
+                confirmButton = {
+                    TextButton(
+                        onClick = {
+                            showClearHistoryDialog = false
+                            onClearHistory()
+                        }
+                    ) {
+                        Text("清空")
+                    }
+                },
+                dismissButton = {
+                    TextButton(onClick = { showClearHistoryDialog = false }) {
+                        Text("取消")
+                    }
+                }
+            )
+        }
+    }
+}
+
+@Composable
+private fun SearchAssistSection(
+    title: String,
+    trailing: @Composable (() -> Unit)? = null,
+    content: @Composable () -> Unit
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 12.dp),
+        verticalArrangement = Arrangement.spacedBy(6.dp)
+    ) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                text = title,
+                style = MaterialTheme.typography.titleSmall,
+                fontWeight = FontWeight.SemiBold,
+                color = AsmrTheme.colorScheme.textPrimary,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                modifier = Modifier.weight(1f)
+            )
+            Box(
+                modifier = Modifier.widthIn(min = 32.dp),
+                contentAlignment = Alignment.CenterEnd
+            ) {
+                trailing?.invoke()
+            }
+        }
+        content()
+    }
+}
+
+@Composable
+private fun SearchAssistTermSection(
+    title: String,
+    terms: List<SearchSuggestionTerm>,
+    expanded: Boolean,
+    onExpandedChange: (Boolean) -> Unit,
+    onTermClick: (String) -> Unit
+) {
+    SearchAssistSection(
+        title = title,
+        trailing = {
+            ExpandCollapseIconButton(
+                expanded = expanded,
+                onClick = { onExpandedChange(!expanded) }
+            )
+        }
+    ) {
+        SearchAssistTermChips(
+            terms = terms,
+            expanded = expanded,
+            onTermClick = onTermClick
+        )
+    }
+}
+
+@Composable
+private fun SearchAssistTextChip(
+    text: String,
+    onClick: () -> Unit
+) {
+    val colorScheme = AsmrTheme.colorScheme
+    val shape = RoundedCornerShape(7.dp)
+    val containerColor = lerp(
+        colorScheme.surface,
+        colorScheme.surfaceVariant,
+        if (colorScheme.isDark) 0.22f else 0.34f
+    ).copy(alpha = 0.96f).compositeOver(colorScheme.background)
+    val borderColor = if (colorScheme.isDark) {
+        Color.White.copy(alpha = 0.10f)
+    } else {
+        colorScheme.onSurfaceVariant.copy(alpha = 0.12f)
+    }
+    Row(
+        modifier = Modifier
+            .widthIn(max = 220.dp)
+            .clip(shape)
+            .background(containerColor)
+            .border(1.dp, borderColor, shape)
+            .clickable(onClick = onClick)
+            .padding(horizontal = 9.dp, vertical = 5.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Text(
+            text = text,
+            style = MaterialTheme.typography.labelMedium,
+            color = colorScheme.textPrimary,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis
+        )
+    }
+}
+
+@Composable
+private fun SearchAssistHistoryChips(
+    history: List<String>,
+    expanded: Boolean,
+    onHistoryClick: (String) -> Unit
+) {
+    SearchAssistChipFlow(expanded = expanded) {
+        history.forEach { item ->
+            SearchAssistTextChip(text = item, onClick = { onHistoryClick(item) })
+        }
+    }
+}
+
+@Composable
+private fun SearchAssistTermChips(
+    terms: List<SearchSuggestionTerm>,
+    expanded: Boolean,
+    onTermClick: (String) -> Unit
+) {
+    SearchAssistChipFlow(expanded = expanded) {
+        terms.forEach { term ->
+            SearchAssistTextChip(
+                text = term.value,
+                onClick = { onTermClick(term.value) }
+            )
+        }
+    }
+}
+
+@Composable
+private fun SearchAssistChipFlow(
+    expanded: Boolean,
+    modifier: Modifier = Modifier,
+    content: @Composable () -> Unit
+) {
+    Layout(
+        content = content,
+        modifier = modifier.fillMaxWidth()
+    ) { measurables, constraints ->
+        val horizontalSpacingPx = 8.dp.roundToPx()
+        val verticalSpacingPx = 6.dp.roundToPx()
+        val maxWidth = constraints.maxWidth
+        val placements = mutableListOf<SearchAssistChipPlacement>()
+        var x = 0
+        var y = 0
+        var rowHeight = 0
+        var row = 1
+
+        measurables.forEach { measurable ->
+            val placeable = measurable.measure(
+                constraints.copy(minWidth = 0, minHeight = 0)
+            )
+            val nextX = if (x == 0) placeable.width else x + horizontalSpacingPx + placeable.width
+            if (x > 0 && nextX > maxWidth) {
+                x = 0
+                y += rowHeight + verticalSpacingPx
+                rowHeight = 0
+                row += 1
+            }
+            val placeX = if (x == 0) 0 else x + horizontalSpacingPx
+            if (expanded || row <= SearchAssistCollapsedRows) {
+                placements += SearchAssistChipPlacement(placeable = placeable, x = placeX, y = y)
+            }
+            x = placeX + placeable.width
+            rowHeight = maxOf(rowHeight, placeable.height)
+        }
+
+        val height = (placements.maxOfOrNull { it.y + it.placeable.height } ?: 0)
+            .coerceIn(constraints.minHeight, constraints.maxHeight)
+        layout(width = constraints.maxWidth, height = height) {
+            placements.forEach { placement ->
+                placement.placeable.placeRelative(placement.x, placement.y)
+            }
+        }
+    }
+}
+
+private data class SearchAssistChipPlacement(
+    val placeable: Placeable,
+    val x: Int,
+    val y: Int
+)
+
+@Composable
+private fun ExpandCollapseIconButton(
+    expanded: Boolean,
+    onClick: () -> Unit
+) {
+    HeaderIconButton(
+        icon = if (expanded) {
+            Icons.Rounded.KeyboardArrowDown
+        } else {
+            Icons.AutoMirrored.Rounded.KeyboardArrowRight
+        },
+        contentDescription = if (expanded) "折叠" else "展开",
+        onClick = onClick
+    )
+}
+
+@Composable
+private fun HeaderIconButton(
+    icon: androidx.compose.ui.graphics.vector.ImageVector,
+    contentDescription: String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val colorScheme = AsmrTheme.colorScheme
+    Box(
+        modifier = modifier
+            .size(32.dp)
+            .clip(CircleShape)
+            .clickable(onClick = onClick),
+        contentAlignment = Alignment.Center
+    ) {
+        Icon(
+            imageVector = icon,
+            contentDescription = contentDescription,
+            tint = colorScheme.textSecondary,
+            modifier = Modifier.size(18.dp)
+        )
+    }
+}
+
+@Composable
+private fun SearchAssistWorkChip(
+    work: SearchAssistHotWork,
+    compact: Boolean,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val colorScheme = AsmrTheme.colorScheme
+    val album = work.album
+    val shape = RoundedCornerShape(8.dp)
+    val coverData = album.coverThumbPath.takeIf { it.isNotBlank() && it.contains("_v2") }
+        .orEmpty()
+        .ifBlank { album.coverPath }
+        .ifBlank { album.coverUrl }
+    val imageModel = remember(coverData) {
+        val headers = if (coverData.startsWith("http", ignoreCase = true)) {
+            DlsiteAntiHotlink.headersForImageUrl(coverData)
+        } else {
+            emptyMap()
+        }
+        if (headers.isEmpty()) coverData else CacheImageModel(data = coverData, headers = headers, keyTag = "dlsite")
+    }
+    val containerColor = colorScheme.surface.copy(alpha = if (colorScheme.isDark) 0.72f else 0.82f)
+        .compositeOver(colorScheme.background)
+    val meta = listOf(album.cv, album.circle)
+        .map { it.trim() }
+        .firstOrNull { it.isNotBlank() }
+        .orEmpty()
+
+    Row(
+        modifier = modifier
+            .height(if (compact) 76.dp else 84.dp)
+            .clip(shape)
+            .background(containerColor)
+            .border(
+                width = 1.dp,
+                color = if (colorScheme.isDark) Color.White.copy(alpha = 0.10f) else colorScheme.primaryStrong.copy(alpha = 0.10f),
+                shape = shape
+            )
+            .clickable(onClick = onClick)
+            .testTag(SEARCH_ASSIST_HOT_WORK_CARD_TAG),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        AsmrAsyncImage(
+            model = imageModel,
+            contentDescription = null,
+            contentScale = ContentScale.Crop,
+            placeholderCornerRadius = 0,
+            modifier = Modifier
+                .aspectRatio(1f)
+                .height(if (compact) 76.dp else 84.dp)
+                .clip(RoundedCornerShape(topStart = 8.dp, bottomStart = 8.dp))
+        )
+        Column(
+            modifier = Modifier
+                .weight(1f)
+                .padding(horizontal = 8.dp, vertical = 7.dp),
+            verticalArrangement = Arrangement.spacedBy(4.dp)
+        ) {
+            Text(
+                text = album.title.ifBlank { "热门作品" },
+                style = MaterialTheme.typography.labelMedium,
+                color = colorScheme.textPrimary,
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis
+            )
+            if (meta.isNotBlank()) {
+                Text(
+                    text = meta,
+                    style = MaterialTheme.typography.labelSmall,
+                    color = colorScheme.textSecondary,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun AssistMutedText(text: String) {
+    Text(
+        text = text,
+        style = MaterialTheme.typography.bodySmall,
+        color = AsmrTheme.colorScheme.textTertiary
+    )
+}

--- a/app/src/main/java/com/asmr/player/ui/search/SearchAssistViewModel.kt
+++ b/app/src/main/java/com/asmr/player/ui/search/SearchAssistViewModel.kt
@@ -1,0 +1,148 @@
+package com.asmr.player.ui.search
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.asmr.player.data.local.datastore.SearchCacheStore
+import com.asmr.player.domain.model.Album
+import com.asmr.player.hotlistening.HotListeningApi
+import com.asmr.player.hotlistening.HotListeningItem
+import com.asmr.player.hotlistening.SearchSuggestionTerm
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+internal const val SEARCH_ASSIST_RESULT_KEY = "searchKeyword"
+internal const val SEARCH_ASSIST_RESULT_SIGNAL_KEY = "searchKeywordSignal"
+internal const val SEARCH_ASSIST_RESULT_ORDER_KEY = "searchOrderName"
+internal const val SEARCH_ASSIST_RESULT_PURCHASED_ONLY_KEY = "searchPurchasedOnly"
+internal const val SEARCH_ASSIST_RESULT_PRESALE_ONLY_KEY = "searchPresaleOnly"
+internal const val SEARCH_ASSIST_RESULT_CHINESE_TRANSLATED_ONLY_KEY = "searchChineseTranslatedOnly"
+internal const val SEARCH_ASSIST_RESULT_COLLECTED_ONLY_KEY = "searchCollectedOnly"
+internal const val SEARCH_ASSIST_RESULT_LOCALE_KEY = "searchLocale"
+
+data class SearchAssistSearchRequest(
+    val keyword: String = "",
+    val orderName: String = SearchSortOption.Trend.name,
+    val purchasedOnly: Boolean = false,
+    val presaleOnly: Boolean = false,
+    val chineseTranslatedOnly: Boolean = false,
+    val collectedOnly: Boolean = true,
+    val locale: String = "ja_JP"
+) {
+    val selectedOrder: SearchSortOption
+        get() = SearchSortOption.values().firstOrNull { it.name == orderName } ?: SearchSortOption.Trend
+
+    val selectedFilter: SearchFilterOption
+        get() = SearchFilterOption.fromState(
+            order = selectedOrder,
+            purchasedOnly = purchasedOnly,
+            presaleOnly = presaleOnly,
+            chineseTranslatedOnly = chineseTranslatedOnly,
+            collectedOnly = collectedOnly
+        )
+}
+
+@HiltViewModel
+class SearchAssistViewModel @Inject constructor(
+    private val searchCacheStore: SearchCacheStore,
+    private val hotListeningApi: HotListeningApi
+) : ViewModel() {
+    private val _uiState = MutableStateFlow(SearchAssistUiState())
+    val uiState: StateFlow<SearchAssistUiState> = _uiState.asStateFlow()
+
+    init {
+        refresh()
+    }
+
+    fun refresh() {
+        viewModelScope.launch {
+            loadHistory()
+            loadSuggestions()
+        }
+    }
+
+    fun submitSearch(request: SearchAssistSearchRequest, onSubmitted: (SearchAssistSearchRequest) -> Unit) {
+        val normalized = request.keyword.trim()
+        if (normalized.isBlank()) return
+        val normalizedRequest = request.copy(keyword = normalized)
+        viewModelScope.launch {
+            searchCacheStore.addHistory(normalized)
+            loadHistory()
+            onSubmitted(normalizedRequest)
+        }
+    }
+
+    fun clearHistory() {
+        viewModelScope.launch {
+            searchCacheStore.clearHistory()
+            _uiState.update { it.copy(history = emptyList()) }
+        }
+    }
+
+    private suspend fun loadHistory() {
+        val history = runCatching { searchCacheStore.readHistory() }.getOrDefault(emptyList())
+        _uiState.update { it.copy(history = history) }
+    }
+
+    private suspend fun loadSuggestions() {
+        if (!hotListeningApi.isBackendConfigured) {
+            _uiState.update {
+                it.copy(isLoadingSuggestions = false, suggestions = SearchSuggestionsUiData())
+            }
+            return
+        }
+        _uiState.update { it.copy(isLoadingSuggestions = true) }
+        val suggestions = runCatching { hotListeningApi.getSearchSuggestions() }.getOrNull()
+        _uiState.update {
+            it.copy(
+                isLoadingSuggestions = false,
+                suggestions = SearchSuggestionsUiData(
+                    hotCvs = suggestions?.hotCvs.orEmpty()
+                        .filter { term -> term.value.isNotBlank() },
+                    hotTags = suggestions?.hotTags.orEmpty()
+                        .filter { term -> term.value.isNotBlank() },
+                    hotWorks = suggestions?.hotWorks.orEmpty()
+                        .filter { item -> item.rj.isNotBlank() || item.title.isNotBlank() }
+                        .take(10)
+                        .map { item -> item.toHotWork() }
+                )
+            )
+        }
+    }
+}
+
+data class SearchAssistUiState(
+    val history: List<String> = emptyList(),
+    val suggestions: SearchSuggestionsUiData = SearchSuggestionsUiData(),
+    val isLoadingSuggestions: Boolean = true
+)
+
+data class SearchSuggestionsUiData(
+    val hotCvs: List<SearchSuggestionTerm> = emptyList(),
+    val hotTags: List<SearchSuggestionTerm> = emptyList(),
+    val hotWorks: List<SearchAssistHotWork> = emptyList()
+)
+
+data class SearchAssistHotWork(
+    val album: Album
+)
+
+internal fun HotListeningItem.toHotWork(): SearchAssistHotWork {
+    val normalizedRj = rj.trim().uppercase()
+    return SearchAssistHotWork(
+        album = Album(
+            title = title.trim().ifBlank { "热门作品" },
+            path = "",
+            workId = normalizedRj,
+            rjCode = normalizedRj,
+            circle = circle.trim(),
+            cv = cv.trim(),
+            tags = tagList,
+            coverUrl = coverUrl.trim()
+        )
+    )
+}

--- a/app/src/main/java/com/asmr/player/ui/search/SearchHotKeywordCarousel.kt
+++ b/app/src/main/java/com/asmr/player/ui/search/SearchHotKeywordCarousel.kt
@@ -1,0 +1,120 @@
+package com.asmr.player.ui.search
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import com.asmr.player.hotlistening.SearchSuggestionTerm
+import kotlinx.coroutines.delay
+
+internal const val DefaultSearchPlaceholder = "搜索专辑、社团、CV..."
+private const val SearchPlaceholderCarouselIntervalMs = 5_000L
+private const val SearchHotKeywordCarouselLimit = 24
+
+internal data class SearchHotKeywordTerm(
+    val value: String
+)
+
+internal data class SearchHotKeywordCarouselItem(
+    val placeholder: String,
+    val keyword: String?
+)
+
+internal fun buildSearchHotKeywordTerms(
+    hotCvs: List<SearchSuggestionTerm>,
+    hotTags: List<SearchSuggestionTerm>,
+    limit: Int = SearchHotKeywordCarouselLimit
+): List<SearchHotKeywordTerm> {
+    val cvTerms = hotCvs.toHotKeywordTerms()
+    val tagTerms = hotTags.toHotKeywordTerms()
+    val maxSize = maxOf(cvTerms.size, tagTerms.size)
+    val merged = buildList {
+        for (index in 0 until maxSize) {
+            cvTerms.getOrNull(index)?.let(::add)
+            tagTerms.getOrNull(index)?.let(::add)
+        }
+    }
+    return merged
+        .distinctBy { it.value.lowercase() }
+        .take(limit.coerceAtLeast(0))
+}
+
+@Composable
+internal fun rememberSearchHotKeywordCarouselItem(
+    terms: List<SearchHotKeywordTerm>,
+    showFallback: Boolean
+): SearchHotKeywordCarouselItem {
+    val keywords = remember(terms) {
+        terms.map { term -> term.value.trim() }
+            .filter { it.isNotBlank() }
+            .distinctBy { it.lowercase() }
+    }
+    val signature = remember(keywords) {
+        keywords.joinToString(separator = "\u001F")
+    }
+    var carouselState by remember(signature) {
+        mutableStateOf(SearchHotKeywordCarouselState(queue = keywords.shuffledAvoidingFirst()))
+    }
+
+    LaunchedEffect(signature) {
+        if (keywords.size <= 1) return@LaunchedEffect
+        while (true) {
+            delay(SearchPlaceholderCarouselIntervalMs)
+            carouselState = carouselState.next()
+        }
+    }
+
+    val keyword = carouselState.current
+    return when {
+        keyword != null -> SearchHotKeywordCarouselItem(placeholder = keyword, keyword = keyword)
+        showFallback -> SearchHotKeywordCarouselItem(placeholder = DefaultSearchPlaceholder, keyword = null)
+        else -> SearchHotKeywordCarouselItem(placeholder = "", keyword = null)
+    }
+}
+
+private fun List<SearchSuggestionTerm>.toHotKeywordTerms(): List<SearchHotKeywordTerm> {
+    return mapNotNull { term ->
+        val value = term.value.trim()
+        if (value.isBlank()) {
+            null
+        } else {
+            SearchHotKeywordTerm(value = value)
+        }
+    }
+}
+
+private data class SearchHotKeywordCarouselState(
+    val queue: List<String>,
+    val index: Int = 0
+) {
+    val current: String?
+        get() = queue.getOrNull(index)
+
+    fun next(): SearchHotKeywordCarouselState {
+        if (queue.size <= 1) return this
+        val nextIndex = index + 1
+        if (nextIndex <= queue.lastIndex) {
+            return copy(index = nextIndex)
+        }
+        return SearchHotKeywordCarouselState(
+            queue = queue.shuffledAvoidingFirst(avoidFirst = current)
+        )
+    }
+}
+
+private fun List<String>.shuffledAvoidingFirst(avoidFirst: String? = null): List<String> {
+    if (size <= 1) return this
+    val shuffled = shuffled().toMutableList()
+    val avoidIndex = avoidFirst?.let { avoided ->
+        shuffled.indexOfFirst { it.equals(avoided, ignoreCase = true) }
+    } ?: -1
+    if (avoidIndex == 0) {
+        val swapIndex = (1 until shuffled.size).random()
+        val first = shuffled[0]
+        shuffled[0] = shuffled[swapIndex]
+        shuffled[swapIndex] = first
+    }
+    return shuffled
+}

--- a/app/src/main/java/com/asmr/player/ui/search/SearchScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/search/SearchScreen.kt
@@ -72,6 +72,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.graphics.vector.rememberVectorPainter
@@ -96,6 +97,7 @@ import com.asmr.player.ui.common.EaraBrandedEmptyState
 import com.asmr.player.ui.common.EaraLogoLoadingIndicator
 import com.asmr.player.ui.common.LocalBottomOverlayPadding
 import com.asmr.player.ui.common.StableWindowInsets
+import com.asmr.player.ui.common.clearFocusOnTapOutside
 import com.asmr.player.ui.common.collapsibleHeaderUiState
 import com.asmr.player.ui.common.rememberCollapsibleHeaderState
 import com.asmr.player.ui.common.thinScrollbar
@@ -171,6 +173,15 @@ private fun SearchFilterIconView(
 fun SearchScreen(
     windowSizeClass: WindowSizeClass,
     onAlbumClick: (Album, Boolean) -> Unit,
+    onOpenSearchAssist: (SearchAssistSearchRequest) -> Unit = {},
+    submittedSearchKeyword: String = "",
+    submittedSearchOrderName: String = SearchSortOption.Trend.name,
+    submittedSearchPurchasedOnly: Boolean = false,
+    submittedSearchPresaleOnly: Boolean = false,
+    submittedSearchChineseTranslatedOnly: Boolean = false,
+    submittedSearchCollectedOnly: Boolean = true,
+    submittedSearchLocale: String = "ja_JP",
+    submittedSearchSignal: Long = 0L,
     scrollToTopSignal: Long = 0L,
     viewModel: SearchViewModel = hiltViewModel()
 ) {
@@ -195,6 +206,12 @@ fun SearchScreen(
     }
     val viewMode by viewModel.viewMode.collectAsState()
     val uiState by viewModel.uiState.collectAsState()
+    val hotKeywordTerms by viewModel.hotKeywordTerms.collectAsState()
+    val showHotKeywordFallback by viewModel.showHotKeywordFallback.collectAsState()
+    val hotKeywordCarouselItem = rememberSearchHotKeywordCarouselItem(
+        terms = hotKeywordTerms,
+        showFallback = showHotKeywordFallback
+    )
     val success = uiState as? SearchUiState.Success
     val currentPageKey = success?.page ?: 0
     val listState = rememberSaveable(currentPageKey, saver = LazyListState.Saver) { LazyListState(0, 0) }
@@ -210,6 +227,7 @@ fun SearchScreen(
 
     var keywordSyncedFromState by rememberSaveable { mutableStateOf(false) }
     var optionsSyncedFromState by rememberSaveable { mutableStateOf(false) }
+    var lastHandledSubmittedSearchSignal by rememberSaveable { mutableStateOf(0L) }
 
     LaunchedEffect(Unit) {
         viewModel.bootstrap(
@@ -277,9 +295,72 @@ fun SearchScreen(
 
     fun submitSearch() {
         if (searchSubmitLocked) return
+        val nextKeyword = keyword.trim()
+            .ifBlank { hotKeywordCarouselItem.keyword.orEmpty() }
+        if (nextKeyword.isBlank()) return
         keyboardController?.hide()
-        viewModel.search(keyword)
+        val accepted = viewModel.search(nextKeyword)
+        if (!accepted) return
+        keyword = nextKeyword
         scrollResultsToTop()
+    }
+
+    fun currentSearchAssistRequest(): SearchAssistSearchRequest {
+        return SearchAssistSearchRequest(
+            keyword = keyword,
+            orderName = selectedOrder.name,
+            purchasedOnly = purchasedOnly,
+            presaleOnly = presaleOnly,
+            chineseTranslatedOnly = chineseTranslatedOnly,
+            collectedOnly = collectedOnly,
+            locale = selectedLocale
+        )
+    }
+
+    LaunchedEffect(
+        submittedSearchSignal,
+        submittedSearchKeyword,
+        submittedSearchOrderName,
+        submittedSearchPurchasedOnly,
+        submittedSearchPresaleOnly,
+        submittedSearchChineseTranslatedOnly,
+        submittedSearchCollectedOnly,
+        submittedSearchLocale,
+        searchSubmitLocked
+    ) {
+        if (
+            submittedSearchSignal == 0L ||
+            submittedSearchSignal == lastHandledSubmittedSearchSignal ||
+            searchSubmitLocked
+        ) {
+            return@LaunchedEffect
+        }
+        val normalizedKeyword = submittedSearchKeyword.trim()
+        if (normalizedKeyword.isBlank() || searchSubmitLocked) return@LaunchedEffect
+        val submittedOrder = SearchSortOption.values()
+            .firstOrNull { it.name == submittedSearchOrderName }
+            ?: SearchSortOption.Trend
+        keyboardController?.hide()
+        val accepted = viewModel.search(
+            keyword = normalizedKeyword,
+            order = submittedOrder,
+            purchasedOnly = submittedSearchPurchasedOnly,
+            presaleOnly = submittedSearchPresaleOnly,
+            chineseTranslatedOnly = submittedSearchChineseTranslatedOnly,
+            collectedOnly = submittedSearchCollectedOnly,
+            locale = submittedSearchLocale
+        )
+        if (!accepted) return@LaunchedEffect
+        lastHandledSubmittedSearchSignal = submittedSearchSignal
+        keyword = normalizedKeyword
+        selectedOrderName = submittedOrder.name
+        purchasedOnly = submittedSearchPurchasedOnly
+        presaleOnly = submittedSearchPresaleOnly
+        chineseTranslatedOnly = submittedSearchChineseTranslatedOnly
+        collectedOnly = submittedSearchCollectedOnly
+        selectedLocale = submittedSearchLocale
+        scrollResultsToTop()
+        chromeState.expand()
     }
 
     val pullToRefreshState = rememberPullToRefreshState()
@@ -427,6 +508,7 @@ fun SearchScreen(
                         Box(
                             modifier = Modifier
                                 .fillMaxSize()
+                                .clearFocusOnTapOutside()
                         ) {
                             when (val state = uiState) {
                             is SearchUiState.Loading -> Column(
@@ -591,6 +673,9 @@ fun SearchScreen(
                         modifier = Modifier.align(Alignment.TopCenter),
                         keyword = keyword,
                         onKeywordChange = { keyword = it },
+                        placeholder = hotKeywordCarouselItem.placeholder,
+                        searchFieldReadOnly = true,
+                        onSearchFieldClick = { onOpenSearchAssist(currentSearchAssistRequest()) },
                         selectedFilter = selectedFilter,
                         selectedLocale = selectedLocale,
                         filterControlsLocked = filterControlsLocked,
@@ -605,7 +690,7 @@ fun SearchScreen(
                         animatedOffsetPx = animatedChromeOffsetPx,
                         collapseFraction = chromeState.collapseFraction,
                         onMeasured = { size: IntSize -> chromeState.updateHeight(size.height.toFloat()) },
-                        onSearchSubmit = ::submitSearch,
+                        onSearchSubmit = { submitSearch() },
                         onFilterSelected = { option ->
                             val nextOrder = option.sortOption ?: selectedOrder
                             val accepted = viewModel.updateSearchOptions(
@@ -713,6 +798,9 @@ internal fun SearchChrome(
     modifier: Modifier = Modifier,
     keyword: String,
     onKeywordChange: (String) -> Unit,
+    placeholder: String = DefaultSearchPlaceholder,
+    searchFieldReadOnly: Boolean = false,
+    onSearchFieldClick: (() -> Unit)? = null,
     selectedFilter: SearchFilterOption,
     selectedLocale: String,
     filterControlsLocked: Boolean,
@@ -726,6 +814,11 @@ internal fun SearchChrome(
     rightPanelToggle: (@Composable (Modifier) -> Unit)?,
     animatedOffsetPx: Float,
     collapseFraction: Float,
+    chromeTestTag: String = SEARCH_CHROME_TAG,
+    inputTestTag: String = SEARCH_INPUT_TAG,
+    clearButtonTestTag: String = SEARCH_CLEAR_BUTTON_TAG,
+    submitButtonTestTag: String = SEARCH_SUBMIT_BUTTON_TAG,
+    inputFocusRequester: FocusRequester? = null,
     onMeasured: (IntSize) -> Unit,
     onSearchSubmit: () -> Unit,
     onFilterSelected: (SearchFilterOption) -> Unit,
@@ -742,16 +835,23 @@ internal fun SearchChrome(
                 alpha = 1f - (collapseFraction.coerceIn(0f, 1f) * 0.1f)
             }
             .semantics { stateDescription = collapsibleHeaderUiState(collapseFraction) }
-            .testTag(SEARCH_CHROME_TAG)
+            .testTag(chromeTestTag)
     ) {
         SearchToolbar(
             keyword = keyword,
             onKeywordChange = onKeywordChange,
+            placeholder = placeholder,
+            searchFieldReadOnly = searchFieldReadOnly,
+            onSearchFieldClick = onSearchFieldClick,
             selectedFilter = selectedFilter,
             selectedLocale = selectedLocale,
             filterControlsLocked = filterControlsLocked,
             searchSubmitLocked = searchSubmitLocked,
             showSearchSpinner = showSearchSpinner,
+            inputTestTag = inputTestTag,
+            clearButtonTestTag = clearButtonTestTag,
+            submitButtonTestTag = submitButtonTestTag,
+            inputFocusRequester = inputFocusRequester,
             onSearchSubmit = onSearchSubmit,
             onFilterSelected = onFilterSelected,
             onLocaleSelected = onLocaleSelected,
@@ -775,11 +875,18 @@ internal fun SearchChrome(
 internal fun SearchToolbar(
     keyword: String,
     onKeywordChange: (String) -> Unit,
+    placeholder: String = DefaultSearchPlaceholder,
+    searchFieldReadOnly: Boolean = false,
+    onSearchFieldClick: (() -> Unit)? = null,
     selectedFilter: SearchFilterOption,
     selectedLocale: String,
     filterControlsLocked: Boolean,
     searchSubmitLocked: Boolean,
     showSearchSpinner: Boolean,
+    inputTestTag: String = SEARCH_INPUT_TAG,
+    clearButtonTestTag: String = SEARCH_CLEAR_BUTTON_TAG,
+    submitButtonTestTag: String = SEARCH_SUBMIT_BUTTON_TAG,
+    inputFocusRequester: FocusRequester? = null,
     onSearchSubmit: () -> Unit,
     onFilterSelected: (SearchFilterOption) -> Unit,
     onLocaleSelected: (String) -> Unit,
@@ -811,10 +918,13 @@ internal fun SearchToolbar(
         CustomSearchBar(
             value = keyword,
             onValueChange = onKeywordChange,
-            placeholder = "搜索专辑、社团、CV...",
+            placeholder = placeholder,
             modifier = Modifier
-                .weight(1f)
-                .testTag(SEARCH_INPUT_TAG),
+                .weight(1f),
+            readOnly = searchFieldReadOnly,
+            onFieldClick = onSearchFieldClick,
+            focusRequester = inputFocusRequester,
+            inputTestTag = inputTestTag,
             leadingIcon = {
                 Box {
                     TextButton(
@@ -894,7 +1004,7 @@ internal fun SearchToolbar(
                             enabled = !searchSubmitLocked,
                             modifier = Modifier
                                 .size(28.dp)
-                                .testTag(SEARCH_CLEAR_BUTTON_TAG)
+                                .testTag(clearButtonTestTag)
                         ) {
                             Icon(
                                 imageVector = Icons.Rounded.Close,
@@ -956,7 +1066,7 @@ internal fun SearchToolbar(
                         enabled = !searchSubmitLocked,
                         modifier = Modifier
                             .size(28.dp)
-                            .testTag(SEARCH_SUBMIT_BUTTON_TAG)
+                            .testTag(submitButtonTestTag)
                     ) {
                         if (showSearchSpinner) {
                             EaraLogoLoadingIndicator(
@@ -969,7 +1079,7 @@ internal fun SearchToolbar(
                             Icon(
                                 imageVector = Icons.Rounded.Search,
                                 contentDescription = null,
-                                tint = colorScheme.primary,
+                                tint = if (!searchSubmitLocked) colorScheme.primary else colorScheme.textTertiary,
                                 modifier = Modifier.size(17.dp)
                             )
                         }

--- a/app/src/main/java/com/asmr/player/ui/search/SearchViewModel.kt
+++ b/app/src/main/java/com/asmr/player/ui/search/SearchViewModel.kt
@@ -11,6 +11,7 @@ import com.asmr.player.data.remote.dlsite.DlsitePlayLibraryClient
 import com.asmr.player.data.remote.scraper.DLSiteScraper
 import com.asmr.player.data.settings.SettingsRepository
 import com.asmr.player.domain.model.Album
+import com.asmr.player.hotlistening.HotListeningApi
 import com.asmr.player.util.AppErrorMessageFormatter
 import com.asmr.player.util.MessageManager
 import androidx.lifecycle.ViewModel
@@ -57,6 +58,7 @@ class SearchViewModel @Inject constructor(
     private val asmrOneAvailabilityApi: AsmrOneAvailabilityApi,
     private val settingsRepository: SettingsRepository,
     private val searchCacheStore: SearchCacheStore,
+    private val hotListeningApi: HotListeningApi,
     val messageManager: MessageManager
 ) : ViewModel() {
     private val pageSize = 30
@@ -75,12 +77,36 @@ class SearchViewModel @Inject constructor(
 
     private val _uiState = MutableStateFlow<SearchUiState>(SearchUiState.Idle)
     val uiState = _uiState.asStateFlow()
+    private val _hotKeywordTerms = MutableStateFlow<List<SearchHotKeywordTerm>>(emptyList())
+    internal val hotKeywordTerms: StateFlow<List<SearchHotKeywordTerm>> = _hotKeywordTerms.asStateFlow()
+    private val _showHotKeywordFallback = MutableStateFlow(false)
+    internal val showHotKeywordFallback: StateFlow<Boolean> = _showHotKeywordFallback.asStateFlow()
 
     val viewMode: StateFlow<Int> = settingsRepository.searchViewMode
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), 1)
 
     private var currentLocale: String? = "ja_JP"
     private var lastRequestedKeyword: String = ""
+
+    init {
+        refreshHotKeywordTerms()
+    }
+
+    private fun refreshHotKeywordTerms() {
+        if (!hotListeningApi.isBackendConfigured) {
+            _showHotKeywordFallback.value = true
+            return
+        }
+        viewModelScope.launch {
+            val suggestions = runCatching { hotListeningApi.getSearchSuggestions() }.getOrNull()
+            val terms = buildSearchHotKeywordTerms(
+                hotCvs = suggestions?.hotCvs.orEmpty(),
+                hotTags = suggestions?.hotTags.orEmpty()
+            )
+            _hotKeywordTerms.value = terms
+            _showHotKeywordFallback.value = terms.isEmpty()
+        }
+    }
 
     fun setViewMode(mode: Int) {
         viewModelScope.launch {
@@ -125,14 +151,51 @@ class SearchViewModel @Inject constructor(
         }
     }
 
-    fun search(keyword: String) {
-        if (_uiState.value is SearchUiState.Loading) return
+    fun search(keyword: String): Boolean {
+        return search(
+            keyword = keyword,
+            order = currentOrder,
+            purchasedOnly = purchasedOnly,
+            presaleOnly = presaleOnly,
+            chineseTranslatedOnly = chineseTranslatedOnly,
+            collectedOnly = collectedOnly,
+            locale = currentLocale
+        )
+    }
+
+    fun search(
+        keyword: String,
+        order: SearchSortOption,
+        purchasedOnly: Boolean,
+        presaleOnly: Boolean,
+        chineseTranslatedOnly: Boolean,
+        collectedOnly: Boolean,
+        locale: String?
+    ): Boolean {
+        if (_uiState.value is SearchUiState.Loading) return false
         val current = _uiState.value as? SearchUiState.Success
-        if (current?.isBusy == true) return
+        if (current?.isBusy == true) return false
+        val nextFilters = normalizeSearchFilters(
+            purchasedOnly = purchasedOnly,
+            presaleOnly = presaleOnly,
+            chineseTranslatedOnly = chineseTranslatedOnly,
+            collectedOnly = collectedOnly
+        )
+        if (nextFilters.purchasedOnly && !dlsitePlayLibraryClient.hasStoredCredentials()) {
+            messageManager.showWarning("请先登录 DLsite 后再使用\"已购\"搜索")
+            return false
+        }
         val normalizedKeyword = keyword.trim()
         Log.d("SearchViewModel", "Search requested: keyword=$normalizedKeyword")
+        currentOrder = order
+        this.purchasedOnly = nextFilters.purchasedOnly
+        this.presaleOnly = nextFilters.presaleOnly
+        this.chineseTranslatedOnly = nextFilters.chineseTranslatedOnly
+        this.collectedOnly = nextFilters.collectedOnly
+        currentLocale = locale
         lastRequestedKeyword = normalizedKeyword
         requestPage(normalizedKeyword, 1, SearchPendingRequestKind.Search)
+        return true
     }
 
     fun setOrder(order: SearchSortOption) {

--- a/app/src/test/java/com/asmr/player/MainNavigationSupportTest.kt
+++ b/app/src/test/java/com/asmr/player/MainNavigationSupportTest.kt
@@ -70,6 +70,12 @@ class MainNavigationSupportTest {
     }
 
     @Test
+    fun resolveCurrentPrimaryDestinationRoute_treatsSearchAssistAsSecondary() {
+        assertEquals(null, resolveCurrentPrimaryDestinationRoute("search_assist"))
+        assertEquals(null, resolveCurrentPrimaryDestinationRoute("search_assist?keyword={keyword}"))
+    }
+
+    @Test
     fun shouldScrollPrimaryRouteToTop_onlyWhenAlreadyAtPrimaryRoot() {
         assertEquals(true, shouldScrollPrimaryRouteToTop("playlists", "playlists", "playlists"))
         assertEquals(false, shouldScrollPrimaryRouteToTop("playlists", "playlists", null))

--- a/app/src/test/java/com/asmr/player/data/local/datastore/SearchCacheStoreTest.kt
+++ b/app/src/test/java/com/asmr/player/data/local/datastore/SearchCacheStoreTest.kt
@@ -1,0 +1,53 @@
+package com.asmr.player.data.local.datastore
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class SearchCacheStoreTest {
+    @Test
+    fun mergeSearchHistory_trimsDeduplicatesAndKeepsRecentFirst() {
+        val result = mergeSearchHistory(
+            keyword = "  Rain  ",
+            existing = listOf("rain", "ASMR", " ", "CV A"),
+            limit = 3
+        )
+
+        assertEquals(listOf("Rain", "ASMR", "CV A"), result)
+    }
+
+    @Test
+    fun mergeSearchHistory_limitsExistingHistoryWhenKeywordIsBlank() {
+        val result = mergeSearchHistory(
+            keyword = "",
+            existing = listOf("one", "two", "ONE", "three"),
+            limit = 2
+        )
+
+        assertEquals(listOf("one", "two"), result)
+    }
+
+    @Test
+    fun mergeSearchHistory_defaultLimitKeepsFiftyItems() {
+        val existing = (1..60).map { "item$it" }
+
+        val result = mergeSearchHistory(
+            keyword = "new",
+            existing = existing
+        )
+
+        assertEquals(50, result.size)
+        assertEquals("new", result.first())
+        assertEquals("item49", result.last())
+    }
+
+    @Test
+    fun mergeSearchHistory_zeroLimitReturnsEmptyList() {
+        val result = mergeSearchHistory(
+            keyword = "new",
+            existing = listOf("old"),
+            limit = 0
+        )
+
+        assertEquals(emptyList<String>(), result)
+    }
+}

--- a/app/src/test/java/com/asmr/player/ui/search/SearchAssistScreenTest.kt
+++ b/app/src/test/java/com/asmr/player/ui/search/SearchAssistScreenTest.kt
@@ -1,0 +1,239 @@
+package com.asmr.player.ui.search
+
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.test.SemanticsMatcher
+import androidx.compose.ui.test.assert
+import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.assertIsFocused
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onAllNodesWithTag
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performImeAction
+import androidx.compose.ui.test.performTextInput
+import androidx.compose.ui.text.TextRange
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.asmr.player.domain.model.Album
+import com.asmr.player.hotlistening.SearchSuggestionTerm
+import com.asmr.player.ui.testWindowSizeClass
+import com.asmr.player.ui.theme.AsmrPlayerTheme
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class SearchAssistScreenTest {
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    @Test
+    fun inputIsFocusedAtTextEndWhenAssistPageOpens() {
+        val initialKeyword = "RJ123456"
+
+        composeRule.setContent {
+            AsmrPlayerTheme {
+                SearchAssistContent(
+                    windowSizeClass = testWindowSizeClass(),
+                    initialRequest = SearchAssistSearchRequest(keyword = initialKeyword),
+                    uiState = SearchAssistUiState(),
+                    onSubmitSearch = {},
+                    onClearHistory = {},
+                    onOpenFullRanking = {}
+                )
+            }
+        }
+
+        composeRule.onNodeWithTag(SEARCH_ASSIST_INPUT_TAG).assertIsFocused()
+        composeRule.onNodeWithTag(SEARCH_ASSIST_INPUT_TAG).assert(
+            SemanticsMatcher.expectValue(
+                SemanticsProperties.TextSelectionRange,
+                TextRange(initialKeyword.length)
+            )
+        )
+    }
+
+    @Test
+    fun imeSearchAndSubmitButtonShareSubmitPath() {
+        val submitted = mutableListOf<SearchAssistSearchRequest>()
+
+        composeRule.setContent {
+            AsmrPlayerTheme {
+                SearchAssistContent(
+                    windowSizeClass = testWindowSizeClass(),
+                    initialRequest = SearchAssistSearchRequest(),
+                    uiState = SearchAssistUiState(),
+                    onSubmitSearch = { submitted += it },
+                    onClearHistory = {},
+                    onOpenFullRanking = {}
+                )
+            }
+        }
+
+        composeRule.onNodeWithTag(SEARCH_ASSIST_INPUT_TAG).performTextInput("  rain  ")
+        composeRule.onNodeWithTag(SEARCH_ASSIST_INPUT_TAG).performImeAction()
+        composeRule.onNodeWithTag(SEARCH_ASSIST_SUBMIT_TAG).performClick()
+
+        composeRule.runOnIdle {
+            assertEquals(listOf("rain", "rain"), submitted.map { it.keyword })
+        }
+    }
+
+    @Test
+    fun historyCvAndTagChipsSubmitTheirText() {
+        val submitted = mutableListOf<SearchAssistSearchRequest>()
+
+        composeRule.setContent {
+            AsmrPlayerTheme {
+                SearchAssistContent(
+                    windowSizeClass = testWindowSizeClass(),
+                    initialRequest = SearchAssistSearchRequest(),
+                    uiState = SearchAssistUiState(
+                        history = listOf("雨声"),
+                        suggestions = SearchSuggestionsUiData(
+                            hotCvs = listOf(SearchSuggestionTerm(value = "CV A", count = 12, rank = 1)),
+                            hotTags = listOf(SearchSuggestionTerm(value = "耳语", count = 8, rank = 1))
+                        )
+                    ),
+                    onSubmitSearch = { submitted += it },
+                    onClearHistory = {},
+                    onOpenFullRanking = {}
+                )
+            }
+        }
+
+        composeRule.onAllNodesWithText("12").assertCountEquals(0)
+        composeRule.onAllNodesWithText("8").assertCountEquals(0)
+        composeRule.onNodeWithText("雨声").performClick()
+        composeRule.onNodeWithText("CV A").performClick()
+        composeRule.onNodeWithText("耳语").performClick()
+
+        composeRule.runOnIdle {
+            assertEquals(listOf("雨声", "CV A", "耳语"), submitted.map { it.keyword })
+        }
+    }
+
+    @Test
+    fun emptySubmitUsesCurrentHotKeywordPlaceholder() {
+        val submitted = mutableListOf<SearchAssistSearchRequest>()
+
+        composeRule.setContent {
+            AsmrPlayerTheme {
+                SearchAssistContent(
+                    windowSizeClass = testWindowSizeClass(),
+                    initialRequest = SearchAssistSearchRequest(),
+                    uiState = SearchAssistUiState(
+                        suggestions = SearchSuggestionsUiData(
+                            hotCvs = listOf(SearchSuggestionTerm(value = "CV A", count = 12, rank = 1))
+                        )
+                    ),
+                    onSubmitSearch = { submitted += it },
+                    onClearHistory = {},
+                    onOpenFullRanking = {}
+                )
+            }
+        }
+
+        composeRule.onNodeWithTag(SEARCH_ASSIST_SUBMIT_TAG).performClick()
+
+        composeRule.runOnIdle {
+            assertEquals(listOf("CV A"), submitted.map { it.keyword })
+        }
+    }
+
+    @Test
+    fun clearHistoryHotWorkAndFullRankingUseSeparateCallbacks() {
+        var clearHistoryCount = 0
+        var fullRankingCount = 0
+        val submitted = mutableListOf<SearchAssistSearchRequest>()
+        val firstAlbum = Album(
+            title = "Rain Work",
+            path = "",
+            workId = "RJ111111",
+            rjCode = "RJ111111",
+            circle = "Circle A",
+            cv = "CV A"
+        )
+        val secondAlbum = Album(
+            title = "Sleep Work",
+            path = "",
+            workId = "RJ222222",
+            rjCode = "RJ222222",
+            circle = "Circle B",
+            cv = "CV B"
+        )
+
+        composeRule.setContent {
+            AsmrPlayerTheme {
+                SearchAssistContent(
+                    windowSizeClass = testWindowSizeClass(),
+                    initialRequest = SearchAssistSearchRequest(),
+                    uiState = SearchAssistUiState(
+                        history = listOf("雨声"),
+                        suggestions = SearchSuggestionsUiData(
+                            hotWorks = listOf(
+                                SearchAssistHotWork(album = firstAlbum),
+                                SearchAssistHotWork(album = secondAlbum)
+                            )
+                        )
+                    ),
+                    onSubmitSearch = { submitted += it },
+                    onClearHistory = { clearHistoryCount += 1 },
+                    onOpenFullRanking = { fullRankingCount += 1 }
+                )
+            }
+        }
+
+        composeRule.onNodeWithTag(SEARCH_ASSIST_HISTORY_CLEAR_TAG).performClick()
+        composeRule.onNodeWithText("是否清空历史搜索记录？").assertExists()
+        composeRule.runOnIdle {
+            assertEquals(0, clearHistoryCount)
+        }
+        composeRule.onNodeWithText("清空").performClick()
+        composeRule.onNodeWithTag(SEARCH_ASSIST_FULL_RANKING_TAG).performClick()
+        composeRule.onAllNodesWithTag(SEARCH_ASSIST_HOT_WORK_CARD_TAG).assertCountEquals(2)
+        composeRule.onAllNodesWithText("RJ111111").assertCountEquals(0)
+        composeRule.onAllNodesWithTag(SEARCH_ASSIST_HOT_WORK_CARD_TAG)[0].performClick()
+
+        composeRule.runOnIdle {
+            assertEquals(1, clearHistoryCount)
+            assertEquals(1, fullRankingCount)
+            assertEquals(listOf("RJ111111"), submitted.map { it.keyword })
+        }
+    }
+
+    @Test
+    fun hotWorkWithoutTitleUsesGenericLabelInsteadOfRj() {
+        composeRule.setContent {
+            AsmrPlayerTheme {
+                SearchAssistContent(
+                    windowSizeClass = testWindowSizeClass(),
+                    initialRequest = SearchAssistSearchRequest(),
+                    uiState = SearchAssistUiState(
+                        suggestions = SearchSuggestionsUiData(
+                            hotWorks = listOf(
+                                SearchAssistHotWork(
+                                    album = Album(
+                                        title = "",
+                                        path = "",
+                                        workId = "RJ333333",
+                                        rjCode = "RJ333333",
+                                        cv = "CV C"
+                                    )
+                                )
+                            )
+                        )
+                    ),
+                    onSubmitSearch = {},
+                    onClearHistory = {},
+                    onOpenFullRanking = {}
+                )
+            }
+        }
+
+        composeRule.onNodeWithText("热门作品").assertExists()
+        composeRule.onAllNodesWithText("RJ333333").assertCountEquals(0)
+    }
+}

--- a/app/src/test/java/com/asmr/player/ui/search/SearchScreenChromeTest.kt
+++ b/app/src/test/java/com/asmr/player/ui/search/SearchScreenChromeTest.kt
@@ -74,6 +74,62 @@ class SearchScreenChromeTest {
     }
 
     @Test
+    fun searchToolbar_readOnlyFieldOpensAssistAndSearchIconSubmits() {
+        var assistOpenCount by mutableIntStateOf(0)
+        var submitCount by mutableIntStateOf(0)
+
+        composeRule.setContent {
+            AsmrPlayerTheme {
+                SearchToolbar(
+                    keyword = "RJ123456",
+                    onKeywordChange = {},
+                    searchFieldReadOnly = true,
+                    onSearchFieldClick = { assistOpenCount += 1 },
+                    selectedFilter = SearchFilterOption.Trend,
+                    selectedLocale = "ja_JP",
+                    filterControlsLocked = false,
+                    searchSubmitLocked = false,
+                    showSearchSpinner = false,
+                    onSearchSubmit = { submitCount += 1 },
+                    onFilterSelected = {},
+                    onLocaleSelected = {}
+                )
+            }
+        }
+
+        composeRule.onNodeWithTag(SEARCH_INPUT_TAG).performClick()
+        composeRule.onNodeWithTag(SEARCH_SUBMIT_BUTTON_TAG).performClick()
+
+        composeRule.runOnIdle {
+            assertEquals(1, assistOpenCount)
+            assertEquals(1, submitCount)
+        }
+    }
+
+    @Test
+    fun searchToolbar_usesHotKeywordPlaceholderWhenKeywordIsEmpty() {
+        composeRule.setContent {
+            AsmrPlayerTheme {
+                SearchToolbar(
+                    keyword = "",
+                    onKeywordChange = {},
+                    placeholder = "CV A",
+                    selectedFilter = SearchFilterOption.Trend,
+                    selectedLocale = "ja_JP",
+                    filterControlsLocked = false,
+                    searchSubmitLocked = false,
+                    showSearchSpinner = false,
+                    onSearchSubmit = {},
+                    onFilterSelected = {},
+                    onLocaleSelected = {}
+                )
+            }
+        }
+
+        composeRule.onNodeWithText("CV A").assertExists()
+    }
+
+    @Test
     fun searchPending_disablesChromeAndShowsSearchSpinner() {
         composeRule.setContent {
             AsmrPlayerTheme {


### PR DESCRIPTION
## Summary
- Add the secondary search assist page with history, hot CV/tag chips, and hot work shortcuts.
- Rotate hot CV/tag keywords in the online search bar with random ordering, placeholder styling, and upward fade transitions.
- Keep search history unique, recent-first, and capped at 50 entries.

## Verification
- `git diff --check`
- `./gradlew.bat :app:compileDebugKotlin --max-workers=1`
- Targeted unit test tasks compiled source and test code, but local Gradle Test Executor failed with `GradleWorkerMain` classpath/pipe errors before running assertions.