### PR TITLE
优化专辑详情首屏体验

### DIFF
--- a/app/src/main/java/com/asmr/player/cache/CacheKeyFactory.kt
+++ b/app/src/main/java/com/asmr/player/cache/CacheKeyFactory.kt
@@ -20,6 +20,20 @@ object CacheKeyFactory {
         return md5("$version|$dark|$w|$h|$data")
     }
 
+    /**
+     * 与 [createKey] 相同的归一化逻辑，但忽略尺寸维度。
+     * 用于按“同一张图片数据”跨尺寸检索已缓存的任意位图（即时占位复用）。
+     */
+    fun createDataKey(
+        context: Context,
+        model: Any,
+        version: String
+    ): String {
+        val data = normalizeModel(model)
+        val dark = isDarkMode(context)
+        return md5("$version|$dark|$data")
+    }
+
     private fun normalizeModel(model: Any): String {
         return when (model) {
             is CacheImageModel -> "model:${model.keyTag}|${normalizeModelData(model.data)}"

--- a/app/src/main/java/com/asmr/player/cache/ImageCacheManager.kt
+++ b/app/src/main/java/com/asmr/player/cache/ImageCacheManager.kt
@@ -46,6 +46,26 @@ class ImageCacheManager(
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
     private val inFlight = ConcurrentHashMap<String, Deferred<Result<ImageBitmap>>>()
 
+    // 数据键(忽略尺寸) -> 最近一次写入内存的完整缓存键。
+    // 用于跨尺寸即时复用同一张图片：列表已加载的小图可作为详情大图的瞬时占位。
+    private val dataKeyToLatestFullKey = ConcurrentHashMap<String, String>()
+
+    private fun putMemory(fullKey: String, dataKey: String, bmp: Bitmap) {
+        memoryCache.put(fullKey, bmp)
+        dataKeyToLatestFullKey[dataKey] = fullKey
+    }
+
+    /**
+     * 同步、仅内存：按图片数据(忽略尺寸)检索任意一张已缓存的位图。
+     * 命中则可立即作为占位显示，避免详情页等待网络重新请求同一张封面。
+     * 未命中返回 null。
+     */
+    fun peekAnySize(model: Any): ImageBitmap? {
+        val dataKey = CacheKeyFactory.createDataKey(appContext, model, config.cacheVersion)
+        val fullKey = dataKeyToLatestFullKey[dataKey] ?: return null
+        return memoryCache.get(fullKey)?.asImageBitmap()
+    }
+
     suspend fun loadImage(
         model: Any,
         size: IntSize?,
@@ -54,12 +74,14 @@ class ImageCacheManager(
         Trace.beginSection("img.load")
         try {
         val key = CacheKeyFactory.createKey(appContext, model, size, config.cacheVersion)
+        val dataKey = CacheKeyFactory.createDataKey(appContext, model, config.cacheVersion)
 
         if (cachePolicy.readMemory) {
             Trace.beginSection("img.mem")
             val cached = memoryCache.get(key)
             if (cached != null) {
                 stats.onMemoryHit()
+                dataKeyToLatestFullKey[dataKey] = key
                 Trace.endSection()
                 return cached.asImageBitmap()
             }
@@ -75,7 +97,7 @@ class ImageCacheManager(
                 Trace.beginSection("img.decodeDisk")
                 val bmp = decodeBytes(entry.bytes)
                 Trace.endSection()
-                if (cachePolicy.writeMemory) memoryCache.put(key, bmp)
+                if (cachePolicy.writeMemory) putMemory(key, dataKey, bmp)
                 Trace.endSection()
                 return bmp.asImageBitmap()
             }
@@ -109,7 +131,7 @@ class ImageCacheManager(
                     )
                 }
                 if (cachePolicy.writeMemory) {
-                    memoryCache.put(key, bmp)
+                    putMemory(key, dataKey, bmp)
                 }
                 bmp.asImageBitmap()
             }.also {
@@ -133,11 +155,13 @@ class ImageCacheManager(
         cachePolicy: CachePolicy = CachePolicy.DEFAULT
     ): ImageBitmap? {
         val key = CacheKeyFactory.createKey(appContext, model, size, config.cacheVersion)
+        val dataKey = CacheKeyFactory.createDataKey(appContext, model, config.cacheVersion)
 
         if (cachePolicy.readMemory) {
             val cached = memoryCache.get(key)
             if (cached != null) {
                 stats.onMemoryHit()
+                dataKeyToLatestFullKey[dataKey] = key
                 return cached.asImageBitmap()
             }
             stats.onMemoryMiss()
@@ -148,7 +172,7 @@ class ImageCacheManager(
             if (entry != null) {
                 stats.onDiskHit()
                 val bmp = decodeBytes(entry.bytes)
-                if (cachePolicy.writeMemory) memoryCache.put(key, bmp)
+                if (cachePolicy.writeMemory) putMemory(key, dataKey, bmp)
                 return bmp.asImageBitmap()
             }
             stats.onDiskMiss()

--- a/app/src/main/java/com/asmr/player/main/MainContainer.kt
+++ b/app/src/main/java/com/asmr/player/main/MainContainer.kt
@@ -42,6 +42,7 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.saveable.rememberSaveableStateHolder
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.graphics.compositeOver
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.BiasAlignment
@@ -234,6 +235,7 @@ internal data class BatchPlaylistPickerRequest(
 private const val SecondaryPageEnterDurationMs = 440
 private const val SecondaryPageExitDurationMs = 420
 private val SecondaryPageSlideEasing = CubicBezierEasing(0.215f, 0.61f, 0.355f, 1f)
+private val AlbumDetailTopBarButtonShape = CircleShape
 
 private fun NavBackStackEntry.usesSecondaryPageSlideTransition(): Boolean {
     return resolveCurrentPrimaryDestinationRoute(
@@ -260,6 +262,20 @@ private fun secondaryPagePopExitTransition(): ExitTransition {
         ),
         targetOffsetX = { fullWidth -> fullWidth }
     )
+}
+
+private fun Modifier.albumDetailTopBarButtonSurface(
+    enabled: Boolean,
+    shape: Shape = AlbumDetailTopBarButtonShape
+): Modifier {
+    return if (!enabled) {
+        this
+    } else {
+        this
+            .clip(shape)
+            .background(Color.Black.copy(alpha = 0.42f))
+            .border(0.5.dp, Color.White.copy(alpha = 0.24f), shape)
+    }
 }
 
 @Composable
@@ -779,7 +795,8 @@ fun MainContainer(
     val colorScheme = AsmrTheme.colorScheme
     val materialColorScheme = MaterialTheme.colorScheme
     val dynamicContainerColor = dynamicPageContainerColor(colorScheme)
-    val topBarContentColor = colorScheme.onSurface
+    val isAlbumDetailRoute = currentRoute?.startsWith("album_detail") == true
+    val topBarContentColor = if (isAlbumDetailRoute) Color.White else colorScheme.onSurface
     val drawerContainerColor = if (colorScheme.isDark) Color(0xFF121212) else Color.White
 
     val defaultSystemUi = remember(activity) {
@@ -1071,9 +1088,13 @@ fun MainContainer(
         val currentScreenIsPrimary = currentPrimaryRoute != null
         val showBackButton = !currentScreenIsPrimary
         val showPrimaryBrand = currentScreenIsPrimary
-        val topBarDividerColor = colorScheme.onSurface.copy(
-            alpha = if (colorScheme.isDark) 0.16f else 0.10f
-        )
+        val topBarDividerColor = if (isAlbumDetailRoute) {
+            Color.Transparent
+        } else {
+            colorScheme.onSurface.copy(
+                alpha = if (colorScheme.isDark) 0.16f else 0.10f
+            )
+        }
         val useLargeBottomChrome = windowSizeClass.widthSizeClass != WindowWidthSizeClass.Compact && !isPhone
         val bottomOverlayPadding = bottomChromeOverlayHeight(useLargeBottomChrome)
         CompositionLocalProvider(
@@ -1158,26 +1179,29 @@ fun MainContainer(
                                                 else -> appName
                                             }
                                             Box(modifier = Modifier.fillMaxHeight(), contentAlignment = Alignment.Center) {
-                                                AnimatedContent(
-                                                    targetState = titleText,
-                                                    transitionSpec = {
-                                                        (fadeIn(animationSpec = tween(220, easing = LinearOutSlowInEasing))
-                                                            + slideInHorizontally(animationSpec = tween(220, easing = LinearOutSlowInEasing)) { it / 4 })
-                                                            .togetherWith(
-                                                                fadeOut(animationSpec = tween(180, easing = FastOutLinearInEasing))
-                                                                    + slideOutHorizontally(animationSpec = tween(180, easing = FastOutLinearInEasing)) { -it / 4 }
-                                                            )
-                                                    },
-                                                    label = "headerTitle"
-                                                ) { targetText ->
-                                                    Text(
-                                                        targetText,
-                                                        style = if (compactTopBar) {
-                                                            MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.SemiBold)
-                                                        } else {
-                                                            MaterialTheme.typography.titleLarge.copy(fontWeight = FontWeight.Bold)
-                                                        }
-                                                    )
+                                                if (!isAlbumDetailRoute) {
+                                                    AnimatedContent(
+                                                        targetState = titleText,
+                                                        transitionSpec = {
+                                                            (fadeIn(animationSpec = tween(220, easing = LinearOutSlowInEasing))
+                                                                + slideInHorizontally(animationSpec = tween(220, easing = LinearOutSlowInEasing)) { it / 4 })
+                                                                .togetherWith(
+                                                                    fadeOut(animationSpec = tween(180, easing = FastOutLinearInEasing))
+                                                                        + slideOutHorizontally(animationSpec = tween(180, easing = FastOutLinearInEasing)) { -it / 4 }
+                                                                )
+                                                        },
+                                                        label = "headerTitle"
+                                                    ) { targetText ->
+                                                        Text(
+                                                            text = targetText,
+                                                            color = topBarContentColor,
+                                                            style = if (compactTopBar) {
+                                                                MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.SemiBold)
+                                                            } else {
+                                                                MaterialTheme.typography.titleLarge.copy(fontWeight = FontWeight.Bold)
+                                                            }
+                                                        )
+                                                    }
                                                 }
                                             }
                                         },
@@ -1190,7 +1214,13 @@ fun MainContainer(
                                         ),
                                         navigationIcon = {
                                             if (showBackButton && hasPreviousBackStackEntry) {
-                                                IconButton(onClick = { navController.popBackStack() }) {
+                                                IconButton(
+                                                    onClick = { navController.popBackStack() },
+                                                    modifier = Modifier
+                                                        .padding(start = if (isAlbumDetailRoute) 4.dp else 0.dp)
+                                                        .size(if (isAlbumDetailRoute) 40.dp else 48.dp)
+                                                        .albumDetailTopBarButtonSurface(isAlbumDetailRoute)
+                                                ) {
                                                     Icon(Icons.AutoMirrored.Rounded.ArrowBack, contentDescription = null)
                                                 }
                                             } else if (showPrimaryBrand) {
@@ -1356,7 +1386,11 @@ fun MainContainer(
                                                             }.orEmpty()
                                                             manualRjInput = currentRj
                                                             showManualRjDialog = true
-                                                        }
+                                                        },
+                                                        modifier = Modifier
+                                                            .padding(end = 8.dp)
+                                                            .size(40.dp)
+                                                            .albumDetailTopBarButtonSurface(true)
                                                     ) {
                                                         Icon(Icons.Rounded.Edit, contentDescription = "手动输入RJ号")
                                                     }
@@ -1387,13 +1421,15 @@ fun MainContainer(
                         Box(
                             modifier = Modifier
                                 .fillMaxSize()
-                                .padding(top = padding.calculateTopPadding())
                         ) {
+                            val topContentPadding = padding.calculateTopPadding()
                             val hasOverlayRoute = currentPrimaryRoute == null
                             primaryContentStateHolder.SaveableStateProvider("primary_pager") {
                                 HorizontalPager(
                                     state = primaryPagerState,
-                                    modifier = Modifier.fillMaxSize(),
+                                    modifier = Modifier
+                                        .fillMaxSize()
+                                        .padding(top = topContentPadding),
                                     userScrollEnabled = !primaryPagerScrollLocked && !hasOverlayRoute,
                                     key = { primaryPagerRoutes[it] }
                                 ) { page ->
@@ -1546,7 +1582,9 @@ fun MainContainer(
                                         ExitTransition.None
                                     }
                                 },
-                                modifier = Modifier.fillMaxSize()
+                                modifier = Modifier
+                                    .fillMaxSize()
+                                    .padding(top = if (isAlbumDetailRoute) 0.dp else topContentPadding)
                             ) {
 
                 composable("library") {
@@ -1691,43 +1729,41 @@ fun MainContainer(
                 ) { backStackEntry ->
                     val rj = backStackEntry.arguments?.getString("rj").orEmpty()
                     val refreshToken by backStackEntry.savedStateHandle.getStateFlow("refreshToken", 0L).collectAsState()
-                    SecondaryPageBackground {
-                        AlbumDetailScreen(
-                            windowSizeClass = windowSizeClass,
-                            rjCode = rj,
-                            initialTab = backStackEntry.arguments?.getString("initialTab").toAlbumDetailInitialTab(),
-                            refreshToken = refreshToken,
-                            onConsumeRefreshToken = { backStackEntry.savedStateHandle["refreshToken"] = 0L },
-                            onPlayTracks = { album, tracks, startTrack ->
-                                scope.launch {
-                                    if (playerViewModel.playTracksPrepared(album, tracks, startTrack)) {
-                                        openNowPlaying()
-                                    }
+                    AlbumDetailScreen(
+                        windowSizeClass = windowSizeClass,
+                        rjCode = rj,
+                        initialTab = backStackEntry.arguments?.getString("initialTab").toAlbumDetailInitialTab(),
+                        refreshToken = refreshToken,
+                        onConsumeRefreshToken = { backStackEntry.savedStateHandle["refreshToken"] = 0L },
+                        onPlayTracks = { album, tracks, startTrack ->
+                            scope.launch {
+                                if (playerViewModel.playTracksPrepared(album, tracks, startTrack)) {
+                                    openNowPlaying()
                                 }
-                            },
-                            onPlayMediaItems = { items, startIndex ->
-                                playerViewModel.playMediaItems(items, startIndex)
-                                openNowPlaying()
-                            },
-                            onAddToQueue = { album, track ->
-                                playerViewModel.addTrackToQueue(album, track)
-                            },
-                            onAddMediaItemsToQueue = { items ->
-                                playerViewModel.addMediaItemsToQueue(items)
-                            },
-                            onAddMediaItemsToFavorites = { items ->
-                                playlistsViewModel.addItemsToFavoritesInBackground(items)
-                            },
-                            onOpenPlaylistPicker = { item ->
-                                albumBatchPlaylistPickerRequest = BatchPlaylistPickerRequest(listOf(item))
-                            },
-                            onOpenGroupPicker = { targetAlbumId ->
-                                navController.navigateSingleTop("group_picker?albumId=$targetAlbumId")
-                            },
-                            onOpenDlsiteLogin = { navController.navigateSingleTop("dlsite_login") },
-                            onOpenAlbumByRj = { navigator.openAlbumDetailByRjStacked(it) }
-                        )
-                    }
+                            }
+                        },
+                        onPlayMediaItems = { items, startIndex ->
+                            playerViewModel.playMediaItems(items, startIndex)
+                            openNowPlaying()
+                        },
+                        onAddToQueue = { album, track ->
+                            playerViewModel.addTrackToQueue(album, track)
+                        },
+                        onAddMediaItemsToQueue = { items ->
+                            playerViewModel.addMediaItemsToQueue(items)
+                        },
+                        onAddMediaItemsToFavorites = { items ->
+                            playlistsViewModel.addItemsToFavoritesInBackground(items)
+                        },
+                        onOpenPlaylistPicker = { item ->
+                            albumBatchPlaylistPickerRequest = BatchPlaylistPickerRequest(listOf(item))
+                        },
+                        onOpenGroupPicker = { targetAlbumId ->
+                            navController.navigateSingleTop("group_picker?albumId=$targetAlbumId")
+                        },
+                        onOpenDlsiteLogin = { navController.navigateSingleTop("dlsite_login") },
+                        onOpenAlbumByRj = { navigator.openAlbumDetailByRjStacked(it) }
+                    )
                 }
                 composable(
                     route = Routes.AlbumDetailByIdPattern,
@@ -1740,44 +1776,42 @@ fun MainContainer(
                     val albumId = backStackEntry.arguments?.getLong("albumId") ?: 0L
                     val rjCode = backStackEntry.arguments?.getString("rjCode")
                     val refreshToken by backStackEntry.savedStateHandle.getStateFlow("refreshToken", 0L).collectAsState()
-                    SecondaryPageBackground {
-                        AlbumDetailScreen(
-                            windowSizeClass = windowSizeClass,
-                            albumId = albumId,
-                            rjCode = rjCode,
-                            initialTab = backStackEntry.arguments?.getString("initialTab").toAlbumDetailInitialTab(),
-                            refreshToken = refreshToken,
-                            onConsumeRefreshToken = { backStackEntry.savedStateHandle["refreshToken"] = 0L },
-                            onPlayTracks = { album, tracks, startTrack ->
-                                scope.launch {
-                                    if (playerViewModel.playTracksPrepared(album, tracks, startTrack)) {
-                                        openNowPlaying()
-                                    }
+                    AlbumDetailScreen(
+                        windowSizeClass = windowSizeClass,
+                        albumId = albumId,
+                        rjCode = rjCode,
+                        initialTab = backStackEntry.arguments?.getString("initialTab").toAlbumDetailInitialTab(),
+                        refreshToken = refreshToken,
+                        onConsumeRefreshToken = { backStackEntry.savedStateHandle["refreshToken"] = 0L },
+                        onPlayTracks = { album, tracks, startTrack ->
+                            scope.launch {
+                                if (playerViewModel.playTracksPrepared(album, tracks, startTrack)) {
+                                    openNowPlaying()
                                 }
-                            },
-                            onPlayMediaItems = { items, startIndex ->
-                                playerViewModel.playMediaItems(items, startIndex)
-                                openNowPlaying()
-                            },
-                            onAddToQueue = { album, track ->
-                                playerViewModel.addTrackToQueue(album, track)
-                            },
-                            onAddMediaItemsToQueue = { items ->
-                                playerViewModel.addMediaItemsToQueue(items)
-                            },
-                            onAddMediaItemsToFavorites = { items ->
-                                playlistsViewModel.addItemsToFavoritesInBackground(items)
-                            },
-                            onOpenPlaylistPicker = { item ->
-                                albumBatchPlaylistPickerRequest = BatchPlaylistPickerRequest(listOf(item))
-                            },
-                            onOpenGroupPicker = { targetAlbumId ->
-                                navController.navigateSingleTop("group_picker?albumId=$targetAlbumId")
-                            },
-                            onOpenDlsiteLogin = { navController.navigateSingleTop("dlsite_login") },
-                            onOpenAlbumByRj = { navigator.openAlbumDetailByRjStacked(it) }
-                        )
-                    }
+                            }
+                        },
+                        onPlayMediaItems = { items, startIndex ->
+                            playerViewModel.playMediaItems(items, startIndex)
+                            openNowPlaying()
+                        },
+                        onAddToQueue = { album, track ->
+                            playerViewModel.addTrackToQueue(album, track)
+                        },
+                        onAddMediaItemsToQueue = { items ->
+                            playerViewModel.addMediaItemsToQueue(items)
+                        },
+                        onAddMediaItemsToFavorites = { items ->
+                            playlistsViewModel.addItemsToFavoritesInBackground(items)
+                        },
+                        onOpenPlaylistPicker = { item ->
+                            albumBatchPlaylistPickerRequest = BatchPlaylistPickerRequest(listOf(item))
+                        },
+                        onOpenGroupPicker = { targetAlbumId ->
+                            navController.navigateSingleTop("group_picker?albumId=$targetAlbumId")
+                        },
+                        onOpenDlsiteLogin = { navController.navigateSingleTop("dlsite_login") },
+                        onOpenAlbumByRj = { navigator.openAlbumDetailByRjStacked(it) }
+                    )
                 }
                 composable(
                     route = "album_detail_online/{rj}",
@@ -1785,36 +1819,34 @@ fun MainContainer(
                 ) { backStackEntry ->
                     val rj = backStackEntry.arguments?.getString("rj").orEmpty()
                     val refreshToken by backStackEntry.savedStateHandle.getStateFlow("refreshToken", 0L).collectAsState()
-                    SecondaryPageBackground {
-                        AlbumDetailScreen(
-                            windowSizeClass = windowSizeClass,
-                            rjCode = rj,
-                            refreshToken = refreshToken,
-                            onConsumeRefreshToken = { backStackEntry.savedStateHandle["refreshToken"] = 0L },
-                            onPlayTracks = { album, tracks, startTrack ->
-                                scope.launch {
-                                    if (playerViewModel.playTracksPrepared(album, tracks, startTrack)) {
-                                        openNowPlaying()
-                                    }
+                    AlbumDetailScreen(
+                        windowSizeClass = windowSizeClass,
+                        rjCode = rj,
+                        refreshToken = refreshToken,
+                        onConsumeRefreshToken = { backStackEntry.savedStateHandle["refreshToken"] = 0L },
+                        onPlayTracks = { album, tracks, startTrack ->
+                            scope.launch {
+                                if (playerViewModel.playTracksPrepared(album, tracks, startTrack)) {
+                                    openNowPlaying()
                                 }
-                            },
-                            onPlayMediaItems = { items, startIndex ->
-                                playerViewModel.playMediaItems(items, startIndex)
-                                openNowPlaying()
-                            },
-                            onAddToQueue = { album, track ->
-                                playerViewModel.addTrackToQueue(album, track)
-                            },
-                            onOpenPlaylistPicker = { item ->
-                                albumBatchPlaylistPickerRequest = BatchPlaylistPickerRequest(listOf(item))
-                            },
-                            onOpenGroupPicker = { albumId ->
-                                navController.navigateSingleTop("group_picker?albumId=$albumId")
-                            },
-                            onOpenDlsiteLogin = { navController.navigateSingleTop("dlsite_login") },
-                            onOpenAlbumByRj = { navigator.openAlbumDetailByRjStacked(it) }
-                        )
-                    }
+                            }
+                        },
+                        onPlayMediaItems = { items, startIndex ->
+                            playerViewModel.playMediaItems(items, startIndex)
+                            openNowPlaying()
+                        },
+                        onAddToQueue = { album, track ->
+                            playerViewModel.addTrackToQueue(album, track)
+                        },
+                        onOpenPlaylistPicker = { item ->
+                            albumBatchPlaylistPickerRequest = BatchPlaylistPickerRequest(listOf(item))
+                        },
+                        onOpenGroupPicker = { albumId ->
+                            navController.navigateSingleTop("group_picker?albumId=$albumId")
+                        },
+                        onOpenDlsiteLogin = { navController.navigateSingleTop("dlsite_login") },
+                        onOpenAlbumByRj = { navigator.openAlbumDetailByRjStacked(it) }
+                    )
                 }
                 composable(
                     route = "album_detail_online/{source}/{workId}",

--- a/app/src/main/java/com/asmr/player/main/MainContainer.kt
+++ b/app/src/main/java/com/asmr/player/main/MainContainer.kt
@@ -1500,7 +1500,13 @@ fun MainContainer(
                                                 windowSizeClass = windowSizeClass,
                                                 scrollToTopSignal = libraryScrollToTopSignal,
                                                 onAlbumClick = { album ->
-                                                    AlbumCoverHintStore.record(album.id, album.rjCode.ifBlank { album.workId }, album.coverUrl)
+                                                    AlbumCoverHintStore.record(
+                                                        albumId = album.id,
+                                                        rjCode = album.rjCode.ifBlank { album.workId },
+                                                        title = album.title,
+                                                        circle = album.circle,
+                                                        coverUrl = album.coverUrl
+                                                    )
                                                     navigator.openAlbumDetail(
                                                         albumId = album.id,
                                                         rj = null
@@ -1542,7 +1548,13 @@ fun MainContainer(
                                                     navController.navigateSingleTop(Routes.searchAssist(request.keyword))
                                                 },
                                                 onAlbumClick = { album, fromPurchasedOnly ->
-                                                    AlbumCoverHintStore.record(album.id, album.rjCode.ifBlank { album.workId }, album.coverUrl)
+                                                    AlbumCoverHintStore.record(
+                                                        albumId = album.id,
+                                                        rjCode = album.rjCode.ifBlank { album.workId },
+                                                        title = album.title,
+                                                        circle = album.circle,
+                                                        coverUrl = album.coverUrl
+                                                    )
                                                     openAlbumDetailFromSearch(
                                                         albumId = album.id,
                                                         rj = album.rjCode.ifBlank { album.workId },
@@ -1558,7 +1570,13 @@ fun MainContainer(
                                                 windowSizeClass = windowSizeClass,
                                                 scrollToTopSignal = hotListeningScrollToTopSignal,
                                                 onAlbumClick = { album ->
-                                                    AlbumCoverHintStore.record(album.id, album.rjCode.ifBlank { album.workId }, album.coverUrl)
+                                                    AlbumCoverHintStore.record(
+                                                        albumId = album.id,
+                                                        rjCode = album.rjCode.ifBlank { album.workId },
+                                                        title = album.title,
+                                                        circle = album.circle,
+                                                        coverUrl = album.coverUrl
+                                                    )
                                                     navigator.openAlbumDetailByRj(album.rjCode.ifBlank { album.workId })
                                                 },
                                                 viewModel = hotListeningViewModel

--- a/app/src/main/java/com/asmr/player/main/MainContainer.kt
+++ b/app/src/main/java/com/asmr/player/main/MainContainer.kt
@@ -139,6 +139,7 @@ import java.net.URLEncoder
 import androidx.compose.material.icons.automirrored.rounded.ArrowBack
 
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
@@ -273,9 +274,47 @@ private fun Modifier.albumDetailTopBarButtonSurface(
         this
     } else {
         this
-            .clip(shape)
-            .background(Color.Black.copy(alpha = 0.42f))
+            .background(Color.Black.copy(alpha = 0.42f), shape)
             .border(0.5.dp, Color.White.copy(alpha = 0.24f), shape)
+            .clip(shape)
+    }
+}
+
+@Composable
+private fun Modifier.albumDetailTopBarButtonMotion(
+    enabled: Boolean,
+    motionKey: Any?
+): Modifier {
+    if (!enabled) return this
+
+    var entered by remember(motionKey) { mutableStateOf(false) }
+    LaunchedEffect(motionKey) {
+        entered = false
+        withFrameNanos { }
+        entered = true
+    }
+    val offsetX by animateDpAsState(
+        targetValue = if (entered) 0.dp else 30.dp,
+        animationSpec = tween(
+            durationMillis = SecondaryPageEnterDurationMs,
+            easing = SecondaryPageSlideEasing
+        ),
+        label = "albumDetailTopBarButtonOffset"
+    )
+    val alpha by animateFloatAsState(
+        targetValue = if (entered) 1f else 0f,
+        animationSpec = tween(
+            durationMillis = 260,
+            delayMillis = 70,
+            easing = LinearOutSlowInEasing
+        ),
+        label = "albumDetailTopBarButtonAlpha"
+    )
+    val density = LocalDensity.current
+    return this.graphicsLayer {
+        translationX = with(density) { offsetX.toPx() }
+        this.alpha = alpha
+        clip = false
     }
 }
 
@@ -1140,9 +1179,14 @@ fun MainContainer(
                                             currentRoute == "downloads" ||
                                             currentRoute == "dlsite_login" ||
                                             currentRoute?.startsWith("album_detail") == true
+                                    val topBarHeight = when {
+                                        isAlbumDetailRoute -> 56.dp
+                                        compactTopBar -> 48.dp
+                                        else -> 64.dp
+                                    }
                                     Spacer(modifier = Modifier.windowInsetsTopHeight(StableWindowInsets.statusBars))
                                     CenterAlignedTopAppBar(
-                                        modifier = Modifier.height(if (compactTopBar) 48.dp else 64.dp),
+                                        modifier = Modifier.height(topBarHeight),
                                         title = {
                                             val entry = navBackStackEntry
                                             val resolvedTitleRoute = if (currentScreenIsPrimary) visualPrimaryRoute else currentRoute
@@ -1223,6 +1267,7 @@ fun MainContainer(
                                                         .padding(start = if (isAlbumDetailRoute) 4.dp else 0.dp)
                                                         .size(if (isAlbumDetailRoute) 40.dp else 48.dp)
                                                         .albumDetailTopBarButtonSurface(isAlbumDetailRoute)
+                                                        .albumDetailTopBarButtonMotion(isAlbumDetailRoute, navBackStackEntry)
                                                 ) {
                                                     Icon(Icons.AutoMirrored.Rounded.ArrowBack, contentDescription = null)
                                                 }
@@ -1394,6 +1439,7 @@ fun MainContainer(
                                                             .padding(end = 8.dp)
                                                             .size(40.dp)
                                                             .albumDetailTopBarButtonSurface(true)
+                                                            .albumDetailTopBarButtonMotion(true, navBackStackEntry)
                                                     ) {
                                                         Icon(Icons.Rounded.Edit, contentDescription = "手动输入RJ号")
                                                     }

--- a/app/src/main/java/com/asmr/player/main/MainContainer.kt
+++ b/app/src/main/java/com/asmr/player/main/MainContainer.kt
@@ -1266,8 +1266,8 @@ fun MainContainer(
                                                     modifier = Modifier
                                                         .padding(start = if (isAlbumDetailRoute) 4.dp else 0.dp)
                                                         .size(if (isAlbumDetailRoute) 40.dp else 48.dp)
-                                                        .albumDetailTopBarButtonSurface(isAlbumDetailRoute)
                                                         .albumDetailTopBarButtonMotion(isAlbumDetailRoute, navBackStackEntry)
+                                                        .albumDetailTopBarButtonSurface(isAlbumDetailRoute)
                                                 ) {
                                                     Icon(Icons.AutoMirrored.Rounded.ArrowBack, contentDescription = null)
                                                 }
@@ -1438,8 +1438,8 @@ fun MainContainer(
                                                         modifier = Modifier
                                                             .padding(end = 8.dp)
                                                             .size(40.dp)
-                                                            .albumDetailTopBarButtonSurface(true)
                                                             .albumDetailTopBarButtonMotion(true, navBackStackEntry)
+                                                            .albumDetailTopBarButtonSurface(true)
                                                     ) {
                                                         Icon(Icons.Rounded.Edit, contentDescription = "手动输入RJ号")
                                                     }

--- a/app/src/main/java/com/asmr/player/main/MainContainer.kt
+++ b/app/src/main/java/com/asmr/player/main/MainContainer.kt
@@ -50,6 +50,7 @@ import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.zIndex
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.platform.LocalFocusManager
@@ -281,6 +282,7 @@ private fun Modifier.albumDetailTopBarButtonSurface(
 @Composable
 private fun SecondaryPageBackground(
     modifier: Modifier = Modifier,
+    topPadding: Dp = 0.dp,
     content: @Composable () -> Unit
 ) {
     val colorScheme = AsmrTheme.colorScheme
@@ -296,6 +298,7 @@ private fun SecondaryPageBackground(
         modifier = modifier
             .fillMaxSize()
             .background(pageBackgroundColor)
+            .padding(top = topPadding)
     ) {
         content()
     }
@@ -1584,14 +1587,13 @@ fun MainContainer(
                                 },
                                 modifier = Modifier
                                     .fillMaxSize()
-                                    .padding(top = if (isAlbumDetailRoute) 0.dp else topContentPadding)
                             ) {
 
                 composable("library") {
                     Box(modifier = Modifier.fillMaxSize())
                 }
                                 composable("library_filter") {
-                    SecondaryPageBackground {
+                    SecondaryPageBackground(topPadding = topContentPadding) {
                         LibraryFilterScreen(
                             onClose = { navController.popBackStack() },
                             viewModel = libraryViewModel
@@ -1675,7 +1677,7 @@ fun MainContainer(
                     Box(modifier = Modifier.fillMaxSize())
                 }
                 composable(route = Routes.SearchAssist) {
-                    SecondaryPageBackground {
+                    SecondaryPageBackground(topPadding = topContentPadding) {
                         SearchAssistScreen(
                             windowSizeClass = windowSizeClass,
                             initialRequest = searchAssistInitialRequest,
@@ -1705,7 +1707,7 @@ fun MainContainer(
                         searchAssistInitialRequest.copy(keyword = initialKeyword)
                     }
 
-                    SecondaryPageBackground {
+                    SecondaryPageBackground(topPadding = topContentPadding) {
                         SearchAssistScreen(
                             windowSizeClass = windowSizeClass,
                             initialRequest = initialRequest,
@@ -1882,7 +1884,7 @@ fun MainContainer(
                 ) { backStackEntry ->
                     val groupId = backStackEntry.arguments?.getLong("groupId") ?: 0L
                     val groupName = decodeRouteArg(backStackEntry.arguments?.getString("groupName").orEmpty())
-                    SecondaryPageBackground {
+                    SecondaryPageBackground(topPadding = topContentPadding) {
                         com.asmr.player.ui.groups.AlbumGroupDetailScreen(
                             windowSizeClass = windowSizeClass,
                             groupId = groupId,
@@ -1901,7 +1903,7 @@ fun MainContainer(
                     )
                 ) { backStackEntry ->
                     val albumId = backStackEntry.arguments?.getLong("albumId") ?: 0L
-                    SecondaryPageBackground {
+                    SecondaryPageBackground(topPadding = topContentPadding) {
                         com.asmr.player.ui.groups.AlbumGroupPickerScreen(
                             windowSizeClass = windowSizeClass,
                             albumId = albumId,
@@ -1919,7 +1921,7 @@ fun MainContainer(
                 ) { backStackEntry ->
                     val playlistId = backStackEntry.arguments?.getLong("playlistId") ?: 0L
                     val playlistName = decodeRouteArg(backStackEntry.arguments?.getString("playlistName").orEmpty())
-                    SecondaryPageBackground {
+                    SecondaryPageBackground(topPadding = topContentPadding) {
                         PlaylistDetailScreen(
                             windowSizeClass = windowSizeClass,
                             playlistId = playlistId,
@@ -1936,7 +1938,7 @@ fun MainContainer(
                     if (type == "favorites") {
                         Box(modifier = Modifier.fillMaxSize())
                     } else {
-                        SecondaryPageBackground {
+                        SecondaryPageBackground(topPadding = topContentPadding) {
                             SystemPlaylistScreen(
                                 windowSizeClass = windowSizeClass,
                                 onPlayAll = { items, startItem ->
@@ -1952,7 +1954,7 @@ fun MainContainer(
                     Box(modifier = Modifier.fillMaxSize())
                 }
                 composable("downloads") {
-                    SecondaryPageBackground {
+                    SecondaryPageBackground(topPadding = topContentPadding) {
                         DownloadsScreen(
                             windowSizeClass = windowSizeClass,
                             scrollToTopSignal = downloadsScrollToTopSignal,

--- a/app/src/main/java/com/asmr/player/main/MainContainer.kt
+++ b/app/src/main/java/com/asmr/player/main/MainContainer.kt
@@ -123,6 +123,7 @@ import com.asmr.player.ui.drawer.DrawerStatusViewModel
 import com.asmr.player.ui.drawer.StatisticsViewModel
 import com.asmr.player.ui.drawer.SiteStatus
 import com.asmr.player.ui.drawer.SiteStatusType
+import com.asmr.player.ui.nav.AlbumCoverHintStore
 import com.asmr.player.ui.nav.AppNavigator
 import com.asmr.player.ui.nav.BottomChrome
 import com.asmr.player.ui.nav.Routes
@@ -1473,12 +1474,21 @@ fun MainContainer(
                         ) {
                             val topContentPadding = padding.calculateTopPadding()
                             val hasOverlayRoute = currentPrimaryRoute == null
+                            // 详情页等 overlay 路由会把共享顶栏增高（48dp->56dp），导致 Scaffold top padding 变大。
+                            // 但底层 pager 始终只承载主路由（库/搜索/热门），转场期间仍可见——若跟随顶栏增高会整体下沉 8dp。
+                            // 因此 pager 专用 padding 在 overlay 激活时冻结为最近一次主路由的值，避免进入详情页时来源列表抖动下沉。
+                            // 注意：NavHost 内的 secondary 页面仍用 topContentPadding（真实值），不受此冻结影响。
+                            var lastPrimaryTopPadding by remember { mutableStateOf(topContentPadding) }
+                            if (!hasOverlayRoute) {
+                                lastPrimaryTopPadding = topContentPadding
+                            }
+                            val pagerTopContentPadding = if (hasOverlayRoute) lastPrimaryTopPadding else topContentPadding
                             primaryContentStateHolder.SaveableStateProvider("primary_pager") {
                                 HorizontalPager(
                                     state = primaryPagerState,
                                     modifier = Modifier
                                         .fillMaxSize()
-                                        .padding(top = topContentPadding),
+                                        .padding(top = pagerTopContentPadding),
                                     userScrollEnabled = !primaryPagerScrollLocked && !hasOverlayRoute,
                                     key = { primaryPagerRoutes[it] }
                                 ) { page ->
@@ -1490,6 +1500,7 @@ fun MainContainer(
                                                 windowSizeClass = windowSizeClass,
                                                 scrollToTopSignal = libraryScrollToTopSignal,
                                                 onAlbumClick = { album ->
+                                                    AlbumCoverHintStore.record(album.id, album.rjCode.ifBlank { album.workId }, album.coverUrl)
                                                     navigator.openAlbumDetail(
                                                         albumId = album.id,
                                                         rj = null
@@ -1531,6 +1542,7 @@ fun MainContainer(
                                                     navController.navigateSingleTop(Routes.searchAssist(request.keyword))
                                                 },
                                                 onAlbumClick = { album, fromPurchasedOnly ->
+                                                    AlbumCoverHintStore.record(album.id, album.rjCode.ifBlank { album.workId }, album.coverUrl)
                                                     openAlbumDetailFromSearch(
                                                         albumId = album.id,
                                                         rj = album.rjCode.ifBlank { album.workId },
@@ -1546,6 +1558,7 @@ fun MainContainer(
                                                 windowSizeClass = windowSizeClass,
                                                 scrollToTopSignal = hotListeningScrollToTopSignal,
                                                 onAlbumClick = { album ->
+                                                    AlbumCoverHintStore.record(album.id, album.rjCode.ifBlank { album.workId }, album.coverUrl)
                                                     navigator.openAlbumDetailByRj(album.rjCode.ifBlank { album.workId })
                                                 },
                                                 viewModel = hotListeningViewModel

--- a/app/src/main/java/com/asmr/player/ui/common/AlbumCarousel.kt
+++ b/app/src/main/java/com/asmr/player/ui/common/AlbumCarousel.kt
@@ -64,15 +64,17 @@ fun AlbumCarousel(
             elevation = CardDefaults.cardElevation(defaultElevation = 4.dp)
         ) {
             Box {
+                val coverData = album.coverThumbPath.takeIf { it.isNotBlank() && it.contains("_v2") }
+                    .orEmpty()
+                    .ifBlank { album.coverPath }
+                    .ifEmpty { album.coverUrl }
                 AsmrAsyncImage(
-                    model = album.coverThumbPath.takeIf { it.isNotBlank() && it.contains("_v2") }
-                        .orEmpty()
-                        .ifBlank { album.coverPath }
-                        .ifEmpty { album.coverUrl },
+                    model = coverData,
                     contentDescription = null,
                     modifier = Modifier.fillMaxSize(),
                     contentScale = ContentScale.Crop,
                     placeholderCornerRadius = 16,
+                    loadAtOriginalSize = coverData.startsWith("http", ignoreCase = true),
                 )
                 Surface(
                     modifier = Modifier

--- a/app/src/main/java/com/asmr/player/ui/common/AsmrAsyncImage.kt
+++ b/app/src/main/java/com/asmr/player/ui/common/AsmrAsyncImage.kt
@@ -50,6 +50,7 @@ fun AsmrAsyncImage(
     loadWhenSizeStableForMillis: Long = 0L,
     fadeIn: Boolean = true,
     fadeInMillis: Int = 500,
+    peekAnySizeForInitial: Boolean = false,
 ) {
     val normalizedModel = remember(model) { normalizeImageModel(model) }
     if (normalizedModel == null) {
@@ -62,11 +63,19 @@ fun AsmrAsyncImage(
         EntryPointAccessors.fromApplication(ctx, ImageCacheEntryPoint::class.java).imageCacheManager()
     }
     val measuredSize: MutableState<IntSize?> = remember { mutableStateOf(null) }
-    val painter: MutableState<Painter?> = remember(normalizedModel) { mutableStateOf(null) }
+    // 跨尺寸即时占位：若该图片已被列表等处加载过，先用任意尺寸的缓存位图立即显示，
+    // 同时仍按精确尺寸加载原图并在完成后无缝替换，避免详情大图等待网络重新请求。
+    val seededPainter = remember(normalizedModel) {
+        if (peekAnySizeForInitial) manager.peekAnySize(normalizedModel)?.let { BitmapPainter(it) } else null
+    }
+    val painter: MutableState<Painter?> = remember(normalizedModel) { mutableStateOf(seededPainter) }
+    val seededPlaceholder = remember(normalizedModel) { mutableStateOf(seededPainter != null) }
     val state: MutableState<AsmrAsyncImageState> =
-        remember(normalizedModel) { mutableStateOf(AsmrAsyncImageState.Loading) }
+        remember(normalizedModel) {
+            mutableStateOf(if (seededPainter != null) AsmrAsyncImageState.Success else AsmrAsyncImageState.Loading)
+        }
     val loadedSize: MutableState<IntSize?> = remember(normalizedModel) { mutableStateOf(null) }
-    val crossfade = remember(normalizedModel) { Animatable(0f) }
+    val crossfade = remember(normalizedModel) { Animatable(if (seededPainter != null) 1f else 0f) }
     val sizedModifier = modifier.onSizeChanged { sz ->
         if (sz.width > 0 && sz.height > 0) measuredSize.value = IntSize(sz.width, sz.height)
     }
@@ -82,7 +91,7 @@ fun AsmrAsyncImage(
         }
         try {
             val hasExistingPainter = painter.value != null
-            val shouldRetainPainter = retainPainterDuringReload && hasExistingPainter
+            val shouldRetainPainter = (retainPainterDuringReload || seededPlaceholder.value) && hasExistingPainter
             if (!shouldRetainPainter) {
                 state.value = AsmrAsyncImageState.Loading
                 painter.value = null
@@ -96,6 +105,7 @@ fun AsmrAsyncImage(
             } ?: throw IllegalStateException("Image load timeout")
             painter.value = BitmapPainter(img)
             loadedSize.value = sz
+            seededPlaceholder.value = false
             state.value = AsmrAsyncImageState.Success
             if (fadeIn && !shouldRetainPainter) {
                 crossfade.animateTo(1f, tween(durationMillis = fadeInMillis))

--- a/app/src/main/java/com/asmr/player/ui/common/AsmrAsyncImage.kt
+++ b/app/src/main/java/com/asmr/player/ui/common/AsmrAsyncImage.kt
@@ -51,6 +51,9 @@ fun AsmrAsyncImage(
     fadeIn: Boolean = true,
     fadeInMillis: Int = 500,
     peekAnySizeForInitial: Boolean = false,
+    // 按原尺寸加载（size=null）：缓存 key 与显示尺寸无关，让列表与详情大图共用同一缓存条目，
+    // 详情页进入即内存命中、不再二次网络请求、不再低分辨率占位闪烁。显示时由 ContentScale 缩放。
+    loadAtOriginalSize: Boolean = false,
 ) {
     val normalizedModel = remember(model) { normalizeImageModel(model) }
     if (normalizedModel == null) {
@@ -86,12 +89,17 @@ fun AsmrAsyncImage(
             delay(loadWhenSizeStableForMillis)
         }
         val sz = measuredSize.value ?: initialSize
+        // 原尺寸加载：load key 与显示尺寸无关，尺寸变化（如 hero 折叠）不应触发重载，
+        // 已加载的位图由 ContentScale 重新裁切即可。
+        if (loadAtOriginalSize && painter.value != null && loadedSize.value != null) {
+            return@LaunchedEffect
+        }
         if (retainPainterDuringReload && loadedSize.value == sz && painter.value != null) {
             return@LaunchedEffect
         }
         try {
             val hasExistingPainter = painter.value != null
-            val shouldRetainPainter = (retainPainterDuringReload || seededPlaceholder.value) && hasExistingPainter
+            val shouldRetainPainter = (retainPainterDuringReload || loadAtOriginalSize || seededPlaceholder.value) && hasExistingPainter
             if (!shouldRetainPainter) {
                 state.value = AsmrAsyncImageState.Loading
                 painter.value = null
@@ -101,7 +109,11 @@ fun AsmrAsyncImage(
                 crossfade.snapTo(1f)
             }
             val img = withTimeoutOrNull(15_000) {
-                manager.loadImage(model = normalizedModel, size = sz, cachePolicy = CachePolicy.DEFAULT)
+                manager.loadImage(
+                    model = normalizedModel,
+                    size = if (loadAtOriginalSize) null else sz,
+                    cachePolicy = CachePolicy.DEFAULT
+                )
             } ?: throw IllegalStateException("Image load timeout")
             painter.value = BitmapPainter(img)
             loadedSize.value = sz

--- a/app/src/main/java/com/asmr/player/ui/hotlistening/HotListeningScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/hotlistening/HotListeningScreen.kt
@@ -10,7 +10,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListState
-import androidx.compose.foundation.lazy.items as lazyItems
+import androidx.compose.foundation.lazy.itemsIndexed as lazyItemsIndexed
 import androidx.compose.foundation.lazy.staggeredgrid.LazyStaggeredGridState
 import androidx.compose.foundation.lazy.staggeredgrid.LazyVerticalStaggeredGrid
 import androidx.compose.foundation.lazy.staggeredgrid.StaggeredGridCells
@@ -64,6 +64,10 @@ private fun stableAlbumKey(album: Album): String {
     if (id.isNotEmpty()) return id
     val seed = "${album.coverUrl}|${album.title}|${album.circle}|${album.cv}"
     return "h${seed.hashCode().absoluteValue}"
+}
+
+private fun hotListeningItemKey(index: Int, album: Album): String {
+    return "hot-listening:${stableAlbumKey(album)}:$index"
 }
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -228,11 +232,11 @@ fun HotListeningScreen(
                         contentPadding = PaddingValues(bottom = 8.dp)
                             .withAddedBottomPadding(LocalBottomOverlayPadding.current)
                     ) {
-                        lazyItems(
+                        lazyItemsIndexed(
                             items = state.entries,
-                            key = { entry -> stableAlbumKey(entry.album) },
-                            contentType = { "album" }
-                        ) { entry ->
+                            key = { index, entry -> hotListeningItemKey(index, entry.album) },
+                            contentType = { _, _ -> "album" }
+                        ) { _, entry ->
                             val album = entry.album
                             AlbumItem(
                                 album = album,
@@ -264,7 +268,7 @@ fun HotListeningScreen(
                     ) {
                         items(
                             state.entries.size,
-                            key = { index -> stableAlbumKey(state.entries[index].album) },
+                            key = { index -> hotListeningItemKey(index, state.entries[index].album) },
                             contentType = { "albumGrid" }
                         ) { index ->
                             val entry = state.entries[index]

--- a/app/src/main/java/com/asmr/player/ui/library/AlbumDetailScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/AlbumDetailScreen.kt
@@ -48,11 +48,12 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.BlendMode
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.CompositingStrategy
 import androidx.compose.ui.graphics.compositeOver
 import androidx.compose.ui.graphics.lerp
 import androidx.compose.ui.graphics.vector.ImageVector
-import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.foundation.gestures.detectTransformGestures
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.pointer.pointerInput
@@ -117,10 +118,10 @@ import kotlinx.coroutines.launch
 
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.clipToBounds
+import androidx.compose.ui.draw.drawWithContent
 import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.zIndex
 import com.asmr.player.data.lyrics.deriveLyricsRelativePathNoExt
-import com.asmr.player.ui.common.rememberDominantColor
 import com.asmr.player.ui.common.SubtitleStamp
 import com.asmr.player.ui.common.DiscPlaceholder
 import com.asmr.player.ui.common.AsmrAsyncImage
@@ -165,9 +166,11 @@ internal data class PreparedMediaPlayback(
 
 private val AlbumDetailTabContentGap = 12.dp
 private val AlbumDetailTabCollapseOvershoot = 10.dp
+private val AlbumDetailScrolledContentFadeSpan = 56.dp
+private const val AlbumDetailHeroThemeGradientStartFraction = 0.38f
+private const val AlbumDetailHeroThemeGradientSolidFraction = 0.82f
 private const val AlbumDetailInitialIntroDurationMs = 1200L
 internal val AlbumDetailHorizontalPadding = 8.dp
-private val AlbumDetailHeaderCornerRadius = 10.dp
 
 private val DlsiteElasticResizeSpring = spring<IntSize>(
     dampingRatio = Spring.DampingRatioLowBouncy,
@@ -250,7 +253,7 @@ fun AlbumDetailScreen(
         modifier = Modifier
             .fillMaxSize()
             .background(AsmrTheme.colorScheme.background),
-        contentAlignment = Alignment.TopCenter // 浠呯敤浜庡钩鏉块€傞厤锛氬眳涓樉绀哄唴瀹?
+        contentAlignment = Alignment.TopCenter // 仅用于平板适配：居中显示内容
     ) {
         val isCompact = windowSizeClass.widthSizeClass == WindowWidthSizeClass.Compact
         
@@ -258,7 +261,7 @@ fun AlbumDetailScreen(
             modifier = if (isCompact) {
                 Modifier.fillMaxSize()
             } else {
-                // 浠呯敤浜庡钩鏉块€傞厤锛氶檺鍒跺唴瀹瑰尯鍩熸渶澶у搴﹀苟濉厖鍙敤绌洪棿
+                // 仅用于平板适配：限制内容区域最大宽度并填充可用空间
                 Modifier
                     .fillMaxHeight()
                     .widthIn(max = 800.dp)
@@ -325,7 +328,6 @@ fun AlbumDetailScreen(
                     } else {
                         56.dp
                     }
-                    val tabContentTopPadding = tabChromeVisibleHeight + AlbumDetailTabContentGap
                     val tabTitles = remember { listOf("本地", "DL", "DL Play") }
                     val tabPagerState = rememberPagerState(
                         initialPage = selectedTab,
@@ -355,26 +357,62 @@ fun AlbumDetailScreen(
                             }
                     }
     
-                    Column(modifier = Modifier.fillMaxSize()) {
+                    BoxWithConstraints(modifier = Modifier.fillMaxSize()) {
+                        val pageContainerColor = dynamicPageContainerColor(colorScheme)
+                        val heroHeightLimit = if (isCompact) {
+                            maxHeight * 0.62f
+                        } else {
+                            maxHeight * 0.64f
+                        }
+                        val heroMinHeight = if (isCompact) 280.dp else 360.dp
+                        val heroPreferredHeight = if (isCompact) {
+                            maxWidth
+                        } else {
+                            maxWidth * 0.88f
+                        }
+                        val heroHeight = heroPreferredHeight
+                            .coerceAtLeast(heroMinHeight)
+                            .coerceAtMost(heroHeightLimit.coerceAtLeast(heroMinHeight))
+                        val heroContentOverlap = (heroHeight * if (isCompact) 0.24f else 0.20f)
+                            .coerceIn(
+                                minimumValue = if (isCompact) 84.dp else 104.dp,
+                                maximumValue = if (isCompact) 120.dp else 152.dp
+                            )
+                        val tabChromeTop = (heroHeight - heroContentOverlap).coerceAtLeast(0.dp)
+                        val tabContentTopPadding = tabChromeTop + tabChromeVisibleHeight + AlbumDetailTabContentGap
+                        val contentFadeEndY = tabChromeTop
+                        val contentFadeStartY = (contentFadeEndY - AlbumDetailScrolledContentFadeSpan).coerceAtLeast(0.dp)
+
+                        fun headerAlbumForTab(tab: Int): Album {
+                            return if (tab == 0) (model.localAlbum ?: album) else album
+                        }
+
+                        fun shouldShowCoverLoading(tab: Int, headerAlbum: Album): Boolean {
+                            val headerHasCover = headerAlbum.coverPath.trim().isNotBlank() ||
+                                headerAlbum.coverUrl.trim().isNotBlank()
+                            return !headerHasCover && when (tab) {
+                                0 -> false
+                                1 -> model.isLoadingDlsite ||
+                                    model.isLoadingAsmrOne ||
+                                    !model.hasResolvedInitialDlsiteTarget
+                                else -> model.isLoadingDlsite ||
+                                    model.isLoadingDlsitePlay ||
+                                    !model.hasResolvedInitialDlsiteTarget
+                            }
+                        }
+
+                        val activeHeroAlbum = headerAlbumForTab(selectedTab)
+                        val pickLocalCoverAction = if (selectedTab == 0 && model.localAlbum != null) {
+                            { coverPicker.launch(arrayOf("image/*")) }
+                        } else {
+                            null
+                        }
+                        val showHeroCoverLoadingState = shouldShowCoverLoading(selectedTab, activeHeroAlbum)
+
                         val headerContent: @Composable (Int) -> Unit = { tab ->
                             val isLocalTab = tab == 0
                             val canSaveOnlineForTab = tab == 1 && asmrOneTree.isNotEmpty()
-                            val headerAlbum = if (isLocalTab) (model.localAlbum ?: album) else album
-                            val headerHasCover = headerAlbum.coverPath.trim().isNotBlank() ||
-                                headerAlbum.coverUrl.trim().isNotBlank()
-                            val showCoverLoadingState = !headerHasCover && when {
-                                isLocalTab -> false
-                                tab == 1 -> {
-                                    model.isLoadingDlsite ||
-                                        model.isLoadingAsmrOne ||
-                                        !model.hasResolvedInitialDlsiteTarget
-                                }
-                                else -> {
-                                    model.isLoadingDlsite ||
-                                        model.isLoadingDlsitePlay ||
-                                        !model.hasResolvedInitialDlsiteTarget
-                                }
-                            }
+                            val headerAlbum = headerAlbumForTab(tab)
                             AlbumHeader(
                                 album = headerAlbum,
                                 listenTogetherRjListenerCount = model.listenTogetherRjListenerCount,
@@ -408,49 +446,53 @@ fun AlbumDetailScreen(
                                 saveEnabled = canSaveOnlineForTab,
                                 showGroupButton = isLocalTab && model.localAlbum != null,
                                 onOpenGroupPicker = onOpenGroupPicker,
-                                onPickLocalCover = if (isLocalTab && model.localAlbum != null) {
-                                    { coverPicker.launch(arrayOf("image/*")) }
-                                } else null,
-                                showCoverLoadingState = showCoverLoadingState,
                                 introSessionKey = introSessionKey,
                                 animateIntro = shouldAnimateHeaderIntro,
                                 messageManager = viewModel.messageManager
-                        )
-                    }
-                    
-                    LaunchedEffect(
-                        selectedTab,
-                        model.rjCode,
-                        model.dlsiteWorkno,
-                        model.hasResolvedInitialDlsiteTarget
-                    ) {
-                        when (selectedTab) {
-                            1 -> {
-                                viewModel.ensureDlsiteLoaded()
-                                viewModel.ensureAsmrOneLoaded()
-                            }
-                            2 -> {
-                                viewModel.ensureDlsiteLoaded()
-                            }
+                            )
                         }
-                    }
 
-                    Box(
-                        modifier = Modifier
-                            .fillMaxSize()
-                            .clipToBounds()
-                            .zIndex(0f)
-                    ) {
-                        Surface(
-                            modifier = Modifier.fillMaxSize(),
-                            color = Color.Transparent,
-                            shape = RectangleShape,
-                            tonalElevation = 0.dp,
-                            shadowElevation = 0.dp
+                        Box(
+                            modifier = Modifier
+                                .fillMaxSize()
+                                .background(pageContainerColor)
+                                .clipToBounds()
+                                .zIndex(0f)
                         ) {
+                            AlbumDetailHeroBackground(
+                                album = activeHeroAlbum,
+                                height = heroHeight,
+                                pageContainerColor = pageContainerColor,
+                                showCoverLoadingState = showHeroCoverLoadingState,
+                                onPickLocalCover = pickLocalCoverAction,
+                                modifier = Modifier.align(Alignment.TopCenter)
+                            )
+
+                            LaunchedEffect(
+                                selectedTab,
+                                model.rjCode,
+                                model.dlsiteWorkno,
+                                model.hasResolvedInitialDlsiteTarget
+                            ) {
+                                when (selectedTab) {
+                                    1 -> {
+                                        viewModel.ensureDlsiteLoaded()
+                                        viewModel.ensureAsmrOneLoaded()
+                                    }
+                                    2 -> {
+                                        viewModel.ensureDlsiteLoaded()
+                                    }
+                                }
+                            }
+
                             HorizontalPager(
                                 state = tabPagerState,
-                                modifier = Modifier.fillMaxSize()
+                                modifier = Modifier
+                                    .fillMaxSize()
+                                    .albumDetailScrolledContentFade(
+                                        fadeStartY = contentFadeStartY,
+                                        fadeEndY = contentFadeEndY
+                                    )
                             ) { tab ->
                                 when (tab) {
                                     0 -> {
@@ -513,7 +555,12 @@ fun AlbumDetailScreen(
                                                 animateIntro = shouldPlayInitialAnimations
                                             )
                                         } else {
-                                            Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                                            Box(
+                                                modifier = Modifier
+                                                    .fillMaxSize()
+                                                    .padding(top = tabContentTopPadding),
+                                                contentAlignment = Alignment.Center
+                                            ) {
                                                 Text("未下载到本地")
                                             }
                                         }
@@ -612,9 +659,10 @@ fun AlbumDetailScreen(
                                     )
                                 }
                             }
-                        }
                         AlbumDetailTabChrome(
-                            modifier = Modifier.align(Alignment.TopCenter),
+                            modifier = Modifier
+                                .align(Alignment.TopCenter)
+                                .offset(y = tabChromeTop),
                             titles = tabTitles,
                             selectedTab = selectedTab,
                             indicatorPageOffset = tabIndicatorPageOffset,
@@ -816,7 +864,7 @@ private fun AlbumDetailTabChrome(
             .graphicsLayer {
                 translationY = animatedOffsetPx -
                     (collapseFraction.coerceIn(0f, 1f) * collapseOvershootPx)
-                alpha = 1f - (collapseFraction.coerceIn(0f, 1f) * 0.08f)
+                alpha = 1f - collapseFraction.coerceIn(0f, 1f)
             }
             .semantics { stateDescription = collapsibleHeaderUiState(collapseFraction) }
             .zIndex(1f)
@@ -927,6 +975,133 @@ private fun AlbumDetailTabChrome(
 }
 
 @Composable
+private fun AlbumDetailHeroBackground(
+    album: Album,
+    height: Dp,
+    pageContainerColor: Color,
+    showCoverLoadingState: Boolean,
+    onPickLocalCover: (() -> Unit)?,
+    modifier: Modifier = Modifier
+) {
+    val imageModel = rememberAlbumCoverImageModel(album)
+
+    Box(
+        modifier = modifier
+            .fillMaxWidth()
+            .height(height)
+            .clipToBounds()
+    ) {
+        AsmrAsyncImage(
+            model = imageModel,
+            contentDescription = null,
+            contentScale = ContentScale.FillWidth,
+            alignment = Alignment.TopCenter,
+            placeholderCornerRadius = 0,
+            modifier = Modifier.fillMaxSize(),
+            placeholder = { m -> DiscPlaceholder(modifier = m, cornerRadius = 0) },
+            loading = { m -> AsmrShimmerPlaceholder(modifier = m, cornerRadius = 0) },
+            empty = { m ->
+                if (showCoverLoadingState) {
+                    AsmrShimmerPlaceholder(modifier = m, cornerRadius = 0)
+                } else {
+                    DiscPlaceholder(modifier = m, cornerRadius = 0)
+                }
+            },
+        )
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(
+                    Brush.verticalGradient(
+                        colorStops = arrayOf(
+                            0f to Color.Black.copy(alpha = 0.44f),
+                            0.42f to Color.Black.copy(alpha = 0.16f),
+                            0.70f to Color.Transparent
+                        )
+                    )
+                )
+        )
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(
+                    Brush.verticalGradient(
+                        colorStops = arrayOf(
+                            0f to Color.Transparent,
+                            AlbumDetailHeroThemeGradientStartFraction to Color.Transparent,
+                            ((AlbumDetailHeroThemeGradientStartFraction + AlbumDetailHeroThemeGradientSolidFraction) / 2f) to
+                                pageContainerColor.copy(alpha = 0.68f),
+                            AlbumDetailHeroThemeGradientSolidFraction to pageContainerColor.copy(alpha = 0.96f),
+                            1f to pageContainerColor
+                        )
+                    )
+                )
+        )
+        if (onPickLocalCover != null) {
+            IconButton(
+                onClick = onPickLocalCover,
+                modifier = Modifier
+                    .align(Alignment.BottomEnd)
+                    .padding(end = 14.dp, bottom = 14.dp)
+                    .size(40.dp)
+                    .background(Color.Black.copy(alpha = 0.38f), RoundedCornerShape(12.dp))
+            ) {
+                Icon(
+                    imageVector = Icons.Rounded.Photo,
+                    contentDescription = "选择封面",
+                    tint = Color.White,
+                    modifier = Modifier.size(18.dp)
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun rememberAlbumCoverImageModel(album: Album): Any {
+    val data = album.coverPath.trim().ifEmpty { album.coverUrl.trim() }
+    return remember(data) {
+        val headers = if (data.startsWith("http", ignoreCase = true)) {
+            DlsiteAntiHotlink.headersForImageUrl(data)
+        } else {
+            emptyMap()
+        }
+        if (headers.isEmpty()) {
+            data
+        } else {
+            CacheImageModel(data = data, headers = headers, keyTag = "dlsite")
+        }
+    }
+}
+
+private fun Modifier.albumDetailScrolledContentFade(
+    fadeStartY: Dp,
+    fadeEndY: Dp
+): Modifier {
+    return this
+        .graphicsLayer {
+            compositingStrategy = CompositingStrategy.Offscreen
+        }
+        .drawWithContent {
+            drawContent()
+            val fadeStartPx = fadeStartY.toPx().coerceAtLeast(0f)
+            val fadeEndPx = fadeEndY.toPx().coerceAtLeast(fadeStartPx + 1f)
+            drawRect(
+                brush = Brush.verticalGradient(
+                    colorStops = arrayOf(
+                        0f to Color.Transparent,
+                        (fadeStartPx / fadeEndPx).coerceIn(0f, 1f) to Color.Transparent,
+                        1f to Color.White
+                    ),
+                    startY = 0f,
+                    endY = fadeEndPx
+                ),
+                blendMode = BlendMode.DstIn
+            )
+        }
+}
+
+@Composable
 @OptIn(ExperimentalLayoutApi::class)
 private fun AlbumHeader(
     album: Album,
@@ -946,8 +1121,6 @@ private fun AlbumHeader(
     saveEnabled: Boolean,
     showGroupButton: Boolean,
     onOpenGroupPicker: (albumId: Long) -> Unit,
-    onPickLocalCover: (() -> Unit)? = null,
-    showCoverLoadingState: Boolean = false,
     introSessionKey: String,
     animateIntro: Boolean,
     messageManager: MessageManager
@@ -955,11 +1128,6 @@ private fun AlbumHeader(
     val context = LocalContext.current
     val colorScheme = AsmrTheme.colorScheme
     val copyMeta = rememberAlbumMetaCopyAction(messageManager)
-    val data = album.coverPath.trim().ifEmpty { album.coverUrl.trim() }
-    val imageModel = remember(data) {
-        val headers = if (data.startsWith("http", ignoreCase = true)) DlsiteAntiHotlink.headersForImageUrl(data) else emptyMap()
-        if (headers.isEmpty()) data else CacheImageModel(data = data, headers = headers, keyTag = "dlsite")
-    }
 
     val rj = album.rjCode.ifBlank { album.workId }
     val normalizedTitle = album.title.trim()
@@ -980,8 +1148,6 @@ private fun AlbumHeader(
     val headerContainerModifier = Modifier
         .fillMaxWidth()
         .padding(horizontal = AlbumDetailHorizontalPadding, vertical = 12.dp)
-        .clip(RoundedCornerShape(AlbumDetailHeaderCornerRadius))
-        .background(colorScheme.surface.copy(alpha = 0.5f))
     val langCandidates = remember(dlsiteEditions) {
         dlsiteEditions
             .filter { it.lang in setOf("JPN", "CHI_HANS", "CHI_HANT") }
@@ -1000,142 +1166,85 @@ private fun AlbumHeader(
             modifier = headerContainerModifier,
             enabled = animateIntro && !headerIntroPlayed
         )
+            .padding(horizontal = 12.dp, vertical = 12.dp),
+        verticalArrangement = Arrangement.spacedBy(12.dp)
     ) {
-        Column {
-            Box(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .height(240.dp)
+        AlbumHeaderInfoReveal(
+            revealKey = "$headerAnimationScopeKey:title",
+            delayMillis = 0,
+            enabled = animateIntro,
+            ready = !isPlaceholderTitle
+        ) {
+            Text(
+                text = album.title,
+                modifier = Modifier.clickable { copyMeta("标题", album.title) },
+                style = MaterialTheme.typography.titleLarge.copy(fontWeight = FontWeight.Bold),
+                color = colorScheme.textPrimary,
+                maxLines = 3,
+                overflow = TextOverflow.Ellipsis
+            )
+        }
+        val circle = album.circle.trim()
+        val showMetaRow = rj.isNotBlank() || circle.isNotBlank() || listenTogetherRjListenerCount != null
+        if (showMetaRow) {
+            AlbumHeaderInfoReveal(
+                revealKey = "$headerAnimationScopeKey:meta",
+                delayMillis = 40,
+                enabled = animateIntro
             ) {
-                AsmrAsyncImage(
-                    model = imageModel,
-                    contentDescription = null,
-                    contentScale = ContentScale.Crop,
-                    placeholderCornerRadius = 0,
-                    modifier = Modifier.fillMaxSize(),
-                    placeholder = { m -> DiscPlaceholder(modifier = m, cornerRadius = 0) },
-                    loading = { m -> AsmrShimmerPlaceholder(modifier = m, cornerRadius = 0) },
-                    empty = { m ->
-                        if (showCoverLoadingState) {
-                            AsmrShimmerPlaceholder(modifier = m, cornerRadius = 0)
-                        } else {
-                            DiscPlaceholder(modifier = m, cornerRadius = 0)
-                        }
-                    },
-                )
-                if (onPickLocalCover != null) {
-                    IconButton(
-                        onClick = onPickLocalCover,
-                        modifier = Modifier
-                            .align(Alignment.TopEnd)
-                            .padding(10.dp)
-                            .background(Color.Black.copy(alpha = 0.35f), RoundedCornerShape(12.dp))
-                            .size(36.dp)
-                    ) {
-                        Icon(
-                            imageVector = Icons.Rounded.Photo,
-                            contentDescription = "閫夋嫨灏侀潰",
-                            tint = Color.White,
-                            modifier = Modifier.size(18.dp)
-                        )
-                    }
-                }
-                Box(
-                    modifier = Modifier
-                        .fillMaxSize()
-                        .background(
-                            Brush.verticalGradient(
-                                colors = listOf(Color.Transparent, Color.Black.copy(alpha = 0.7f))
-                            )
-                        )
-                )
-                Column(
-                    modifier = Modifier
-                        .align(Alignment.BottomStart)
-                        .padding(12.dp),
-                    verticalArrangement = Arrangement.spacedBy(6.dp)
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    verticalAlignment = Alignment.CenterVertically
                 ) {
-                    AlbumHeaderInfoReveal(
-                        revealKey = "$headerAnimationScopeKey:title",
-                        delayMillis = 0,
-                        enabled = animateIntro,
-                        ready = !isPlaceholderTitle
-                    ) {
-                    Text(
-                        text = album.title,
-                        modifier = Modifier.clickable { copyMeta("标题", album.title) },
-                        style = MaterialTheme.typography.titleLarge.copy(fontWeight = FontWeight.Bold),
-                        color = Color.White,
-                        maxLines = 2,
-                        overflow = TextOverflow.Ellipsis
+                    AlbumPrimaryMetaRow(
+                        rjCode = rj,
+                        circle = circle,
+                        modifier = Modifier.weight(1f),
+                        rjOnClick = { copyMeta("RJ", rj) },
+                        circleOnClick = { copyMeta("社团", circle) },
+                        leadingVisual = AlbumMetaLeadingVisual.Icon,
                     )
-                    }
-                    val circle = album.circle.trim()
-                    val showMetaRow = rj.isNotBlank() || circle.isNotBlank() || listenTogetherRjListenerCount != null
-                    if (showMetaRow) {
+                    if (listenTogetherRjListenerCount != null && rj.isNotBlank()) {
+                        Spacer(modifier = Modifier.width(8.dp))
                         AlbumHeaderInfoReveal(
-                            revealKey = "$headerAnimationScopeKey:meta",
-                            delayMillis = 40,
+                            revealKey = "$headerAnimationScopeKey:listenTogetherRjCount",
+                            delayMillis = 60,
                             enabled = animateIntro
                         ) {
-                            Row(
-                                modifier = Modifier.fillMaxWidth(),
-                                verticalAlignment = Alignment.CenterVertically
-                            ) {
-                                AlbumPrimaryMetaRow(
-                                    rjCode = rj,
-                                    circle = circle,
-                                    modifier = Modifier.weight(1f),
-                                    rjOnClick = { copyMeta("RJ", rj) },
-                                    circleOnClick = { copyMeta("社团", circle) },
-                                    appearance = AlbumMetaAppearance.OnImage,
-                                    leadingVisual = AlbumMetaLeadingVisual.Icon,
+                            Surface(
+                                color = colorScheme.primary.copy(alpha = if (colorScheme.isDark) 0.16f else 0.10f),
+                                contentColor = colorScheme.primary,
+                                shape = RoundedCornerShape(999.dp),
+                                border = androidx.compose.foundation.BorderStroke(
+                                    width = 0.5.dp,
+                                    color = colorScheme.primary.copy(alpha = 0.18f)
                                 )
-                                if (listenTogetherRjListenerCount != null && rj.isNotBlank()) {
-                                    Spacer(modifier = Modifier.width(8.dp))
-                                    AlbumHeaderInfoReveal(
-                                        revealKey = "$headerAnimationScopeKey:listenTogetherRjCount",
-                                        delayMillis = 60,
-                                        enabled = animateIntro
-                                    ) {
-                                        Surface(
-                                            color = Color.White.copy(alpha = 0.16f),
-                                            contentColor = Color.White.copy(alpha = 0.96f),
-                                            shape = RoundedCornerShape(999.dp),
-                                            border = androidx.compose.foundation.BorderStroke(
-                                                width = 0.5.dp,
-                                                color = Color.White.copy(alpha = 0.2f)
-                                            )
-                                        ) {
-                                            Row(
-                                                modifier = Modifier.padding(horizontal = 7.dp, vertical = 2.dp),
-                                                horizontalArrangement = Arrangement.spacedBy(4.dp),
-                                                verticalAlignment = Alignment.CenterVertically
-                                            ) {
-                                                Icon(
-                                                    painter = painterResource(id = com.asmr.player.R.drawable.ic_users_round),
-                                                    contentDescription = null,
-                                                    tint = Color.White.copy(alpha = 0.96f),
-                                                    modifier = Modifier.size(12.dp)
-                                                )
-                                                Text(
-                                                    text = "${listenTogetherRjListenerCount.coerceAtLeast(0)} 人正在听",
-                                                    style = MaterialTheme.typography.labelSmall,
-                                                    color = Color.White.copy(alpha = 0.96f),
-                                                    maxLines = 1,
-                                                    overflow = TextOverflow.Ellipsis,
-                                                )
-                                            }
-                                        }
-                                    }
+                            ) {
+                                Row(
+                                    modifier = Modifier.padding(horizontal = 7.dp, vertical = 2.dp),
+                                    horizontalArrangement = Arrangement.spacedBy(4.dp),
+                                    verticalAlignment = Alignment.CenterVertically
+                                ) {
+                                    Icon(
+                                        painter = painterResource(id = com.asmr.player.R.drawable.ic_users_round),
+                                        contentDescription = null,
+                                        tint = colorScheme.primary,
+                                        modifier = Modifier.size(12.dp)
+                                    )
+                                    Text(
+                                        text = "${listenTogetherRjListenerCount.coerceAtLeast(0)} 人正在听",
+                                        style = MaterialTheme.typography.labelSmall,
+                                        color = colorScheme.primary,
+                                        maxLines = 1,
+                                        overflow = TextOverflow.Ellipsis,
+                                    )
                                 }
                             }
                         }
                     }
                 }
             }
-
-            Column(modifier = Modifier.padding(12.dp), verticalArrangement = Arrangement.spacedBy(12.dp)) {
+        }
                 if (album.cv.isNotBlank()) {
                     AlbumHeaderInfoReveal(
                         revealKey = "$headerAnimationScopeKey:cv",
@@ -1382,9 +1491,6 @@ private fun AlbumHeader(
                 }
             }
         }
-    }
-}
-
 private fun dlsiteLanguageButtonLabel(lang: String): String {
     return when (lang.trim().uppercase()) {
         "CHI_HANS" -> "简中"

--- a/app/src/main/java/com/asmr/player/ui/library/AlbumDetailScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/AlbumDetailScreen.kt
@@ -812,8 +812,10 @@ private fun AlbumDetailHeroBackground(
         }
     }
 
-    // 真实“折叠”而非整体缩放：只压缩 hero 的布局高度（宽度保持满宽 -> 不会出现左右空白），
-    // 封面用 requiredHeight 固定为全高并顶部对齐，因此随高度收缩只是从顶部重新裁切、不变形也不重新加载；
+    // 真实“折叠”而非整体缩放：只压缩 hero 的布局高度（宽度保持满宽 -> 不会出现左右空白）。
+    // 封面填充折叠后的盒子高度（fillMaxSize + Crop）：盒子变矮时 Crop 的缩放因子随之减小，
+    // 宽方向原本被裁掉的左右两侧逐渐显露出来（封面通常较宽，折叠即“横向缩小”露出更多画面）。
+    // 折叠过程中保留当前位图、稳定后再按新尺寸重载，避免逐帧重复解码与闪烁。
     // 标题/元信息底部对齐，会随折叠后的底边上移但尺寸保持不变。
     Box(
         modifier = modifier
@@ -837,9 +839,9 @@ private fun AlbumDetailHeroBackground(
             alignment = Alignment.TopCenter,
             placeholderCornerRadius = 0,
             peekAnySizeForInitial = true,
+            loadAtOriginalSize = true,
             modifier = Modifier
-                .requiredHeight(height)
-                .fillMaxWidth()
+                .fillMaxSize()
                 .graphicsLayer {
                     compositingStrategy = CompositingStrategy.Offscreen
                 }
@@ -885,9 +887,9 @@ private fun AlbumDetailHeroBackground(
             alignment = Alignment.TopCenter,
             placeholderCornerRadius = 0,
             peekAnySizeForInitial = true,
+            loadAtOriginalSize = true,
             modifier = Modifier
-                .requiredHeight(height)
-                .fillMaxWidth()
+                .fillMaxSize()
                 .then(blurModifier)
                 .graphicsLayer {
                     compositingStrategy = CompositingStrategy.Offscreen
@@ -1155,6 +1157,11 @@ private fun AlbumHeader(
         headerIntroPlayed = true
     }
 
+    // 记录“首帧时各信息块是否已存在”：本地库专辑进入时 cv/tags 已就绪，应直接淡入不撑开（消除下沉抖动）；
+    // 在线专辑进入时 cv/tags 为空，待网络返回后才出现，那时才用 expandVertically 平滑撑开下方内容。
+    val cvPresentInitially = remember(headerAnimationScopeKey) { album.cv.isNotBlank() }
+    val tagsPresentInitially = remember(headerAnimationScopeKey) { album.tags.isNotEmpty() }
+
     val headerContainerModifier = Modifier
         .fillMaxWidth()
         .padding(horizontal = AlbumDetailHorizontalPadding)
@@ -1183,7 +1190,8 @@ private fun AlbumHeader(
                     AlbumHeaderInfoReveal(
                         revealKey = "$headerAnimationScopeKey:cv",
                         delayMillis = 80,
-                        enabled = animateIntro
+                        enabled = animateIntro,
+                        expandLayout = !cvPresentInitially
                     ) {
                         AlbumCvChipsFlow(
                             cvText = album.cv,
@@ -1199,7 +1207,8 @@ private fun AlbumHeader(
                     AlbumHeaderInfoReveal(
                         revealKey = "$headerAnimationScopeKey:tags",
                         delayMillis = 120,
-                        enabled = animateIntro
+                        enabled = animateIntro,
+                        expandLayout = !tagsPresentInitially
                     ) {
                         AlbumTagsFlow(
                             tags = album.tags,
@@ -1214,7 +1223,8 @@ private fun AlbumHeader(
                 AlbumHeaderInfoReveal(
                     revealKey = "$headerAnimationScopeKey:actions",
                     delayMillis = 160,
-                    enabled = animateIntro
+                    enabled = animateIntro,
+                    expandLayout = false
                 ) {
                     BoxWithConstraints(
                         modifier = Modifier
@@ -1440,6 +1450,7 @@ private fun AlbumHeaderInfoReveal(
     delayMillis: Int = 0,
     enabled: Boolean = true,
     ready: Boolean = true,
+    expandLayout: Boolean = true,
     content: @Composable () -> Unit
 ) {
     var hasPlayed by rememberSaveable(revealKey) { mutableStateOf(false) }
@@ -1484,6 +1495,21 @@ private fun AlbumHeaderInfoReveal(
         label = "albumHeaderInfoOffsetY"
     )
     val density = LocalDensity.current
+    if (!expandLayout) {
+        // 进入时就已存在的内容（本地库 cv/tags、按钮行）：只做淡入 + 轻微上移，
+        // 不改变布局高度，避免从 0 高度展开把下方列表先推下再回弹（“下沉”抖动）。
+        Box(
+            modifier = Modifier.graphicsLayer {
+                this.alpha = alpha
+                translationY = with(density) { offsetY.toPx() }
+            }
+        ) {
+            content()
+        }
+        return
+    }
+    // 网络数据到达后才出现的内容（在线 cv/tags）：用 expandVertically 平滑撑开下方内容，
+    // 避免数据突然出现、生硬撑开造成的突兀感。
     AnimatedVisibility(
         visible = visible,
         enter = fadeIn(animationSpec = tween(durationMillis = 220)) + expandVertically(

--- a/app/src/main/java/com/asmr/player/ui/library/AlbumDetailScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/AlbumDetailScreen.kt
@@ -9,6 +9,7 @@ import androidx.activity.compose.BackHandler
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.animateContentSize
 import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.animation.core.spring
@@ -26,6 +27,7 @@ import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
 import androidx.compose.ui.input.nestedscroll.NestedScrollSource
+import androidx.compose.ui.unit.Velocity
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.foundation.layout.*
@@ -53,6 +55,7 @@ import androidx.compose.ui.graphics.BlendMode
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.CompositingStrategy
 import androidx.compose.ui.graphics.Shadow
+import androidx.compose.ui.graphics.TransformOrigin
 import androidx.compose.ui.graphics.asComposeRenderEffect
 import androidx.compose.ui.graphics.compositeOver
 import androidx.compose.ui.graphics.lerp
@@ -147,6 +150,7 @@ import com.asmr.player.util.Formatting
 import com.asmr.player.util.MessageManager
 import com.asmr.player.util.RemoteSubtitleSource
 import java.util.UUID
+import kotlin.math.abs
 import kotlin.math.roundToInt
 
 private enum class AlbumPrimaryAction {
@@ -176,7 +180,20 @@ private val AlbumDetailHeroTransitionHeight = 96.dp
 private val AlbumDetailHeroBlurRampHeight = 188.dp
 private val AlbumDetailScrolledContentFadeSpan = 10.dp
 private const val AlbumDetailInitialIntroDurationMs = 1200L
+private const val AlbumDetailHeroOvershootResistance = 0.32f
+private const val AlbumDetailHeroExpandOvershootScale = 0.18f
+private const val AlbumDetailRevealSettleMs = 760L
+private const val AlbumDetailHeroTitleRevealDelayMs = 120
+private const val AlbumDetailHeroMetaRevealDelayMs = 280
+private const val AlbumDetailCvRevealDelayMs = 220
+private const val AlbumDetailTagsRevealDelayMs = 360
+private const val AlbumDetailActionsRevealDelayMs = 500
 internal val AlbumDetailHorizontalPadding = 8.dp
+
+private val AlbumDetailHeroBounceBackSpec = spring<Float>(
+    dampingRatio = Spring.DampingRatioNoBouncy,
+    stiffness = Spring.StiffnessVeryLow
+)
 
 private val DlsiteElasticResizeSpring = spring<IntSize>(
     dampingRatio = Spring.DampingRatioLowBouncy,
@@ -321,21 +338,70 @@ fun AlbumDetailScreen(
                         val contentFadeStartY = 0.dp
                         val contentFadeEndY = AlbumDetailScrolledContentFadeSpan
 
-                        // 随滑动自适应缩放 hero：用户向上浏览内容时 hero 跟随手指逐渐缩小，
-                        // 最多缩到原本的二分之一（顶部锚定），向上滑回顶部时再恢复。
+                        // 随滑动自适应缩放 hero：布局边界仍是 0%~50% 折叠。
+                        // 只有展开端允许封面图继续放大，松手后缓慢回落；折叠端到 50% 后直接交给列表滚动。
                         val heroDensity = LocalDensity.current
                         val heroCollapseMaxPx = with(heroDensity) { (heroHeight * 0.5f).toPx() }
+                        val heroVisualOvershootMaxPx = with(heroDensity) { (heroHeight * 0.10f).toPx() }
                         val contentViewportTopPx = with(heroDensity) { contentViewportTop.toPx() }
-                        var heroCollapsePx by remember { mutableFloatStateOf(0f) }
-                        val heroNestedScroll = remember(heroCollapseMaxPx) {
+                        val heroCollapseAnim = remember { Animatable(0f) }
+                        val heroVisualOvershootAnim = remember { Animatable(0f) }
+                        val heroCollapsePx = heroCollapseAnim.value.coerceIn(0f, heroCollapseMaxPx)
+                        val heroVisualOvershootPx = heroVisualOvershootAnim.value
+                        val scope = rememberCoroutineScope()
+                        LaunchedEffect(heroCollapseMaxPx, heroVisualOvershootMaxPx) {
+                            heroCollapseAnim.snapTo(
+                                heroCollapseAnim.value.coerceIn(0f, heroCollapseMaxPx)
+                            )
+                            heroVisualOvershootAnim.snapTo(
+                                heroVisualOvershootAnim.value.coerceIn(
+                                    -heroVisualOvershootMaxPx,
+                                    0f
+                                )
+                            )
+                        }
+                        val heroNestedScroll = remember(heroCollapseMaxPx, heroVisualOvershootMaxPx, scope) {
                             object : NestedScrollConnection {
+                                private fun settleVisualOvershoot(): Boolean {
+                                    if (abs(heroVisualOvershootAnim.value) < 0.5f) return false
+                                    scope.launch {
+                                        heroVisualOvershootAnim.animateTo(
+                                            0f,
+                                            animationSpec = AlbumDetailHeroBounceBackSpec
+                                        )
+                                    }
+                                    return true
+                                }
+
+                                private fun applyCollapseDelta(delta: Float): Float {
+                                    if (delta == 0f) return 0f
+                                    scope.launch { heroCollapseAnim.stop() }
+                                    scope.launch { heroVisualOvershootAnim.stop() }
+                                    val current = heroCollapseAnim.value.coerceIn(0f, heroCollapseMaxPx)
+                                    val rawTarget = current + delta
+                                    val target = rawTarget.coerceIn(0f, heroCollapseMaxPx)
+                                    val overflow = rawTarget - target
+                                    if (overflow < 0f) {
+                                        val visualTarget = (heroVisualOvershootAnim.value + overflow * AlbumDetailHeroOvershootResistance)
+                                            .coerceIn(-heroVisualOvershootMaxPx, 0f)
+                                        scope.launch { heroVisualOvershootAnim.snapTo(visualTarget) }
+                                    } else if (heroVisualOvershootAnim.value != 0f) {
+                                        scope.launch { heroVisualOvershootAnim.snapTo(0f) }
+                                    }
+                                    scope.launch { heroCollapseAnim.snapTo(target) }
+                                    return target - current
+                                }
+
                                 override fun onPreScroll(available: Offset, source: NestedScrollSource): Offset {
                                     val dy = available.y
                                     // 向上浏览（手指上滑，dy<0）：先把滚动用于折叠 hero，再交给列表。
-                                    if (dy < 0f && heroCollapsePx < heroCollapseMaxPx) {
-                                        val target = (heroCollapsePx - dy).coerceIn(0f, heroCollapseMaxPx)
-                                        val consumed = heroCollapsePx - target // 与 dy 同号(负)
-                                        heroCollapsePx = target
+                                    if (dy < 0f && (
+                                            heroCollapseAnim.value < heroCollapseMaxPx ||
+                                                heroVisualOvershootAnim.value < 0f
+                                            )
+                                    ) {
+                                        val applied = applyCollapseDelta(-dy)
+                                        val consumed = if (applied != 0f) -applied else dy
                                         return Offset(0f, consumed)
                                     }
                                     return Offset.Zero
@@ -348,13 +414,26 @@ fun AlbumDetailScreen(
                                 ): Offset {
                                     val dy = available.y
                                     // 列表已到顶仍有下滑剩余（dy>0）：把剩余滚动用于展开 hero。
-                                    if (dy > 0f && heroCollapsePx > 0f) {
-                                        val target = (heroCollapsePx - dy).coerceIn(0f, heroCollapseMaxPx)
-                                        val released = heroCollapsePx - target // 与 dy 同号(正)
-                                        heroCollapsePx = target
+                                    if (dy > 0f && (
+                                            heroCollapseAnim.value > 0f ||
+                                                heroVisualOvershootAnim.value > -heroVisualOvershootMaxPx
+                                            )
+                                    ) {
+                                        val applied = applyCollapseDelta(-dy)
+                                        val released = if (applied != 0f) -applied else dy
                                         return Offset(0f, released)
                                     }
                                     return Offset.Zero
+                                }
+
+                                override suspend fun onPreFling(available: Velocity): Velocity {
+                                    settleVisualOvershoot()
+                                    return Velocity.Zero
+                                }
+
+                                override suspend fun onPostFling(consumed: Velocity, available: Velocity): Velocity {
+                                    settleVisualOvershoot()
+                                    return Velocity.Zero
                                 }
                             }
                         }
@@ -431,6 +510,9 @@ fun AlbumDetailScreen(
                         ) {
                             AlbumDetailHeroBackground(
                                 album = activeHeroAlbum,
+                                coverSessionKey = screenKey,
+                                introSessionKey = introSessionKey,
+                                animateIntro = shouldAnimateHeaderIntro,
                                 height = heroHeight,
                                 pageContainerColor = pageContainerColor,
                                 listenTogetherRjListenerCount = model.listenTogetherRjListenerCount,
@@ -438,6 +520,8 @@ fun AlbumDetailScreen(
                                 messageManager = viewModel.messageManager,
                                 collapsePx = { heroCollapsePx },
                                 collapseMaxPx = heroCollapseMaxPx,
+                                visualOvershootPx = { heroVisualOvershootPx },
+                                visualOvershootMaxPx = heroVisualOvershootMaxPx,
                                 modifier = Modifier.align(Alignment.TopCenter)
                             )
 
@@ -539,7 +623,11 @@ fun AlbumDetailScreen(
                                                     .fillMaxSize(),
                                                 contentAlignment = Alignment.Center
                                             ) {
-                                                Text("未下载到本地")
+                                                if (albumId != null && albumId > 0) {
+                                                    EaraLogoLoadingIndicator(tint = AsmrTheme.colorScheme.primary)
+                                                } else {
+                                                    Text("未下载到本地")
+                                                }
                                             }
                                         }
                                     }
@@ -787,6 +875,9 @@ fun AlbumDetailScreen(
 @Composable
 private fun AlbumDetailHeroBackground(
     album: Album,
+    coverSessionKey: String,
+    introSessionKey: String,
+    animateIntro: Boolean,
     height: Dp,
     pageContainerColor: Color,
     listenTogetherRjListenerCount: Int?,
@@ -794,11 +885,19 @@ private fun AlbumDetailHeroBackground(
     messageManager: MessageManager,
     modifier: Modifier = Modifier,
     collapsePx: () -> Float = { 0f },
-    collapseMaxPx: Float = 0f
+    collapseMaxPx: Float = 0f,
+    visualOvershootPx: () -> Float = { 0f },
+    visualOvershootMaxPx: Float = 1f
 ) {
-    val imageModel = rememberAlbumCoverImageModel(album)
+    val coverSource = rememberStableAlbumHeroCoverSource(album, coverSessionKey)
+    val imageModel = rememberAlbumCoverImageModel(coverSource)
     val density = LocalDensity.current
     val fullHeightPx = with(density) { height.toPx() }
+    val visualOvershootScale = run {
+        val max = visualOvershootMaxPx.coerceAtLeast(1f)
+        val expandProgress = (-visualOvershootPx() / max).coerceIn(0f, 1f)
+        1f + expandProgress * AlbumDetailHeroExpandOvershootScale
+    }
     val blurModifier = remember {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
             Modifier.graphicsLayer {
@@ -844,6 +943,9 @@ private fun AlbumDetailHeroBackground(
                 .fillMaxSize()
                 .graphicsLayer {
                     compositingStrategy = CompositingStrategy.Offscreen
+                    scaleX = visualOvershootScale
+                    scaleY = visualOvershootScale
+                    transformOrigin = TransformOrigin(0.5f, 0f)
                 }
                 .drawWithCache {
                     val fadeHeightPx = AlbumDetailHeroBlurRampHeight.toPx()
@@ -893,6 +995,9 @@ private fun AlbumDetailHeroBackground(
                 .then(blurModifier)
                 .graphicsLayer {
                     compositingStrategy = CompositingStrategy.Offscreen
+                    scaleX = visualOvershootScale
+                    scaleY = visualOvershootScale
+                    transformOrigin = TransformOrigin(0.5f, 0f)
                 }
                 .drawWithCache {
                     val rampHeightPx = AlbumDetailHeroBlurRampHeight.toPx()
@@ -956,6 +1061,8 @@ private fun AlbumDetailHeroBackground(
         )
         AlbumHeroIdentityOverlay(
             album = album,
+            introSessionKey = introSessionKey,
+            animateIntro = animateIntro,
             listenTogetherRjListenerCount = listenTogetherRjListenerCount,
             messageManager = messageManager,
             modifier = Modifier.align(Alignment.BottomStart)
@@ -966,16 +1073,20 @@ private fun AlbumDetailHeroBackground(
 @Composable
 private fun AlbumHeroIdentityOverlay(
     album: Album,
+    introSessionKey: String,
+    animateIntro: Boolean,
     listenTogetherRjListenerCount: Int?,
     messageManager: MessageManager,
     modifier: Modifier = Modifier
 ) {
     val colorScheme = AsmrTheme.colorScheme
     val copyMeta = rememberAlbumMetaCopyAction(messageManager)
-    val rj = album.rjCode.ifBlank { album.workId }.trim()
-    val circle = album.circle.trim()
+    val identity = rememberStableAlbumHeroIdentity(album, introSessionKey)
+    val rj = identity.rj
+    val circle = identity.circle
     val showMetaRow = rj.isNotBlank() || circle.isNotBlank() ||
         (listenTogetherRjListenerCount != null && rj.isNotBlank())
+    val heroRevealKey = remember(introSessionKey) { "albumHero:$introSessionKey" }
 
     Column(
         modifier = modifier
@@ -987,73 +1098,87 @@ private fun AlbumHeroIdentityOverlay(
             ),
         verticalArrangement = Arrangement.spacedBy(9.dp)
     ) {
-        Text(
-            text = album.title,
-            modifier = Modifier.clickable { copyMeta("标题", album.title) },
-            style = MaterialTheme.typography.titleMedium.copy(
-                fontWeight = FontWeight.Bold,
-                fontSize = 20.sp,
-                shadow = Shadow(
-                    color = if (colorScheme.isDark) Color.White.copy(alpha = 0.58f) else Color.Black.copy(alpha = 0.58f),
-                    offset = Offset(0f, 2f),
-                    blurRadius = 8f
-                )
-            ),
-            color = if (colorScheme.isDark) Color.White else Color.Black,
-            maxLines = 3,
-            overflow = TextOverflow.Ellipsis
-        )
+        AlbumHeaderInfoReveal(
+            revealKey = "$heroRevealKey:title",
+            delayMillis = AlbumDetailHeroTitleRevealDelayMs,
+            enabled = animateIntro,
+            expandLayout = false
+        ) {
+            Text(
+                text = identity.title,
+                modifier = Modifier.clickable { copyMeta("标题", identity.title) },
+                style = MaterialTheme.typography.titleMedium.copy(
+                    fontWeight = FontWeight.Bold,
+                    fontSize = 20.sp,
+                    shadow = Shadow(
+                        color = if (colorScheme.isDark) Color.White.copy(alpha = 0.58f) else Color.Black.copy(alpha = 0.58f),
+                        offset = Offset(0f, 2f),
+                        blurRadius = 8f
+                    )
+                ),
+                color = if (colorScheme.isDark) Color.White else Color.Black,
+                maxLines = 3,
+                overflow = TextOverflow.Ellipsis
+            )
+        }
 
         if (showMetaRow) {
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                verticalAlignment = Alignment.CenterVertically
+            AlbumHeaderInfoReveal(
+                revealKey = "$heroRevealKey:meta",
+                delayMillis = AlbumDetailHeroMetaRevealDelayMs,
+                enabled = animateIntro,
+                expandLayout = false
             ) {
-                AlbumPrimaryMetaRow(
-                    rjCode = rj,
-                    circle = circle,
-                    modifier = Modifier.weight(1f),
-                    rjOnClick = { copyMeta("RJ", rj) },
-                    circleOnClick = { copyMeta("社团", circle) },
-                    appearance = AlbumMetaAppearance.OnImage,
-                    leadingVisual = AlbumMetaLeadingVisual.Icon,
-                )
-                if (listenTogetherRjListenerCount != null && rj.isNotBlank()) {
-                    Spacer(modifier = Modifier.width(8.dp))
-                    val listenerContainer = colorScheme.primary.copy(alpha = if (colorScheme.isDark) 0.36f else 0.30f)
-                    val listenerContent = if (colorScheme.isDark) {
-                        Color.White.copy(alpha = 0.96f)
-                    } else {
-                        colorScheme.textPrimary.copy(alpha = 0.88f)
-                    }
-                    val listenerBorder = colorScheme.primary.copy(alpha = if (colorScheme.isDark) 0.52f else 0.42f)
-                    Surface(
-                        color = listenerContainer,
-                        contentColor = listenerContent,
-                        shape = RoundedCornerShape(999.dp),
-                        border = androidx.compose.foundation.BorderStroke(
-                            width = 0.5.dp,
-                            color = listenerBorder
-                        )
-                    ) {
-                        Row(
-                            modifier = Modifier.padding(horizontal = 7.dp, vertical = 2.dp),
-                            horizontalArrangement = Arrangement.spacedBy(4.dp),
-                            verticalAlignment = Alignment.CenterVertically
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    AlbumPrimaryMetaRow(
+                        rjCode = rj,
+                        circle = circle,
+                        modifier = Modifier.weight(1f),
+                        rjOnClick = { copyMeta("RJ", rj) },
+                        circleOnClick = { copyMeta("社团", circle) },
+                        appearance = AlbumMetaAppearance.OnImage,
+                        leadingVisual = AlbumMetaLeadingVisual.Icon,
+                    )
+                    if (listenTogetherRjListenerCount != null && rj.isNotBlank()) {
+                        Spacer(modifier = Modifier.width(8.dp))
+                        val listenerContainer = colorScheme.primary.copy(alpha = if (colorScheme.isDark) 0.36f else 0.30f)
+                        val listenerContent = if (colorScheme.isDark) {
+                            Color.White.copy(alpha = 0.96f)
+                        } else {
+                            colorScheme.textPrimary.copy(alpha = 0.88f)
+                        }
+                        val listenerBorder = colorScheme.primary.copy(alpha = if (colorScheme.isDark) 0.52f else 0.42f)
+                        Surface(
+                            color = listenerContainer,
+                            contentColor = listenerContent,
+                            shape = RoundedCornerShape(999.dp),
+                            border = androidx.compose.foundation.BorderStroke(
+                                width = 0.5.dp,
+                                color = listenerBorder
+                            )
                         ) {
-                            Icon(
-                                painter = painterResource(id = com.asmr.player.R.drawable.ic_users_round),
-                                contentDescription = null,
-                                tint = listenerContent,
-                                modifier = Modifier.size(12.dp)
-                            )
-                            Text(
-                                text = "${listenTogetherRjListenerCount.coerceAtLeast(0)} 人正在听",
-                                style = MaterialTheme.typography.labelSmall,
-                                color = listenerContent,
-                                maxLines = 1,
-                                overflow = TextOverflow.Ellipsis,
-                            )
+                            Row(
+                                modifier = Modifier.padding(horizontal = 7.dp, vertical = 2.dp),
+                                horizontalArrangement = Arrangement.spacedBy(4.dp),
+                                verticalAlignment = Alignment.CenterVertically
+                            ) {
+                                Icon(
+                                    painter = painterResource(id = com.asmr.player.R.drawable.ic_users_round),
+                                    contentDescription = null,
+                                    tint = listenerContent,
+                                    modifier = Modifier.size(12.dp)
+                                )
+                                Text(
+                                    text = "${listenTogetherRjListenerCount.coerceAtLeast(0)} 人正在听",
+                                    style = MaterialTheme.typography.labelSmall,
+                                    color = listenerContent,
+                                    maxLines = 1,
+                                    overflow = TextOverflow.Ellipsis,
+                                )
+                            }
                         }
                     }
                 }
@@ -1062,9 +1187,36 @@ private fun AlbumHeroIdentityOverlay(
     }
 }
 
+private data class StableAlbumHeroIdentity(
+    val title: String,
+    val rj: String,
+    val circle: String
+)
+
 @Composable
-private fun rememberAlbumCoverImageModel(album: Album): Any {
-    val data = album.coverPath.trim().ifEmpty { album.coverUrl.trim() }
+private fun rememberStableAlbumHeroIdentity(album: Album, identitySessionKey: String): StableAlbumHeroIdentity {
+    val current = StableAlbumHeroIdentity(
+        title = album.title.trim().ifBlank { "专辑" },
+        rj = album.rjCode.ifBlank { album.workId }.trim(),
+        circle = album.circle.trim()
+    )
+    return remember(identitySessionKey) { current }
+}
+
+@Composable
+private fun rememberStableAlbumHeroCoverSource(album: Album, coverSessionKey: String): String {
+    val current = album.coverPath.trim().ifEmpty { album.coverUrl.trim() }
+    var stable by remember(coverSessionKey) { mutableStateOf(current) }
+    LaunchedEffect(current) {
+        if (stable.isBlank() && current.isNotBlank()) {
+            stable = current
+        }
+    }
+    return stable
+}
+
+@Composable
+private fun rememberAlbumCoverImageModel(data: String): Any {
     return remember(data) {
         val headers = if (data.startsWith("http", ignoreCase = true)) {
             DlsiteAntiHotlink.headersForImageUrl(data)
@@ -1189,7 +1341,7 @@ private fun AlbumHeader(
                 if (album.cv.isNotBlank()) {
                     AlbumHeaderInfoReveal(
                         revealKey = "$headerAnimationScopeKey:cv",
-                        delayMillis = 80,
+                        delayMillis = AlbumDetailCvRevealDelayMs,
                         enabled = animateIntro,
                         expandLayout = !cvPresentInitially
                     ) {
@@ -1206,7 +1358,7 @@ private fun AlbumHeader(
                 if (album.tags.isNotEmpty()) {
                     AlbumHeaderInfoReveal(
                         revealKey = "$headerAnimationScopeKey:tags",
-                        delayMillis = 120,
+                        delayMillis = AlbumDetailTagsRevealDelayMs,
                         enabled = animateIntro,
                         expandLayout = !tagsPresentInitially
                     ) {
@@ -1222,7 +1374,7 @@ private fun AlbumHeader(
 
                 AlbumHeaderInfoReveal(
                     revealKey = "$headerAnimationScopeKey:actions",
-                    delayMillis = 160,
+                    delayMillis = AlbumDetailActionsRevealDelayMs,
                     enabled = animateIntro,
                     expandLayout = false
                 ) {
@@ -1475,22 +1627,22 @@ private fun AlbumHeaderInfoReveal(
         }
         withFrameNanos { }
         visible = true
-        delay(420)
+        delay(AlbumDetailRevealSettleMs)
         hasPlayed = true
     }
     val alpha by animateFloatAsState(
         targetValue = if (visible) 1f else 0f,
         animationSpec = spring(
             dampingRatio = Spring.DampingRatioNoBouncy,
-            stiffness = Spring.StiffnessMediumLow
+            stiffness = Spring.StiffnessLow
         ),
         label = "albumHeaderInfoAlpha"
     )
     val offsetY by animateDpAsState(
-        targetValue = if (visible) 0.dp else 10.dp,
+        targetValue = if (visible) 0.dp else 14.dp,
         animationSpec = spring(
             dampingRatio = Spring.DampingRatioNoBouncy,
-            stiffness = Spring.StiffnessMediumLow
+            stiffness = Spring.StiffnessLow
         ),
         label = "albumHeaderInfoOffsetY"
     )
@@ -1512,9 +1664,9 @@ private fun AlbumHeaderInfoReveal(
     // 避免数据突然出现、生硬撑开造成的突兀感。
     AnimatedVisibility(
         visible = visible,
-        enter = fadeIn(animationSpec = tween(durationMillis = 220)) + expandVertically(
+        enter = fadeIn(animationSpec = tween(durationMillis = 420)) + expandVertically(
             animationSpec = spring(
-                dampingRatio = Spring.DampingRatioLowBouncy,
+                dampingRatio = Spring.DampingRatioNoBouncy,
                 stiffness = Spring.StiffnessLow
             ),
             expandFrom = Alignment.Top

--- a/app/src/main/java/com/asmr/player/ui/library/AlbumDetailScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/AlbumDetailScreen.kt
@@ -1,7 +1,10 @@
 ﻿package com.asmr.player.ui.library
 
 import android.content.Intent
+import android.graphics.RenderEffect
+import android.graphics.Shader
 import android.net.Uri
+import android.os.Build
 import android.provider.DocumentsContract
 import androidx.activity.compose.BackHandler
 import androidx.activity.compose.rememberLauncherForActivityResult
@@ -23,8 +26,6 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.ExperimentalFoundationApi
-import androidx.compose.foundation.pager.HorizontalPager
-import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
@@ -51,6 +52,7 @@ import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.BlendMode
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.CompositingStrategy
+import androidx.compose.ui.graphics.asComposeRenderEffect
 import androidx.compose.ui.graphics.compositeOver
 import androidx.compose.ui.graphics.lerp
 import androidx.compose.ui.graphics.vector.ImageVector
@@ -118,6 +120,8 @@ import kotlinx.coroutines.launch
 
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.clipToBounds
+import androidx.compose.ui.draw.blur
+import androidx.compose.ui.draw.drawWithCache
 import androidx.compose.ui.draw.drawWithContent
 import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.zIndex
@@ -165,8 +169,7 @@ internal data class PreparedMediaPlayback(
 )
 
 private val AlbumDetailTabContentGap = 12.dp
-private val AlbumDetailTabCollapseOvershoot = 10.dp
-private val AlbumDetailScrolledContentFadeSpan = 56.dp
+private val AlbumDetailScrolledContentFadeSpan = 112.dp
 private const val AlbumDetailHeroThemeGradientStartFraction = 0.38f
 private const val AlbumDetailHeroThemeGradientSolidFraction = 0.82f
 private const val AlbumDetailInitialIntroDurationMs = 1200L
@@ -217,23 +220,17 @@ fun AlbumDetailScreen(
         if (rjPart.isNotBlank()) "album:$rjPart" else "albumId:$idPart"
     }
     val introSessionKey = remember(screenKey) { "intro:${UUID.randomUUID()}" }
-    val initialSelectedTab = remember(albumId, initialTab) {
+    // 入口决定固定展示的二级页面：本地库->本地，在线/搜索->DL，preferDlsitePlay->DL Play。
+    // 不再提供页内 tab 切换与左右滑动。
+    val selectedTab = remember(albumId, initialTab) {
         initialTab?.coerceIn(0, 2) ?: if (albumId != null && albumId > 0) 0 else 1
     }
-    var selectedTab by rememberSaveable(screenKey, initialSelectedTab) {
-        mutableIntStateOf(initialSelectedTab)
-    }
-    var lastChromeResetTab by rememberSaveable(screenKey) {
-        mutableIntStateOf(selectedTab)
-    }
-    var userSelectedTab by remember(screenKey) { mutableStateOf(false) }
     var initialIntroSettled by remember(screenKey) { mutableStateOf(false) }
     var showAsmrDownloadDialog by remember { mutableStateOf(false) }
     var showOnlineSaveDialog by remember { mutableStateOf(false) }
     var pendingOnlineSaveSelection by remember { mutableStateOf<Set<String>?>(null) }
     var batchPlaylistItems by remember { mutableStateOf<List<MediaItem>?>(null) }
     var downloadSource by remember { mutableStateOf(OnlineDownloadSource.AsmrOne) }
-    val scope = rememberCoroutineScope()
 
     LaunchedEffect(albumId, rjCode) {
         viewModel.loadAlbum(albumId, rjCode, force = false)
@@ -286,8 +283,8 @@ fun AlbumDetailScreen(
                     val trialDownloadTree = remember(model.dlsiteTrialTracks) {
                         buildDlsiteTrialDownloadTree(model.dlsiteTrialTracks)
                     }
-                    val shouldPlayInitialAnimations = !initialIntroSettled && !userSelectedTab
-                    val shouldAnimateHeaderIntro = !userSelectedTab
+                    val shouldPlayInitialAnimations = !initialIntroSettled
+                    val shouldAnimateHeaderIntro = true
                     val availableTags by viewModel.availableTags.collectAsState()
                     val userTagsByTrackId by viewModel.userTagsByTrackId.collectAsState()
                     val libraryViewModel: LibraryViewModel = hiltViewModel()
@@ -310,53 +307,10 @@ fun AlbumDetailScreen(
                     var localPreviewFile by remember { mutableStateOf<LocalTreeUiEntry.File?>(null) }
                     var onlinePreviewFile by remember { mutableStateOf<AsmrTreeUiEntry.File?>(null) }
                     var imagePreviewRequest by remember { mutableStateOf<ImagePreviewRequest?>(null) }
+                    // tab 标签栏已移除，但各二级页面组件仍需要一个折叠头状态用于嵌套滚动协调。
+                    // 由于不再渲染 chrome，其 heightPx 始终为 0，相关调用均为安全空操作。
                     val tabChromeState = rememberCollapsibleHeaderState()
-                    val animatedTabChromeOffsetPx by animateFloatAsState(
-                        targetValue = tabChromeState.offsetPx,
-                        animationSpec = spring(
-                            dampingRatio = Spring.DampingRatioNoBouncy,
-                            stiffness = Spring.StiffnessMediumLow
-                        ),
-                        label = "albumDetailTabChromeOffset"
-                    )
-                    val tabChromeVisibleHeight = if (tabChromeState.heightPx > 0f) {
-                        with(LocalDensity.current) {
-                            (tabChromeState.heightPx + tabChromeState.offsetPx)
-                                .coerceIn(0f, tabChromeState.heightPx)
-                                .toDp()
-                        }
-                    } else {
-                        56.dp
-                    }
-                    val tabTitles = remember { listOf("本地", "DL", "DL Play") }
-                    val tabPagerState = rememberPagerState(
-                        initialPage = selectedTab,
-                        pageCount = { tabTitles.size }
-                    )
-                    val tabIndicatorPageOffset =
-                        (tabPagerState.currentPage + tabPagerState.currentPageOffsetFraction)
-                            .coerceIn(0f, tabTitles.lastIndex.coerceAtLeast(0).toFloat())
-    
-                    LaunchedEffect(selectedTab) {
-                        if (lastChromeResetTab != selectedTab) {
-                            tabChromeState.expand()
-                            lastChromeResetTab = selectedTab
-                        }
-                    }
 
-                    LaunchedEffect(tabPagerState) {
-                        snapshotFlow { tabPagerState.isScrollInProgress }
-                            .collect { scrolling ->
-                                if (!scrolling) {
-                                    val page = tabPagerState.currentPage
-                                    if (selectedTab != page) {
-                                        selectedTab = page
-                                        userSelectedTab = true
-                                    }
-                                }
-                            }
-                    }
-    
                     BoxWithConstraints(modifier = Modifier.fillMaxSize()) {
                         val pageContainerColor = dynamicPageContainerColor(colorScheme)
                         val heroHeightLimit = if (isCompact) {
@@ -379,7 +333,7 @@ fun AlbumDetailScreen(
                                 maximumValue = if (isCompact) 120.dp else 152.dp
                             )
                         val tabChromeTop = (heroHeight - heroContentOverlap).coerceAtLeast(0.dp)
-                        val tabContentTopPadding = tabChromeTop + tabChromeVisibleHeight + AlbumDetailTabContentGap
+                        val tabContentTopPadding = tabChromeTop + AlbumDetailTabContentGap
                         val contentFadeEndY = tabChromeTop
                         val contentFadeStartY = (contentFadeEndY - AlbumDetailScrolledContentFadeSpan).coerceAtLeast(0.dp)
 
@@ -485,16 +439,15 @@ fun AlbumDetailScreen(
                                 }
                             }
 
-                            HorizontalPager(
-                                state = tabPagerState,
+                            Box(
                                 modifier = Modifier
                                     .fillMaxSize()
                                     .albumDetailScrolledContentFade(
                                         fadeStartY = contentFadeStartY,
                                         fadeEndY = contentFadeEndY
                                     )
-                            ) { tab ->
-                                when (tab) {
+                            ) {
+                                when (selectedTab) {
                                     0 -> {
                                         val local = model.localAlbum
                                         if (local != null) {
@@ -520,7 +473,7 @@ fun AlbumDetailScreen(
                                                 topContentPadding = tabContentTopPadding,
                                                 chromeState = tabChromeState,
                                                 album = local,
-                                                header = { headerContent(tab) },
+                                                header = { headerContent(0) },
                                                 onPlayMediaItems = onPlayMediaItems,
                                                 onAddToQueue = { track ->
                                                     onAddToQueue(local, track)
@@ -567,7 +520,7 @@ fun AlbumDetailScreen(
                                     }
                                     1 -> AlbumDlsiteInfoBreadcrumbTabV2(
                                         album = album,
-                                        header = { headerContent(tab) },
+                                        header = { headerContent(1) },
                                         dlsiteInfo = model.dlsiteInfo,
                                         galleryUrls = model.dlsiteGalleryUrls,
                                         trialTracks = model.dlsiteTrialTracks,
@@ -621,7 +574,7 @@ fun AlbumDetailScreen(
                                         loadRemoteFileSize = { viewModel.loadRemoteFileSize(it) }
                                     )
                                     else -> AlbumDlsitePlayBreadcrumbTabV2(
-                                        header = { headerContent(tab) },
+                                        header = { headerContent(2) },
                                         album = album,
                                         rjCode = model.rjCode,
                                         tree = model.dlsitePlayTree,
@@ -659,28 +612,6 @@ fun AlbumDetailScreen(
                                     )
                                 }
                             }
-                        AlbumDetailTabChrome(
-                            modifier = Modifier
-                                .align(Alignment.TopCenter)
-                                .offset(y = tabChromeTop),
-                            titles = tabTitles,
-                            selectedTab = selectedTab,
-                            indicatorPageOffset = tabIndicatorPageOffset,
-                            animatedOffsetPx = animatedTabChromeOffsetPx,
-                            collapseFraction = tabChromeState.collapseFraction,
-                            onMeasured = { tabChromeState.updateHeight(it.height.toFloat()) },
-                            onTabSelected = { index ->
-                                userSelectedTab = true
-                                if (selectedTab != index) {
-                                    selectedTab = index
-                                }
-                                if (tabPagerState.currentPage != index) {
-                                    scope.launch {
-                                        tabPagerState.animateScrollToPage(index)
-                                    }
-                                }
-                            }
-                        )
                     }
                 }
 
@@ -829,152 +760,6 @@ fun AlbumDetailScreen(
 }
 
 @Composable
-private fun AlbumDetailTabChrome(
-    modifier: Modifier = Modifier,
-    titles: List<String>,
-    selectedTab: Int,
-    indicatorPageOffset: Float,
-    animatedOffsetPx: Float,
-    collapseFraction: Float,
-    onMeasured: (IntSize) -> Unit,
-    onTabSelected: (Int) -> Unit
-) {
-    val colorScheme = AsmrTheme.colorScheme
-    val isDark = colorScheme.isDark
-    val tabContainerShape = RoundedCornerShape(16.dp)
-    val tabItemShape = RoundedCornerShape(12.dp)
-    val collapseOvershootPx = with(LocalDensity.current) { AlbumDetailTabCollapseOvershoot.toPx() }
-    val tabContainerColor = lerp(
-        colorScheme.surface,
-        colorScheme.primarySoft,
-        if (isDark) 0.18f else 0.28f
-    ).copy(alpha = if (isDark) 0.95f else 0.97f)
-        .compositeOver(colorScheme.background)
-    val tabBorderColor = if (isDark) {
-        colorScheme.primary.copy(alpha = 0.11f)
-    } else {
-        colorScheme.primary.copy(alpha = 0.09f)
-    }
-
-    BoxWithConstraints(
-        modifier = modifier
-            .fillMaxWidth()
-            .padding(horizontal = AlbumDetailHorizontalPadding, vertical = 6.dp)
-            .onSizeChanged(onMeasured)
-            .graphicsLayer {
-                translationY = animatedOffsetPx -
-                    (collapseFraction.coerceIn(0f, 1f) * collapseOvershootPx)
-                alpha = 1f - collapseFraction.coerceIn(0f, 1f)
-            }
-            .semantics { stateDescription = collapsibleHeaderUiState(collapseFraction) }
-            .zIndex(1f)
-    ) {
-        val count = titles.size.coerceAtLeast(1)
-        val segmentGap = 4.dp
-        val segmentPadding = 4.dp
-        val segmentHeight = 36.dp
-        val slotWidth = (maxWidth - (segmentPadding * 2) - (segmentGap * (count - 1))) / count
-        val highlightX = (slotWidth + segmentGap) *
-            indicatorPageOffset.coerceIn(0f, (count - 1).coerceAtLeast(0).toFloat())
-
-        Surface(
-            modifier = Modifier
-                .fillMaxWidth()
-                .shadow(
-                    elevation = if (isDark) 10.dp else 6.dp,
-                    shape = tabContainerShape,
-                    spotColor = if (isDark) Color.Black.copy(alpha = 0.8f) else Color.Black.copy(alpha = 0.25f),
-                    ambientColor = if (isDark) Color.Black.copy(alpha = 0.8f) else Color.Black.copy(alpha = 0.25f)
-                )
-                .then(
-                    Modifier.border(
-                        width = 1.dp,
-                        color = tabBorderColor,
-                        shape = tabContainerShape
-                    )
-                ),
-            color = tabContainerColor,
-            contentColor = colorScheme.textPrimary,
-            shape = tabContainerShape,
-            tonalElevation = 0.dp,
-            shadowElevation = 0.dp
-        ) {
-            Box(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(segmentPadding)
-            ) {
-                Box(
-                    modifier = Modifier
-                        .offset(x = highlightX)
-                        .width(slotWidth)
-                        .height(segmentHeight)
-                        .clip(tabItemShape)
-                        .background(
-                            color = if (isDark) {
-                                colorScheme.primary.copy(alpha = 0.22f)
-                            } else {
-                                colorScheme.primary.copy(alpha = 0.12f)
-                            },
-                            shape = tabItemShape
-                        )
-                        .border(
-                            width = 1.dp,
-                            color = if (isDark) {
-                                colorScheme.primary.copy(alpha = 0.28f)
-                            } else {
-                                colorScheme.primary.copy(alpha = 0.18f)
-                            },
-                            shape = tabItemShape
-                        )
-                )
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.spacedBy(segmentGap),
-                    verticalAlignment = Alignment.CenterVertically
-                ) {
-                    titles.forEachIndexed { index, title ->
-                        val selected = selectedTab == index
-                        Box(
-                            modifier = Modifier
-                                .width(slotWidth)
-                                .height(segmentHeight)
-                                .clip(tabItemShape)
-                                .clickable(
-                                    indication = null,
-                                    interactionSource = remember { MutableInteractionSource() }
-                                ) { onTabSelected(index) }
-                                .padding(horizontal = 4.dp),
-                            contentAlignment = Alignment.Center
-                        ) {
-                            Text(
-                                text = title,
-                                modifier = Modifier.fillMaxWidth(),
-                                color = if (selected) {
-                                    if (isDark) {
-                                        colorScheme.primary
-                                    } else {
-                                        colorScheme.primary
-                                    }
-                                } else {
-                                    colorScheme.textSecondary
-                                },
-                                style = MaterialTheme.typography.labelLarge.copy(
-                                    fontWeight = if (selected) FontWeight.Bold else FontWeight.Medium
-                                ),
-                                textAlign = androidx.compose.ui.text.style.TextAlign.Center,
-                                maxLines = 1,
-                                overflow = TextOverflow.Ellipsis
-                            )
-                        }
-                    }
-                }
-            }
-        }
-    }
-}
-
-@Composable
 private fun AlbumDetailHeroBackground(
     album: Album,
     height: Dp,
@@ -984,6 +769,18 @@ private fun AlbumDetailHeroBackground(
     modifier: Modifier = Modifier
 ) {
     val imageModel = rememberAlbumCoverImageModel(album)
+    val blurModifier = remember {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            Modifier.graphicsLayer {
+                val blurPx = 36.dp.toPx()
+                renderEffect = RenderEffect
+                    .createBlurEffect(blurPx, blurPx, Shader.TileMode.CLAMP)
+                    .asComposeRenderEffect()
+            }
+        } else {
+            Modifier.blur(28.dp)
+        }
+    }
 
     Box(
         modifier = modifier
@@ -1008,6 +805,41 @@ private fun AlbumDetailHeroBackground(
                 }
             },
         )
+        // 渐进式毛玻璃：在锐利封面之上叠加一层模糊副本，并用 smoothstep 缓动的垂直遮罩
+        // 让模糊从中部开始、向下逐渐加强，形成自上而下平滑过渡的高级质感。
+        AsmrAsyncImage(
+            model = imageModel,
+            contentDescription = null,
+            contentScale = ContentScale.FillWidth,
+            alignment = Alignment.TopCenter,
+            placeholderCornerRadius = 0,
+            modifier = Modifier
+                .fillMaxSize()
+                .then(blurModifier)
+                .drawWithCache {
+                    val stops = (0..6).map { i ->
+                        val t = i / 6f
+                        val pos = 0.34f + (1f - 0.34f) * t
+                        val eased = t * t * (3f - 2f * t)
+                        pos to Color.White.copy(alpha = eased)
+                    }.toTypedArray()
+                    val mask = Brush.verticalGradient(
+                        colorStops = arrayOf(
+                            0f to Color.Transparent,
+                            0.34f to Color.Transparent,
+                            *stops
+                        )
+                    )
+                    onDrawWithContent {
+                        drawContent()
+                        drawRect(brush = mask, blendMode = BlendMode.DstIn)
+                    }
+                },
+            placeholder = {},
+            loading = {},
+            empty = {},
+        )
+        // 顶部深色蒙版，保证返回按钮等控件的可读性
         Box(
             modifier = Modifier
                 .fillMaxSize()
@@ -1021,6 +853,7 @@ private fun AlbumDetailHeroBackground(
                     )
                 )
         )
+        // 底部色彩渐变，让 hero 平滑融入页面底色
         Box(
             modifier = Modifier
                 .fillMaxSize()
@@ -1030,8 +863,8 @@ private fun AlbumDetailHeroBackground(
                             0f to Color.Transparent,
                             AlbumDetailHeroThemeGradientStartFraction to Color.Transparent,
                             ((AlbumDetailHeroThemeGradientStartFraction + AlbumDetailHeroThemeGradientSolidFraction) / 2f) to
-                                pageContainerColor.copy(alpha = 0.68f),
-                            AlbumDetailHeroThemeGradientSolidFraction to pageContainerColor.copy(alpha = 0.96f),
+                                pageContainerColor.copy(alpha = 0.62f),
+                            AlbumDetailHeroThemeGradientSolidFraction to pageContainerColor.copy(alpha = 0.94f),
                             1f to pageContainerColor
                         )
                     )
@@ -1086,11 +919,23 @@ private fun Modifier.albumDetailScrolledContentFade(
             drawContent()
             val fadeStartPx = fadeStartY.toPx().coerceAtLeast(0f)
             val fadeEndPx = fadeEndY.toPx().coerceAtLeast(fadeStartPx + 1f)
+            val rampStart = (fadeStartPx / fadeEndPx).coerceIn(0f, 1f)
+            val rampSpan = (1f - rampStart).coerceAtLeast(0.0001f)
+            // 用 smoothstep 缓动的多段渐变替代线性裁切，使内容向上滚入 hero 区域时
+            // 平滑自然地溶解消失，而不是生硬地一刀切。
+            fun stopAt(t: Float): Pair<Float, Color> {
+                val eased = t * t * (3f - 2f * t)
+                return (rampStart + rampSpan * t) to Color.White.copy(alpha = eased)
+            }
             drawRect(
                 brush = Brush.verticalGradient(
                     colorStops = arrayOf(
                         0f to Color.Transparent,
-                        (fadeStartPx / fadeEndPx).coerceIn(0f, 1f) to Color.Transparent,
+                        rampStart to Color.Transparent,
+                        stopAt(0.2f),
+                        stopAt(0.4f),
+                        stopAt(0.6f),
+                        stopAt(0.8f),
                         1f to Color.White
                     ),
                     startY = 0f,

--- a/app/src/main/java/com/asmr/player/ui/library/AlbumDetailScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/AlbumDetailScreen.kt
@@ -169,6 +169,7 @@ internal data class PreparedMediaPlayback(
 
 private val AlbumDetailHeroContentGap = 8.dp
 private val AlbumDetailHeroTransitionHeight = 96.dp
+private val AlbumDetailHeroBlurRampHeight = 188.dp
 private val AlbumDetailScrolledContentFadeSpan = 10.dp
 private const val AlbumDetailInitialIntroDurationMs = 1200L
 internal val AlbumDetailHorizontalPadding = 8.dp
@@ -777,13 +778,14 @@ private fun AlbumDetailHeroBackground(
                     compositingStrategy = CompositingStrategy.Offscreen
                 }
                 .drawWithCache {
-                    val fadeHeightPx = AlbumDetailHeroTransitionHeight.toPx()
-                        .coerceAtMost(size.height * 0.28f)
+                    val fadeHeightPx = AlbumDetailHeroBlurRampHeight.toPx()
+                        .coerceAtMost(size.height * 0.52f)
                     val fadeStartY = (size.height - fadeHeightPx).coerceAtLeast(0f)
                     val stops = (0..5).map { i ->
                         val t = i / 5f
                         val eased = t * t * (3f - 2f * t)
-                        t to Color.White.copy(alpha = 1f - eased)
+                        val alpha = 1f - eased * 0.38f
+                        t to Color.White.copy(alpha = alpha)
                     }.toTypedArray()
                     val mask = Brush.verticalGradient(
                         colorStops = arrayOf(
@@ -809,8 +811,7 @@ private fun AlbumDetailHeroBackground(
                 }
             },
         )
-        // 渐进式毛玻璃：在锐利封面之上叠加一层模糊副本，并用 smoothstep 缓动的垂直遮罩
-        // 让模糊从中部开始、向下逐渐加强，形成自上而下平滑过渡的高级质感。
+        // 渐进式毛玻璃：从标题区域开始叠加模糊副本，让标题和元信息下方仍保留封面纹理。
         AsmrAsyncImage(
             model = imageModel,
             contentDescription = null,
@@ -824,13 +825,13 @@ private fun AlbumDetailHeroBackground(
                     compositingStrategy = CompositingStrategy.Offscreen
                 }
                 .drawWithCache {
-                    val rampHeightPx = AlbumDetailHeroTransitionHeight.toPx()
-                        .coerceAtMost(size.height * 0.28f)
+                    val rampHeightPx = AlbumDetailHeroBlurRampHeight.toPx()
+                        .coerceAtMost(size.height * 0.52f)
                     val rampStartY = (size.height - rampHeightPx).coerceAtLeast(0f)
                     val stops = (0..6).map { i ->
                         val t = i / 6f
                         val eased = t * t * (3f - 2f * t)
-                        t to Color.White.copy(alpha = eased)
+                        t to Color.White.copy(alpha = 0.18f + eased * 0.82f)
                     }.toTypedArray()
                     val mask = Brush.verticalGradient(
                         colorStops = arrayOf(
@@ -864,17 +865,20 @@ private fun AlbumDetailHeroBackground(
                     )
                 )
         )
-        // 底部短渐变，让封面快速融入页面底色，避免过渡区随屏幕高度变胖。
+        // 只在封面容器内部做底缘融色，让封面边缘轻轻透出页面背景。
         Box(
             modifier = Modifier
                 .align(Alignment.BottomCenter)
                 .fillMaxWidth()
-                .height(AlbumDetailHeroTransitionHeight)
+                .height(AlbumDetailHeroTransitionHeight * 1.7f)
                 .background(
                     Brush.verticalGradient(
                         colorStops = arrayOf(
                             0f to Color.Transparent,
-                            0.52f to pageContainerColor.copy(alpha = 0.82f),
+                            0.28f to pageContainerColor.copy(alpha = 0.08f),
+                            0.52f to pageContainerColor.copy(alpha = 0.30f),
+                            0.74f to pageContainerColor.copy(alpha = 0.70f),
+                            0.88f to pageContainerColor,
                             1f to pageContainerColor
                         )
                     )
@@ -896,6 +900,7 @@ private fun AlbumHeroIdentityOverlay(
     messageManager: MessageManager,
     modifier: Modifier = Modifier
 ) {
+    val colorScheme = AsmrTheme.colorScheme
     val copyMeta = rememberAlbumMetaCopyAction(messageManager)
     val rj = album.rjCode.ifBlank { album.workId }.trim()
     val circle = album.circle.trim()
@@ -915,15 +920,16 @@ private fun AlbumHeroIdentityOverlay(
         Text(
             text = album.title,
             modifier = Modifier.clickable { copyMeta("标题", album.title) },
-            style = MaterialTheme.typography.titleLarge.copy(
+            style = MaterialTheme.typography.titleMedium.copy(
                 fontWeight = FontWeight.Bold,
+                fontSize = 20.sp,
                 shadow = Shadow(
-                    color = Color.Black.copy(alpha = 0.58f),
+                    color = if (colorScheme.isDark) Color.White.copy(alpha = 0.58f) else Color.Black.copy(alpha = 0.58f),
                     offset = Offset(0f, 2f),
                     blurRadius = 8f
                 )
             ),
-            color = Color.White,
+            color = if (colorScheme.isDark) Color.White else Color.Black,
             maxLines = 3,
             overflow = TextOverflow.Ellipsis
         )
@@ -944,13 +950,20 @@ private fun AlbumHeroIdentityOverlay(
                 )
                 if (listenTogetherRjListenerCount != null && rj.isNotBlank()) {
                     Spacer(modifier = Modifier.width(8.dp))
+                    val listenerContainer = colorScheme.primary.copy(alpha = if (colorScheme.isDark) 0.36f else 0.30f)
+                    val listenerContent = if (colorScheme.isDark) {
+                        Color.White.copy(alpha = 0.96f)
+                    } else {
+                        colorScheme.textPrimary.copy(alpha = 0.88f)
+                    }
+                    val listenerBorder = colorScheme.primary.copy(alpha = if (colorScheme.isDark) 0.52f else 0.42f)
                     Surface(
-                        color = Color.Black.copy(alpha = 0.46f),
-                        contentColor = Color.White,
+                        color = listenerContainer,
+                        contentColor = listenerContent,
                         shape = RoundedCornerShape(999.dp),
                         border = androidx.compose.foundation.BorderStroke(
                             width = 0.5.dp,
-                            color = Color.White.copy(alpha = 0.22f)
+                            color = listenerBorder
                         )
                     ) {
                         Row(
@@ -961,13 +974,13 @@ private fun AlbumHeroIdentityOverlay(
                             Icon(
                                 painter = painterResource(id = com.asmr.player.R.drawable.ic_users_round),
                                 contentDescription = null,
-                                tint = Color.White.copy(alpha = 0.94f),
+                                tint = listenerContent,
                                 modifier = Modifier.size(12.dp)
                             )
                             Text(
                                 text = "${listenTogetherRjListenerCount.coerceAtLeast(0)} 人正在听",
                                 style = MaterialTheme.typography.labelSmall,
-                                color = Color.White.copy(alpha = 0.94f),
+                                color = listenerContent,
                                 maxLines = 1,
                                 overflow = TextOverflow.Ellipsis,
                             )
@@ -1095,7 +1108,7 @@ private fun AlbumHeader(
             modifier = headerContainerModifier,
             enabled = animateIntro && !headerIntroPlayed
         )
-            .padding(top = 18.dp, bottom = 12.dp),
+            .padding(top = 10.dp, bottom = 12.dp),
         verticalArrangement = Arrangement.spacedBy(12.dp)
     ) {
                 if (album.cv.isNotBlank()) {

--- a/app/src/main/java/com/asmr/player/ui/library/AlbumDetailScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/AlbumDetailScreen.kt
@@ -5,10 +5,7 @@ import android.graphics.RenderEffect
 import android.graphics.Shader
 import android.net.Uri
 import android.os.Build
-import android.provider.DocumentsContract
 import androidx.activity.compose.BackHandler
-import androidx.activity.compose.rememberLauncherForActivityResult
-import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.animateContentSize
 import androidx.compose.animation.core.Spring
@@ -48,10 +45,12 @@ import androidx.compose.runtime.*
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.BlendMode
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.CompositingStrategy
+import androidx.compose.ui.graphics.Shadow
 import androidx.compose.ui.graphics.asComposeRenderEffect
 import androidx.compose.ui.graphics.compositeOver
 import androidx.compose.ui.graphics.lerp
@@ -168,10 +167,9 @@ internal data class PreparedMediaPlayback(
     val startIndex: Int
 )
 
-private val AlbumDetailTabContentGap = 0.dp
-private val AlbumDetailScrolledContentFadeSpan = 56.dp
-private const val AlbumDetailHeroThemeGradientStartFraction = 0.42f
-private const val AlbumDetailHeroThemeGradientSolidFraction = 0.86f
+private val AlbumDetailHeroContentGap = 8.dp
+private val AlbumDetailHeroTransitionHeight = 96.dp
+private val AlbumDetailScrolledContentFadeSpan = 10.dp
 private const val AlbumDetailInitialIntroDurationMs = 1200L
 internal val AlbumDetailHorizontalPadding = 8.dp
 
@@ -290,20 +288,6 @@ fun AlbumDetailScreen(
                     val libraryViewModel: LibraryViewModel = hiltViewModel()
                     var showTagManager by remember { mutableStateOf(false) }
                     var tagManageTrack by remember { mutableStateOf<Track?>(null) }
-                    val context = LocalContext.current
-                    val coverPicker = rememberLauncherForActivityResult(
-                        contract = ActivityResultContracts.OpenDocument(),
-                        onResult = { uri ->
-                            if (uri == null) return@rememberLauncherForActivityResult
-                            runCatching {
-                                context.contentResolver.takePersistableUriPermission(
-                                    uri,
-                                    Intent.FLAG_GRANT_READ_URI_PERMISSION
-                                )
-                            }
-                            viewModel.setLocalCoverPath(uri.toString())
-                        }
-                    )
                     var localPreviewFile by remember { mutableStateOf<LocalTreeUiEntry.File?>(null) }
                     var onlinePreviewFile by remember { mutableStateOf<AsmrTreeUiEntry.File?>(null) }
                     var imagePreviewRequest by remember { mutableStateOf<ImagePreviewRequest?>(null) }
@@ -320,22 +304,17 @@ fun AlbumDetailScreen(
                         }
                         val heroMinHeight = if (isCompact) 280.dp else 360.dp
                         val heroPreferredHeight = if (isCompact) {
-                            maxWidth
-                        } else {
                             maxWidth * 0.88f
+                        } else {
+                            maxWidth * 0.78f
                         }
                         val heroHeight = heroPreferredHeight
                             .coerceAtLeast(heroMinHeight)
                             .coerceAtMost(heroHeightLimit.coerceAtLeast(heroMinHeight))
-                        val heroContentOverlap = (heroHeight * if (isCompact) 0.30f else 0.26f)
-                            .coerceIn(
-                                minimumValue = if (isCompact) 104.dp else 124.dp,
-                                maximumValue = if (isCompact) 148.dp else 184.dp
-                            )
-                        val tabChromeTop = (heroHeight - heroContentOverlap).coerceAtLeast(0.dp)
-                        val tabContentTopPadding = tabChromeTop + AlbumDetailTabContentGap
-                        val contentFadeEndY = tabChromeTop
-                        val contentFadeStartY = (contentFadeEndY - AlbumDetailScrolledContentFadeSpan).coerceAtLeast(0.dp)
+                        val contentViewportTop = heroHeight + AlbumDetailHeroContentGap
+                        val contentViewportHeight = (maxHeight - contentViewportTop).coerceAtLeast(0.dp)
+                        val contentFadeStartY = 0.dp
+                        val contentFadeEndY = AlbumDetailScrolledContentFadeSpan
 
                         fun headerAlbumForTab(tab: Int): Album {
                             return if (tab == 0) (model.localAlbum ?: album) else album
@@ -356,25 +335,14 @@ fun AlbumDetailScreen(
                         }
 
                         val activeHeroAlbum = headerAlbumForTab(selectedTab)
-                        val pickLocalCoverAction = if (selectedTab == 0 && model.localAlbum != null) {
-                            { coverPicker.launch(arrayOf("image/*")) }
-                        } else {
-                            null
-                        }
                         val showHeroCoverLoadingState = shouldShowCoverLoading(selectedTab, activeHeroAlbum)
 
                         val headerContent: @Composable (Int) -> Unit = { tab ->
                             val isLocalTab = tab == 0
                             val canSaveOnlineForTab = tab == 1 && asmrOneTree.isNotEmpty()
                             val headerAlbum = headerAlbumForTab(tab)
-                            Surface(
-                                modifier = Modifier.fillMaxWidth(),
-                                color = pageContainerColor,
-                                shape = RoundedCornerShape(topStart = 24.dp, topEnd = 24.dp)
-                            ) {
-                                AlbumHeader(
+                            AlbumHeader(
                                 album = headerAlbum,
-                                listenTogetherRjListenerCount = model.listenTogetherRjListenerCount,
                                 dlsiteUrl = model.dlsiteWorkno.takeIf { it.isNotBlank() }?.let { "https://www.dlsite.com/maniax/work/=/product_id/$it.html" }.orEmpty(),
                                 asmrOneUrl = model.asmrOneWorkId?.takeIf { it.isNotBlank() }?.let { "https://asmr.one/work/$it" }.orEmpty(),
                                 dlsiteEditions = if (isLocalTab) emptyList() else model.dlsiteEditions,
@@ -409,7 +377,6 @@ fun AlbumDetailScreen(
                                 animateIntro = shouldAnimateHeaderIntro,
                                 messageManager = viewModel.messageManager
                             )
-                            }
                         }
 
                         Box(
@@ -423,8 +390,9 @@ fun AlbumDetailScreen(
                                 album = activeHeroAlbum,
                                 height = heroHeight,
                                 pageContainerColor = pageContainerColor,
+                                listenTogetherRjListenerCount = model.listenTogetherRjListenerCount,
                                 showCoverLoadingState = showHeroCoverLoadingState,
-                                onPickLocalCover = pickLocalCoverAction,
+                                messageManager = viewModel.messageManager,
                                 modifier = Modifier.align(Alignment.TopCenter)
                             )
 
@@ -447,7 +415,10 @@ fun AlbumDetailScreen(
 
                             Box(
                                 modifier = Modifier
-                                    .fillMaxSize()
+                                    .align(Alignment.BottomCenter)
+                                    .fillMaxWidth()
+                                    .height(contentViewportHeight)
+                                    .clipToBounds()
                                     .albumDetailScrolledContentFade(
                                         fadeStartY = contentFadeStartY,
                                         fadeEndY = contentFadeEndY
@@ -476,7 +447,7 @@ fun AlbumDetailScreen(
                                                 onPersistScroll = { index, offset ->
                                                     viewModel.persistListScrollPosition("scroll:$localTreeStateKey", index, offset)
                                                 },
-                                                topContentPadding = tabContentTopPadding,
+                                                topContentPadding = 0.dp,
                                                 chromeState = tabChromeState,
                                                 album = local,
                                                 header = { headerContent(0) },
@@ -516,8 +487,7 @@ fun AlbumDetailScreen(
                                         } else {
                                             Box(
                                                 modifier = Modifier
-                                                    .fillMaxSize()
-                                                    .padding(top = tabContentTopPadding),
+                                                    .fillMaxSize(),
                                                 contentAlignment = Alignment.Center
                                             ) {
                                                 Text("未下载到本地")
@@ -564,7 +534,7 @@ fun AlbumDetailScreen(
                                         onPreviewFile = { onlinePreviewFile = it },
                                         treeStateKey = "tree:asmrOne:${model.rjCode.trim().uppercase()}",
                                         initialCurrentPath = viewModel.getTreeCurrentPath("tree:asmrOne:${model.rjCode.trim().uppercase()}"),
-                                        topContentPadding = tabContentTopPadding,
+                                        topContentPadding = 0.dp,
                                         chromeState = tabChromeState,
                                         animateIntro = shouldPlayInitialAnimations,
                                         onPersistCurrentPath = { path ->
@@ -603,7 +573,7 @@ fun AlbumDetailScreen(
                                         prepareImagePreview = viewModel::prepareDlsitePlayImagePreview,
                                         treeStateKey = "tree:dlsitePlay:${model.baseRjCode.ifBlank { model.rjCode }.trim().uppercase()}",
                                         initialCurrentPath = viewModel.getTreeCurrentPath("tree:dlsitePlay:${model.baseRjCode.ifBlank { model.rjCode }.trim().uppercase()}"),
-                                        topContentPadding = tabContentTopPadding,
+                                        topContentPadding = 0.dp,
                                         chromeState = tabChromeState,
                                         animateIntro = shouldPlayInitialAnimations,
                                         onPersistCurrentPath = { path ->
@@ -770,21 +740,22 @@ private fun AlbumDetailHeroBackground(
     album: Album,
     height: Dp,
     pageContainerColor: Color,
+    listenTogetherRjListenerCount: Int?,
     showCoverLoadingState: Boolean,
-    onPickLocalCover: (() -> Unit)?,
+    messageManager: MessageManager,
     modifier: Modifier = Modifier
 ) {
     val imageModel = rememberAlbumCoverImageModel(album)
     val blurModifier = remember {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
             Modifier.graphicsLayer {
-                val blurPx = 52.dp.toPx()
+                val blurPx = 84.dp.toPx()
                 renderEffect = RenderEffect
                     .createBlurEffect(blurPx, blurPx, Shader.TileMode.CLAMP)
                     .asComposeRenderEffect()
             }
         } else {
-            Modifier.blur(40.dp)
+            Modifier.blur(64.dp)
         }
     }
 
@@ -797,10 +768,37 @@ private fun AlbumDetailHeroBackground(
         AsmrAsyncImage(
             model = imageModel,
             contentDescription = null,
-            contentScale = ContentScale.FillWidth,
+            contentScale = ContentScale.Crop,
             alignment = Alignment.TopCenter,
             placeholderCornerRadius = 0,
-            modifier = Modifier.fillMaxSize(),
+            modifier = Modifier
+                .fillMaxSize()
+                .graphicsLayer {
+                    compositingStrategy = CompositingStrategy.Offscreen
+                }
+                .drawWithCache {
+                    val fadeHeightPx = AlbumDetailHeroTransitionHeight.toPx()
+                        .coerceAtMost(size.height * 0.28f)
+                    val fadeStartY = (size.height - fadeHeightPx).coerceAtLeast(0f)
+                    val stops = (0..5).map { i ->
+                        val t = i / 5f
+                        val eased = t * t * (3f - 2f * t)
+                        t to Color.White.copy(alpha = 1f - eased)
+                    }.toTypedArray()
+                    val mask = Brush.verticalGradient(
+                        colorStops = arrayOf(
+                            0f to Color.White,
+                            *stops,
+                            1f to Color.Transparent
+                        ),
+                        startY = fadeStartY,
+                        endY = size.height
+                    )
+                    onDrawWithContent {
+                        drawContent()
+                        drawRect(brush = mask, blendMode = BlendMode.DstIn)
+                    }
+                },
             placeholder = { m -> DiscPlaceholder(modifier = m, cornerRadius = 0) },
             loading = { m -> AsmrShimmerPlaceholder(modifier = m, cornerRadius = 0) },
             empty = { m ->
@@ -816,28 +814,32 @@ private fun AlbumDetailHeroBackground(
         AsmrAsyncImage(
             model = imageModel,
             contentDescription = null,
-            contentScale = ContentScale.FillWidth,
+            contentScale = ContentScale.Crop,
             alignment = Alignment.TopCenter,
             placeholderCornerRadius = 0,
             modifier = Modifier
                 .fillMaxSize()
                 .then(blurModifier)
+                .graphicsLayer {
+                    compositingStrategy = CompositingStrategy.Offscreen
+                }
                 .drawWithCache {
-                    val rampStart = 0.18f
-                    val rampEnd = 0.86f
+                    val rampHeightPx = AlbumDetailHeroTransitionHeight.toPx()
+                        .coerceAtMost(size.height * 0.28f)
+                    val rampStartY = (size.height - rampHeightPx).coerceAtLeast(0f)
                     val stops = (0..6).map { i ->
                         val t = i / 6f
-                        val pos = rampStart + (rampEnd - rampStart) * t
                         val eased = t * t * (3f - 2f * t)
-                        pos to Color.White.copy(alpha = eased)
+                        t to Color.White.copy(alpha = eased)
                     }.toTypedArray()
                     val mask = Brush.verticalGradient(
                         colorStops = arrayOf(
                             0f to Color.Transparent,
-                            rampStart to Color.Transparent,
                             *stops,
                             1f to Color.White
-                        )
+                        ),
+                        startY = rampStartY,
+                        endY = size.height
                     )
                     onDrawWithContent {
                         drawContent()
@@ -862,40 +864,116 @@ private fun AlbumDetailHeroBackground(
                     )
                 )
         )
-        // 底部色彩渐变，让 hero 平滑融入页面底色。
-        // 在 SolidFraction 处即达到完全不透明的容器色，并保持到底部，
-        // 从而彻底遮住封面被裁切的底部边缘，消除割裂感。
+        // 底部短渐变，让封面快速融入页面底色，避免过渡区随屏幕高度变胖。
         Box(
             modifier = Modifier
-                .fillMaxSize()
+                .align(Alignment.BottomCenter)
+                .fillMaxWidth()
+                .height(AlbumDetailHeroTransitionHeight)
                 .background(
                     Brush.verticalGradient(
                         colorStops = arrayOf(
                             0f to Color.Transparent,
-                            AlbumDetailHeroThemeGradientStartFraction to Color.Transparent,
-                            ((AlbumDetailHeroThemeGradientStartFraction + AlbumDetailHeroThemeGradientSolidFraction) / 2f) to
-                                pageContainerColor.copy(alpha = 0.70f),
-                            AlbumDetailHeroThemeGradientSolidFraction to pageContainerColor,
+                            0.52f to pageContainerColor.copy(alpha = 0.82f),
                             1f to pageContainerColor
                         )
                     )
                 )
         )
-        if (onPickLocalCover != null) {
-            IconButton(
-                onClick = onPickLocalCover,
-                modifier = Modifier
-                    .align(Alignment.BottomEnd)
-                    .padding(end = 14.dp, bottom = 14.dp)
-                    .size(40.dp)
-                    .background(Color.Black.copy(alpha = 0.38f), RoundedCornerShape(12.dp))
-            ) {
-                Icon(
-                    imageVector = Icons.Rounded.Photo,
-                    contentDescription = "选择封面",
-                    tint = Color.White,
-                    modifier = Modifier.size(18.dp)
+        AlbumHeroIdentityOverlay(
+            album = album,
+            listenTogetherRjListenerCount = listenTogetherRjListenerCount,
+            messageManager = messageManager,
+            modifier = Modifier.align(Alignment.BottomStart)
+        )
+    }
+}
+
+@Composable
+private fun AlbumHeroIdentityOverlay(
+    album: Album,
+    listenTogetherRjListenerCount: Int?,
+    messageManager: MessageManager,
+    modifier: Modifier = Modifier
+) {
+    val copyMeta = rememberAlbumMetaCopyAction(messageManager)
+    val rj = album.rjCode.ifBlank { album.workId }.trim()
+    val circle = album.circle.trim()
+    val showMetaRow = rj.isNotBlank() || circle.isNotBlank() ||
+        (listenTogetherRjListenerCount != null && rj.isNotBlank())
+
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(
+                start = AlbumDetailHorizontalPadding + 12.dp,
+                end = 72.dp,
+                bottom = 18.dp
+            ),
+        verticalArrangement = Arrangement.spacedBy(9.dp)
+    ) {
+        Text(
+            text = album.title,
+            modifier = Modifier.clickable { copyMeta("标题", album.title) },
+            style = MaterialTheme.typography.titleLarge.copy(
+                fontWeight = FontWeight.Bold,
+                shadow = Shadow(
+                    color = Color.Black.copy(alpha = 0.58f),
+                    offset = Offset(0f, 2f),
+                    blurRadius = 8f
                 )
+            ),
+            color = Color.White,
+            maxLines = 3,
+            overflow = TextOverflow.Ellipsis
+        )
+
+        if (showMetaRow) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                AlbumPrimaryMetaRow(
+                    rjCode = rj,
+                    circle = circle,
+                    modifier = Modifier.weight(1f),
+                    rjOnClick = { copyMeta("RJ", rj) },
+                    circleOnClick = { copyMeta("社团", circle) },
+                    appearance = AlbumMetaAppearance.OnImage,
+                    leadingVisual = AlbumMetaLeadingVisual.Icon,
+                )
+                if (listenTogetherRjListenerCount != null && rj.isNotBlank()) {
+                    Spacer(modifier = Modifier.width(8.dp))
+                    Surface(
+                        color = Color.White.copy(alpha = 0.14f),
+                        contentColor = Color.White,
+                        shape = RoundedCornerShape(999.dp),
+                        border = androidx.compose.foundation.BorderStroke(
+                            width = 0.5.dp,
+                            color = Color.White.copy(alpha = 0.22f)
+                        )
+                    ) {
+                        Row(
+                            modifier = Modifier.padding(horizontal = 7.dp, vertical = 2.dp),
+                            horizontalArrangement = Arrangement.spacedBy(4.dp),
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            Icon(
+                                painter = painterResource(id = com.asmr.player.R.drawable.ic_users_round),
+                                contentDescription = null,
+                                tint = Color.White.copy(alpha = 0.94f),
+                                modifier = Modifier.size(12.dp)
+                            )
+                            Text(
+                                text = "${listenTogetherRjListenerCount.coerceAtLeast(0)} 人正在听",
+                                style = MaterialTheme.typography.labelSmall,
+                                color = Color.White.copy(alpha = 0.94f),
+                                maxLines = 1,
+                                overflow = TextOverflow.Ellipsis,
+                            )
+                        }
+                    }
+                }
             }
         }
     }
@@ -961,7 +1039,6 @@ private fun Modifier.albumDetailScrolledContentFade(
 @OptIn(ExperimentalLayoutApi::class)
 private fun AlbumHeader(
     album: Album,
-    listenTogetherRjListenerCount: Int?,
     dlsiteUrl: String,
     asmrOneUrl: String,
     dlsiteEditions: List<DlsiteLanguageEdition>,
@@ -985,10 +1062,6 @@ private fun AlbumHeader(
     val colorScheme = AsmrTheme.colorScheme
     val copyMeta = rememberAlbumMetaCopyAction(messageManager)
 
-    val rj = album.rjCode.ifBlank { album.workId }
-    val normalizedTitle = album.title.trim()
-    val isPlaceholderTitle = normalizedTitle.isBlank() ||
-        (normalizedTitle.equals(rj, ignoreCase = true) && album.id <= 0L && album.path.isBlank())
     val headerAnimationScopeKey = remember(introSessionKey) { "albumHeader:$introSessionKey" }
     var headerIntroPlayed by rememberSaveable(headerAnimationScopeKey) { mutableStateOf(false) }
     LaunchedEffect(headerAnimationScopeKey, animateIntro) {
@@ -1025,82 +1098,6 @@ private fun AlbumHeader(
             .padding(start = 12.dp, end = 12.dp, top = 18.dp, bottom = 12.dp),
         verticalArrangement = Arrangement.spacedBy(12.dp)
     ) {
-        AlbumHeaderInfoReveal(
-            revealKey = "$headerAnimationScopeKey:title",
-            delayMillis = 0,
-            enabled = animateIntro,
-            ready = !isPlaceholderTitle
-        ) {
-            Text(
-                text = album.title,
-                modifier = Modifier.clickable { copyMeta("标题", album.title) },
-                style = MaterialTheme.typography.titleLarge.copy(fontWeight = FontWeight.Bold),
-                color = colorScheme.textPrimary,
-                maxLines = 3,
-                overflow = TextOverflow.Ellipsis
-            )
-        }
-        val circle = album.circle.trim()
-        val showMetaRow = rj.isNotBlank() || circle.isNotBlank() || listenTogetherRjListenerCount != null
-        if (showMetaRow) {
-            AlbumHeaderInfoReveal(
-                revealKey = "$headerAnimationScopeKey:meta",
-                delayMillis = 40,
-                enabled = animateIntro
-            ) {
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    verticalAlignment = Alignment.CenterVertically
-                ) {
-                    AlbumPrimaryMetaRow(
-                        rjCode = rj,
-                        circle = circle,
-                        modifier = Modifier.weight(1f),
-                        rjOnClick = { copyMeta("RJ", rj) },
-                        circleOnClick = { copyMeta("社团", circle) },
-                        leadingVisual = AlbumMetaLeadingVisual.Icon,
-                    )
-                    if (listenTogetherRjListenerCount != null && rj.isNotBlank()) {
-                        Spacer(modifier = Modifier.width(8.dp))
-                        AlbumHeaderInfoReveal(
-                            revealKey = "$headerAnimationScopeKey:listenTogetherRjCount",
-                            delayMillis = 60,
-                            enabled = animateIntro
-                        ) {
-                            Surface(
-                                color = colorScheme.primary.copy(alpha = if (colorScheme.isDark) 0.16f else 0.10f),
-                                contentColor = colorScheme.primary,
-                                shape = RoundedCornerShape(999.dp),
-                                border = androidx.compose.foundation.BorderStroke(
-                                    width = 0.5.dp,
-                                    color = colorScheme.primary.copy(alpha = 0.18f)
-                                )
-                            ) {
-                                Row(
-                                    modifier = Modifier.padding(horizontal = 7.dp, vertical = 2.dp),
-                                    horizontalArrangement = Arrangement.spacedBy(4.dp),
-                                    verticalAlignment = Alignment.CenterVertically
-                                ) {
-                                    Icon(
-                                        painter = painterResource(id = com.asmr.player.R.drawable.ic_users_round),
-                                        contentDescription = null,
-                                        tint = colorScheme.primary,
-                                        modifier = Modifier.size(12.dp)
-                                    )
-                                    Text(
-                                        text = "${listenTogetherRjListenerCount.coerceAtLeast(0)} 人正在听",
-                                        style = MaterialTheme.typography.labelSmall,
-                                        color = colorScheme.primary,
-                                        maxLines = 1,
-                                        overflow = TextOverflow.Ellipsis,
-                                    )
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        }
                 if (album.cv.isNotBlank()) {
                     AlbumHeaderInfoReveal(
                         revealKey = "$headerAnimationScopeKey:cv",
@@ -1527,6 +1524,3 @@ internal data class PlaylistAddTarget(
         }
     }
 }
-
-
-

--- a/app/src/main/java/com/asmr/player/ui/library/AlbumDetailScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/AlbumDetailScreen.kt
@@ -24,6 +24,8 @@ import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
+import androidx.compose.ui.input.nestedscroll.NestedScrollSource
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.foundation.layout.*
@@ -59,6 +61,7 @@ import androidx.compose.foundation.gestures.detectTransformGestures
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.layout.layout
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
@@ -144,6 +147,7 @@ import com.asmr.player.util.Formatting
 import com.asmr.player.util.MessageManager
 import com.asmr.player.util.RemoteSubtitleSource
 import java.util.UUID
+import kotlin.math.roundToInt
 
 private enum class AlbumPrimaryAction {
     Download,
@@ -317,6 +321,44 @@ fun AlbumDetailScreen(
                         val contentFadeStartY = 0.dp
                         val contentFadeEndY = AlbumDetailScrolledContentFadeSpan
 
+                        // 随滑动自适应缩放 hero：用户向上浏览内容时 hero 跟随手指逐渐缩小，
+                        // 最多缩到原本的二分之一（顶部锚定），向上滑回顶部时再恢复。
+                        val heroDensity = LocalDensity.current
+                        val heroCollapseMaxPx = with(heroDensity) { (heroHeight * 0.5f).toPx() }
+                        val contentViewportTopPx = with(heroDensity) { contentViewportTop.toPx() }
+                        var heroCollapsePx by remember { mutableFloatStateOf(0f) }
+                        val heroNestedScroll = remember(heroCollapseMaxPx) {
+                            object : NestedScrollConnection {
+                                override fun onPreScroll(available: Offset, source: NestedScrollSource): Offset {
+                                    val dy = available.y
+                                    // 向上浏览（手指上滑，dy<0）：先把滚动用于折叠 hero，再交给列表。
+                                    if (dy < 0f && heroCollapsePx < heroCollapseMaxPx) {
+                                        val target = (heroCollapsePx - dy).coerceIn(0f, heroCollapseMaxPx)
+                                        val consumed = heroCollapsePx - target // 与 dy 同号(负)
+                                        heroCollapsePx = target
+                                        return Offset(0f, consumed)
+                                    }
+                                    return Offset.Zero
+                                }
+
+                                override fun onPostScroll(
+                                    consumed: Offset,
+                                    available: Offset,
+                                    source: NestedScrollSource
+                                ): Offset {
+                                    val dy = available.y
+                                    // 列表已到顶仍有下滑剩余（dy>0）：把剩余滚动用于展开 hero。
+                                    if (dy > 0f && heroCollapsePx > 0f) {
+                                        val target = (heroCollapsePx - dy).coerceIn(0f, heroCollapseMaxPx)
+                                        val released = heroCollapsePx - target // 与 dy 同号(正)
+                                        heroCollapsePx = target
+                                        return Offset(0f, released)
+                                    }
+                                    return Offset.Zero
+                                }
+                            }
+                        }
+
                         fun headerAlbumForTab(tab: Int): Album {
                             return if (tab == 0) (model.localAlbum ?: album) else album
                         }
@@ -394,6 +436,8 @@ fun AlbumDetailScreen(
                                 listenTogetherRjListenerCount = model.listenTogetherRjListenerCount,
                                 showCoverLoadingState = showHeroCoverLoadingState,
                                 messageManager = viewModel.messageManager,
+                                collapsePx = { heroCollapsePx },
+                                collapseMaxPx = heroCollapseMaxPx,
                                 modifier = Modifier.align(Alignment.TopCenter)
                             )
 
@@ -416,9 +460,13 @@ fun AlbumDetailScreen(
 
                             Box(
                                 modifier = Modifier
-                                    .align(Alignment.BottomCenter)
+                                    .align(Alignment.TopCenter)
                                     .fillMaxWidth()
-                                    .height(contentViewportHeight)
+                                    .height(contentViewportHeight + heroHeight * 0.5f)
+                                    .offset {
+                                        IntOffset(0, (contentViewportTopPx - heroCollapsePx).roundToInt())
+                                    }
+                                    .nestedScroll(heroNestedScroll)
                                     .clipToBounds()
                                     .albumDetailScrolledContentFade(
                                         fadeStartY = contentFadeStartY,
@@ -744,9 +792,13 @@ private fun AlbumDetailHeroBackground(
     listenTogetherRjListenerCount: Int?,
     showCoverLoadingState: Boolean,
     messageManager: MessageManager,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    collapsePx: () -> Float = { 0f },
+    collapseMaxPx: Float = 0f
 ) {
     val imageModel = rememberAlbumCoverImageModel(album)
+    val density = LocalDensity.current
+    val fullHeightPx = with(density) { height.toPx() }
     val blurModifier = remember {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
             Modifier.graphicsLayer {
@@ -760,10 +812,22 @@ private fun AlbumDetailHeroBackground(
         }
     }
 
+    // 真实“折叠”而非整体缩放：只压缩 hero 的布局高度（宽度保持满宽 -> 不会出现左右空白），
+    // 封面用 requiredHeight 固定为全高并顶部对齐，因此随高度收缩只是从顶部重新裁切、不变形也不重新加载；
+    // 标题/元信息底部对齐，会随折叠后的底边上移但尺寸保持不变。
     Box(
         modifier = modifier
             .fillMaxWidth()
-            .height(height)
+            .layout { measurable, constraints ->
+                val collapse = collapsePx().coerceIn(0f, collapseMaxPx)
+                val targetHeight = (fullHeightPx - collapse).coerceAtLeast(1f).roundToInt()
+                val placeable = measurable.measure(
+                    constraints.copy(minHeight = targetHeight, maxHeight = targetHeight)
+                )
+                layout(placeable.width, targetHeight) {
+                    placeable.place(0, 0)
+                }
+            }
             .clipToBounds()
     ) {
         AsmrAsyncImage(
@@ -772,8 +836,10 @@ private fun AlbumDetailHeroBackground(
             contentScale = ContentScale.Crop,
             alignment = Alignment.TopCenter,
             placeholderCornerRadius = 0,
+            peekAnySizeForInitial = true,
             modifier = Modifier
-                .fillMaxSize()
+                .requiredHeight(height)
+                .fillMaxWidth()
                 .graphicsLayer {
                     compositingStrategy = CompositingStrategy.Offscreen
                 }
@@ -818,8 +884,10 @@ private fun AlbumDetailHeroBackground(
             contentScale = ContentScale.Crop,
             alignment = Alignment.TopCenter,
             placeholderCornerRadius = 0,
+            peekAnySizeForInitial = true,
             modifier = Modifier
-                .fillMaxSize()
+                .requiredHeight(height)
+                .fillMaxWidth()
                 .then(blurModifier)
                 .graphicsLayer {
                     compositingStrategy = CompositingStrategy.Offscreen

--- a/app/src/main/java/com/asmr/player/ui/library/AlbumDetailScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/AlbumDetailScreen.kt
@@ -906,9 +906,9 @@ private fun AlbumHeroIdentityOverlay(
         modifier = modifier
             .fillMaxWidth()
             .padding(
-                start = AlbumDetailHorizontalPadding + 12.dp,
-                end = 72.dp,
-                bottom = 18.dp
+                start = AlbumDetailHorizontalPadding,
+                end = AlbumDetailHorizontalPadding,
+                bottom = 4.dp
             ),
         verticalArrangement = Arrangement.spacedBy(9.dp)
     ) {
@@ -945,7 +945,7 @@ private fun AlbumHeroIdentityOverlay(
                 if (listenTogetherRjListenerCount != null && rj.isNotBlank()) {
                     Spacer(modifier = Modifier.width(8.dp))
                     Surface(
-                        color = Color.White.copy(alpha = 0.14f),
+                        color = Color.Black.copy(alpha = 0.46f),
                         contentColor = Color.White,
                         shape = RoundedCornerShape(999.dp),
                         border = androidx.compose.foundation.BorderStroke(
@@ -1095,7 +1095,7 @@ private fun AlbumHeader(
             modifier = headerContainerModifier,
             enabled = animateIntro && !headerIntroPlayed
         )
-            .padding(start = 12.dp, end = 12.dp, top = 18.dp, bottom = 12.dp),
+            .padding(top = 18.dp, bottom = 12.dp),
         verticalArrangement = Arrangement.spacedBy(12.dp)
     ) {
                 if (album.cv.isNotBlank()) {

--- a/app/src/main/java/com/asmr/player/ui/library/AlbumDetailScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/AlbumDetailScreen.kt
@@ -168,10 +168,10 @@ internal data class PreparedMediaPlayback(
     val startIndex: Int
 )
 
-private val AlbumDetailTabContentGap = 12.dp
-private val AlbumDetailScrolledContentFadeSpan = 112.dp
-private const val AlbumDetailHeroThemeGradientStartFraction = 0.38f
-private const val AlbumDetailHeroThemeGradientSolidFraction = 0.82f
+private val AlbumDetailTabContentGap = 0.dp
+private val AlbumDetailScrolledContentFadeSpan = 56.dp
+private const val AlbumDetailHeroThemeGradientStartFraction = 0.42f
+private const val AlbumDetailHeroThemeGradientSolidFraction = 0.86f
 private const val AlbumDetailInitialIntroDurationMs = 1200L
 internal val AlbumDetailHorizontalPadding = 8.dp
 
@@ -327,10 +327,10 @@ fun AlbumDetailScreen(
                         val heroHeight = heroPreferredHeight
                             .coerceAtLeast(heroMinHeight)
                             .coerceAtMost(heroHeightLimit.coerceAtLeast(heroMinHeight))
-                        val heroContentOverlap = (heroHeight * if (isCompact) 0.24f else 0.20f)
+                        val heroContentOverlap = (heroHeight * if (isCompact) 0.30f else 0.26f)
                             .coerceIn(
-                                minimumValue = if (isCompact) 84.dp else 104.dp,
-                                maximumValue = if (isCompact) 120.dp else 152.dp
+                                minimumValue = if (isCompact) 104.dp else 124.dp,
+                                maximumValue = if (isCompact) 148.dp else 184.dp
                             )
                         val tabChromeTop = (heroHeight - heroContentOverlap).coerceAtLeast(0.dp)
                         val tabContentTopPadding = tabChromeTop + AlbumDetailTabContentGap
@@ -367,7 +367,12 @@ fun AlbumDetailScreen(
                             val isLocalTab = tab == 0
                             val canSaveOnlineForTab = tab == 1 && asmrOneTree.isNotEmpty()
                             val headerAlbum = headerAlbumForTab(tab)
-                            AlbumHeader(
+                            Surface(
+                                modifier = Modifier.fillMaxWidth(),
+                                color = pageContainerColor,
+                                shape = RoundedCornerShape(topStart = 24.dp, topEnd = 24.dp)
+                            ) {
+                                AlbumHeader(
                                 album = headerAlbum,
                                 listenTogetherRjListenerCount = model.listenTogetherRjListenerCount,
                                 dlsiteUrl = model.dlsiteWorkno.takeIf { it.isNotBlank() }?.let { "https://www.dlsite.com/maniax/work/=/product_id/$it.html" }.orEmpty(),
@@ -404,6 +409,7 @@ fun AlbumDetailScreen(
                                 animateIntro = shouldAnimateHeaderIntro,
                                 messageManager = viewModel.messageManager
                             )
+                            }
                         }
 
                         Box(
@@ -772,13 +778,13 @@ private fun AlbumDetailHeroBackground(
     val blurModifier = remember {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
             Modifier.graphicsLayer {
-                val blurPx = 36.dp.toPx()
+                val blurPx = 52.dp.toPx()
                 renderEffect = RenderEffect
                     .createBlurEffect(blurPx, blurPx, Shader.TileMode.CLAMP)
                     .asComposeRenderEffect()
             }
         } else {
-            Modifier.blur(28.dp)
+            Modifier.blur(40.dp)
         }
     }
 
@@ -817,17 +823,20 @@ private fun AlbumDetailHeroBackground(
                 .fillMaxSize()
                 .then(blurModifier)
                 .drawWithCache {
+                    val rampStart = 0.18f
+                    val rampEnd = 0.86f
                     val stops = (0..6).map { i ->
                         val t = i / 6f
-                        val pos = 0.34f + (1f - 0.34f) * t
+                        val pos = rampStart + (rampEnd - rampStart) * t
                         val eased = t * t * (3f - 2f * t)
                         pos to Color.White.copy(alpha = eased)
                     }.toTypedArray()
                     val mask = Brush.verticalGradient(
                         colorStops = arrayOf(
                             0f to Color.Transparent,
-                            0.34f to Color.Transparent,
-                            *stops
+                            rampStart to Color.Transparent,
+                            *stops,
+                            1f to Color.White
                         )
                     )
                     onDrawWithContent {
@@ -853,7 +862,9 @@ private fun AlbumDetailHeroBackground(
                     )
                 )
         )
-        // 底部色彩渐变，让 hero 平滑融入页面底色
+        // 底部色彩渐变，让 hero 平滑融入页面底色。
+        // 在 SolidFraction 处即达到完全不透明的容器色，并保持到底部，
+        // 从而彻底遮住封面被裁切的底部边缘，消除割裂感。
         Box(
             modifier = Modifier
                 .fillMaxSize()
@@ -863,8 +874,8 @@ private fun AlbumDetailHeroBackground(
                             0f to Color.Transparent,
                             AlbumDetailHeroThemeGradientStartFraction to Color.Transparent,
                             ((AlbumDetailHeroThemeGradientStartFraction + AlbumDetailHeroThemeGradientSolidFraction) / 2f) to
-                                pageContainerColor.copy(alpha = 0.62f),
-                            AlbumDetailHeroThemeGradientSolidFraction to pageContainerColor.copy(alpha = 0.94f),
+                                pageContainerColor.copy(alpha = 0.70f),
+                            AlbumDetailHeroThemeGradientSolidFraction to pageContainerColor,
                             1f to pageContainerColor
                         )
                     )
@@ -992,7 +1003,7 @@ private fun AlbumHeader(
 
     val headerContainerModifier = Modifier
         .fillMaxWidth()
-        .padding(horizontal = AlbumDetailHorizontalPadding, vertical = 12.dp)
+        .padding(horizontal = AlbumDetailHorizontalPadding)
     val langCandidates = remember(dlsiteEditions) {
         dlsiteEditions
             .filter { it.lang in setOf("JPN", "CHI_HANS", "CHI_HANT") }
@@ -1011,7 +1022,7 @@ private fun AlbumHeader(
             modifier = headerContainerModifier,
             enabled = animateIntro && !headerIntroPlayed
         )
-            .padding(horizontal = 12.dp, vertical = 12.dp),
+            .padding(start = 12.dp, end = 12.dp, top = 18.dp, bottom = 12.dp),
         verticalArrangement = Arrangement.spacedBy(12.dp)
     ) {
         AlbumHeaderInfoReveal(

--- a/app/src/main/java/com/asmr/player/ui/library/AlbumDetailViewModel.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/AlbumDetailViewModel.kt
@@ -455,7 +455,9 @@ class AlbumDetailViewModel @Inject constructor(
         candidates: List<DlsiteCloudSyncCandidate>
     ): String? {
         cancelCloudSyncSelection()
-        val normalizedCandidates = candidates.distinctBy { it.workno }.filter { it.workno.isNotBlank() }
+        val normalizedCandidates = candidates
+            .filter { it.workno.isNotBlank() }
+            .distinctBy { it.workno.trim().uppercase() }
         if (normalizedCandidates.isEmpty()) return null
         val deferred = CompletableDeferred<String?>()
         pendingCloudSyncSelection = deferred

--- a/app/src/main/java/com/asmr/player/ui/library/AlbumDetailViewModel.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/AlbumDetailViewModel.kt
@@ -46,6 +46,7 @@ import com.asmr.player.domain.model.Album
 import com.asmr.player.domain.model.Track
 import com.asmr.player.listentogether.ListenTogetherRepository
 import com.asmr.player.ui.common.queryTrackFileSize
+import com.asmr.player.ui.nav.AlbumCoverHint
 import com.asmr.player.ui.nav.AlbumCoverHintStore
 import com.asmr.player.util.OnlineLyricsStore
 import com.asmr.player.util.RemoteSubtitleSource
@@ -550,8 +551,15 @@ class AlbumDetailViewModel @Inject constructor(
         val current = _uiState.value as? AlbumDetailUiState.Success
         if (!force && current != null && lastAlbumKey == key) return
         lastAlbumKey = key
+        val initialHint = AlbumCoverHintStore.peekHint(albumId, normalizedRj)
+        val initialRj = normalizedRj.ifBlank { initialHint?.rjCode.orEmpty() }
+        _uiState.value = AlbumDetailUiState.Success(
+            model = createInitialAlbumDetailModel(
+                rj = initialRj,
+                displayAlbum = albumFromInitialHint(initialRj, initialHint)
+            )
+        )
         viewModelScope.launch {
-            _uiState.value = AlbumDetailUiState.Loading
             try {
                 val localAlbum = if (albumId != null && albumId > 0) {
                     loadLocalAlbumById(albumId)
@@ -565,40 +573,22 @@ class AlbumDetailViewModel @Inject constructor(
                     localAlbum?.rjCode?.trim().orEmpty().ifBlank { localAlbum?.workId?.trim().orEmpty() }
                 }.uppercase()
 
+                val hint = AlbumCoverHintStore.peekHint(albumId, rj) ?: initialHint
                 val displayAlbum = localAlbum ?: Album(
-                    title = rj.ifBlank { "专辑" },
+                    title = hint?.title?.ifBlank { rj }.orEmpty().ifBlank { "专辑" },
                     path = "",
-                    workId = localAlbum?.workId.orEmpty(),
-                    rjCode = rj,
+                    workId = rj,
+                    rjCode = hint?.rjCode?.ifBlank { rj }.orEmpty().ifBlank { rj },
+                    circle = hint?.circle.orEmpty(),
                     // 种入列表点击时记录的封面 URL：让 hero 与列表卡片使用相同图片 model，
                     // 在网络解析完成前即可命中跨尺寸内存缓存，避免重复请求封面。
-                    coverUrl = AlbumCoverHintStore.peek(albumId, rj).orEmpty()
+                    coverUrl = hint?.coverUrl.orEmpty()
                 )
                 _uiState.value = AlbumDetailUiState.Success(
-                    model = AlbumDetailModel(
-                        baseRjCode = rj,
-                        rjCode = rj,
-                        listenTogetherRjListenerCount = null,
+                    model = createInitialAlbumDetailModel(
+                        rj = rj,
                         displayAlbum = displayAlbum,
-                        localAlbum = localAlbum,
-                        dlsiteInfo = null,
-                        dlsiteGalleryUrls = emptyList(),
-                        dlsiteTrialTracks = emptyList(),
-                        dlsiteRecommendations = DlsiteRecommendations(),
-                        dlsiteWorkno = rj,
-                        dlsitePlayWorkno = "",
-                        dlsiteEditions = defaultDlsiteEditions(rj),
-                        dlsiteSelectedLang = "JPN",
-                        hasResolvedInitialDlsiteTarget = false,
-                        isDlsiteLanguageUserSelected = false,
-                        asmrOneWorkId = null,
-                        asmrOneSite = null,
-                        asmrOneTree = emptyList(),
-                        dlsitePlayTree = emptyList(),
-                        isLoadingDlsite = false,
-                        isLoadingDlsiteTrial = false,
-                        isLoadingAsmrOne = false,
-                        isLoadingDlsitePlay = false
+                        localAlbum = localAlbum
                     )
                 )
                 localTracksObserveJob?.cancel()
@@ -1630,6 +1620,50 @@ class AlbumDetailViewModel @Inject constructor(
             rjCode = rjCode.ifBlank { base.rjCode.ifBlank { base.workId } },
             // 网络解析尚未返回封面时，保留列表种入/上一帧的 coverUrl，避免 hero 先空白再加载。
             coverUrl = base.coverUrl.ifBlank { fallbackCoverUrl }
+        )
+    }
+
+    private fun albumFromInitialHint(rj: String, hint: AlbumCoverHint?): Album {
+        val normalizedRj = rj.ifBlank { hint?.rjCode.orEmpty() }
+        return Album(
+            title = hint?.title?.ifBlank { normalizedRj }.orEmpty().ifBlank { "专辑" },
+            path = "",
+            workId = normalizedRj,
+            rjCode = normalizedRj,
+            circle = hint?.circle.orEmpty(),
+            coverUrl = hint?.coverUrl.orEmpty()
+        )
+    }
+
+    private fun createInitialAlbumDetailModel(
+        rj: String,
+        displayAlbum: Album,
+        localAlbum: Album? = null
+    ): AlbumDetailModel {
+        return AlbumDetailModel(
+            baseRjCode = rj,
+            rjCode = rj,
+            listenTogetherRjListenerCount = null,
+            displayAlbum = displayAlbum,
+            localAlbum = localAlbum,
+            dlsiteInfo = null,
+            dlsiteGalleryUrls = emptyList(),
+            dlsiteTrialTracks = emptyList(),
+            dlsiteRecommendations = DlsiteRecommendations(),
+            dlsiteWorkno = rj,
+            dlsitePlayWorkno = "",
+            dlsiteEditions = defaultDlsiteEditions(rj),
+            dlsiteSelectedLang = "JPN",
+            hasResolvedInitialDlsiteTarget = false,
+            isDlsiteLanguageUserSelected = false,
+            asmrOneWorkId = null,
+            asmrOneSite = null,
+            asmrOneTree = emptyList(),
+            dlsitePlayTree = emptyList(),
+            isLoadingDlsite = false,
+            isLoadingDlsiteTrial = false,
+            isLoadingAsmrOne = false,
+            isLoadingDlsitePlay = false
         )
     }
 

--- a/app/src/main/java/com/asmr/player/ui/library/AlbumDetailViewModel.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/AlbumDetailViewModel.kt
@@ -46,6 +46,7 @@ import com.asmr.player.domain.model.Album
 import com.asmr.player.domain.model.Track
 import com.asmr.player.listentogether.ListenTogetherRepository
 import com.asmr.player.ui.common.queryTrackFileSize
+import com.asmr.player.ui.nav.AlbumCoverHintStore
 import com.asmr.player.util.OnlineLyricsStore
 import com.asmr.player.util.RemoteSubtitleSource
 import com.asmr.player.util.SubtitleMatchSupport
@@ -568,7 +569,10 @@ class AlbumDetailViewModel @Inject constructor(
                     title = rj.ifBlank { "专辑" },
                     path = "",
                     workId = localAlbum?.workId.orEmpty(),
-                    rjCode = rj
+                    rjCode = rj,
+                    // 种入列表点击时记录的封面 URL：让 hero 与列表卡片使用相同图片 model，
+                    // 在网络解析完成前即可命中跨尺寸内存缓存，避免重复请求封面。
+                    coverUrl = AlbumCoverHintStore.peek(albumId, rj).orEmpty()
                 )
                 _uiState.value = AlbumDetailUiState.Success(
                     model = AlbumDetailModel(
@@ -1089,7 +1093,8 @@ class AlbumDetailViewModel @Inject constructor(
                             rjCode = resolvedTarget.workno,
                             localAlbum = latestResolved.localAlbum,
                             dlsiteInfo = latestResolved.dlsiteInfo,
-                            asmrOneWorkId = latestResolved.asmrOneWorkId
+                            asmrOneWorkId = latestResolved.asmrOneWorkId,
+                            fallbackCoverUrl = latestResolved.displayAlbum.coverUrl
                         ),
                         dlsiteWorkno = resolvedTarget.workno,
                         dlsiteEditions = resolvedTarget.editions,
@@ -1163,7 +1168,7 @@ class AlbumDetailViewModel @Inject constructor(
                 )
                 val updated = (_uiState.value as? AlbumDetailUiState.Success)?.model ?: return@launch
                 if (token != dlsiteLoadToken) return@launch
-                val displayAlbum = buildDisplayAlbum(updated.rjCode, updated.localAlbum, dlsiteInfo, updated.asmrOneWorkId)
+                val displayAlbum = buildDisplayAlbum(updated.rjCode, updated.localAlbum, dlsiteInfo, updated.asmrOneWorkId, updated.displayAlbum.coverUrl)
                 _uiState.value = AlbumDetailUiState.Success(
                     model = updated.copy(
                         displayAlbum = displayAlbum,
@@ -1228,7 +1233,8 @@ class AlbumDetailViewModel @Inject constructor(
                     rjCode = workno,
                     localAlbum = current.model.localAlbum,
                     dlsiteInfo = null,
-                    asmrOneWorkId = null
+                    asmrOneWorkId = null,
+                    fallbackCoverUrl = current.model.displayAlbum.coverUrl
                 ),
                 dlsiteInfo = null,
                 dlsiteGalleryUrls = emptyList(),
@@ -1257,7 +1263,7 @@ class AlbumDetailViewModel @Inject constructor(
             }
             val updated = (_uiState.value as? AlbumDetailUiState.Success)?.model ?: return@launch
             if (!updated.rjCode.equals(workno, ignoreCase = true)) return@launch
-            val displayAlbum = buildDisplayAlbum(updated.rjCode, local, updated.dlsiteInfo, updated.asmrOneWorkId)
+            val displayAlbum = buildDisplayAlbum(updated.rjCode, local, updated.dlsiteInfo, updated.asmrOneWorkId, updated.displayAlbum.coverUrl)
             _uiState.value = AlbumDetailUiState.Success(
                 model = updated.copy(
                     localAlbum = local,
@@ -1459,7 +1465,7 @@ class AlbumDetailViewModel @Inject constructor(
                     }
                     return@launch
                 }
-                val displayAlbum = buildDisplayAlbum(updated.rjCode, updated.localAlbum, updated.dlsiteInfo, workId)
+                val displayAlbum = buildDisplayAlbum(updated.rjCode, updated.localAlbum, updated.dlsiteInfo, workId, updated.displayAlbum.coverUrl)
                 _uiState.value = AlbumDetailUiState.Success(
                     model = updated.copy(
                         displayAlbum = displayAlbum,
@@ -1615,12 +1621,15 @@ class AlbumDetailViewModel @Inject constructor(
         rjCode: String,
         localAlbum: Album?,
         dlsiteInfo: Album?,
-        asmrOneWorkId: String?
+        asmrOneWorkId: String?,
+        fallbackCoverUrl: String = ""
     ): Album {
         val base = dlsiteInfo ?: localAlbum ?: Album(title = rjCode.ifBlank { "专辑" }, path = "")
         return base.copy(
             workId = asmrOneWorkId?.takeIf { it.isNotBlank() } ?: base.workId,
-            rjCode = rjCode.ifBlank { base.rjCode.ifBlank { base.workId } }
+            rjCode = rjCode.ifBlank { base.rjCode.ifBlank { base.workId } },
+            // 网络解析尚未返回封面时，保留列表种入/上一帧的 coverUrl，避免 hero 先空白再加载。
+            coverUrl = base.coverUrl.ifBlank { fallbackCoverUrl }
         )
     }
 

--- a/app/src/main/java/com/asmr/player/ui/library/AlbumItem.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/AlbumItem.kt
@@ -98,6 +98,9 @@ fun AlbumItem(
         val headers = if (data.startsWith("http", ignoreCase = true)) DlsiteAntiHotlink.headersForImageUrl(data) else emptyMap()
         if (headers.isEmpty()) data else CacheImageModel(data = data, headers = headers, keyTag = "dlsite")
     }
+    // 在线封面按原尺寸加载并缓存：缓存 key 与显示尺寸无关，详情页 hero 用相同 model 即可命中此缓存，
+    // 不再二次网络请求、不再低分辨率占位。本地文件封面保持按尺寸加载，避免缩略图占用过多内存。
+    val loadCoverAtOriginalSize = remember(data) { data.startsWith("http", ignoreCase = true) }
     val screenWidthDp = LocalConfiguration.current.screenWidthDp
     val listItemHeight = (screenWidthDp.dp * 0.24f).coerceIn(112.dp, 140.dp)
     val coverSize = listItemHeight
@@ -133,6 +136,7 @@ fun AlbumItem(
                             contentDescription = null,
                             contentScale = ContentScale.Crop,
                             placeholderCornerRadius = 0,
+                            loadAtOriginalSize = loadCoverAtOriginalSize,
                             modifier = Modifier.fillMaxSize().clip(coverShape),
                             empty = { m -> AsmrShimmerPlaceholder(modifier = m, cornerRadius = 0) },
                         )
@@ -142,6 +146,7 @@ fun AlbumItem(
                             contentDescription = null,
                             contentScale = ContentScale.Crop,
                             placeholderCornerRadius = 0,
+                            loadAtOriginalSize = loadCoverAtOriginalSize,
                             modifier = Modifier.fillMaxSize().clip(coverShape),
                         )
                     }
@@ -338,6 +343,8 @@ fun AlbumGridItem(
         val headers = if (data.startsWith("http", ignoreCase = true)) DlsiteAntiHotlink.headersForImageUrl(data) else emptyMap()
         if (headers.isEmpty()) data else CacheImageModel(data = data, headers = headers, keyTag = "dlsite")
     }
+    // 在线封面按原尺寸加载并缓存，详情页 hero 用相同 model 直接命中（见 AlbumItem 同名说明）。
+    val loadCoverAtOriginalSize = remember(data) { data.startsWith("http", ignoreCase = true) }
 
     Column(
         modifier = modifier
@@ -355,6 +362,7 @@ fun AlbumGridItem(
                     contentDescription = null,
                     contentScale = ContentScale.Crop,
                     placeholderCornerRadius = 0,
+                    loadAtOriginalSize = loadCoverAtOriginalSize,
                     modifier = Modifier.fillMaxSize().clip(coverShape),
                     empty = { m -> AsmrShimmerPlaceholder(modifier = m, cornerRadius = 0) },
                 )
@@ -364,6 +372,7 @@ fun AlbumGridItem(
                     contentDescription = null,
                     contentScale = ContentScale.Crop,
                     placeholderCornerRadius = 0,
+                    loadAtOriginalSize = loadCoverAtOriginalSize,
                     modifier = Modifier.fillMaxSize().clip(coverShape),
                 )
             }

--- a/app/src/main/java/com/asmr/player/ui/library/AlbumMetaChips.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/AlbumMetaChips.kt
@@ -417,14 +417,14 @@ private fun albumMetaPalette(
     if (appearance == AlbumMetaAppearance.OnImage) {
         return when (tone) {
             AlbumMetaTone.Rj -> AlbumMetaPalette(
-                container = Color.White.copy(alpha = 0.22f),
+                container = Color.Black.copy(alpha = 0.5f),
                 content = Color.White,
-                border = Color.White.copy(alpha = 0.28f),
+                border = Color.White.copy(alpha = 0.24f),
             )
             AlbumMetaTone.Circle -> AlbumMetaPalette(
-                container = Color.White.copy(alpha = 0.12f),
-                content = Color.White.copy(alpha = 0.96f),
-                border = Color.White.copy(alpha = 0.18f),
+                container = Color.Black.copy(alpha = 0.46f),
+                content = Color.White,
+                border = Color.White.copy(alpha = 0.22f),
             )
             AlbumMetaTone.CvLabel -> AlbumMetaPalette(
                 container = Color.White.copy(alpha = 0.18f),

--- a/app/src/main/java/com/asmr/player/ui/library/AlbumMetaChips.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/AlbumMetaChips.kt
@@ -415,31 +415,39 @@ private fun albumMetaPalette(
     appearance: AlbumMetaAppearance,
 ): AlbumMetaPalette {
     if (appearance == AlbumMetaAppearance.OnImage) {
+        val primaryContainer = colorScheme.primary.copy(alpha = if (colorScheme.isDark) 0.36f else 0.30f)
+        val primarySoftContainer = colorScheme.primary.copy(alpha = if (colorScheme.isDark) 0.24f else 0.20f)
+        val primaryContent = if (colorScheme.isDark) {
+            Color.White.copy(alpha = 0.96f)
+        } else {
+            colorScheme.textPrimary.copy(alpha = 0.88f)
+        }
+        val primaryBorder = colorScheme.primary.copy(alpha = if (colorScheme.isDark) 0.52f else 0.42f)
         return when (tone) {
             AlbumMetaTone.Rj -> AlbumMetaPalette(
-                container = Color.Black.copy(alpha = 0.5f),
-                content = Color.White,
-                border = Color.White.copy(alpha = 0.24f),
+                container = primaryContainer,
+                content = primaryContent,
+                border = primaryBorder,
             )
             AlbumMetaTone.Circle -> AlbumMetaPalette(
-                container = Color.Black.copy(alpha = 0.46f),
-                content = Color.White,
-                border = Color.White.copy(alpha = 0.22f),
+                container = primarySoftContainer,
+                content = primaryContent,
+                border = primaryBorder.copy(alpha = 0.78f),
             )
             AlbumMetaTone.CvLabel -> AlbumMetaPalette(
-                container = Color.White.copy(alpha = 0.18f),
-                content = Color.White,
-                border = Color.White.copy(alpha = 0.24f),
+                container = primarySoftContainer,
+                content = primaryContent,
+                border = primaryBorder.copy(alpha = 0.72f),
             )
             AlbumMetaTone.CvValue -> AlbumMetaPalette(
-                container = Color.White.copy(alpha = 0.1f),
-                content = Color.White.copy(alpha = 0.96f),
-                border = Color.White.copy(alpha = 0.16f),
+                container = colorScheme.primary.copy(alpha = if (colorScheme.isDark) 0.18f else 0.16f),
+                content = primaryContent,
+                border = primaryBorder.copy(alpha = 0.56f),
             )
             AlbumMetaTone.Tag -> AlbumMetaPalette(
-                container = Color.Black.copy(alpha = 0.26f),
-                content = Color.White.copy(alpha = 0.92f),
-                border = Color.White.copy(alpha = 0.12f),
+                container = colorScheme.primary.copy(alpha = if (colorScheme.isDark) 0.18f else 0.14f),
+                content = primaryContent.copy(alpha = 0.92f),
+                border = primaryBorder.copy(alpha = 0.42f),
             )
         }
     }

--- a/app/src/main/java/com/asmr/player/ui/library/CloudSyncSelectionDialog.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/CloudSyncSelectionDialog.kt
@@ -19,7 +19,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.ButtonDefaults
@@ -190,7 +190,13 @@ internal fun CloudSyncSelectionDialog(
                         .thinScrollbar(listState),
                     verticalArrangement = Arrangement.spacedBy(CLOUD_SYNC_SELECTION_ROW_SPACING)
                 ) {
-                    items(state.candidates, key = { it.workno }) { candidate ->
+                    itemsIndexed(
+                        items = state.candidates,
+                        key = { index, candidate ->
+                            val workno = candidate.workno.trim().uppercase()
+                            "cloud-sync-candidate:$workno:$index"
+                        }
+                    ) { _, candidate ->
                         CloudSyncSelectionCandidateRow(
                             candidate = candidate,
                             onClick = { onSelect(candidate.workno) }

--- a/app/src/main/java/com/asmr/player/ui/library/CloudSyncSelectionRequestQueue.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/CloudSyncSelectionRequestQueue.kt
@@ -50,7 +50,9 @@ internal class CloudSyncSelectionRequestQueue {
         albumTitle: String,
         candidates: List<DlsiteCloudSyncCandidate>
     ): CompletableDeferred<String?> {
-        val normalizedCandidates = candidates.distinctBy { it.workno }.filter { it.workno.isNotBlank() }
+        val normalizedCandidates = candidates
+            .filter { it.workno.isNotBlank() }
+            .distinctBy { it.workno.trim().uppercase() }
         val deferred = CompletableDeferred<String?>()
         if (normalizedCandidates.isEmpty()) {
             deferred.complete(null)

--- a/app/src/main/java/com/asmr/player/ui/library/LibraryScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/LibraryScreen.kt
@@ -1364,6 +1364,7 @@ private fun AlbumGridItem(
                 contentDescription = null,
                 contentScale = ContentScale.Crop,
                 placeholderCornerRadius = 0,
+                loadAtOriginalSize = coverModel?.startsWith("http", ignoreCase = true) == true,
                 modifier = Modifier.fillMaxSize().clip(coverShape),
             )
             
@@ -1551,6 +1552,7 @@ private fun AlbumItem(
                         contentDescription = null,
                         contentScale = ContentScale.Crop,
                         placeholderCornerRadius = 0,
+                        loadAtOriginalSize = coverModel?.startsWith("http", ignoreCase = true) == true,
                         modifier = Modifier.fillMaxSize().clip(coverShape),
                     )
                     

--- a/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailSharedSections.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailSharedSections.kt
@@ -2,10 +2,7 @@
 
 import android.content.Intent
 import android.net.Uri
-import android.provider.DocumentsContract
 import androidx.activity.compose.BackHandler
-import androidx.activity.compose.rememberLauncherForActivityResult
-import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.animateContentSize
 import androidx.compose.animation.core.Spring
@@ -285,7 +282,13 @@ private fun DlsiteRecommendationsBlock(
             color = colorScheme.textPrimary
         )
         LazyRow(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
-            items(items.take(30), key = { sanitizeRj(it.rjCode).ifBlank { it.rjCode } }) { w ->
+            itemsIndexed(
+                items = items.take(30),
+                key = { index, work ->
+                    val rj = sanitizeRj(work.rjCode).ifBlank { work.rjCode }
+                    "recommendation:$rj:$index"
+                }
+            ) { _, w ->
                 val rj = sanitizeRj(w.rjCode).ifBlank { w.rjCode }
                 DlsiteRecommendedWorkCard(work = w, displayRj = rj, onClick = { onOpenAlbumByRj(rj) })
             }

--- a/app/src/main/java/com/asmr/player/ui/nav/AlbumCoverHintStore.kt
+++ b/app/src/main/java/com/asmr/player/ui/nav/AlbumCoverHintStore.kt
@@ -1,0 +1,43 @@
+package com.asmr.player.ui.nav
+
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * 轻量内存存储：在列表点击进入专辑详情时，记录列表已加载的封面 URL，
+ * 供详情页在网络解析完成前先种入 [com.asmr.player.domain.model.Album.coverUrl]。
+ *
+ * 这样 hero 封面与列表卡片使用完全相同的图片 model（同一 coverUrl + 同一 keyTag），
+ * 跨尺寸缓存复用（peekAnySize）即可命中，避免重复发起网络请求。
+ *
+ * 仅用于在线来源（搜索/热门收听）——本地专辑已带 coverPath，无需提示。
+ */
+object AlbumCoverHintStore {
+    private const val MAX_ENTRIES = 64
+    private val hints = object : LinkedHashMap<String, String>(16, 0.75f, true) {
+        override fun removeEldestEntry(eldest: MutableMap.MutableEntry<String, String>): Boolean {
+            return size > MAX_ENTRIES
+        }
+    }
+    private val lock = Any()
+
+    fun record(albumId: Long?, rjCode: String?, coverUrl: String?) {
+        val url = coverUrl?.trim().orEmpty()
+        if (url.isBlank() || !url.startsWith("http", ignoreCase = true)) return
+        val rj = rjCode?.trim().orEmpty().uppercase()
+        val id = albumId ?: 0L
+        synchronized(lock) {
+            if (rj.isNotBlank()) hints["rj:$rj"] = url
+            if (id > 0L) hints["id:$id"] = url
+        }
+    }
+
+    fun peek(albumId: Long?, rjCode: String?): String? {
+        val rj = rjCode?.trim().orEmpty().uppercase()
+        val id = albumId ?: 0L
+        synchronized(lock) {
+            if (rj.isNotBlank()) hints["rj:$rj"]?.let { return it }
+            if (id > 0L) hints["id:$id"]?.let { return it }
+        }
+        return null
+    }
+}

--- a/app/src/main/java/com/asmr/player/ui/nav/AlbumCoverHintStore.kt
+++ b/app/src/main/java/com/asmr/player/ui/nav/AlbumCoverHintStore.kt
@@ -1,37 +1,52 @@
 package com.asmr.player.ui.nav
 
-import java.util.concurrent.ConcurrentHashMap
-
 /**
- * 轻量内存存储：在列表点击进入专辑详情时，记录列表已加载的封面 URL，
- * 供详情页在网络解析完成前先种入 [com.asmr.player.domain.model.Album.coverUrl]。
+ * 轻量内存存储：在列表点击进入专辑详情时，记录列表已知的首屏信息，
+ * 供详情页在网络解析完成前先种入标题、RJ、社团与封面。
  *
  * 这样 hero 封面与列表卡片使用完全相同的图片 model（同一 coverUrl + 同一 keyTag），
  * 跨尺寸缓存复用（peekAnySize）即可命中，避免重复发起网络请求。
- *
- * 仅用于在线来源（搜索/热门收听）——本地专辑已带 coverPath，无需提示。
  */
 object AlbumCoverHintStore {
     private const val MAX_ENTRIES = 64
-    private val hints = object : LinkedHashMap<String, String>(16, 0.75f, true) {
-        override fun removeEldestEntry(eldest: MutableMap.MutableEntry<String, String>): Boolean {
+    private val hints = object : LinkedHashMap<String, AlbumCoverHint>(16, 0.75f, true) {
+        override fun removeEldestEntry(eldest: MutableMap.MutableEntry<String, AlbumCoverHint>): Boolean {
             return size > MAX_ENTRIES
         }
     }
     private val lock = Any()
 
     fun record(albumId: Long?, rjCode: String?, coverUrl: String?) {
-        val url = coverUrl?.trim().orEmpty()
-        if (url.isBlank() || !url.startsWith("http", ignoreCase = true)) return
-        val rj = rjCode?.trim().orEmpty().uppercase()
+        record(
+            albumId = albumId,
+            rjCode = rjCode,
+            title = null,
+            circle = null,
+            coverUrl = coverUrl
+        )
+    }
+
+    fun record(albumId: Long?, rjCode: String?, title: String?, circle: String?, coverUrl: String?) {
+        val hint = AlbumCoverHint(
+            title = title?.trim().orEmpty(),
+            rjCode = rjCode?.trim().orEmpty().uppercase(),
+            circle = circle?.trim().orEmpty(),
+            coverUrl = coverUrl?.trim().orEmpty().takeIf { it.startsWith("http", ignoreCase = true) }.orEmpty()
+        )
+        if (hint.isBlank()) return
+        val rj = hint.rjCode
         val id = albumId ?: 0L
         synchronized(lock) {
-            if (rj.isNotBlank()) hints["rj:$rj"] = url
-            if (id > 0L) hints["id:$id"] = url
+            if (rj.isNotBlank()) hints["rj:$rj"] = hint
+            if (id > 0L) hints["id:$id"] = hint
         }
     }
 
     fun peek(albumId: Long?, rjCode: String?): String? {
+        return peekHint(albumId, rjCode)?.coverUrl
+    }
+
+    fun peekHint(albumId: Long?, rjCode: String?): AlbumCoverHint? {
         val rj = rjCode?.trim().orEmpty().uppercase()
         val id = albumId ?: 0L
         synchronized(lock) {
@@ -39,5 +54,16 @@ object AlbumCoverHintStore {
             if (id > 0L) hints["id:$id"]?.let { return it }
         }
         return null
+    }
+}
+
+data class AlbumCoverHint(
+    val title: String,
+    val rjCode: String,
+    val circle: String,
+    val coverUrl: String
+) {
+    fun isBlank(): Boolean {
+        return title.isBlank() && rjCode.isBlank() && circle.isBlank() && coverUrl.isBlank()
     }
 }

--- a/app/src/main/java/com/asmr/player/ui/search/SearchAssistScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/search/SearchAssistScreen.kt
@@ -801,6 +801,8 @@ private fun SearchAssistWorkChip(
         }
         if (headers.isEmpty()) coverData else CacheImageModel(data = coverData, headers = headers, keyTag = "dlsite")
     }
+    // 在线封面按原尺寸加载并缓存，详情页 hero 用相同 model 直接命中、不再二次网络请求。
+    val loadCoverAtOriginalSize = remember(coverData) { coverData.startsWith("http", ignoreCase = true) }
     val containerColor = colorScheme.surface.copy(alpha = if (colorScheme.isDark) 0.72f else 0.82f)
         .compositeOver(colorScheme.background)
     val meta = listOf(album.cv, album.circle)
@@ -827,6 +829,7 @@ private fun SearchAssistWorkChip(
             contentDescription = null,
             contentScale = ContentScale.Crop,
             placeholderCornerRadius = 0,
+            loadAtOriginalSize = loadCoverAtOriginalSize,
             modifier = Modifier
                 .aspectRatio(1f)
                 .height(if (compact) 76.dp else 84.dp)

--- a/app/src/main/java/com/asmr/player/ui/search/SearchScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/search/SearchScreen.kt
@@ -31,7 +31,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListState
-import androidx.compose.foundation.lazy.items as lazyItems
+import androidx.compose.foundation.lazy.itemsIndexed as lazyItemsIndexed
 import androidx.compose.foundation.lazy.staggeredgrid.LazyStaggeredGridState
 import androidx.compose.foundation.lazy.staggeredgrid.LazyVerticalStaggeredGrid
 import androidx.compose.foundation.lazy.staggeredgrid.StaggeredGridCells
@@ -148,6 +148,10 @@ private fun stableAlbumKey(album: Album): String {
     if (id.isNotEmpty()) return id
     val seed = "${album.coverUrl}|${album.title}|${album.circle}|${album.cv}"
     return "h${seed.hashCode().absoluteValue}"
+}
+
+private fun searchResultItemKey(index: Int, album: Album): String {
+    return "search-result:${stableAlbumKey(album)}:$index"
 }
 
 private fun onlineDetailLoadingFor(album: Album, state: SearchUiState.Success): Boolean {
@@ -723,11 +727,11 @@ fun SearchScreen(
                                         contentPadding = PaddingValues(top = topPadding, bottom = 8.dp)
                                             .withAddedBottomPadding(LocalBottomOverlayPadding.current)
                                     ) {
-                                        lazyItems(
+                                        lazyItemsIndexed(
                                             items = state.results,
-                                            key = { album -> stableAlbumKey(album) },
-                                            contentType = { "album" }
-                                        ) { album ->
+                                            key = { index, album -> searchResultItemKey(index, album) },
+                                            contentType = { _, _ -> "album" }
+                                        ) { _, album ->
                                             val onlineDetailLoading = onlineDetailLoadingFor(album, state)
                                             AlbumItem(
                                                 album = album,
@@ -760,7 +764,7 @@ fun SearchScreen(
                                     ) {
                                         items(
                                             state.results.size,
-                                            key = { index -> stableAlbumKey(state.results[index]) },
+                                            key = { index -> searchResultItemKey(index, state.results[index]) },
                                             contentType = { "albumGrid" }
                                         ) { index ->
                                             val album = state.results[index]


### PR DESCRIPTION
## 变更
- 专辑列表跳转详情时传递标题、社团和封面提示，减少首屏空白与重复请求
- 优化详情页 hero 封面展开/折叠、回弹和首屏信息渐入表现
- 在本地专辑加载前使用提示数据预渲染详情首屏

## 验证
- git diff --check