### PR TITLE
fix: 调整在线搜索栏清空行为

### DIFF
--- a/app/src/main/java/com/asmr/player/ui/common/SearchBar.kt
+++ b/app/src/main/java/com/asmr/player/ui/common/SearchBar.kt
@@ -264,6 +264,7 @@ fun CustomSearchBar(
 ) {
     val colorScheme = AsmrTheme.colorScheme
     val interactionSource = remember { MutableInteractionSource() }
+    val fieldClickInteractionSource = remember { MutableInteractionSource() }
     val popupTextToolbar = remember { SearchBarPopupTextToolbar() }
     val isDark = colorScheme.isDark
     val containerBaseColor = if (isDark) {
@@ -424,7 +425,11 @@ fun CustomSearchBar(
                     Box(
                         modifier = Modifier
                             .matchParentSize()
-                            .clickable(onClick = onFieldClick)
+                            .clickable(
+                                interactionSource = fieldClickInteractionSource,
+                                indication = null,
+                                onClick = onFieldClick
+                            )
                     )
                 }
             }

--- a/app/src/main/java/com/asmr/player/ui/search/SearchScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/search/SearchScreen.kt
@@ -359,6 +359,16 @@ fun SearchScreen(
         scrollResultsToTop()
     }
 
+    fun clearKeywordAndSearch() {
+        if (searchSubmitLocked) return
+        keyword = ""
+        keyboardController?.hide()
+        val accepted = viewModel.search("")
+        if (!accepted) return
+        scrollResultsToTop()
+        chromeState.expand()
+    }
+
     fun currentSearchAssistRequest(): SearchAssistSearchRequest {
         return SearchAssistSearchRequest(
             keyword = keyword,
@@ -875,6 +885,7 @@ fun SearchScreen(
                         collapseFraction = chromeState.collapseFraction,
                         onMeasured = { size: IntSize -> chromeState.updateHeight(size.height.toFloat()) },
                         onSearchSubmit = { submitSearch() },
+                        onClearKeyword = { clearKeywordAndSearch() },
                         onFilterSelected = { option ->
                             val nextOrder = option.sortOption ?: selectedOrder
                             val nextKeyword = keyword.trim()
@@ -1108,6 +1119,7 @@ internal fun SearchChrome(
     inputFocusRequester: FocusRequester? = null,
     onMeasured: (IntSize) -> Unit,
     onSearchSubmit: () -> Unit,
+    onClearKeyword: (() -> Unit)? = null,
     onFilterSelected: (SearchFilterOption) -> Unit,
     onLocaleSelected: (String) -> Unit,
     onCollectedSortSelected: (SearchCollectedSortOption) -> Unit = {},
@@ -1141,6 +1153,7 @@ internal fun SearchChrome(
             submitButtonTestTag = submitButtonTestTag,
             inputFocusRequester = inputFocusRequester,
             onSearchSubmit = onSearchSubmit,
+            onClearKeyword = onClearKeyword,
             onFilterSelected = onFilterSelected,
             onLocaleSelected = onLocaleSelected,
             onCollectedSortSelected = onCollectedSortSelected,
@@ -1178,6 +1191,7 @@ internal fun SearchToolbar(
     submitButtonTestTag: String = SEARCH_SUBMIT_BUTTON_TAG,
     inputFocusRequester: FocusRequester? = null,
     onSearchSubmit: () -> Unit,
+    onClearKeyword: (() -> Unit)? = null,
     onFilterSelected: (SearchFilterOption) -> Unit,
     onLocaleSelected: (String) -> Unit,
     onCollectedSortSelected: (SearchCollectedSortOption) -> Unit = {},
@@ -1292,7 +1306,7 @@ internal fun SearchToolbar(
                 ) {
                     if (keyword.isNotBlank()) {
                         IconButton(
-                            onClick = { onKeywordChange("") },
+                            onClick = { onClearKeyword?.invoke() ?: onKeywordChange("") },
                             enabled = !searchSubmitLocked,
                             modifier = Modifier
                                 .size(28.dp)

--- a/app/src/test/java/com/asmr/player/ui/search/SearchScreenChromeTest.kt
+++ b/app/src/test/java/com/asmr/player/ui/search/SearchScreenChromeTest.kt
@@ -373,6 +373,47 @@ class SearchScreenChromeTest {
     }
 
     @Test
+    fun clearButton_runsCustomClearActionWhenProvided() {
+        var clearSearchCount by mutableIntStateOf(0)
+        var valueChangeCount by mutableIntStateOf(0)
+        var latestKeyword = "RJ123456"
+
+        composeRule.setContent {
+            var keyword by remember { mutableStateOf("RJ123456") }
+            latestKeyword = keyword
+
+            AsmrPlayerTheme {
+                SearchToolbar(
+                    keyword = keyword,
+                    onKeywordChange = {
+                        valueChangeCount += 1
+                        keyword = it
+                    },
+                    selectedFilter = SearchFilterOption.Trend,
+                    selectedLocale = "ja_JP",
+                    filterControlsLocked = false,
+                    searchSubmitLocked = false,
+                    showSearchSpinner = false,
+                    onSearchSubmit = {},
+                    onClearKeyword = {
+                        keyword = ""
+                        clearSearchCount += 1
+                    },
+                    onFilterSelected = {},
+                    onLocaleSelected = {}
+                )
+            }
+        }
+
+        composeRule.onNodeWithTag(SEARCH_CLEAR_BUTTON_TAG).performClick()
+        composeRule.runOnIdle {
+            assertEquals("", latestKeyword)
+            assertEquals(1, clearSearchCount)
+            assertEquals(0, valueChangeCount)
+        }
+    }
+
+    @Test
     fun searchChrome_collapsesAndExpandsWhileKeepingControlsMounted() {
         composeRule.mainClock.autoAdvance = false
         lateinit var chromeState: CollapsibleHeaderState


### PR DESCRIPTION
## 简要说明
- 去掉一级在线搜索栏进入二级搜索页时的点击反馈
- 一级搜索栏点击清空后触发一次空搜索
- 二级搜索页内清空仍只清空输入，不触发搜索

## 验证
- git diff --check
- ./gradlew.bat :app:compileDebugKotlin :app:compileDebugUnitTestKotlin