### PR TITLE
fix: unify album meta copy interactions

### DIFF
--- a/app/src/main/java/com/asmr/player/ui/hotlistening/HotListeningScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/hotlistening/HotListeningScreen.kt
@@ -54,6 +54,7 @@ import com.asmr.player.ui.library.AlbumGridItem
 import com.asmr.player.ui.library.AlbumGridItemSpacing
 import com.asmr.player.ui.library.AlbumCoverBadge
 import com.asmr.player.ui.library.AlbumItem
+import com.asmr.player.ui.library.rememberAlbumMetaCopyAction
 import com.asmr.player.ui.theme.AsmrTheme
 import kotlinx.coroutines.launch
 import kotlin.math.absoluteValue
@@ -78,6 +79,7 @@ fun HotListeningScreen(
     val selectedSortMode by viewModel.sortMode.collectAsState()
     val selectedPeriod by viewModel.selectedPeriod.collectAsState()
     val colorScheme = AsmrTheme.colorScheme
+    val copyMeta = rememberAlbumMetaCopyAction(viewModel.messageManager)
     val scope = rememberCoroutineScope()
     val isCompactWidth = windowSizeClass.widthSizeClass == WindowWidthSizeClass.Compact
 
@@ -236,7 +238,11 @@ fun HotListeningScreen(
                                 album = album,
                                 onClick = { onAlbumClick(album) },
                                 emptyCoverUseShimmer = true,
-                                coverBadge = entry.toCoverBadge()
+                                coverBadge = entry.toCoverBadge(),
+                                onRjClick = { copyMeta("RJ", it) },
+                                onCircleClick = { copyMeta("社团", it) },
+                                onCvClick = { copyMeta("CV", it) },
+                                onTagClick = { copyMeta("标签", it) },
                             )
                         }
                     }
@@ -267,7 +273,11 @@ fun HotListeningScreen(
                                 album = album,
                                 onClick = { onAlbumClick(album) },
                                 emptyCoverUseShimmer = true,
-                                coverBadge = entry.toCoverBadge()
+                                coverBadge = entry.toCoverBadge(),
+                                onRjClick = { copyMeta("RJ", it) },
+                                onCircleClick = { copyMeta("社团", it) },
+                                onCvClick = { copyMeta("CV", it) },
+                                onTagClick = { copyMeta("标签", it) },
                             )
                         }
                     }

--- a/app/src/main/java/com/asmr/player/ui/hotlistening/HotListeningViewModel.kt
+++ b/app/src/main/java/com/asmr/player/ui/hotlistening/HotListeningViewModel.kt
@@ -7,6 +7,7 @@ import com.asmr.player.domain.model.Album
 import com.asmr.player.hotlistening.HotListeningApi
 import com.asmr.player.hotlistening.HotListeningItem
 import com.asmr.player.hotlistening.HotListeningSortMode
+import com.asmr.player.util.MessageManager
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
@@ -22,7 +23,8 @@ import javax.inject.Inject
 @HiltViewModel
 class HotListeningViewModel @Inject constructor(
     private val hotListeningApi: HotListeningApi,
-    private val settingsRepository: SettingsRepository
+    private val settingsRepository: SettingsRepository,
+    val messageManager: MessageManager,
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow<HotListeningUiState>(HotListeningUiState.Loading)

--- a/app/src/main/java/com/asmr/player/ui/library/AlbumItem.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/AlbumItem.kt
@@ -377,7 +377,7 @@ fun AlbumGridItem(
                     modifier = Modifier
                         .align(Alignment.TopStart)
                         .padding(8.dp)
-                        .background(Color.Black.copy(alpha = 0.5f), RoundedCornerShape(4.dp))
+                        .clip(RoundedCornerShape(4.dp))
                         .let { base ->
                             if (onRjClick != null) {
                                 base.clickable { onRjClick(rj) }
@@ -385,6 +385,7 @@ fun AlbumGridItem(
                                 base
                             }
                         }
+                        .background(Color.Black.copy(alpha = 0.5f), RoundedCornerShape(4.dp))
                         .padding(horizontal = 4.dp, vertical = 2.dp)
                 )
             }

--- a/app/src/main/java/com/asmr/player/ui/library/AlbumMetaChips.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/AlbumMetaChips.kt
@@ -21,6 +21,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
@@ -373,13 +374,14 @@ private fun AlbumMetaBadge(
     val palette = albumMetaPalette(tone, colorScheme, appearance)
     val styledModifier = modifier
         .then(if (maxWidth != null) Modifier.widthIn(max = maxWidth) else Modifier)
+        .clip(shape)
+        .let { if (onClick != null) it.clickable(onClick = onClick) else it }
         .background(palette.container, shape)
         .border(0.5.dp, palette.border, shape)
         .padding(
             horizontal = 7.dp,
             vertical = 2.dp,
         )
-        .let { if (onClick != null) it.clickable(onClick = onClick) else it }
 
     Row(
         modifier = styledModifier,

--- a/app/src/main/java/com/asmr/player/ui/library/LibraryScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/LibraryScreen.kt
@@ -1420,7 +1420,7 @@ private fun AlbumGridItem(
                     modifier = Modifier
                         .align(Alignment.TopStart)
                         .padding(8.dp)
-                        .background(Color.Black.copy(alpha = 0.5f), RoundedCornerShape(4.dp))
+                        .clip(RoundedCornerShape(4.dp))
                         .let { base ->
                             if (onRjClick != null) {
                                 base.clickable { onRjClick(rj) }
@@ -1428,6 +1428,7 @@ private fun AlbumGridItem(
                                 base
                             }
                         }
+                        .background(Color.Black.copy(alpha = 0.5f), RoundedCornerShape(4.dp))
                         .padding(horizontal = 4.dp, vertical = 2.dp)
                 )
             }


### PR DESCRIPTION
## Summary
- enable quick-copy for circle, RJ, CV, and tag capsules in Hot Listening album lists
- move copy tap feedback to the capsule container so list and grid badges respond consistently
- keep Hot Listening aligned with Library and Search copy behavior

## Testing
- ./gradlew.bat :app:compileDebugKotlin