### PR TITLE
feat: 为已收录搜索添加排序选项

### DIFF
--- a/app/src/main/java/com/asmr/player/data/local/datastore/SearchCacheStore.kt
+++ b/app/src/main/java/com/asmr/player/data/local/datastore/SearchCacheStore.kt
@@ -24,6 +24,7 @@ data class LastSearchStateV1(
     val presaleOnly: Boolean = false,
     val chineseTranslatedOnly: Boolean = false,
     val collectedOnly: Boolean = false,
+    val collectedSortName: String = "",
     val locale: String?,
     val page: Int,
     val canGoNext: Boolean,

--- a/app/src/main/java/com/asmr/player/data/remote/api/AsmrOneAvailabilityApi.kt
+++ b/app/src/main/java/com/asmr/player/data/remote/api/AsmrOneAvailabilityApi.kt
@@ -41,6 +41,7 @@ data class AsmrOneCollectedSearchResponse(
     val total: Int = 0,
     val limit: Int = 0,
     val offset: Int = 0,
+    val sort: String = "",
     val serverTimeEpochMs: Long = 0L
 )
 
@@ -105,7 +106,7 @@ class AsmrOneAvailabilityApi @Inject constructor(
         }.getOrDefault(emptyMap())
     }
 
-    suspend fun search(keyword: String, limit: Int, offset: Int): AsmrOneCollectedSearchResponse {
+    suspend fun search(keyword: String, limit: Int, offset: Int, sort: String): AsmrOneCollectedSearchResponse {
         if (baseUrl.isBlank()) throw IOException("asmr.one backend is not configured")
         return withContext(Dispatchers.IO) {
             val url = resolveUrl("api/asmr-one/search")
@@ -114,6 +115,7 @@ class AsmrOneAvailabilityApi @Inject constructor(
                 ?.addQueryParameter("q", keyword.trim())
                 ?.addQueryParameter("limit", limit.coerceIn(1, 100).toString())
                 ?.addQueryParameter("offset", offset.coerceAtLeast(0).toString())
+                ?.addQueryParameter("sort", sort.trim().ifBlank { "release" })
                 ?.build()
                 ?: throw IOException("invalid asmr.one backend url")
             val request = Request.Builder()

--- a/app/src/main/java/com/asmr/player/main/MainContainer.kt
+++ b/app/src/main/java/com/asmr/player/main/MainContainer.kt
@@ -92,6 +92,7 @@ import com.asmr.player.ui.playlists.PlaylistsViewModel
 import com.asmr.player.ui.playlists.SystemPlaylistScreen
 import com.asmr.player.ui.search.SEARCH_ASSIST_RESULT_CHINESE_TRANSLATED_ONLY_KEY
 import com.asmr.player.ui.search.SEARCH_ASSIST_RESULT_COLLECTED_ONLY_KEY
+import com.asmr.player.ui.search.SEARCH_ASSIST_RESULT_COLLECTED_SORT_KEY
 import com.asmr.player.ui.search.SEARCH_ASSIST_RESULT_KEY
 import com.asmr.player.ui.search.SEARCH_ASSIST_RESULT_LOCALE_KEY
 import com.asmr.player.ui.search.SEARCH_ASSIST_RESULT_ORDER_KEY
@@ -378,6 +379,9 @@ fun MainContainer(
         mutableStateOf(SearchAssistSearchRequest().chineseTranslatedOnly)
     }
     var submittedSearchCollectedOnly by rememberSaveable { mutableStateOf(SearchAssistSearchRequest().collectedOnly) }
+    var submittedSearchCollectedSortName by rememberSaveable {
+        mutableStateOf(SearchAssistSearchRequest().collectedSortName)
+    }
     var submittedSearchLocale by rememberSaveable { mutableStateOf(SearchAssistSearchRequest().locale) }
     var submittedSearchSignal by rememberSaveable { mutableLongStateOf(0L) }
     var searchAssistInitialRequest by remember { mutableStateOf(SearchAssistSearchRequest()) }
@@ -529,6 +533,7 @@ fun MainContainer(
             request.chineseTranslatedOnly
         )
         targetEntry?.savedStateHandle?.set(SEARCH_ASSIST_RESULT_COLLECTED_ONLY_KEY, request.collectedOnly)
+        targetEntry?.savedStateHandle?.set(SEARCH_ASSIST_RESULT_COLLECTED_SORT_KEY, request.collectedSortName)
         targetEntry?.savedStateHandle?.set(SEARCH_ASSIST_RESULT_LOCALE_KEY, request.locale)
         targetEntry?.savedStateHandle?.set(
             SEARCH_ASSIST_RESULT_SIGNAL_KEY,
@@ -1294,6 +1299,7 @@ fun MainContainer(
                                                 submittedSearchPresaleOnly = submittedSearchPresaleOnly,
                                                 submittedSearchChineseTranslatedOnly = submittedSearchChineseTranslatedOnly,
                                                 submittedSearchCollectedOnly = submittedSearchCollectedOnly,
+                                                submittedSearchCollectedSortName = submittedSearchCollectedSortName,
                                                 submittedSearchLocale = submittedSearchLocale,
                                                 submittedSearchSignal = submittedSearchSignal,
                                                 onOpenSearchAssist = { request ->
@@ -1424,6 +1430,12 @@ fun MainContainer(
                     val submittedCollectedOnly by backStackEntry.savedStateHandle
                         .getStateFlow(SEARCH_ASSIST_RESULT_COLLECTED_ONLY_KEY, SearchAssistSearchRequest().collectedOnly)
                         .collectAsState()
+                    val submittedCollectedSortName by backStackEntry.savedStateHandle
+                        .getStateFlow(
+                            SEARCH_ASSIST_RESULT_COLLECTED_SORT_KEY,
+                            SearchAssistSearchRequest().collectedSortName
+                        )
+                        .collectAsState()
                     val submittedLocale by backStackEntry.savedStateHandle
                         .getStateFlow(SEARCH_ASSIST_RESULT_LOCALE_KEY, SearchAssistSearchRequest().locale)
                         .collectAsState()
@@ -1439,6 +1451,7 @@ fun MainContainer(
                         submittedPresaleOnly,
                         submittedChineseTranslatedOnly,
                         submittedCollectedOnly,
+                        submittedCollectedSortName,
                         submittedLocale
                     ) {
                         if (submittedSignal <= 0L) return@LaunchedEffect
@@ -1448,6 +1461,7 @@ fun MainContainer(
                         submittedSearchPresaleOnly = submittedPresaleOnly
                         submittedSearchChineseTranslatedOnly = submittedChineseTranslatedOnly
                         submittedSearchCollectedOnly = submittedCollectedOnly
+                        submittedSearchCollectedSortName = submittedCollectedSortName
                         submittedSearchLocale = submittedLocale
                         submittedSearchSignal = submittedSignal
                         backStackEntry.savedStateHandle[SEARCH_ASSIST_RESULT_KEY] = ""
@@ -1461,6 +1475,8 @@ fun MainContainer(
                             SearchAssistSearchRequest().chineseTranslatedOnly
                         backStackEntry.savedStateHandle[SEARCH_ASSIST_RESULT_COLLECTED_ONLY_KEY] =
                             SearchAssistSearchRequest().collectedOnly
+                        backStackEntry.savedStateHandle[SEARCH_ASSIST_RESULT_COLLECTED_SORT_KEY] =
+                            SearchAssistSearchRequest().collectedSortName
                         backStackEntry.savedStateHandle[SEARCH_ASSIST_RESULT_LOCALE_KEY] =
                             SearchAssistSearchRequest().locale
                         backStackEntry.savedStateHandle[SEARCH_ASSIST_RESULT_SIGNAL_KEY] = 0L

--- a/app/src/main/java/com/asmr/player/main/MainContainer.kt
+++ b/app/src/main/java/com/asmr/player/main/MainContainer.kt
@@ -1441,7 +1441,7 @@ fun MainContainer(
                         submittedCollectedOnly,
                         submittedLocale
                     ) {
-                        if (submittedSignal <= 0L || submittedKeyword.isBlank()) return@LaunchedEffect
+                        if (submittedSignal <= 0L) return@LaunchedEffect
                         submittedSearchKeyword = submittedKeyword
                         submittedSearchOrderName = submittedOrderName
                         submittedSearchPurchasedOnly = submittedPurchasedOnly

--- a/app/src/main/java/com/asmr/player/main/MainContainer.kt
+++ b/app/src/main/java/com/asmr/player/main/MainContainer.kt
@@ -105,6 +105,7 @@ import com.asmr.player.ui.search.SearchViewModel
 import com.asmr.player.domain.model.SearchSource
 import com.asmr.player.ui.settings.SettingsScreen
 import com.asmr.player.ui.settings.SettingsViewModel
+import com.asmr.player.ui.common.FlatTextFieldDialog
 import com.asmr.player.ui.common.glassMenu
 import com.asmr.player.ui.drawer.DrawerStatusViewModel
 import com.asmr.player.ui.drawer.StatisticsViewModel
@@ -1757,32 +1758,18 @@ fun MainContainer(
                 (currentRoute?.startsWith("album_detail/{albumId}") == true || currentRoute?.startsWith("album_detail/") == true)
             ) {
                 val albumDetailViewModel: AlbumDetailViewModel = hiltViewModel(navBackStackEntry!!)
-                AlertDialog(
+                FlatTextFieldDialog(
                     onDismissRequest = { showManualRjDialog = false },
-                    title = { Text("手动绑定 RJ") },
-                    text = {
-                        Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
-                            Text("请输入 RJ 号，保存后将自动执行云同步。", style = MaterialTheme.typography.bodySmall)
-                            OutlinedTextField(
-                                value = manualRjInput,
-                                onValueChange = { manualRjInput = it },
-                                singleLine = true,
-                                label = { Text("RJ号（如 RJ123456）") },
-                                modifier = Modifier.fillMaxWidth()
-                            )
-                        }
+                    message = "请输入 RJ 号，保存后将自动执行云同步。",
+                    value = manualRjInput,
+                    onValueChange = { manualRjInput = it },
+                    placeholder = "RJ号（如 RJ123456）",
+                    confirmText = "同步",
+                    confirmEnabled = manualRjInput.trim().isNotBlank(),
+                    onConfirm = {
+                        showManualRjDialog = false
+                        albumDetailViewModel.manualSetRjAndSync(manualRjInput.trim())
                     },
-                    confirmButton = {
-                        TextButton(
-                            onClick = {
-                                showManualRjDialog = false
-                                albumDetailViewModel.manualSetRjAndSync(manualRjInput)
-                            }
-                        ) { Text("同步") }
-                    },
-                    dismissButton = {
-                        TextButton(onClick = { showManualRjDialog = false }) { Text("取消") }
-                    }
                 )
             }
 

--- a/app/src/main/java/com/asmr/player/ui/common/AppVolumeSafetyUi.kt
+++ b/app/src/main/java/com/asmr/player/ui/common/AppVolumeSafetyUi.kt
@@ -1,8 +1,5 @@
 package com.asmr.player.ui.common
 
-import androidx.compose.material3.AlertDialog
-import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.getValue
@@ -93,24 +90,12 @@ fun AppVolumeHearingWarningDialog(
     state: ProtectedAppVolumeChangeState
 ) {
     val pendingChange = state.pendingChange ?: return
-    AlertDialog(
+    FlatActionDialog(
         onDismissRequest = state::dismissPendingChange,
-        title = { Text("听力损伤提醒") },
-        text = {
-            Text(
-                "当前要调整到 ${pendingChange.targetPercent}% 音量，已经超过 40%，" +
-                    "可能造成听力损伤。确认后，本次启动内不再重复提示。"
-            )
-        },
-        confirmButton = {
-            TextButton(onClick = state::confirmPendingChange) {
-                Text("确认")
-            }
-        },
-        dismissButton = {
-            TextButton(onClick = state::dismissPendingChange) {
-                Text("取消")
-            }
-        }
+        message = "当前要调整到 ${pendingChange.targetPercent}% 音量，已经超过 40%，可能造成听力损伤。确认后，本次启动内不再重复提示。",
+        actions = listOf(
+            FlatDialogAction("取消", state::dismissPendingChange),
+            FlatDialogAction("确认", state::confirmPendingChange, FlatDialogActionTone.Primary)
+        )
     )
 }

--- a/app/src/main/java/com/asmr/player/ui/common/EqualizerPanel.kt
+++ b/app/src/main/java/com/asmr/player/ui/common/EqualizerPanel.kt
@@ -1168,36 +1168,21 @@ fun EqualizerPanel(
     }
 
     if (showSaveDialog) {
-        AlertDialog(
+        FlatTextFieldDialog(
             onDismissRequest = { showSaveDialog = false },
-            title = { Text("保存预设") },
-            text = {
-                OutlinedTextField(
-                    value = newPresetName,
-                    onValueChange = { newPresetName = it },
-                    label = { Text("预设名称") },
-                    singleLine = true,
-                    modifier = Modifier.fillMaxWidth()
-                )
-            },
-            confirmButton = {
-                TextButton(
-                    onClick = {
-                        if (newPresetName.isNotBlank()) {
-                            onSavePreset(newPresetName)
-                            showSaveDialog = false
-                            newPresetName = ""
-                        }
-                    }
-                ) {
-                    Text("保存")
+            message = "请输入自定义预设名称。",
+            value = newPresetName,
+            onValueChange = { newPresetName = it },
+            placeholder = "预设名称",
+            confirmText = "保存",
+            confirmEnabled = newPresetName.trim().isNotBlank(),
+            onConfirm = {
+                if (newPresetName.isNotBlank()) {
+                    onSavePreset(newPresetName.trim())
+                    showSaveDialog = false
+                    newPresetName = ""
                 }
             },
-            dismissButton = {
-                TextButton(onClick = { showSaveDialog = false }) {
-                    Text("取消")
-                }
-            }
         )
     }
 }

--- a/app/src/main/java/com/asmr/player/ui/common/FlatDialog.kt
+++ b/app/src/main/java/com/asmr/player/ui/common/FlatDialog.kt
@@ -1,0 +1,173 @@
+package com.asmr.player.ui.common
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TextField
+import androidx.compose.material3.TextFieldDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
+import com.asmr.player.ui.theme.AsmrTheme
+
+enum class FlatDialogActionTone {
+    Neutral,
+    Primary,
+    Danger,
+}
+
+data class FlatDialogAction(
+    val text: String,
+    val onClick: () -> Unit,
+    val tone: FlatDialogActionTone = FlatDialogActionTone.Neutral,
+    val enabled: Boolean = true,
+)
+
+@Composable
+fun FlatActionDialog(
+    message: String,
+    actions: List<FlatDialogAction>,
+    onDismissRequest: () -> Unit,
+    modifier: Modifier = Modifier,
+    properties: DialogProperties = DialogProperties(),
+    content: (@Composable () -> Unit)? = null,
+) {
+    if (actions.isEmpty()) return
+
+    val colorScheme = AsmrTheme.colorScheme
+    Dialog(
+        onDismissRequest = onDismissRequest,
+        properties = properties,
+    ) {
+        Column(
+            modifier = modifier
+                .widthIn(max = 380.dp)
+                .fillMaxWidth()
+                .clip(RoundedCornerShape(18.dp))
+                .background(colorScheme.surface)
+                .padding(top = 22.dp, bottom = 8.dp),
+            verticalArrangement = Arrangement.spacedBy(18.dp),
+        ) {
+            Column(
+                modifier = Modifier.padding(horizontal = 22.dp),
+                verticalArrangement = Arrangement.spacedBy(14.dp),
+            ) {
+                Text(
+                    text = message,
+                    style = MaterialTheme.typography.bodyMedium.copy(fontWeight = FontWeight.SemiBold),
+                    color = colorScheme.textPrimary,
+                    textAlign = TextAlign.Center,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+                content?.invoke()
+            }
+
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 8.dp),
+                horizontalArrangement = Arrangement.spacedBy(6.dp),
+            ) {
+                actions.forEach { action ->
+                    TextButton(
+                        onClick = action.onClick,
+                        enabled = action.enabled,
+                        modifier = Modifier.weight(1f),
+                        colors = ButtonDefaults.textButtonColors(
+                            contentColor = when (action.tone) {
+                                FlatDialogActionTone.Neutral -> colorScheme.textSecondary
+                                FlatDialogActionTone.Primary -> colorScheme.primary
+                                FlatDialogActionTone.Danger -> colorScheme.danger
+                            },
+                            disabledContentColor = colorScheme.textTertiary.copy(alpha = 0.55f),
+                        ),
+                    ) {
+                        Text(
+                            text = action.text,
+                            maxLines = 1,
+                            textAlign = TextAlign.Center,
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun FlatTextFieldDialog(
+    message: String,
+    value: String,
+    onValueChange: (String) -> Unit,
+    placeholder: String,
+    confirmText: String,
+    onConfirm: () -> Unit,
+    onDismissRequest: () -> Unit,
+    modifier: Modifier = Modifier,
+    confirmEnabled: Boolean = value.trim().isNotBlank(),
+    keyboardOptions: KeyboardOptions = KeyboardOptions.Default,
+) {
+    val colorScheme = AsmrTheme.colorScheme
+    FlatActionDialog(
+        message = message,
+        onDismissRequest = onDismissRequest,
+        modifier = modifier,
+        actions = listOf(
+            FlatDialogAction("取消", onDismissRequest),
+            FlatDialogAction(
+                text = confirmText,
+                onClick = onConfirm,
+                tone = FlatDialogActionTone.Primary,
+                enabled = confirmEnabled,
+            ),
+        ),
+    ) {
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .clip(RoundedCornerShape(10.dp))
+                .background(colorScheme.background.copy(alpha = 0.8f)),
+        ) {
+            TextField(
+                value = value,
+                onValueChange = onValueChange,
+                singleLine = true,
+                keyboardOptions = keyboardOptions,
+                placeholder = {
+                    Text(
+                        text = placeholder,
+                        color = colorScheme.textTertiary,
+                    )
+                },
+                modifier = Modifier.fillMaxWidth(),
+                colors = TextFieldDefaults.colors(
+                    focusedContainerColor = Color.Transparent,
+                    unfocusedContainerColor = Color.Transparent,
+                    disabledContainerColor = Color.Transparent,
+                    focusedIndicatorColor = Color.Transparent,
+                    unfocusedIndicatorColor = Color.Transparent,
+                    focusedTextColor = colorScheme.textPrimary,
+                    unfocusedTextColor = colorScheme.textPrimary,
+                    cursorColor = colorScheme.primary,
+                ),
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/asmr/player/ui/downloads/DownloadsScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/downloads/DownloadsScreen.kt
@@ -38,7 +38,6 @@ import androidx.compose.material.icons.rounded.Pause
 import androidx.compose.material.icons.rounded.PlayArrow
 import androidx.compose.material.icons.rounded.Refresh
 import androidx.compose.material.icons.rounded.Subtitles
-import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -46,7 +45,6 @@ import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.material3.windowsizeclass.WindowSizeClass
 import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
 import androidx.compose.runtime.Composable
@@ -70,6 +68,9 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
+import com.asmr.player.ui.common.FlatActionDialog
+import com.asmr.player.ui.common.FlatDialogAction
+import com.asmr.player.ui.common.FlatDialogActionTone
 import com.asmr.player.ui.common.LocalBottomOverlayPadding
 import com.asmr.player.ui.common.thinScrollbar
 import com.asmr.player.ui.theme.AsmrTheme
@@ -202,7 +203,6 @@ fun DownloadsScreen(
                     is PendingDeleteAction.Task -> {
                         val task = tasks.firstOrNull { it.taskId == action.taskId } ?: return@remember null
                         ResolvedDeleteText(
-                            title = "确认删除",
                             message = "将物理删除“${task.title}”目录下的文件，且不可恢复。"
                         )
                     }
@@ -212,7 +212,6 @@ fun DownloadsScreen(
                             .flatMap { it.items.asSequence() }
                             .firstOrNull { it.workId == action.workId } ?: return@remember null
                         ResolvedDeleteText(
-                            title = "确认删除",
                             message = "将物理删除文件“${item.fileName}”，且不可恢复。"
                         )
                     }
@@ -220,12 +219,14 @@ fun DownloadsScreen(
             }
 
             if (resolved != null) {
-                AlertDialog(
+                FlatActionDialog(
                     onDismissRequest = { pendingDelete = null },
-                    title = { Text(resolved.title) },
-                    text = { Text(resolved.message) },
-                    confirmButton = {
-                        TextButton(
+                    message = resolved.message,
+                    actions = listOf(
+                        FlatDialogAction("取消", onClick = { pendingDelete = null }),
+                        FlatDialogAction(
+                            text = "删除",
+                            tone = FlatDialogActionTone.Danger,
                             onClick = {
                                 pendingDelete = null
                                 when (action) {
@@ -233,15 +234,8 @@ fun DownloadsScreen(
                                     is PendingDeleteAction.Item -> viewModel.deleteItem(action.workId)
                                 }
                             }
-                        ) {
-                            Text("删除")
-                        }
-                    },
-                    dismissButton = {
-                        TextButton(onClick = { pendingDelete = null }) {
-                            Text("取消")
-                        }
-                    }
+                        )
+                    )
                 )
             } else {
                 pendingDelete = null
@@ -256,7 +250,6 @@ private sealed class PendingDeleteAction {
 }
 
 private data class ResolvedDeleteText(
-    val title: String,
     val message: String
 )
 

--- a/app/src/main/java/com/asmr/player/ui/groups/AlbumGroupDetailScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/groups/AlbumGroupDetailScreen.kt
@@ -30,7 +30,6 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.Delete
 import androidx.compose.material.icons.rounded.Folder
 import androidx.compose.material.icons.rounded.MoreVert
-import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.HorizontalDivider
@@ -38,7 +37,6 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.material3.windowsizeclass.WindowSizeClass
 import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
 import androidx.compose.runtime.Composable
@@ -71,6 +69,9 @@ import com.asmr.player.ui.common.AsmrAsyncImage
 import com.asmr.player.ui.common.AudioItemMenuAction
 import com.asmr.player.ui.common.AudioItemRow
 import com.asmr.player.ui.common.EaraBrandedEmptyState
+import com.asmr.player.ui.common.FlatActionDialog
+import com.asmr.player.ui.common.FlatDialogAction
+import com.asmr.player.ui.common.FlatDialogActionTone
 import com.asmr.player.ui.common.LocalBottomOverlayPadding
 import com.asmr.player.ui.common.StableWindowInsets
 import com.asmr.player.ui.common.queryTrackFileSize
@@ -309,40 +310,38 @@ internal fun AlbumGroupDetailContent(
     }
 
     pendingRemoveTrack?.let { track ->
-        AlertDialog(
+        FlatActionDialog(
             onDismissRequest = { pendingRemoveTrack = null },
-            title = { Text("确认移除") },
-            text = { Text("确定从「$title」移除“${track.trackTitle.ifBlank { "未命名" }}”吗？") },
-            confirmButton = {
-                TextButton(
+            message = "确定从「$title」移除“${track.trackTitle.ifBlank { "未命名" }}”吗？",
+            actions = listOf(
+                FlatDialogAction("取消", onClick = { pendingRemoveTrack = null }),
+                FlatDialogAction(
+                    text = "移除",
+                    tone = FlatDialogActionTone.Danger,
                     onClick = {
                         pendingRemoveTrack = null
                         onRemoveTrack(track.mediaId)
                     }
-                ) { Text("移除") }
-            },
-            dismissButton = {
-                TextButton(onClick = { pendingRemoveTrack = null }) { Text("取消") }
-            }
+                )
+            )
         )
     }
 
     pendingRemoveAlbum?.let { album ->
-        AlertDialog(
+        FlatActionDialog(
             onDismissRequest = { pendingRemoveAlbum = null },
-            title = { Text("确认移除") },
-            text = { Text("确定从「$title」移除专辑“${album.second}”吗？") },
-            confirmButton = {
-                TextButton(
+            message = "确定从「$title」移除专辑“${album.second}”吗？",
+            actions = listOf(
+                FlatDialogAction("取消", onClick = { pendingRemoveAlbum = null }),
+                FlatDialogAction(
+                    text = "移除",
+                    tone = FlatDialogActionTone.Danger,
                     onClick = {
                         pendingRemoveAlbum = null
                         onRemoveAlbum(album.first)
                     }
-                ) { Text("移除") }
-            },
-            dismissButton = {
-                TextButton(onClick = { pendingRemoveAlbum = null }) { Text("取消") }
-            }
+                )
+            )
         )
     }
 }

--- a/app/src/main/java/com/asmr/player/ui/groups/AlbumGroupsScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/groups/AlbumGroupsScreen.kt
@@ -26,15 +26,12 @@ import androidx.compose.material.icons.rounded.Add
 import androidx.compose.material.icons.rounded.Delete
 import androidx.compose.material.icons.rounded.Edit
 import androidx.compose.material.icons.rounded.Folder
-import androidx.compose.material3.AlertDialog
-import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.material3.windowsizeclass.WindowSizeClass
 import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
 import androidx.compose.runtime.Composable
@@ -57,6 +54,10 @@ import com.asmr.player.data.local.db.dao.AlbumGroupStatsRow
 import com.asmr.player.data.local.db.entities.AlbumGroupEntity
 import com.asmr.player.ui.common.AsmrAsyncImage
 import com.asmr.player.ui.common.EaraBrandedEmptyState
+import com.asmr.player.ui.common.FlatActionDialog
+import com.asmr.player.ui.common.FlatDialogAction
+import com.asmr.player.ui.common.FlatDialogActionTone
+import com.asmr.player.ui.common.FlatTextFieldDialog
 import com.asmr.player.ui.common.LocalBottomOverlayPadding
 import com.asmr.player.ui.common.StableWindowInsets
 import com.asmr.player.ui.common.thinScrollbar
@@ -228,32 +229,20 @@ private fun AlbumGroupRow(
     }
 
     if (showDeleteConfirm) {
-        AlertDialog(
+        FlatActionDialog(
             onDismissRequest = { showDeleteConfirm = false },
-            containerColor = colorScheme.surface,
-            titleContentColor = colorScheme.textPrimary,
-            textContentColor = colorScheme.textSecondary,
-            title = { Text("确认删除", style = MaterialTheme.typography.titleLarge.copy(fontWeight = FontWeight.Bold)) },
-            text = { Text("确定要删除分组“${group.name}”吗？此操作不可撤销。") },
-            confirmButton = {
-                TextButton(
+            message = "确定要删除分组“${group.name}”吗？此操作不可撤销。",
+            actions = listOf(
+                FlatDialogAction("取消", onClick = { showDeleteConfirm = false }),
+                FlatDialogAction(
+                    text = "删除",
+                    tone = FlatDialogActionTone.Danger,
                     onClick = {
                         showDeleteConfirm = false
                         onDelete()
-                    },
-                    colors = ButtonDefaults.textButtonColors(contentColor = colorScheme.danger)
-                ) {
-                    Text("删除")
-                }
-            },
-            dismissButton = {
-                TextButton(
-                    onClick = { showDeleteConfirm = false },
-                    colors = ButtonDefaults.textButtonColors(contentColor = colorScheme.textSecondary)
-                ) {
-                    Text("取消")
-                }
-            }
+                    }
+                )
+            )
         )
     }
 
@@ -275,37 +264,16 @@ private fun CreateAlbumGroupDialog(
     onCreate: (String) -> Unit
 ) {
     var name by remember { mutableStateOf("") }
-    val colorScheme = AsmrTheme.colorScheme
 
-    AlertDialog(
+    FlatTextFieldDialog(
         onDismissRequest = onDismiss,
-        containerColor = colorScheme.surface,
-        title = { Text("新建分组") },
-        text = {
-            androidx.compose.material3.TextField(
-                value = name,
-                onValueChange = { name = it },
-                singleLine = true,
-                placeholder = { Text("分组名称") },
-                colors = androidx.compose.material3.TextFieldDefaults.colors(
-                    focusedContainerColor = colorScheme.surface,
-                    unfocusedContainerColor = colorScheme.surface
-                )
-            )
-        },
-        confirmButton = {
-            TextButton(
-                onClick = { onCreate(name) },
-                enabled = name.trim().isNotBlank()
-            ) {
-                Text("创建")
-            }
-        },
-        dismissButton = {
-            TextButton(onClick = onDismiss) {
-                Text("取消")
-            }
-        }
+        message = "请输入新分组名称。",
+        value = name,
+        onValueChange = { name = it },
+        placeholder = "分组名称",
+        confirmText = "创建",
+        confirmEnabled = name.trim().isNotBlank(),
+        onConfirm = { onCreate(name.trim()) },
     )
 }
 
@@ -316,36 +284,15 @@ private fun RenameAlbumGroupDialog(
     onRename: (String) -> Unit
 ) {
     var name by remember(initialName) { mutableStateOf(initialName) }
-    val colorScheme = AsmrTheme.colorScheme
 
-    AlertDialog(
+    FlatTextFieldDialog(
         onDismissRequest = onDismiss,
-        containerColor = colorScheme.surface,
-        title = { Text("重命名分组") },
-        text = {
-            androidx.compose.material3.TextField(
-                value = name,
-                onValueChange = { name = it },
-                singleLine = true,
-                placeholder = { Text("分组名称") },
-                colors = androidx.compose.material3.TextFieldDefaults.colors(
-                    focusedContainerColor = colorScheme.surface,
-                    unfocusedContainerColor = colorScheme.surface
-                )
-            )
-        },
-        confirmButton = {
-            TextButton(
-                onClick = { onRename(name) },
-                enabled = name.trim().isNotBlank()
-            ) {
-                Text("确定")
-            }
-        },
-        dismissButton = {
-            TextButton(onClick = onDismiss) {
-                Text("取消")
-            }
-        }
+        message = "请输入新的分组名称。",
+        value = name,
+        onValueChange = { name = it },
+        placeholder = "分组名称",
+        confirmText = "确定",
+        confirmEnabled = name.trim().isNotBlank(),
+        onConfirm = { onRename(name.trim()) },
     )
 }

--- a/app/src/main/java/com/asmr/player/ui/library/AlbumItem.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/AlbumItem.kt
@@ -16,6 +16,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.background
 import androidx.compose.ui.graphics.Color
@@ -56,8 +57,13 @@ private val AlbumItemVerticalPadding = 2.dp
 private val AlbumItemCoverContentSpacing = 8.dp
 private val AlbumGridInfoHorizontalPadding = 6.dp
 private val AlbumGridInfoVerticalPadding = 8.dp
+private val AlbumDetailSkeletonHeight = 18.dp
 internal const val ALBUM_ITEM_CARD_TAG = "album_item_card"
 internal const val ALBUM_ITEM_STATS_TAG = "album_item_stats"
+
+private fun Album.hasRatingInfo(): Boolean {
+    return (ratingValue?.let { it > 0.0 } == true) || ratingCount > 0
+}
 
 @Composable
 @OptIn(ExperimentalFoundationApi::class)
@@ -72,6 +78,7 @@ fun AlbumItem(
     onCvClick: ((String) -> Unit)? = null,
     onTagClick: ((String) -> Unit)? = null,
     coverBadge: AlbumCoverBadge? = null,
+    onlineDetailLoading: Boolean = false,
 ) {
     val colorScheme = AsmrTheme.colorScheme
     val shape = remember { RoundedCornerShape(AlbumListItemCornerRadius) }
@@ -210,6 +217,8 @@ fun AlbumItem(
                             onCvClick = onCvClick,
                             leadingVisual = Icon,
                         )
+                    } else if (onlineDetailLoading) {
+                        AlbumDetailSkeletonLine(widthFraction = 0.62f)
                     }
                     if (album.tags.isNotEmpty()) {
                         AlbumTagsSingleLine(
@@ -218,6 +227,8 @@ fun AlbumItem(
                             onTagClick = onTagClick,
                             leadingVisual = Icon,
                         )
+                    } else if (onlineDetailLoading) {
+                        AlbumDetailSkeletonLine(widthFraction = 0.86f)
                     }
 
                     if (statsText.isNotBlank()) {
@@ -230,6 +241,12 @@ fun AlbumItem(
                             modifier = Modifier
                                 .fillMaxWidth()
                                 .testTag(ALBUM_ITEM_STATS_TAG)
+                        )
+                    }
+                    if (onlineDetailLoading && !album.hasRatingInfo()) {
+                        AlbumDetailSkeletonLine(
+                            widthFraction = 0.46f,
+                            modifier = if (statsText.isBlank()) Modifier.testTag(ALBUM_ITEM_STATS_TAG) else Modifier
                         )
                     }
                 }
@@ -301,6 +318,7 @@ fun AlbumGridItem(
     onCvClick: ((String) -> Unit)? = null,
     onTagClick: ((String) -> Unit)? = null,
     coverBadge: AlbumCoverBadge? = null,
+    onlineDetailLoading: Boolean = false,
 ) {
     val colorScheme = AsmrTheme.colorScheme
     val shape = remember { RoundedCornerShape(AlbumGridItemCornerRadius) }
@@ -421,11 +439,15 @@ fun AlbumGridItem(
                 leadingVisual = Icon,
             )
 
-            AlbumCvChipsFlow(
-                cvText = album.cv,
-                onCvClick = onCvClick,
-                leadingVisual = Icon,
-            )
+            if (album.cv.isNotBlank()) {
+                AlbumCvChipsFlow(
+                    cvText = album.cv,
+                    onCvClick = onCvClick,
+                    leadingVisual = Icon,
+                )
+            } else if (onlineDetailLoading) {
+                AlbumDetailSkeletonLine(widthFraction = 0.72f)
+            }
 
             val statsText = remember(album.ratingValue, album.ratingCount, album.priceJpy) {
                 buildString {
@@ -448,6 +470,8 @@ fun AlbumGridItem(
                     onTagClick = onTagClick,
                     leadingVisual = Icon,
                 )
+            } else if (onlineDetailLoading) {
+                AlbumDetailSkeletonLine(widthFraction = 0.92f)
             }
 
             if (statsText.isNotBlank()) {
@@ -459,8 +483,25 @@ fun AlbumGridItem(
                     overflow = TextOverflow.Ellipsis
                 )
             }
+            if (onlineDetailLoading && !album.hasRatingInfo()) {
+                AlbumDetailSkeletonLine(widthFraction = 0.54f)
+            }
         }
     }
+}
+
+@Composable
+private fun AlbumDetailSkeletonLine(
+    widthFraction: Float,
+    modifier: Modifier = Modifier,
+) {
+    val fraction = widthFraction.coerceIn(0.2f, 1f)
+    AsmrShimmerPlaceholder(
+        modifier = modifier
+            .fillMaxWidth(fraction)
+            .height(AlbumDetailSkeletonHeight),
+        cornerRadius = 7,
+    )
 }
 
 data class AlbumCoverBadge(

--- a/app/src/main/java/com/asmr/player/ui/library/LibraryFilterSheet.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/LibraryFilterSheet.kt
@@ -30,7 +30,6 @@ import androidx.compose.material.icons.rounded.Delete
 import androidx.compose.material.icons.rounded.FilterList
 import androidx.compose.material.icons.rounded.Restore
 import androidx.compose.material.icons.rounded.Search
-import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.ElevatedCard
 import androidx.compose.material3.FilterChip
 import androidx.compose.material3.FilterChipDefaults
@@ -55,6 +54,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.asmr.player.data.local.db.dao.TagWithCount
+import com.asmr.player.ui.common.FlatTextFieldDialog
 import com.asmr.player.ui.common.LocalBottomOverlayPadding
 import com.asmr.player.ui.common.thinScrollbar
 import com.asmr.player.ui.common.withAddedBottomPadding
@@ -341,36 +341,20 @@ fun LibraryFilterSheet(
     }
 
     if (showSavePreset) {
-        AlertDialog(
+        FlatTextFieldDialog(
             onDismissRequest = { showSavePreset = false },
-            title = { Text("保存筛选预设") },
-            text = {
-                OutlinedTextField(
-                    value = presetName,
-                    onValueChange = { presetName = it },
-                    modifier = Modifier.fillMaxWidth(),
-                    singleLine = true,
-                    placeholder = { Text("请输入预设名称") }
-                )
+            message = "请输入筛选预设名称。",
+            value = presetName,
+            onValueChange = { presetName = it },
+            placeholder = "请输入预设名称",
+            confirmText = "保存",
+            confirmEnabled = presetName.trim().isNotBlank(),
+            onConfirm = {
+                val name = presetName.trim()
+                if (name.isNotBlank()) onSavePreset(name)
+                presetName = ""
+                showSavePreset = false
             },
-            confirmButton = {
-                TextButton(
-                    onClick = {
-                        val name = presetName.trim()
-                        if (name.isNotBlank()) onSavePreset(name)
-                        presetName = ""
-                        showSavePreset = false
-                    }
-                ) { Text("保存") }
-            },
-            dismissButton = {
-                TextButton(
-                    onClick = {
-                        presetName = ""
-                        showSavePreset = false
-                    }
-                ) { Text("取消") }
-            }
         )
     }
 }

--- a/app/src/main/java/com/asmr/player/ui/library/LibraryScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/LibraryScreen.kt
@@ -43,7 +43,6 @@ import androidx.compose.material.icons.rounded.Sync
 import androidx.compose.material.icons.rounded.MoreVert
 import androidx.compose.material.icons.rounded.ViewList
 import androidx.compose.material.icons.rounded.Audiotrack
-import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.CardDefaults
@@ -59,6 +58,9 @@ import com.asmr.player.ui.common.AudioItemMenuAction
 import com.asmr.player.ui.common.AudioItemRow
 import com.asmr.player.ui.common.EaraBrandedEmptyState
 import com.asmr.player.ui.common.EaraLogoLoadingIndicator
+import com.asmr.player.ui.common.FlatActionDialog
+import com.asmr.player.ui.common.FlatDialogAction
+import com.asmr.player.ui.common.FlatDialogActionTone
 import com.asmr.player.ui.common.StableWindowInsets
 import com.asmr.player.ui.common.rememberAudioMeta
 import com.asmr.player.ui.common.rememberAudioMetaText
@@ -847,7 +849,7 @@ fun LibraryScreen(
         }
     }
     
-    // ... rest of the file (ModalBottomSheet, AlertDialog)
+    // ... rest of the file (ModalBottomSheet, dialogs)
 
 
     if (showAlbumActions) {
@@ -945,25 +947,20 @@ fun LibraryScreen(
     if (showDeleteConfirm) {
         val album = actionAlbum
         if (album != null) {
-            AlertDialog(
+            FlatActionDialog(
                 onDismissRequest = { showDeleteConfirm = false },
-                confirmButton = {
-                    TextButton(
+                message = "将从本地库中移除该专辑，并尝试删除本地文件。",
+                actions = listOf(
+                    FlatDialogAction("取消", onClick = { showDeleteConfirm = false }),
+                    FlatDialogAction(
+                        text = "删除",
+                        tone = FlatDialogActionTone.Danger,
                         onClick = {
                             showDeleteConfirm = false
                             viewModel.deleteAlbum(album)
                         }
-                    ) {
-                        Text("删除")
-                    }
-                },
-                dismissButton = {
-                    TextButton(onClick = { showDeleteConfirm = false }) {
-                        Text("取消")
-                    }
-                },
-                title = { Text("删除专辑") },
-                text = { Text("将从本地库中移除该专辑，并尝试删除本地文件。") }
+                    )
+                )
             )
         }
     }

--- a/app/src/main/java/com/asmr/player/ui/library/TagManagerSheet.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/TagManagerSheet.kt
@@ -15,7 +15,6 @@ import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.rounded.ArrowBack
-import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.ListItem
@@ -34,6 +33,9 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.asmr.player.data.local.db.dao.TagWithCount
+import com.asmr.player.ui.common.FlatActionDialog
+import com.asmr.player.ui.common.FlatDialogAction
+import com.asmr.player.ui.common.FlatDialogActionTone
 import com.asmr.player.ui.common.thinScrollbar
 import com.asmr.player.ui.theme.AsmrTheme
 
@@ -137,58 +139,57 @@ fun TagManagerSheet(
     if (showRenameDialog) {
         val tag = selected
         if (tag != null) {
-            AlertDialog(
+            FlatActionDialog(
                 onDismissRequest = { showRenameDialog = false },
-                title = { Text("重命名标签") },
-                text = {
-                    OutlinedTextField(
-                        value = renameText,
-                        onValueChange = { renameText = it },
-                        modifier = Modifier.fillMaxWidth(),
-                        singleLine = true
-                    )
-                },
-                confirmButton = {
-                    TextButton(
+                message = "修改标签名称，或删除这个用户标签。",
+                actions = listOf(
+                    FlatDialogAction(
+                        text = "删除",
+                        tone = FlatDialogActionTone.Danger,
                         onClick = {
-                            onRename(tag.id, renameText)
+                            showRenameDialog = false
+                            showDeleteDialog = true
+                        }
+                    ),
+                    FlatDialogAction("取消", onClick = { showRenameDialog = false }),
+                    FlatDialogAction(
+                        text = "保存",
+                        tone = FlatDialogActionTone.Primary,
+                        enabled = renameText.trim().isNotBlank(),
+                        onClick = {
+                            onRename(tag.id, renameText.trim())
                             showRenameDialog = false
                         }
-                    ) { Text("保存") }
-                },
-                dismissButton = {
-                    Row {
-                        TextButton(
-                            onClick = {
-                                showRenameDialog = false
-                                showDeleteDialog = true
-                            }
-                        ) { Text("删除") }
-                        TextButton(onClick = { showRenameDialog = false }) { Text("取消") }
-                    }
-                }
-            )
+                    )
+                )
+            ) {
+                OutlinedTextField(
+                    value = renameText,
+                    onValueChange = { renameText = it },
+                    modifier = Modifier.fillMaxWidth(),
+                    singleLine = true
+                )
+            }
         }
     }
 
     if (showDeleteDialog) {
         val tag = selected
         if (tag != null) {
-            AlertDialog(
+            FlatActionDialog(
                 onDismissRequest = { showDeleteDialog = false },
-                title = { Text("删除标签") },
-                text = { Text("将从所有用户标注中移除该标签。") },
-                confirmButton = {
-                    TextButton(
+                message = "将从所有用户标注中移除该标签。",
+                actions = listOf(
+                    FlatDialogAction("取消", onClick = { showDeleteDialog = false }),
+                    FlatDialogAction(
+                        text = "删除",
+                        tone = FlatDialogActionTone.Danger,
                         onClick = {
                             onDelete(tag.id)
                             showDeleteDialog = false
                         }
-                    ) { Text("删除") }
-                },
-                dismissButton = {
-                    TextButton(onClick = { showDeleteDialog = false }) { Text("取消") }
-                }
+                    )
+                )
             )
         }
     }

--- a/app/src/main/java/com/asmr/player/ui/player/SleepTimerSheet.kt
+++ b/app/src/main/java/com/asmr/player/ui/player/SleepTimerSheet.kt
@@ -11,13 +11,11 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardOptions
-import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.ListItem
 import androidx.compose.material3.ListItemDefaults
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -35,6 +33,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
+import com.asmr.player.ui.common.FlatTextFieldDialog
 import com.asmr.player.ui.theme.AsmrTheme
 import kotlinx.coroutines.delay
 import java.util.Locale
@@ -180,38 +179,23 @@ fun SleepTimerSheetContent(
     }
 
     if (showCustomDialog) {
-        AlertDialog(
+        FlatTextFieldDialog(
             onDismissRequest = { showCustomDialog = false },
-            title = { Text("自定义时长") },
-            text = {
-                OutlinedTextField(
-                    value = customMinutesText,
-                    onValueChange = { customMinutesText = it.filter { ch -> ch.isDigit() }.take(4) },
-                    modifier = Modifier.fillMaxWidth(),
-                    singleLine = true,
-                    placeholder = { Text("输入分钟数") },
-                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number)
-                )
-            },
-            confirmButton = {
-                TextButton(
-                    onClick = {
-                        val minutes = customMinutesText.toIntOrNull() ?: 0
-                        if (minutes > 0) {
-                            viewModel.setSleepTimerMinutes(minutes)
-                            onDismiss()
-                        }
-                        showCustomDialog = false
-                    }
-                ) {
-                    Text("确定")
+            message = "输入定时关闭的分钟数。",
+            value = customMinutesText,
+            onValueChange = { customMinutesText = it.filter { ch -> ch.isDigit() }.take(4) },
+            placeholder = "输入分钟数",
+            confirmText = "确定",
+            confirmEnabled = (customMinutesText.toIntOrNull() ?: 0) > 0,
+            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+            onConfirm = {
+                val minutes = customMinutesText.toIntOrNull() ?: 0
+                if (minutes > 0) {
+                    viewModel.setSleepTimerMinutes(minutes)
+                    onDismiss()
                 }
+                showCustomDialog = false
             },
-            dismissButton = {
-                TextButton(onClick = { showCustomDialog = false }) {
-                    Text("取消")
-                }
-            }
         )
     }
 }

--- a/app/src/main/java/com/asmr/player/ui/playlists/PlaylistDetailScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/playlists/PlaylistDetailScreen.kt
@@ -25,7 +25,6 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.rounded.QueueMusic
 import androidx.compose.material.icons.rounded.Favorite
 import androidx.compose.material.icons.rounded.MoreVert
-import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.HorizontalDivider
@@ -34,7 +33,6 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.material3.windowsizeclass.WindowSizeClass
 import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
 import androidx.compose.runtime.Composable
@@ -63,6 +61,9 @@ import com.asmr.player.ui.common.AsmrAsyncImage
 import com.asmr.player.ui.common.AudioItemMenuAction
 import com.asmr.player.ui.common.AudioItemRow
 import com.asmr.player.ui.common.EaraBrandedEmptyState
+import com.asmr.player.ui.common.FlatActionDialog
+import com.asmr.player.ui.common.FlatDialogAction
+import com.asmr.player.ui.common.FlatDialogActionTone
 import com.asmr.player.ui.common.LocalBottomOverlayPadding
 import com.asmr.player.ui.common.StableWindowInsets
 import com.asmr.player.ui.common.rememberAudioMeta
@@ -239,30 +240,20 @@ internal fun PlaylistDetailContent(
     }
 
     pendingRemoveItem?.let { item ->
-        AlertDialog(
+        FlatActionDialog(
             onDismissRequest = { pendingRemoveItem = null },
-            title = { Text("确认移除") },
-            text = {
-                Text(
-                    text = "确定从「$title」移除“${item.title.ifBlank { "未命名" }}”吗？",
-                    style = MaterialTheme.typography.bodyMedium
-                )
-            },
-            confirmButton = {
-                TextButton(
+            message = "确定从「$title」移除“${item.title.ifBlank { "未命名" }}”吗？",
+            actions = listOf(
+                FlatDialogAction("取消", onClick = { pendingRemoveItem = null }),
+                FlatDialogAction(
+                    text = "移除",
+                    tone = FlatDialogActionTone.Danger,
                     onClick = {
                         pendingRemoveItem = null
                         onRemoveItem(item.mediaId)
                     }
-                ) {
-                    Text("移除")
-                }
-            },
-            dismissButton = {
-                TextButton(onClick = { pendingRemoveItem = null }) {
-                    Text("取消")
-                }
-            }
+                )
+            )
         )
     }
 }

--- a/app/src/main/java/com/asmr/player/ui/playlists/PlaylistsScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/playlists/PlaylistsScreen.kt
@@ -45,14 +45,15 @@ import com.asmr.player.data.local.db.dao.PlaylistStatsRow
 import com.asmr.player.data.local.db.entities.PlaylistEntity
 import com.asmr.player.ui.common.AsmrAsyncImage
 
-import androidx.compose.material3.ButtonDefaults
 import androidx.compose.ui.text.font.FontWeight
 import com.asmr.player.ui.theme.AsmrTheme
 import androidx.compose.foundation.background
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.TextField
-import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.ui.graphics.Color
+import com.asmr.player.ui.common.FlatActionDialog
+import com.asmr.player.ui.common.FlatDialogAction
+import com.asmr.player.ui.common.FlatDialogActionTone
+import com.asmr.player.ui.common.FlatTextFieldDialog
 import com.asmr.player.ui.common.LocalBottomOverlayPadding
 import com.asmr.player.ui.common.StableWindowInsets
 import com.asmr.player.ui.common.EaraBrandedEmptyState
@@ -235,32 +236,20 @@ private fun PlaylistRow(
     }
 
     if (showDeleteConfirm) {
-        AlertDialog(
+        FlatActionDialog(
             onDismissRequest = { showDeleteConfirm = false },
-            containerColor = colorScheme.surface,
-            titleContentColor = colorScheme.textPrimary,
-            textContentColor = colorScheme.textSecondary,
-            title = { Text("确认删除", style = MaterialTheme.typography.titleLarge.copy(fontWeight = FontWeight.Bold)) },
-            text = { Text("确定要删除列表“${playlist.name}”吗？此操作不可撤销。") },
-            confirmButton = {
-                TextButton(
+            message = "确定要删除列表“${playlist.name}”吗？此操作不可撤销。",
+            actions = listOf(
+                FlatDialogAction("取消", onClick = { showDeleteConfirm = false }),
+                FlatDialogAction(
+                    text = "删除",
+                    tone = FlatDialogActionTone.Danger,
                     onClick = {
                         showDeleteConfirm = false
                         onDelete()
-                    },
-                    colors = ButtonDefaults.textButtonColors(contentColor = colorScheme.danger)
-                ) {
-                    Text("删除")
-                }
-            },
-            dismissButton = {
-                TextButton(
-                    onClick = { showDeleteConfirm = false },
-                    colors = ButtonDefaults.textButtonColors(contentColor = colorScheme.textSecondary)
-                ) {
-                    Text("取消")
-                }
-            }
+                    }
+                )
+            )
         )
     }
 
@@ -282,50 +271,16 @@ private fun CreatePlaylistDialog(
     onCreate: (String) -> Unit
 ) {
     var name by remember { mutableStateOf("") }
-    val colorScheme = AsmrTheme.colorScheme
-    
-    AlertDialog(
+
+    FlatTextFieldDialog(
         onDismissRequest = onDismiss,
-        containerColor = colorScheme.surface,
-        titleContentColor = colorScheme.textPrimary,
-        textContentColor = colorScheme.textSecondary,
-        confirmButton = {
-            TextButton(
-                onClick = { onCreate(name) },
-                enabled = name.isNotBlank(),
-                colors = ButtonDefaults.textButtonColors(contentColor = colorScheme.primary)
-            ) {
-                Text("创建")
-            }
-        },
-        dismissButton = {
-            TextButton(
-                onClick = onDismiss,
-                colors = ButtonDefaults.textButtonColors(contentColor = colorScheme.textSecondary)
-            ) {
-                Text("取消")
-            }
-        },
-        title = { Text("新建列表", style = MaterialTheme.typography.titleLarge.copy(fontWeight = FontWeight.Bold)) },
-        text = {
-            TextField(
-                value = name,
-                onValueChange = { name = it },
-                singleLine = true,
-                placeholder = { Text("请输入列表名称", color = colorScheme.textTertiary) },
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .clip(RoundedCornerShape(12.dp)),
-                colors = TextFieldDefaults.colors(
-                    focusedContainerColor = colorScheme.background,
-                    unfocusedContainerColor = colorScheme.background,
-                    focusedIndicatorColor = colorScheme.primary,
-                    unfocusedIndicatorColor = Color.Transparent,
-                    focusedTextColor = colorScheme.textPrimary,
-                    unfocusedTextColor = colorScheme.textSecondary
-                )
-            )
-        }
+        message = "请输入新列表名称。",
+        value = name,
+        onValueChange = { name = it },
+        placeholder = "请输入列表名称",
+        confirmText = "创建",
+        confirmEnabled = name.trim().isNotBlank(),
+        onConfirm = { onCreate(name.trim()) },
     )
 }
 
@@ -336,48 +291,15 @@ private fun RenamePlaylistDialog(
     onRename: (String) -> Unit
 ) {
     var name by remember(initialName) { mutableStateOf(initialName) }
-    val colorScheme = AsmrTheme.colorScheme
 
-    AlertDialog(
+    FlatTextFieldDialog(
         onDismissRequest = onDismiss,
-        containerColor = colorScheme.surface,
-        titleContentColor = colorScheme.textPrimary,
-        textContentColor = colorScheme.textSecondary,
-        confirmButton = {
-            TextButton(
-                onClick = { onRename(name) },
-                enabled = name.isNotBlank() && name.trim() != initialName.trim(),
-                colors = ButtonDefaults.textButtonColors(contentColor = colorScheme.primary)
-            ) {
-                Text("确定")
-            }
-        },
-        dismissButton = {
-            TextButton(
-                onClick = onDismiss,
-                colors = ButtonDefaults.textButtonColors(contentColor = colorScheme.textSecondary)
-            ) {
-                Text("取消")
-            }
-        },
-        title = { Text("重命名列表", style = MaterialTheme.typography.titleLarge.copy(fontWeight = FontWeight.Bold)) },
-        text = {
-            TextField(
-                value = name,
-                onValueChange = { name = it },
-                singleLine = true,
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .clip(RoundedCornerShape(12.dp)),
-                colors = TextFieldDefaults.colors(
-                    focusedContainerColor = colorScheme.background,
-                    unfocusedContainerColor = colorScheme.background,
-                    focusedIndicatorColor = colorScheme.primary,
-                    unfocusedIndicatorColor = Color.Transparent,
-                    focusedTextColor = colorScheme.textPrimary,
-                    unfocusedTextColor = colorScheme.textSecondary
-                )
-            )
-        }
+        message = "请输入新的列表名称。",
+        value = name,
+        onValueChange = { name = it },
+        placeholder = "请输入列表名称",
+        confirmText = "确定",
+        confirmEnabled = name.trim().isNotBlank() && name.trim() != initialName.trim(),
+        onConfirm = { onRename(name.trim()) },
     )
 }

--- a/app/src/main/java/com/asmr/player/ui/search/SearchAssistScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/search/SearchAssistScreen.kt
@@ -27,7 +27,6 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.Delete
 import androidx.compose.material.icons.rounded.KeyboardArrowDown
 import androidx.compose.material.icons.rounded.Leaderboard
-import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
@@ -66,6 +65,9 @@ import com.asmr.player.cache.CacheImageModel
 import com.asmr.player.hotlistening.SearchSuggestionTerm
 import com.asmr.player.ui.common.AsmrAsyncImage
 import com.asmr.player.ui.common.EaraLogoLoadingIndicator
+import com.asmr.player.ui.common.FlatActionDialog
+import com.asmr.player.ui.common.FlatDialogAction
+import com.asmr.player.ui.common.FlatDialogActionTone
 import com.asmr.player.ui.common.LocalBottomOverlayPadding
 import com.asmr.player.ui.common.clearFocusOnTapOutside
 import com.asmr.player.ui.common.rememberCollapsibleHeaderState
@@ -389,25 +391,20 @@ internal fun SearchAssistContent(
         )
 
         if (showClearHistoryDialog) {
-            AlertDialog(
+            FlatActionDialog(
                 onDismissRequest = { showClearHistoryDialog = false },
-                title = { Text("清空历史搜索") },
-                text = { Text("是否清空历史搜索记录？") },
-                confirmButton = {
-                    TextButton(
+                message = "是否清空历史搜索记录？",
+                actions = listOf(
+                    FlatDialogAction("取消", onClick = { showClearHistoryDialog = false }),
+                    FlatDialogAction(
+                        text = "清空",
+                        tone = FlatDialogActionTone.Danger,
                         onClick = {
                             showClearHistoryDialog = false
                             onClearHistory()
                         }
-                    ) {
-                        Text("清空")
-                    }
-                },
-                dismissButton = {
-                    TextButton(onClick = { showClearHistoryDialog = false }) {
-                        Text("取消")
-                    }
-                }
+                    )
+                )
             )
         }
     }

--- a/app/src/main/java/com/asmr/player/ui/search/SearchAssistScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/search/SearchAssistScreen.kt
@@ -189,21 +189,56 @@ internal fun SearchAssistContent(
     }
     val topPadding = with(density) { chromeReservedHeightPx.toDp() } + SearchAssistChromeContentGap
 
+    fun buildRequest(
+        requestKeyword: String,
+        order: SearchSortOption = selectedOrder,
+        purchasedOnlyValue: Boolean = purchasedOnly,
+        presaleOnlyValue: Boolean = presaleOnly,
+        chineseTranslatedOnlyValue: Boolean = chineseTranslatedOnly,
+        collectedOnlyValue: Boolean = collectedOnly,
+        locale: String = selectedLocale
+    ) = SearchAssistSearchRequest(
+        keyword = requestKeyword,
+        orderName = order.name,
+        purchasedOnly = purchasedOnlyValue,
+        presaleOnly = presaleOnlyValue,
+        chineseTranslatedOnly = chineseTranslatedOnlyValue,
+        collectedOnly = collectedOnlyValue,
+        locale = locale
+    )
+
     fun submit(value: String = keyword) {
         val normalized = value.trim()
             .ifBlank { hotKeywordCarouselItem.keyword.orEmpty() }
         if (normalized.isBlank()) return
         keyword = normalized
         keyboardController?.hide()
+        onSubmitSearch(buildRequest(requestKeyword = normalized))
+    }
+
+    fun submitFilter(option: SearchFilterOption) {
+        val nextOrder = option.sortOption ?: selectedOrder
+        val nextKeyword = keyword.trim()
+        val nextPurchasedOnly = option.isPurchasedOnly
+        val nextPresaleOnly = option.isPresaleOnly
+        val nextChineseTranslatedOnly = option.isChineseTranslated
+        val nextCollectedOnly = option.isCollectedOnly
+
+        keyword = nextKeyword
+        selectedOrderName = nextOrder.name
+        purchasedOnly = nextPurchasedOnly
+        presaleOnly = nextPresaleOnly
+        chineseTranslatedOnly = nextChineseTranslatedOnly
+        collectedOnly = nextCollectedOnly
+        keyboardController?.hide()
         onSubmitSearch(
-            SearchAssistSearchRequest(
-                keyword = normalized,
-                orderName = selectedOrder.name,
-                purchasedOnly = purchasedOnly,
-                presaleOnly = presaleOnly,
-                chineseTranslatedOnly = chineseTranslatedOnly,
-                collectedOnly = collectedOnly,
-                locale = selectedLocale
+            buildRequest(
+                requestKeyword = nextKeyword,
+                order = nextOrder,
+                purchasedOnlyValue = nextPurchasedOnly,
+                presaleOnlyValue = nextPresaleOnly,
+                chineseTranslatedOnlyValue = nextChineseTranslatedOnly,
+                collectedOnlyValue = nextCollectedOnly
             )
         )
     }
@@ -376,14 +411,7 @@ internal fun SearchAssistContent(
             inputFocusRequester = inputFocusRequester,
             onMeasured = { size -> chromeState.updateHeight(size.height.toFloat()) },
             onSearchSubmit = { submit() },
-            onFilterSelected = { option ->
-                val nextOrder = option.sortOption ?: selectedOrder
-                selectedOrderName = nextOrder.name
-                purchasedOnly = option.isPurchasedOnly
-                presaleOnly = option.isPresaleOnly
-                chineseTranslatedOnly = option.isChineseTranslated
-                collectedOnly = option.isCollectedOnly
-            },
+            onFilterSelected = ::submitFilter,
             onLocaleSelected = { locale -> selectedLocale = locale },
             onFirstPage = {},
             onPrev = {},

--- a/app/src/main/java/com/asmr/player/ui/search/SearchAssistScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/search/SearchAssistScreen.kt
@@ -141,8 +141,14 @@ internal fun SearchAssistContent(
     var selectedOrderName by rememberSaveable(initialRequest.orderName) {
         mutableStateOf(initialRequest.orderName)
     }
+    var selectedCollectedSortName by rememberSaveable(initialRequest.collectedSortName) {
+        mutableStateOf(initialRequest.collectedSortName)
+    }
     val selectedOrder = remember(selectedOrderName) {
         SearchSortOption.values().firstOrNull { it.name == selectedOrderName } ?: SearchSortOption.Trend
+    }
+    val selectedCollectedSort = remember(selectedCollectedSortName) {
+        SearchCollectedSortOption.fromName(selectedCollectedSortName)
     }
     val selectedFilter = remember(
         selectedOrderName,
@@ -196,6 +202,7 @@ internal fun SearchAssistContent(
         presaleOnlyValue: Boolean = presaleOnly,
         chineseTranslatedOnlyValue: Boolean = chineseTranslatedOnly,
         collectedOnlyValue: Boolean = collectedOnly,
+        collectedSort: SearchCollectedSortOption = selectedCollectedSort,
         locale: String = selectedLocale
     ) = SearchAssistSearchRequest(
         keyword = requestKeyword,
@@ -204,6 +211,7 @@ internal fun SearchAssistContent(
         presaleOnly = presaleOnlyValue,
         chineseTranslatedOnly = chineseTranslatedOnlyValue,
         collectedOnly = collectedOnlyValue,
+        collectedSortName = collectedSort.name,
         locale = locale
     )
 
@@ -230,6 +238,9 @@ internal fun SearchAssistContent(
         presaleOnly = nextPresaleOnly
         chineseTranslatedOnly = nextChineseTranslatedOnly
         collectedOnly = nextCollectedOnly
+        if (nextCollectedOnly) {
+            selectedCollectedSortName = selectedCollectedSort.name
+        }
         keyboardController?.hide()
         onSubmitSearch(
             buildRequest(
@@ -392,6 +403,7 @@ internal fun SearchAssistContent(
             onKeywordChange = { keyword = it },
             placeholder = hotKeywordCarouselItem.placeholder,
             selectedFilter = selectedFilter,
+            selectedCollectedSort = selectedCollectedSort,
             selectedLocale = selectedLocale,
             filterControlsLocked = false,
             searchSubmitLocked = false,
@@ -413,6 +425,7 @@ internal fun SearchAssistContent(
             onSearchSubmit = { submit() },
             onFilterSelected = ::submitFilter,
             onLocaleSelected = { locale -> selectedLocale = locale },
+            onCollectedSortSelected = { sort -> selectedCollectedSortName = sort.name },
             onFirstPage = {},
             onPrev = {},
             onNext = {}

--- a/app/src/main/java/com/asmr/player/ui/search/SearchAssistViewModel.kt
+++ b/app/src/main/java/com/asmr/player/ui/search/SearchAssistViewModel.kt
@@ -22,6 +22,7 @@ internal const val SEARCH_ASSIST_RESULT_PURCHASED_ONLY_KEY = "searchPurchasedOnl
 internal const val SEARCH_ASSIST_RESULT_PRESALE_ONLY_KEY = "searchPresaleOnly"
 internal const val SEARCH_ASSIST_RESULT_CHINESE_TRANSLATED_ONLY_KEY = "searchChineseTranslatedOnly"
 internal const val SEARCH_ASSIST_RESULT_COLLECTED_ONLY_KEY = "searchCollectedOnly"
+internal const val SEARCH_ASSIST_RESULT_COLLECTED_SORT_KEY = "searchCollectedSortName"
 internal const val SEARCH_ASSIST_RESULT_LOCALE_KEY = "searchLocale"
 
 data class SearchAssistSearchRequest(
@@ -31,6 +32,7 @@ data class SearchAssistSearchRequest(
     val presaleOnly: Boolean = false,
     val chineseTranslatedOnly: Boolean = false,
     val collectedOnly: Boolean = true,
+    val collectedSortName: String = SearchCollectedSortOption.ReleaseNew.name,
     val locale: String = "ja_JP"
 ) {
     val selectedOrder: SearchSortOption
@@ -44,6 +46,9 @@ data class SearchAssistSearchRequest(
             chineseTranslatedOnly = chineseTranslatedOnly,
             collectedOnly = collectedOnly
         )
+
+    val selectedCollectedSort: SearchCollectedSortOption
+        get() = SearchCollectedSortOption.fromName(collectedSortName)
 }
 
 @HiltViewModel

--- a/app/src/main/java/com/asmr/player/ui/search/SearchAssistViewModel.kt
+++ b/app/src/main/java/com/asmr/player/ui/search/SearchAssistViewModel.kt
@@ -67,11 +67,12 @@ class SearchAssistViewModel @Inject constructor(
 
     fun submitSearch(request: SearchAssistSearchRequest, onSubmitted: (SearchAssistSearchRequest) -> Unit) {
         val normalized = request.keyword.trim()
-        if (normalized.isBlank()) return
         val normalizedRequest = request.copy(keyword = normalized)
         viewModelScope.launch {
-            searchCacheStore.addHistory(normalized)
-            loadHistory()
+            if (normalized.isNotBlank()) {
+                searchCacheStore.addHistory(normalized)
+                loadHistory()
+            }
             onSubmitted(normalizedRequest)
         }
     }

--- a/app/src/main/java/com/asmr/player/ui/search/SearchScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/search/SearchScreen.kt
@@ -116,6 +116,7 @@ internal const val SEARCH_INPUT_TAG = "search_input"
 internal const val SEARCH_SCOPE_BUTTON_TAG = "search_scope_button"
 internal const val SEARCH_SCOPE_OPTION_TAG_PREFIX = "search_scope_option"
 internal const val SEARCH_LANGUAGE_BUTTON_TAG = "search_language_button"
+internal const val SEARCH_COLLECTED_SORT_BUTTON_TAG = "search_collected_sort_button"
 internal const val SEARCH_CLEAR_BUTTON_TAG = "search_clear_button"
 internal const val SEARCH_SUBMIT_BUTTON_TAG = "search_submit_button"
 internal const val SEARCH_SUBMIT_SPINNER_TAG = "search_submit_spinner"
@@ -187,6 +188,7 @@ fun SearchScreen(
     submittedSearchPresaleOnly: Boolean = false,
     submittedSearchChineseTranslatedOnly: Boolean = false,
     submittedSearchCollectedOnly: Boolean = true,
+    submittedSearchCollectedSortName: String = SearchCollectedSortOption.ReleaseNew.name,
     submittedSearchLocale: String = "ja_JP",
     submittedSearchSignal: Long = 0L,
     scrollToTopSignal: Long = 0L,
@@ -197,10 +199,14 @@ fun SearchScreen(
     var presaleOnly by rememberSaveable { mutableStateOf(false) }
     var chineseTranslatedOnly by rememberSaveable { mutableStateOf(false) }
     var collectedOnly by rememberSaveable { mutableStateOf(true) }
+    var selectedCollectedSortName by rememberSaveable { mutableStateOf(SearchCollectedSortOption.ReleaseNew.name) }
     var selectedLocale by rememberSaveable { mutableStateOf("ja_JP") }
     var selectedOrderName by rememberSaveable { mutableStateOf(SearchSortOption.Trend.name) }
     val selectedOrder = remember(selectedOrderName) {
         SearchSortOption.values().firstOrNull { it.name == selectedOrderName } ?: SearchSortOption.Trend
+    }
+    val selectedCollectedSort = remember(selectedCollectedSortName) {
+        SearchCollectedSortOption.fromName(selectedCollectedSortName)
     }
     val selectedFilter = remember(selectedOrderName, purchasedOnly, presaleOnly, chineseTranslatedOnly, collectedOnly) {
         SearchFilterOption.fromState(
@@ -241,7 +247,8 @@ fun SearchScreen(
             initialKeyword = keyword,
             initialPurchasedOnly = purchasedOnly,
             initialLocale = selectedLocale,
-            initialCollectedOnly = collectedOnly
+            initialCollectedOnly = collectedOnly,
+            initialCollectedSort = selectedCollectedSort
         )
     }
 
@@ -256,6 +263,7 @@ fun SearchScreen(
     LaunchedEffect(
         success?.pendingRequest,
         success?.order,
+        success?.collectedSort,
         success?.purchasedOnly,
         success?.presaleOnly,
         success?.chineseTranslatedOnly,
@@ -268,6 +276,7 @@ fun SearchScreen(
             presaleOnly = state.presaleOnly
             chineseTranslatedOnly = state.chineseTranslatedOnly
             collectedOnly = state.collectedOnly
+            selectedCollectedSortName = state.collectedSort.name
             selectedLocale = state.locale ?: "ja_JP"
             selectedOrderName = state.order.name
             optionsSyncedFromState = true
@@ -320,6 +329,7 @@ fun SearchScreen(
             presaleOnly = presaleOnly,
             chineseTranslatedOnly = chineseTranslatedOnly,
             collectedOnly = collectedOnly,
+            collectedSortName = selectedCollectedSort.name,
             locale = selectedLocale
         )
     }
@@ -332,6 +342,7 @@ fun SearchScreen(
         submittedSearchPresaleOnly,
         submittedSearchChineseTranslatedOnly,
         submittedSearchCollectedOnly,
+        submittedSearchCollectedSortName,
         submittedSearchLocale,
         searchSubmitLocked
     ) {
@@ -347,10 +358,12 @@ fun SearchScreen(
         val submittedOrder = SearchSortOption.values()
             .firstOrNull { it.name == submittedSearchOrderName }
             ?: SearchSortOption.Trend
+        val submittedCollectedSort = SearchCollectedSortOption.fromName(submittedSearchCollectedSortName)
         keyboardController?.hide()
         val accepted = viewModel.search(
             keyword = normalizedKeyword,
             order = submittedOrder,
+            collectedSort = submittedCollectedSort,
             purchasedOnly = submittedSearchPurchasedOnly,
             presaleOnly = submittedSearchPresaleOnly,
             chineseTranslatedOnly = submittedSearchChineseTranslatedOnly,
@@ -361,6 +374,7 @@ fun SearchScreen(
         lastHandledSubmittedSearchSignal = submittedSearchSignal
         keyword = normalizedKeyword
         selectedOrderName = submittedOrder.name
+        selectedCollectedSortName = submittedCollectedSort.name
         purchasedOnly = submittedSearchPurchasedOnly
         presaleOnly = submittedSearchPresaleOnly
         chineseTranslatedOnly = submittedSearchChineseTranslatedOnly
@@ -688,6 +702,7 @@ fun SearchScreen(
                         searchFieldReadOnly = true,
                         onSearchFieldClick = { onOpenSearchAssist(currentSearchAssistRequest()) },
                         selectedFilter = selectedFilter,
+                        selectedCollectedSort = selectedCollectedSort,
                         selectedLocale = selectedLocale,
                         filterControlsLocked = filterControlsLocked,
                         searchSubmitLocked = searchSubmitLocked,
@@ -708,6 +723,7 @@ fun SearchScreen(
                             val accepted = viewModel.search(
                                 keyword = nextKeyword,
                                 order = nextOrder,
+                                collectedSort = selectedCollectedSort,
                                 purchasedOnly = option.isPurchasedOnly,
                                 presaleOnly = option.isPresaleOnly,
                                 chineseTranslatedOnly = option.isChineseTranslated,
@@ -729,12 +745,29 @@ fun SearchScreen(
                             selectedLocale = locale
                             viewModel.updateSearchOptions(
                                 order = selectedOrder,
+                                collectedSort = selectedCollectedSort,
                                 purchasedOnly = purchasedOnly,
                                 presaleOnly = presaleOnly,
                                 chineseTranslatedOnly = chineseTranslatedOnly,
                                 collectedOnly = collectedOnly,
                                 locale = locale
                             )
+                        },
+                        onCollectedSortSelected = { sort ->
+                            selectedCollectedSortName = sort.name
+                            val accepted = viewModel.updateSearchOptions(
+                                order = selectedOrder,
+                                collectedSort = sort,
+                                purchasedOnly = purchasedOnly,
+                                presaleOnly = presaleOnly,
+                                chineseTranslatedOnly = chineseTranslatedOnly,
+                                collectedOnly = collectedOnly,
+                                locale = selectedLocale
+                            )
+                            if (accepted) {
+                                scrollResultsToTop()
+                                chromeState.expand()
+                            }
                         },
                         onFirstPage = {
                             scrollResultsToTop()
@@ -818,6 +851,7 @@ internal fun SearchChrome(
     searchFieldReadOnly: Boolean = false,
     onSearchFieldClick: (() -> Unit)? = null,
     selectedFilter: SearchFilterOption,
+    selectedCollectedSort: SearchCollectedSortOption = SearchCollectedSortOption.ReleaseNew,
     selectedLocale: String,
     filterControlsLocked: Boolean,
     searchSubmitLocked: Boolean,
@@ -839,6 +873,7 @@ internal fun SearchChrome(
     onSearchSubmit: () -> Unit,
     onFilterSelected: (SearchFilterOption) -> Unit,
     onLocaleSelected: (String) -> Unit,
+    onCollectedSortSelected: (SearchCollectedSortOption) -> Unit = {},
     onFirstPage: () -> Unit,
     onPrev: () -> Unit,
     onNext: () -> Unit
@@ -860,6 +895,7 @@ internal fun SearchChrome(
             searchFieldReadOnly = searchFieldReadOnly,
             onSearchFieldClick = onSearchFieldClick,
             selectedFilter = selectedFilter,
+            selectedCollectedSort = selectedCollectedSort,
             selectedLocale = selectedLocale,
             filterControlsLocked = filterControlsLocked,
             searchSubmitLocked = searchSubmitLocked,
@@ -871,6 +907,7 @@ internal fun SearchChrome(
             onSearchSubmit = onSearchSubmit,
             onFilterSelected = onFilterSelected,
             onLocaleSelected = onLocaleSelected,
+            onCollectedSortSelected = onCollectedSortSelected,
             rightPanelToggle = rightPanelToggle
         )
         if (showPagination) {
@@ -895,6 +932,7 @@ internal fun SearchToolbar(
     searchFieldReadOnly: Boolean = false,
     onSearchFieldClick: (() -> Unit)? = null,
     selectedFilter: SearchFilterOption,
+    selectedCollectedSort: SearchCollectedSortOption = SearchCollectedSortOption.ReleaseNew,
     selectedLocale: String,
     filterControlsLocked: Boolean,
     searchSubmitLocked: Boolean,
@@ -906,11 +944,12 @@ internal fun SearchToolbar(
     onSearchSubmit: () -> Unit,
     onFilterSelected: (SearchFilterOption) -> Unit,
     onLocaleSelected: (String) -> Unit,
+    onCollectedSortSelected: (SearchCollectedSortOption) -> Unit = {},
     rightPanelToggle: (@Composable (Modifier) -> Unit)? = null
 ) {
     val colorScheme = AsmrTheme.colorScheme
     var scopeMenuExpanded by remember { mutableStateOf(false) }
-    var languageMenuExpanded by remember { mutableStateOf(false) }
+    var secondaryMenuExpanded by remember { mutableStateOf(false) }
     val dropdownContainerColor = lerp(
         colorScheme.surface,
         colorScheme.primarySoft,
@@ -921,7 +960,7 @@ internal fun SearchToolbar(
     LaunchedEffect(filterControlsLocked, searchSubmitLocked) {
         if (filterControlsLocked || searchSubmitLocked) {
             scopeMenuExpanded = false
-            languageMenuExpanded = false
+            secondaryMenuExpanded = false
         }
     }
 
@@ -1031,50 +1070,78 @@ internal fun SearchToolbar(
                             )
                         }
                     }
-                    val languageLabel = when (selectedLocale.trim()) {
-                        "zh_CN" -> "简中"
-                        "zh_TW" -> "繁中"
-                        else -> "日语"
-                    }
                     Box {
+                        val secondaryButtonTag = if (selectedFilter.isCollectedOnly) {
+                            SEARCH_COLLECTED_SORT_BUTTON_TAG
+                        } else {
+                            SEARCH_LANGUAGE_BUTTON_TAG
+                        }
                         TextButton(
-                            onClick = { languageMenuExpanded = true },
+                            onClick = { secondaryMenuExpanded = true },
                             enabled = !filterControlsLocked,
                             modifier = Modifier
                                 .defaultMinSize(minWidth = 1.dp, minHeight = 30.dp)
                                 .height(30.dp)
-                                .testTag(SEARCH_LANGUAGE_BUTTON_TAG),
+                                .testTag(secondaryButtonTag),
                             contentPadding = PaddingValues(horizontal = 4.dp, vertical = 0.dp),
                             colors = ButtonDefaults.textButtonColors(
                                 contentColor = colorScheme.primary
                             )
                         ) {
-                            Text(languageLabel, style = MaterialTheme.typography.labelSmall, maxLines = 1)
+                            val label = if (selectedFilter.isCollectedOnly) {
+                                selectedCollectedSort.label
+                            } else {
+                                when (selectedLocale.trim()) {
+                                    "zh_CN" -> "简中"
+                                    "zh_TW" -> "繁中"
+                                    else -> "日语"
+                                }
+                            }
+                            Text(label, style = MaterialTheme.typography.labelSmall, maxLines = 1)
                         }
                         DropdownMenu(
-                            expanded = languageMenuExpanded,
-                            onDismissRequest = { languageMenuExpanded = false },
+                            expanded = secondaryMenuExpanded,
+                            onDismissRequest = { secondaryMenuExpanded = false },
                             modifier = Modifier.background(dropdownContainerColor)
                         ) {
-                            listOf(
-                                "ja_JP" to "日语",
-                                "zh_CN" to "简中",
-                                "zh_TW" to "繁中"
-                            ).forEachIndexed { index, (locale, label) ->
-                                if (index > 0) {
-                                    HorizontalDivider(
-                                        modifier = Modifier.padding(horizontal = 8.dp),
-                                        thickness = 0.5.dp,
-                                        color = colorScheme.textSecondary.copy(alpha = 0.2f)
+                            if (selectedFilter.isCollectedOnly) {
+                                SearchCollectedSortOption.values().forEachIndexed { index, option ->
+                                    if (index > 0) {
+                                        HorizontalDivider(
+                                            modifier = Modifier.padding(horizontal = 8.dp),
+                                            thickness = 0.5.dp,
+                                            color = colorScheme.textSecondary.copy(alpha = 0.2f)
+                                        )
+                                    }
+                                    DropdownMenuItem(
+                                        text = { Text(option.label, color = colorScheme.textPrimary) },
+                                        onClick = {
+                                            secondaryMenuExpanded = false
+                                            onCollectedSortSelected(option)
+                                        }
                                     )
                                 }
-                                DropdownMenuItem(
-                                    text = { Text(label, color = colorScheme.textPrimary) },
-                                    onClick = {
-                                        languageMenuExpanded = false
-                                        onLocaleSelected(locale)
+                            } else {
+                                listOf(
+                                    "ja_JP" to "日语",
+                                    "zh_CN" to "简中",
+                                    "zh_TW" to "繁中"
+                                ).forEachIndexed { index, (locale, label) ->
+                                    if (index > 0) {
+                                        HorizontalDivider(
+                                            modifier = Modifier.padding(horizontal = 8.dp),
+                                            thickness = 0.5.dp,
+                                            color = colorScheme.textSecondary.copy(alpha = 0.2f)
+                                        )
                                     }
-                                )
+                                    DropdownMenuItem(
+                                        text = { Text(label, color = colorScheme.textPrimary) },
+                                        onClick = {
+                                            secondaryMenuExpanded = false
+                                            onLocaleSelected(locale)
+                                        }
+                                    )
+                                }
                             }
                         }
                     }

--- a/app/src/main/java/com/asmr/player/ui/search/SearchScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/search/SearchScreen.kt
@@ -114,6 +114,7 @@ import kotlin.math.absoluteValue
 
 internal const val SEARCH_INPUT_TAG = "search_input"
 internal const val SEARCH_SCOPE_BUTTON_TAG = "search_scope_button"
+internal const val SEARCH_SCOPE_OPTION_TAG_PREFIX = "search_scope_option"
 internal const val SEARCH_LANGUAGE_BUTTON_TAG = "search_language_button"
 internal const val SEARCH_CLEAR_BUTTON_TAG = "search_clear_button"
 internal const val SEARCH_SUBMIT_BUTTON_TAG = "search_submit_button"
@@ -342,7 +343,7 @@ fun SearchScreen(
             return@LaunchedEffect
         }
         val normalizedKeyword = submittedSearchKeyword.trim()
-        if (normalizedKeyword.isBlank() || searchSubmitLocked) return@LaunchedEffect
+        if (searchSubmitLocked) return@LaunchedEffect
         val submittedOrder = SearchSortOption.values()
             .firstOrNull { it.name == submittedSearchOrderName }
             ?: SearchSortOption.Trend
@@ -703,7 +704,9 @@ fun SearchScreen(
                         onSearchSubmit = { submitSearch() },
                         onFilterSelected = { option ->
                             val nextOrder = option.sortOption ?: selectedOrder
-                            val accepted = viewModel.updateSearchOptions(
+                            val nextKeyword = keyword.trim()
+                            val accepted = viewModel.search(
+                                keyword = nextKeyword,
                                 order = nextOrder,
                                 purchasedOnly = option.isPurchasedOnly,
                                 presaleOnly = option.isPresaleOnly,
@@ -717,6 +720,9 @@ fun SearchScreen(
                                 presaleOnly = option.isPresaleOnly
                                 chineseTranslatedOnly = option.isChineseTranslated
                                 collectedOnly = option.isCollectedOnly
+                                keyword = nextKeyword
+                                scrollResultsToTop()
+                                chromeState.expand()
                             }
                         },
                         onLocaleSelected = { locale ->
@@ -978,6 +984,7 @@ internal fun SearchToolbar(
                                 )
                             }
                             DropdownMenuItem(
+                                modifier = Modifier.testTag("${SEARCH_SCOPE_OPTION_TAG_PREFIX}_${option.name}"),
                                 text = {
                                     Row(
                                         horizontalArrangement = Arrangement.spacedBy(8.dp),

--- a/app/src/main/java/com/asmr/player/ui/search/SearchScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/search/SearchScreen.kt
@@ -135,6 +135,12 @@ private fun stableAlbumKey(album: Album): String {
     return "h${seed.hashCode().absoluteValue}"
 }
 
+private fun onlineDetailLoadingFor(album: Album, state: SearchUiState.Success): Boolean {
+    if (!state.isEnriching || state.purchasedOnly || state.collectedOnly) return false
+    val rj = album.rjCode.ifBlank { album.workId }.trim().uppercase()
+    return rj.isNotBlank() && rj in state.enrichingRjCodes
+}
+
 private fun Modifier.consumeTapThrough(): Modifier =
     pointerInput(Unit) {
         awaitEachGesture {
@@ -549,10 +555,12 @@ fun SearchScreen(
                                             key = { album -> stableAlbumKey(album) },
                                             contentType = { "album" }
                                         ) { album ->
+                                            val onlineDetailLoading = onlineDetailLoadingFor(album, state)
                                             AlbumItem(
                                                 album = album,
                                                 onClick = { onAlbumClick(album, state.purchasedOnly) },
                                                 emptyCoverUseShimmer = true,
+                                                onlineDetailLoading = onlineDetailLoading,
                                                 onRjClick = { copyMeta("RJ", it) },
                                                 onCircleClick = { copyMeta("社团", it) },
                                                 onCvClick = { copyMeta("CV", it) },
@@ -583,10 +591,12 @@ fun SearchScreen(
                                             contentType = { "albumGrid" }
                                         ) { index ->
                                             val album = state.results[index]
+                                            val onlineDetailLoading = onlineDetailLoadingFor(album, state)
                                             AlbumGridItem(
                                                 album = album,
                                                 onClick = { onAlbumClick(album, state.purchasedOnly) },
                                                 emptyCoverUseShimmer = true,
+                                                onlineDetailLoading = onlineDetailLoading,
                                                 onRjClick = { copyMeta("RJ", it) },
                                                 onCircleClick = { copyMeta("社团", it) },
                                                 onCvClick = { copyMeta("CV", it) },

--- a/app/src/main/java/com/asmr/player/ui/search/SearchSortOption.kt
+++ b/app/src/main/java/com/asmr/player/ui/search/SearchSortOption.kt
@@ -10,3 +10,16 @@ enum class SearchSortOption(
     PriceHigh("价格最高", "price_d")
 }
 
+enum class SearchCollectedSortOption(
+    val label: String,
+    val backendSort: String
+) {
+    ReleaseNew("最新发售", "release"),
+    RatingHigh("评分最高", "rating");
+
+    companion object {
+        fun fromName(name: String?): SearchCollectedSortOption {
+            return values().firstOrNull { it.name == name } ?: ReleaseNew
+        }
+    }
+}

--- a/app/src/main/java/com/asmr/player/ui/search/SearchViewModel.kt
+++ b/app/src/main/java/com/asmr/player/ui/search/SearchViewModel.kt
@@ -63,6 +63,7 @@ class SearchViewModel @Inject constructor(
 ) : ViewModel() {
     private val pageSize = 30
     private var currentOrder: SearchSortOption = SearchSortOption.Trend
+    private var currentCollectedSort: SearchCollectedSortOption = SearchCollectedSortOption.ReleaseNew
     private var purchasedOnly: Boolean = false
     private var presaleOnly: Boolean = false
     private var chineseTranslatedOnly: Boolean = false
@@ -118,7 +119,8 @@ class SearchViewModel @Inject constructor(
         initialKeyword: String,
         initialPurchasedOnly: Boolean,
         initialLocale: String?,
-        initialCollectedOnly: Boolean = true
+        initialCollectedOnly: Boolean = true,
+        initialCollectedSort: SearchCollectedSortOption = SearchCollectedSortOption.ReleaseNew
     ) {
         if (!bootstrapped.compareAndSet(false, true)) return
         viewModelScope.launch {
@@ -131,6 +133,7 @@ class SearchViewModel @Inject constructor(
                 presaleOnly = false
                 chineseTranslatedOnly = false
                 collectedOnly = initialCollectedOnly
+                currentCollectedSort = initialCollectedSort
                 currentLocale = initialLocale
                 lastRequestedKeyword = initialKeyword.trim()
                 requestPage(lastRequestedKeyword, 1, SearchPendingRequestKind.Search)
@@ -156,6 +159,7 @@ class SearchViewModel @Inject constructor(
         return search(
             keyword = keyword,
             order = currentOrder,
+            collectedSort = currentCollectedSort,
             purchasedOnly = purchasedOnly,
             presaleOnly = presaleOnly,
             chineseTranslatedOnly = chineseTranslatedOnly,
@@ -167,6 +171,7 @@ class SearchViewModel @Inject constructor(
     fun search(
         keyword: String,
         order: SearchSortOption,
+        collectedSort: SearchCollectedSortOption,
         purchasedOnly: Boolean,
         presaleOnly: Boolean,
         chineseTranslatedOnly: Boolean,
@@ -189,6 +194,7 @@ class SearchViewModel @Inject constructor(
         val normalizedKeyword = keyword.trim()
         Log.d("SearchViewModel", "Search requested: keyword=$normalizedKeyword")
         currentOrder = order
+        currentCollectedSort = collectedSort
         this.purchasedOnly = nextFilters.purchasedOnly
         this.presaleOnly = nextFilters.presaleOnly
         this.chineseTranslatedOnly = nextFilters.chineseTranslatedOnly
@@ -217,6 +223,7 @@ class SearchViewModel @Inject constructor(
 
     fun updateSearchOptions(
         order: SearchSortOption = currentOrder,
+        collectedSort: SearchCollectedSortOption = currentCollectedSort,
         purchasedOnly: Boolean = this.purchasedOnly,
         presaleOnly: Boolean = this.presaleOnly,
         chineseTranslatedOnly: Boolean = this.chineseTranslatedOnly,
@@ -237,6 +244,7 @@ class SearchViewModel @Inject constructor(
         }
         if (
             currentOrder == order &&
+            currentCollectedSort == collectedSort &&
             this.purchasedOnly == nextFilters.purchasedOnly &&
             this.presaleOnly == nextFilters.presaleOnly &&
             this.chineseTranslatedOnly == nextFilters.chineseTranslatedOnly &&
@@ -244,6 +252,7 @@ class SearchViewModel @Inject constructor(
             currentLocale == locale
         ) return true
         currentOrder = order
+        currentCollectedSort = collectedSort
         this.purchasedOnly = nextFilters.purchasedOnly
         this.presaleOnly = nextFilters.presaleOnly
         this.chineseTranslatedOnly = nextFilters.chineseTranslatedOnly
@@ -304,6 +313,7 @@ class SearchViewModel @Inject constructor(
                     keyword = normalizedKeyword,
                     page = page,
                     order = currentOrder,
+                    collectedSort = currentCollectedSort,
                     purchasedOnly = purchasedOnly,
                     presaleOnly = presaleOnly,
                     chineseTranslatedOnly = chineseTranslatedOnly,
@@ -314,6 +324,7 @@ class SearchViewModel @Inject constructor(
                     keyword = normalizedKeyword,
                     page = page,
                     order = currentOrder,
+                    collectedSort = currentCollectedSort,
                     purchasedOnly = purchasedOnly,
                     presaleOnly = presaleOnly,
                     chineseTranslatedOnly = chineseTranslatedOnly,
@@ -362,6 +373,7 @@ class SearchViewModel @Inject constructor(
                 messageManager.showError(msg)
                 if (previousSuccess != null) {
                     currentOrder = previousSuccess.order
+                    currentCollectedSort = previousSuccess.collectedSort
                     purchasedOnly = previousSuccess.purchasedOnly
                     presaleOnly = previousSuccess.presaleOnly
                     chineseTranslatedOnly = previousSuccess.chineseTranslatedOnly
@@ -408,6 +420,7 @@ class SearchViewModel @Inject constructor(
         keyword: String,
         page: Int,
         order: SearchSortOption,
+        collectedSort: SearchCollectedSortOption,
         purchasedOnly: Boolean,
         presaleOnly: Boolean,
         chineseTranslatedOnly: Boolean,
@@ -419,7 +432,7 @@ class SearchViewModel @Inject constructor(
         }
         if (collectedOnly) {
             val offset = (page.coerceAtLeast(1) - 1) * pageSize
-            val resp = asmrOneAvailabilityApi.search(keyword, pageSize, offset)
+            val resp = asmrOneAvailabilityApi.search(keyword, pageSize, offset, collectedSort.backendSort)
             val items = resp.items.orEmpty().map { it.toCollectedAlbum() }
             val total = resp.total.coerceAtLeast(0)
             val responseOffset = resp.offset.coerceAtLeast(offset)
@@ -545,6 +558,7 @@ class SearchViewModel @Inject constructor(
         val order = SearchSortOption.values()
             .firstOrNull { it.name == cached.orderName }
             ?: SearchSortOption.Trend
+        val collectedSort = SearchCollectedSortOption.fromName(cached.collectedSortName)
         val page = cached.page.coerceAtLeast(1)
         val filters = normalizeSearchFilters(
             purchasedOnly = cached.purchasedOnly,
@@ -553,6 +567,7 @@ class SearchViewModel @Inject constructor(
             collectedOnly = cached.collectedOnly
         )
         currentOrder = order
+        currentCollectedSort = collectedSort
         purchasedOnly = filters.purchasedOnly
         presaleOnly = filters.presaleOnly
         chineseTranslatedOnly = filters.chineseTranslatedOnly
@@ -563,6 +578,7 @@ class SearchViewModel @Inject constructor(
             keyword = cached.keyword,
             page = page,
             order = order,
+            collectedSort = collectedSort,
             purchasedOnly = filters.purchasedOnly,
             presaleOnly = filters.presaleOnly,
             chineseTranslatedOnly = filters.chineseTranslatedOnly,
@@ -594,6 +610,7 @@ class SearchViewModel @Inject constructor(
                         savedAtMs = System.currentTimeMillis(),
                         keyword = latest.keyword,
                         orderName = latest.order.name,
+                        collectedSortName = latest.collectedSort.name,
                         purchasedOnly = latest.purchasedOnly,
                         presaleOnly = latest.presaleOnly,
                         chineseTranslatedOnly = latest.chineseTranslatedOnly,
@@ -832,6 +849,7 @@ sealed class SearchUiState {
         val keyword: String,
         val page: Int,
         val order: SearchSortOption,
+        val collectedSort: SearchCollectedSortOption,
         val purchasedOnly: Boolean,
         val presaleOnly: Boolean,
         val chineseTranslatedOnly: Boolean,

--- a/app/src/main/java/com/asmr/player/ui/search/SearchViewModel.kt
+++ b/app/src/main/java/com/asmr/player/ui/search/SearchViewModel.kt
@@ -144,6 +144,7 @@ class SearchViewModel @Inject constructor(
             val cur = state as? SearchUiState.Success ?: return@update state
             cur.copy(
                 isEnriching = false,
+                enrichingRjCodes = emptySet(),
                 isAsmrOneChecking = false,
                 asmrOneChecked = 0,
                 asmrOneTotal = 0
@@ -292,6 +293,7 @@ class SearchViewModel @Inject constructor(
             _uiState.value = previousSuccess?.copy(
                 pendingRequest = SearchPendingRequest(kind = requestKind, targetPage = page),
                 isEnriching = false,
+                enrichingRjCodes = emptySet(),
                 isAsmrOneChecking = false,
                 asmrOneChecked = 0,
                 asmrOneTotal = 0
@@ -322,6 +324,7 @@ class SearchViewModel @Inject constructor(
                     pendingRequest = null,
                     visitedPages = buildVisitedPages(previousSuccess, requestKind, page),
                     isEnriching = false,
+                    enrichingRjCodes = emptySet(),
                     isAsmrOneChecking = false,
                     asmrOneChecked = 0,
                     asmrOneTotal = 0
@@ -367,6 +370,7 @@ class SearchViewModel @Inject constructor(
                     _uiState.value = previousSuccess.copy(
                         pendingRequest = null,
                         isEnriching = false,
+                        enrichingRjCodes = emptySet(),
                         isAsmrOneChecking = false,
                         asmrOneChecked = 0,
                         asmrOneTotal = 0
@@ -463,40 +467,62 @@ class SearchViewModel @Inject constructor(
         enrichJob = viewModelScope.launch {
             val current0 = _uiState.value as? SearchUiState.Success ?: return@launch
             if (current0.keyword != keyword || current0.page != page || current0.purchasedOnly || current0.collectedOnly) return@launch
-            _uiState.value = current0.copy(isEnriching = true)
+            val enrichTargets = baseItems
+                .mapNotNull { it.rjCode.ifBlank { it.workId }.trim().uppercase().takeIf(String::isNotBlank) }
+                .distinct()
+                .toSet()
+            if (enrichTargets.isEmpty()) return@launch
+            _uiState.value = current0.copy(
+                isEnriching = true,
+                enrichingRjCodes = enrichTargets
+            )
 
             coroutineScope {
                 val sem = Semaphore(6)
                 val deferreds = baseItems.mapIndexedNotNull { index, base ->
                     val rj = base.rjCode.ifBlank { base.workId }.trim().uppercase()
-                    if (rj.isBlank()) return@mapIndexedNotNull null
+                    if (rj.isBlank() || rj !in enrichTargets) return@mapIndexedNotNull null
                     async(enrichDispatcher) {
                         sem.withPermit {
                             val cached = dlsiteDetailCache[rj]
                             val detail = cached ?: runCatching { dlsiteScraper.getWorkInfo(rj)?.album }.getOrNull()
                             if (detail != null) dlsiteDetailCache[rj] = detail
-                            index to detail
+                            Triple(index, rj, detail)
                         }
                     }
                 }
                 deferreds.forEach { deferred ->
-                    val result = runCatching { deferred.await() }.getOrNull() ?: return@forEach
+                    val result = runCatching { deferred.await() }.getOrNull()
+                    if (result == null) {
+                        val current = _uiState.value as? SearchUiState.Success ?: return@forEach
+                        if (current.keyword == keyword && current.page == page && !current.purchasedOnly && !current.collectedOnly) {
+                            _uiState.value = current.copy(enrichingRjCodes = emptySet())
+                        }
+                        return@forEach
+                    }
                     val idx = result.first
-                    val detail = result.second
-                    if (detail == null) return@forEach
+                    val rj = result.second
+                    val detail = result.third
                     val cur = _uiState.value as? SearchUiState.Success ?: return@forEach
                     if (cur.keyword != keyword || cur.page != page || cur.purchasedOnly || cur.collectedOnly) return@forEach
                     val list = cur.results.toMutableList()
-                    if (idx !in list.indices) return@forEach
-                    list[idx] = mergeAlbum(list[idx], detail)
-                    _uiState.value = cur.copy(results = list)
-                    scheduleCacheWrite()
+                    if (detail != null && idx in list.indices) {
+                        list[idx] = mergeAlbum(list[idx], detail)
+                    }
+                    _uiState.value = cur.copy(
+                        results = list,
+                        enrichingRjCodes = cur.enrichingRjCodes - rj
+                    )
+                    if (detail != null) scheduleCacheWrite()
                 }
             }
 
             val current1 = _uiState.value as? SearchUiState.Success ?: return@launch
             if (current1.keyword == keyword && current1.page == page && !current1.purchasedOnly && !current1.collectedOnly) {
-                _uiState.value = current1.copy(isEnriching = false)
+                _uiState.value = current1.copy(
+                    isEnriching = false,
+                    enrichingRjCodes = emptySet()
+                )
                 scheduleCacheWrite()
             }
         }
@@ -547,6 +573,7 @@ class SearchViewModel @Inject constructor(
             pendingRequest = null,
             visitedPages = listOf(page),
             isEnriching = false,
+            enrichingRjCodes = emptySet(),
             isAsmrOneChecking = false,
             asmrOneChecked = 0,
             asmrOneTotal = 0
@@ -815,6 +842,7 @@ sealed class SearchUiState {
         val pendingRequest: SearchPendingRequest? = null,
         val visitedPages: List<Int> = listOf(page),
         val isEnriching: Boolean = false,
+        val enrichingRjCodes: Set<String> = emptySet(),
         val isAsmrOneChecking: Boolean = false,
         val asmrOneChecked: Int = 0,
         val asmrOneTotal: Int = 0

--- a/app/src/main/java/com/asmr/player/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/settings/SettingsScreen.kt
@@ -65,6 +65,9 @@ import com.asmr.player.ui.library.BulkPhase
 import com.asmr.player.ui.library.LibraryViewModel
 import com.asmr.player.ui.common.AppSupportStatusSection
 import com.asmr.player.ui.common.EaraLogoLoadingIndicator
+import com.asmr.player.ui.common.FlatActionDialog
+import com.asmr.player.ui.common.FlatDialogAction
+import com.asmr.player.ui.common.FlatDialogActionTone
 import com.asmr.player.ui.theme.AsmrTheme
 import com.asmr.player.ui.common.LocalBottomOverlayPadding
 import com.asmr.player.ui.common.StableWindowInsets
@@ -809,12 +812,14 @@ fun SettingsScreen(
 
     val removeRoot = pendingRemoveRoot
     if (removeRoot != null) {
-        AlertDialog(
+        FlatActionDialog(
             onDismissRequest = { pendingRemoveRoot = null },
-            title = { Text("移除目录") },
-            text = { Text("将从列表中移除该目录，后续不会再扫描它。") },
-            confirmButton = {
-                TextButton(
+            message = "将从列表中移除该目录，后续不会再扫描它。",
+            actions = listOf(
+                FlatDialogAction("取消", onClick = { pendingRemoveRoot = null }),
+                FlatDialogAction(
+                    text = "移除",
+                    tone = FlatDialogActionTone.Danger,
                     onClick = {
                         val uri = runCatching { Uri.parse(removeRoot) }.getOrNull()
                         if (uri != null) {
@@ -824,15 +829,8 @@ fun SettingsScreen(
                         libraryViewModel.removeScanRootAndDeleteAlbums(removeRoot)
                         pendingRemoveRoot = null
                     }
-                ) {
-                    Text("移除")
-                }
-            },
-            dismissButton = {
-                TextButton(onClick = { pendingRemoveRoot = null }) {
-                    Text("取消")
-                }
-            }
+                )
+            )
         )
     }
 }

--- a/app/src/test/java/com/asmr/player/ui/search/SearchAssistScreenTest.kt
+++ b/app/src/test/java/com/asmr/player/ui/search/SearchAssistScreenTest.kt
@@ -144,6 +144,67 @@ class SearchAssistScreenTest {
     }
 
     @Test
+    fun currentFilterSelectionSubmitsInputWithoutHotKeywordFallback() {
+        val submitted = mutableListOf<SearchAssistSearchRequest>()
+
+        composeRule.setContent {
+            AsmrPlayerTheme {
+                SearchAssistContent(
+                    windowSizeClass = testWindowSizeClass(),
+                    initialRequest = SearchAssistSearchRequest(),
+                    uiState = SearchAssistUiState(
+                        suggestions = SearchSuggestionsUiData(
+                            hotCvs = listOf(SearchSuggestionTerm(value = "CV A", count = 12, rank = 1))
+                        )
+                    ),
+                    onSubmitSearch = { submitted += it },
+                    onClearHistory = {},
+                    onOpenFullRanking = {}
+                )
+            }
+        }
+
+        composeRule.onNodeWithTag(SEARCH_SCOPE_BUTTON_TAG).performClick()
+        composeRule.onNodeWithTag("${SEARCH_SCOPE_OPTION_TAG_PREFIX}_${SearchFilterOption.Collected.name}")
+            .performClick()
+
+        composeRule.runOnIdle {
+            assertEquals(1, submitted.size)
+            assertEquals("", submitted.single().keyword)
+            assertEquals(SearchFilterOption.Collected, submitted.single().selectedFilter)
+        }
+    }
+
+    @Test
+    fun filterSelectionSubmitsTypedInputAndSelectedFilter() {
+        val submitted = mutableListOf<SearchAssistSearchRequest>()
+
+        composeRule.setContent {
+            AsmrPlayerTheme {
+                SearchAssistContent(
+                    windowSizeClass = testWindowSizeClass(),
+                    initialRequest = SearchAssistSearchRequest(),
+                    uiState = SearchAssistUiState(),
+                    onSubmitSearch = { submitted += it },
+                    onClearHistory = {},
+                    onOpenFullRanking = {}
+                )
+            }
+        }
+
+        composeRule.onNodeWithTag(SEARCH_ASSIST_INPUT_TAG).performTextInput("  rain  ")
+        composeRule.onNodeWithTag(SEARCH_SCOPE_BUTTON_TAG).performClick()
+        composeRule.onNodeWithTag("${SEARCH_SCOPE_OPTION_TAG_PREFIX}_${SearchFilterOption.ChineseTranslated.name}")
+            .performClick()
+
+        composeRule.runOnIdle {
+            assertEquals(1, submitted.size)
+            assertEquals("rain", submitted.single().keyword)
+            assertEquals(SearchFilterOption.ChineseTranslated, submitted.single().selectedFilter)
+        }
+    }
+
+    @Test
     fun clearHistoryHotWorkAndFullRankingUseSeparateCallbacks() {
         var clearHistoryCount = 0
         var fullRankingCount = 0

--- a/app/src/test/java/com/asmr/player/ui/search/SearchScreenChromeTest.kt
+++ b/app/src/test/java/com/asmr/player/ui/search/SearchScreenChromeTest.kt
@@ -18,6 +18,7 @@ import androidx.compose.ui.test.assertIsNotEnabled
 import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onAllNodesWithTag
+import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
@@ -201,6 +202,40 @@ class SearchScreenChromeTest {
         composeRule.onNodeWithText("最新发售").assertExists()
         composeRule.onNodeWithText("销量最高").assertExists()
         composeRule.onNodeWithText("价格最高").assertExists()
+    }
+
+    @Test
+    fun collectedFilter_usesSortMenuInsteadOfLanguageMenu() {
+        var selectedSort = SearchCollectedSortOption.ReleaseNew
+
+        composeRule.setContent {
+            AsmrPlayerTheme {
+                SearchToolbar(
+                    keyword = "",
+                    onKeywordChange = {},
+                    selectedFilter = SearchFilterOption.Collected,
+                    selectedCollectedSort = selectedSort,
+                    selectedLocale = "zh_CN",
+                    filterControlsLocked = false,
+                    searchSubmitLocked = false,
+                    showSearchSpinner = false,
+                    onSearchSubmit = {},
+                    onFilterSelected = {},
+                    onLocaleSelected = {},
+                    onCollectedSortSelected = { selectedSort = it }
+                )
+            }
+        }
+
+        composeRule.onNodeWithTag(SEARCH_COLLECTED_SORT_BUTTON_TAG).performClick()
+        composeRule.onNodeWithText("最新发售").assertExists()
+        composeRule.onNodeWithText("评分最高").assertExists()
+        composeRule.onAllNodesWithText("时长最长").assertCountEquals(0)
+        composeRule.onNodeWithText("评分最高").performClick()
+
+        composeRule.runOnIdle {
+            assertEquals(SearchCollectedSortOption.RatingHigh, selectedSort)
+        }
     }
 
     @Test


### PR DESCRIPTION
## Summary
- 将在线搜索「已收录」右侧控制从语种切换为后端排序选项
- 支持最新发售和评分最高，并把排序状态接入搜索、缓存和辅助搜索返回
- 更新搜索工具栏测试，确认不再显示时长最长选项

## Tests
- .\\gradlew.bat :app:compileDebugKotlin :app:compileDebugUnitTestKotlin