### PR TITLE
fix: add search request timeouts

### DIFF
--- a/app/src/main/java/com/asmr/player/data/remote/SearchRequestTimeouts.kt
+++ b/app/src/main/java/com/asmr/player/data/remote/SearchRequestTimeouts.kt
@@ -1,0 +1,19 @@
+package com.asmr.player.data.remote
+
+import okhttp3.OkHttpClient
+import java.util.concurrent.TimeUnit
+
+internal const val SEARCH_CALL_TIMEOUT_SECONDS = 20L
+internal const val SEARCH_CONNECT_TIMEOUT_SECONDS = 10L
+internal const val SEARCH_READ_TIMEOUT_SECONDS = 15L
+internal const val SEARCH_WRITE_TIMEOUT_SECONDS = 15L
+
+internal fun OkHttpClient.withSearchTimeouts(): OkHttpClient =
+    newBuilder()
+        // Bound the full request lifecycle so stalled DNS or TCP handshakes do not keep
+        // the search screen locked forever.
+        .callTimeout(SEARCH_CALL_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+        .connectTimeout(SEARCH_CONNECT_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+        .readTimeout(SEARCH_READ_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+        .writeTimeout(SEARCH_WRITE_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+        .build()

--- a/app/src/main/java/com/asmr/player/data/remote/api/AsmrOneAvailabilityApi.kt
+++ b/app/src/main/java/com/asmr/player/data/remote/api/AsmrOneAvailabilityApi.kt
@@ -3,6 +3,7 @@ package com.asmr.player.data.remote.api
 import android.os.Build
 import com.asmr.player.BuildConfig
 import com.asmr.player.data.remote.NetworkHeaders
+import com.asmr.player.data.remote.withSearchTimeouts
 import com.asmr.player.listentogether.XxHash64
 import com.google.gson.Gson
 import kotlinx.coroutines.Dispatchers
@@ -73,6 +74,7 @@ class AsmrOneAvailabilityApi @Inject constructor(
     private val appHeaderValue = "com.asmr.player/${BuildConfig.VERSION_NAME} (${BuildConfig.VERSION_CODE})"
     private val deviceFingerprint = buildDeviceFingerprint()
     private val userAgent = buildUserAgent()
+    private val requestClient by lazy { okHttpClient.withSearchTimeouts() }
 
     suspend fun check(rjs: List<String>): Map<String, Boolean> {
         val normalized = rjs
@@ -95,7 +97,7 @@ class AsmrOneAvailabilityApi @Inject constructor(
                     .header(NetworkHeaders.HEADER_SILENT_IO_ERROR, NetworkHeaders.SILENT_IO_ERROR_ON)
                     .post(gson.toJson(AsmrOneAvailabilityRequest(normalized)).toRequestBody(JSON_MEDIA_TYPE))
                     .build()
-                okHttpClient.newCall(request).execute().use { response ->
+                requestClient.newCall(request).execute().use { response ->
                     if (!response.isSuccessful) return@withContext emptyMap()
                     val raw = response.body?.string().orEmpty()
                     if (raw.isBlank()) return@withContext emptyMap()
@@ -127,7 +129,7 @@ class AsmrOneAvailabilityApi @Inject constructor(
                 .header(NetworkHeaders.HEADER_SILENT_IO_ERROR, NetworkHeaders.SILENT_IO_ERROR_ON)
                 .get()
                 .build()
-            okHttpClient.newCall(request).execute().use { response ->
+            requestClient.newCall(request).execute().use { response ->
                 if (!response.isSuccessful) {
                     throw IOException("asmr.one search failed: HTTP ${response.code}")
                 }

--- a/app/src/main/java/com/asmr/player/data/remote/dlsite/DlsitePlayLibraryClient.kt
+++ b/app/src/main/java/com/asmr/player/data/remote/dlsite/DlsitePlayLibraryClient.kt
@@ -2,6 +2,7 @@ package com.asmr.player.data.remote.dlsite
 
 import android.content.Context
 import com.asmr.player.data.remote.NetworkHeaders
+import com.asmr.player.data.remote.withSearchTimeouts
 import com.asmr.player.data.remote.auth.DlsiteAuthStore
 import com.asmr.player.domain.model.Album
 import com.google.gson.Gson
@@ -25,6 +26,7 @@ class DlsitePlayLibraryClient @Inject constructor(
     private val authStore = DlsiteAuthStore(context)
     private val gson = Gson()
     private val cacheTtlMs = TimeUnit.MINUTES.toMillis(5)
+    private val requestClient by lazy { okHttpClient.withSearchTimeouts() }
 
     private var cachedAlbums: List<Album> = emptyList()
     private var cachedTs: Long = 0L
@@ -138,7 +140,7 @@ class DlsitePlayLibraryClient @Inject constructor(
             .get()
             .build()
 
-        okHttpClient.newCall(request).execute().use { resp ->
+        requestClient.newCall(request).execute().use { resp ->
             if (!resp.isSuccessful) {
                 if (resp.code == 401) {
                     throw IllegalStateException("已购库鉴权失败（401），请重新登录 DLsite")
@@ -183,7 +185,7 @@ class DlsitePlayLibraryClient @Inject constructor(
             val body = gson.toJson(chunk).toRequestBody(jsonType)
             val reqBuilder = Request.Builder().url("https://play.dlsite.com/api/v3/content/works").post(body)
             headers.forEach { (k, v) -> reqBuilder.header(k, v) }
-            okHttpClient.newCall(reqBuilder.build()).execute().use { resp ->
+            requestClient.newCall(reqBuilder.build()).execute().use { resp ->
                     if (!resp.isSuccessful) {
                         if (resp.code == 401) {
                             throw IllegalStateException("已购库鉴权失败（401），请重新登录 DLsite")
@@ -277,7 +279,7 @@ class DlsitePlayLibraryClient @Inject constructor(
             .header("Pragma", "no-cache")
             .get()
             .build()
-        okHttpClient.newCall(request).execute().use { resp ->
+        requestClient.newCall(request).execute().use { resp ->
             val mergedCookie = mergeCookieHeader(cookie, resp.headers("Set-Cookie"))
             val body = if (resp.isSuccessful) resp.body?.string().orEmpty() else ""
             val ok = resp.isSuccessful && body.isNotBlank() && body != "null" && body != "{}"
@@ -295,7 +297,7 @@ class DlsitePlayLibraryClient @Inject constructor(
             .header(NetworkHeaders.HEADER_SILENT_IO_ERROR, NetworkHeaders.SILENT_IO_ERROR_ON)
             .get()
             .build()
-        okHttpClient.newCall(request).execute().use { resp ->
+        requestClient.newCall(request).execute().use { resp ->
             return resp.headers("Set-Cookie")
         }
     }

--- a/app/src/main/java/com/asmr/player/ui/search/SearchScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/search/SearchScreen.kt
@@ -153,6 +153,25 @@ private fun onlineDetailLoadingFor(album: Album, state: SearchUiState.Success): 
     return rj.isNotBlank() && rj in state.enrichingRjCodes
 }
 
+internal data class SearchChromeLockState(
+    val interactionLocked: Boolean,
+    val filterControlsLocked: Boolean,
+    val searchSubmitLocked: Boolean,
+    val showSearchSpinner: Boolean
+)
+
+internal fun resolveSearchChromeLockState(uiState: SearchUiState): SearchChromeLockState {
+    val success = uiState as? SearchUiState.Success
+    val interactionLocked = success?.isBusy == true
+    val requestLocked = uiState is SearchUiState.Loading || interactionLocked
+    return SearchChromeLockState(
+        interactionLocked = interactionLocked,
+        filterControlsLocked = requestLocked,
+        searchSubmitLocked = requestLocked,
+        showSearchSpinner = interactionLocked
+    )
+}
+
 private fun Modifier.consumeTapThrough(): Modifier =
     pointerInput(Unit) {
         awaitEachGesture {
@@ -293,10 +312,11 @@ fun SearchScreen(
         }
     }
 
-    val interactionLocked = success?.isBusy == true
-    val filterControlsLocked = success == null || interactionLocked
-    val searchSubmitLocked = uiState is SearchUiState.Loading || interactionLocked
-    val showSearchSpinner = success?.isBusy == true
+    val chromeLockState = remember(uiState) { resolveSearchChromeLockState(uiState) }
+    val interactionLocked = chromeLockState.interactionLocked
+    val filterControlsLocked = chromeLockState.filterControlsLocked
+    val searchSubmitLocked = chromeLockState.searchSubmitLocked
+    val showSearchSpinner = chromeLockState.showSearchSpinner
     val highlightedPage = success?.page ?: 1
     val canGoPrev = success?.canGoPrev == true && !success.isSearching
     val canGoNext = success?.canGoNext == true && !success.isSearching

--- a/app/src/test/java/com/asmr/player/ui/search/SearchChromeLockStateTest.kt
+++ b/app/src/test/java/com/asmr/player/ui/search/SearchChromeLockStateTest.kt
@@ -1,0 +1,56 @@
+package com.asmr.player.ui.search
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class SearchChromeLockStateTest {
+    @Test
+    fun loadingState_locksSearchChrome() {
+        val lockState = resolveSearchChromeLockState(SearchUiState.Loading)
+
+        assertTrue(lockState.filterControlsLocked)
+        assertTrue(lockState.searchSubmitLocked)
+        assertFalse(lockState.showSearchSpinner)
+        assertFalse(lockState.interactionLocked)
+    }
+
+    @Test
+    fun errorState_keepsSearchChromeAvailable() {
+        val lockState = resolveSearchChromeLockState(SearchUiState.Error("timeout"))
+
+        assertFalse(lockState.filterControlsLocked)
+        assertFalse(lockState.searchSubmitLocked)
+        assertFalse(lockState.showSearchSpinner)
+        assertFalse(lockState.interactionLocked)
+    }
+
+    @Test
+    fun busySuccessState_showsInlineSpinnerAndLocksActions() {
+        val lockState = resolveSearchChromeLockState(
+            SearchUiState.Success(
+                results = emptyList(),
+                keyword = "test",
+                page = 1,
+                order = SearchSortOption.Trend,
+                collectedSort = SearchCollectedSortOption.ReleaseNew,
+                purchasedOnly = false,
+                presaleOnly = false,
+                chineseTranslatedOnly = false,
+                collectedOnly = true,
+                locale = "ja_JP",
+                canGoPrev = false,
+                canGoNext = false,
+                pendingRequest = SearchPendingRequest(
+                    kind = SearchPendingRequestKind.Search,
+                    targetPage = 1
+                )
+            )
+        )
+
+        assertTrue(lockState.filterControlsLocked)
+        assertTrue(lockState.searchSubmitLocked)
+        assertTrue(lockState.showSearchSpinner)
+        assertTrue(lockState.interactionLocked)
+    }
+}


### PR DESCRIPTION
## Summary
- add dedicated timeout settings for search-related OkHttp calls so stalled DNS or weak-network requests do not keep the search page locked forever
- apply the timeout-bounded client to asmr.one collected search and DLsite purchased search requests
- keep search chrome controls available in the error state and cover the lock-state behavior with a unit test

## Verification
- ./gradlew :app:compileDebugKotlin :app:compileDebugUnitTestKotlin