### PR TITLE
fix: 专辑详情页在线加载与信息行展开动画优化

### DIFF
--- a/app/src/main/java/com/asmr/player/data/remote/scraper/DLSiteScraper.kt
+++ b/app/src/main/java/com/asmr/player/data/remote/scraper/DLSiteScraper.kt
@@ -108,6 +108,11 @@ data class DlsiteWorkInfo(
     val recommendations: DlsiteRecommendations
 )
 
+data class DlsiteWorkInitialDetail(
+    val workInfo: DlsiteWorkInfo?,
+    val trialTracks: List<Track> = emptyList()
+)
+
 data class DlsiteRecommendedWork(
     val rjCode: String,
     val title: String,
@@ -455,8 +460,21 @@ class DLSiteScraper @Inject constructor(
 
     suspend fun getWorkInfo(workId: String, locale: String? = null): DlsiteWorkInfo? = withContext(Dispatchers.IO) {
         val doc = fetchWorkDocument(workId, locale = locale) ?: return@withContext null
+        parseWorkInfo(workId, doc)
+    }
 
-        val title = doc.selectFirst("#work_name")?.text()?.trim() ?: return@withContext null
+    suspend fun getInitialWorkDetail(workId: String, locale: String? = null): DlsiteWorkInitialDetail = withContext(Dispatchers.IO) {
+        val clean = workId.trim().uppercase()
+        if (clean.isBlank()) return@withContext DlsiteWorkInitialDetail(workInfo = null)
+        val doc = fetchWorkDocument(clean, locale = locale) ?: return@withContext DlsiteWorkInitialDetail(workInfo = null)
+        DlsiteWorkInitialDetail(
+            workInfo = parseWorkInfo(clean, doc),
+            trialTracks = parseTracksFromWorkDocument(clean, locale, doc, allowFallback = true)
+        )
+    }
+
+    private fun parseWorkInfo(workId: String, doc: Document): DlsiteWorkInfo? {
+        val title = doc.selectFirst("#work_name")?.text()?.trim() ?: return null
         val circle = doc.selectFirst(".maker_name a")?.text()?.trim() ?: ""
         
         val cvNames = mutableListOf<String>()
@@ -507,7 +525,7 @@ class DLSiteScraper @Inject constructor(
         val galleryUrls = runCatching { extractGalleryUrls(doc, doc.baseUri()) }.getOrDefault(emptyList())
         val recommendations = runCatching { extractRecommendations(doc, doc.baseUri()) }.getOrDefault(DlsiteRecommendations())
 
-        DlsiteWorkInfo(
+        return DlsiteWorkInfo(
             album = Album(
                 title = title,
                 path = "",
@@ -530,6 +548,16 @@ class DLSiteScraper @Inject constructor(
     }
 
     suspend fun getTracks(workId: String, locale: String? = null): List<Track> = withContext(Dispatchers.IO) {
+        val doc = fetchWorkDocument(workId, locale = locale) ?: return@withContext emptyList()
+        parseTracksFromWorkDocument(workId, locale, doc, allowFallback = true)
+    }
+
+    private suspend fun parseTracksFromWorkDocument(
+        workId: String,
+        locale: String?,
+        doc: Document,
+        allowFallback: Boolean
+    ): List<Track> {
         fun parseTrackListFromDoc(doc: Document): List<Track> {
             val out = mutableListOf<Track>()
             doc.select(".track-list li").forEach { item ->
@@ -602,14 +630,13 @@ class DLSiteScraper @Inject constructor(
             return u
         }
 
-        suspend fun internal(workId0: String, allowFallback: Boolean): List<Track> {
-            val doc = fetchWorkDocument(workId0, locale = locale) ?: return emptyList()
+        suspend fun internal(workId0: String, doc0: Document, allowFallback0: Boolean): List<Track> {
             val tracks = mutableListOf<Track>()
 
-            tracks.addAll(parseTrackListFromDoc(doc))
+            tracks.addAll(parseTrackListFromDoc(doc0))
             if (tracks.isNotEmpty()) return tracks
 
-            doc.select(".work_parts_area audio source, .work_parts_area video source").forEach { source ->
+            doc0.select(".work_parts_area audio source, .work_parts_area video source").forEach { source ->
                 val src = source.attr("src").trim()
                 if (src.isNotEmpty()) {
                     val fullUrl = if (src.startsWith("//")) "https:$src" else if (src.startsWith("/")) "https://www.dlsite.com$src" else src
@@ -620,7 +647,7 @@ class DLSiteScraper @Inject constructor(
 
             var embedUrl = fetchChobitEmbedUrl(workId0)
             if (embedUrl.isBlank()) {
-                embedUrl = parseChobitFromHtml(doc.html())
+                embedUrl = parseChobitFromHtml(doc0.html())
             }
             if (embedUrl.isNotBlank()) {
                 val acceptLanguage = acceptLanguageForLocale(locale)
@@ -639,24 +666,25 @@ class DLSiteScraper @Inject constructor(
                 if (v.isNotEmpty()) return v
             }
 
-            if (allowFallback) {
-                val jpLink = doc.select("a.work_edition_linklist_item").firstOrNull { it.text().contains("日本語") }
+            if (allowFallback0) {
+                val jpLink = doc0.select("a.work_edition_linklist_item").firstOrNull { it.text().contains("日本語") }
                 val href = jpLink?.attr("href").orEmpty()
                 val m = Regex("""product_id/(RJ\d+)""", RegexOption.IGNORE_CASE).find(href)
                 val jpId = m?.groupValues?.getOrNull(1).orEmpty().uppercase()
                 if (jpId.isNotBlank() && jpId != workId0.uppercase()) {
-                    val fallback = internal(jpId, allowFallback = false)
+                    val jpDoc = fetchWorkDocument(jpId, locale = locale)
+                    val fallback = if (jpDoc != null) internal(jpId, jpDoc, allowFallback0 = false) else emptyList()
                     if (fallback.isNotEmpty()) return fallback
                 }
             }
 
-            val dl = parseTrialDownload(doc)
+            val dl = parseTrialDownload(doc0)
             if (dl.isNotEmpty()) return dl
 
             return emptyList()
         }
 
-        internal(workId, allowFallback = true)
+        return internal(workId, doc, allowFallback0 = allowFallback)
     }
 
     private fun extractGalleryUrls(doc: Document, baseUrl: String): List<String> {

--- a/app/src/main/java/com/asmr/player/ui/library/AlbumDetailScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/AlbumDetailScreen.kt
@@ -1433,9 +1433,15 @@ private fun AlbumHeader(
             modifier = headerContainerModifier,
             enabled = animateIntro && !headerIntroPlayed && !headerHasDeferredMeta
         )
-            .padding(top = 10.dp, bottom = 12.dp),
-        verticalArrangement = Arrangement.spacedBy(12.dp)
+            .padding(top = 10.dp, bottom = 12.dp)
+        // 不用 spacedBy 控制信息行之间的间距：cv/tags 行在网络数据到达后会以 0 高度组合、再通过
+        // AnimatedVisibility 纵向展开，而 spacedBy 的固定间距会在“0 高度的折叠内容刚组合”的那一帧
+        // 立即出现，把下方按钮行瞬间下推一截，造成展开前的下沉抖动。改为把行间距/与按钮行的间距作为
+        // 每个信息行自身的底部 padding 放进 reveal 内部——这样间距属于被 expandVertically 裁剪的高度，
+        // 会随展开动画一起从 0 平滑增长，按钮行始终被平滑下移而非瞬间跳变。
     ) {
+                // cv 行与 tags 行同属“信息行”，行间距与行内换行间距（6.dp）保持一致；
+                // 末尾信息行携带 12.dp 底部 padding 作为与下方按钮行的间距。
                 if (album.cv.isNotBlank()) {
                     AlbumHeaderInfoReveal(
                         revealKey = "$headerAnimationScopeKey:cv",
@@ -1443,13 +1449,15 @@ private fun AlbumHeader(
                         enabled = animateIntro,
                         expandLayout = !cvPresentInitially
                     ) {
-                        AlbumCvChipsFlow(
-                            cvText = album.cv,
-                            horizontalArrangement = Arrangement.spacedBy(8.dp),
-                            verticalArrangement = Arrangement.spacedBy(6.dp),
-                            onCvClick = { cv -> copyMeta("CV", cv) },
-                            leadingVisual = AlbumMetaLeadingVisual.Icon,
-                        )
+                        Box(modifier = Modifier.padding(bottom = if (album.tags.isNotEmpty()) 6.dp else 12.dp)) {
+                            AlbumCvChipsFlow(
+                                cvText = album.cv,
+                                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                                verticalArrangement = Arrangement.spacedBy(6.dp),
+                                onCvClick = { cv -> copyMeta("CV", cv) },
+                                leadingVisual = AlbumMetaLeadingVisual.Icon,
+                            )
+                        }
                     }
                 }
 
@@ -1460,13 +1468,15 @@ private fun AlbumHeader(
                         enabled = animateIntro,
                         expandLayout = !tagsPresentInitially
                     ) {
-                        AlbumTagsFlow(
-                            tags = album.tags,
-                            horizontalArrangement = Arrangement.spacedBy(8.dp),
-                            verticalArrangement = Arrangement.spacedBy(6.dp),
-                            onTagClick = { tag -> copyMeta("标签", tag) },
-                            leadingVisual = AlbumMetaLeadingVisual.Icon,
-                        )
+                        Box(modifier = Modifier.padding(bottom = 12.dp)) {
+                            AlbumTagsFlow(
+                                tags = album.tags,
+                                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                                verticalArrangement = Arrangement.spacedBy(6.dp),
+                                onTagClick = { tag -> copyMeta("标签", tag) },
+                                leadingVisual = AlbumMetaLeadingVisual.Icon,
+                            )
+                        }
                     }
                 }
 

--- a/app/src/main/java/com/asmr/player/ui/library/AlbumDetailScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/AlbumDetailScreen.kt
@@ -543,11 +543,25 @@ fun AlbumDetailScreen(
                             val isLocalTab = tab == 0
                             val canSaveOnlineForTab = tab == 1 && asmrOneTree.isNotEmpty()
                             val headerAlbum = headerAlbumForTab(tab)
+                            val headerDlsiteEditions = if (isLocalTab) {
+                                emptyList()
+                            } else {
+                                model.dlsiteEditions.ifEmpty {
+                                    listOf(
+                                        DlsiteLanguageEdition(
+                                            workno = model.baseRjCode.ifBlank { model.rjCode },
+                                            lang = "JPN",
+                                            label = "日本語",
+                                            displayOrder = 1
+                                        )
+                                    )
+                                }
+                            }
                             AlbumHeader(
                                 album = headerAlbum,
                                 dlsiteUrl = model.dlsiteWorkno.takeIf { it.isNotBlank() }?.let { "https://www.dlsite.com/maniax/work/=/product_id/$it.html" }.orEmpty(),
                                 asmrOneUrl = model.asmrOneWorkId?.takeIf { it.isNotBlank() }?.let { "https://asmr.one/work/$it" }.orEmpty(),
-                                dlsiteEditions = if (isLocalTab) emptyList() else model.dlsiteEditions,
+                                dlsiteEditions = headerDlsiteEditions,
                                 dlsiteSelectedLang = model.dlsiteSelectedLang,
                                 onDlsiteLangSelected = { viewModel.selectDlsiteLanguage(it) },
                                 canSaveOnline = canSaveOnlineForTab,
@@ -577,6 +591,7 @@ fun AlbumDetailScreen(
                                 onOpenGroupPicker = onOpenGroupPicker,
                                 introSessionKey = introSessionKey,
                                 animateIntro = shouldAnimateHeaderIntro,
+                                deferMetaRevealExpected = !isLocalTab,
                                 messageManager = viewModel.messageManager
                             )
                         }
@@ -719,6 +734,7 @@ fun AlbumDetailScreen(
                                         trialTracks = model.dlsiteTrialTracks,
                                         trialDownloadEnabled = trialDownloadTree.isNotEmpty(),
                                         isLoading = model.isLoadingDlsite,
+                                        isAwaitingInitialLoad = !model.hasResolvedInitialDlsiteTarget,
                                         asmrOneTree = asmrOneTree,
                                         isLoadingAsmrOne = model.isLoadingAsmrOne,
                                         isLoadingTrial = model.isLoadingDlsiteTrial,
@@ -1371,6 +1387,7 @@ private fun AlbumHeader(
     onOpenGroupPicker: (albumId: Long) -> Unit,
     introSessionKey: String,
     animateIntro: Boolean,
+    deferMetaRevealExpected: Boolean,
     messageManager: MessageManager
 ) {
     val context = LocalContext.current
@@ -1390,9 +1407,10 @@ private fun AlbumHeader(
     }
 
     // 记录“首帧时各信息块是否已存在”：本地库专辑进入时 cv/tags 已就绪，应直接淡入不撑开（消除下沉抖动）；
-    // 在线专辑进入时 cv/tags 为空，待网络返回后才出现，那时才用 expandVertically 平滑撑开下方内容。
+    // 在线专辑进入时 cv/tags 为空，待网络返回后由信息行自身执行展开动画。
     val cvPresentInitially = remember(headerAnimationScopeKey) { album.cv.isNotBlank() }
     val tagsPresentInitially = remember(headerAnimationScopeKey) { album.tags.isNotEmpty() }
+    val headerHasDeferredMeta = deferMetaRevealExpected && (!cvPresentInitially || !tagsPresentInitially)
 
     val headerContainerModifier = Modifier
         .fillMaxWidth()
@@ -1413,7 +1431,7 @@ private fun AlbumHeader(
     Column(
         modifier = dlsiteElasticItemModifier(
             modifier = headerContainerModifier,
-            enabled = animateIntro && !headerIntroPlayed
+            enabled = animateIntro && !headerIntroPlayed && !headerHasDeferredMeta
         )
             .padding(top = 10.dp, bottom = 12.dp),
         verticalArrangement = Arrangement.spacedBy(12.dp)
@@ -1597,28 +1615,37 @@ private fun AlbumHeader(
                                 }
                             }
 
-                            if (langCandidates.size > 1) {
+                            if (langCandidates.isNotEmpty()) {
                                 Box {
                                     OutlinedButton(
-                                        onClick = { languageMenuExpanded = true },
+                                        onClick = {
+                                            if (langCandidates.size > 1) languageMenuExpanded = true
+                                        },
+                                        enabled = langCandidates.size > 1,
                                         modifier = Modifier
                                             .height(36.dp)
                                             .widthIn(min = selectorMinWidth, max = selectorMaxWidth),
                                         shape = RoundedCornerShape(10.dp),
                                         contentPadding = PaddingValues(horizontal = smallButtonPadding, vertical = 0.dp),
-                                        border = androidx.compose.foundation.BorderStroke(1.dp, colorScheme.primary.copy(alpha = 0.3f))
+                                        border = androidx.compose.foundation.BorderStroke(
+                                            1.dp,
+                                            colorScheme.primary.copy(alpha = if (langCandidates.size > 1) 0.3f else 0.16f)
+                                        ),
+                                        colors = ButtonDefaults.outlinedButtonColors(
+                                            disabledContentColor = colorScheme.textSecondary
+                                        )
                                     ) {
                                         Text(
                                             text = selectedLangLabel,
                                             style = MaterialTheme.typography.labelMedium,
-                                            color = colorScheme.primary,
+                                            color = if (langCandidates.size > 1) colorScheme.primary else colorScheme.textSecondary,
                                             maxLines = 1
                                         )
                                         Spacer(modifier = Modifier.width(if (compact) 2.dp else 4.dp))
                                         Icon(
                                             imageVector = Icons.Rounded.ArrowDropDown,
                                             contentDescription = null,
-                                            tint = colorScheme.primary,
+                                            tint = if (langCandidates.size > 1) colorScheme.primary else colorScheme.textTertiary,
                                             modifier = Modifier.size(primaryIconSize)
                                         )
                                     }
@@ -1740,8 +1767,8 @@ private fun AlbumHeaderInfoReveal(
         }
         return
     }
-    // 网络数据到达后才出现的内容（在线 cv/tags）：用 expandVertically 平滑撑开下方内容，
-    // 避免数据突然出现、生硬撑开造成的突兀感。
+    // 网络数据到达后才出现的内容（在线 cv/tags）：保留原有的纵向展开，
+    // 但避免再叠加父级 animateContentSize，减少同一尺寸变化被双重动画驱动。
     AnimatedVisibility(
         visible = visible,
         enter = fadeIn(animationSpec = tween(durationMillis = 420)) + expandVertically(

--- a/app/src/main/java/com/asmr/player/ui/library/AlbumDetailViewModel.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/AlbumDetailViewModel.kt
@@ -70,6 +70,8 @@ import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeoutOrNull
+import kotlinx.coroutines.sync.Semaphore
+import kotlinx.coroutines.sync.withPermit
 import java.io.File
 import java.io.FileOutputStream
 import java.util.concurrent.atomic.AtomicBoolean
@@ -1039,14 +1041,37 @@ class AlbumDetailViewModel @Inject constructor(
     }
 
     private suspend fun enrichRecommendationsWithAsmrOne(recommendations: DlsiteRecommendations): DlsiteRecommendations {
-        suspend fun enrich(list: List<DlsiteRecommendedWork>): List<DlsiteRecommendedWork> {
-            return list.map { w ->
-                val rj = w.rjCode.trim().uppercase()
-                val asmr = runCatching { asmrOneCrawler.getDetails(rj) }.getOrNull()
-                if (asmr == null) return@map w
-                w.copy(
-                    title = asmr.title.ifBlank { w.title },
-                    coverUrl = asmr.mainCoverUrl.ifBlank { w.coverUrl }
+        val candidates = (recommendations.circleWorks + recommendations.sameVoiceWorks + recommendations.alsoBoughtWorks)
+            .asSequence()
+            .map { it.rjCode.trim().uppercase() }
+            .filter { it.isNotBlank() }
+            .distinct()
+            .take(MAX_RECOMMENDATION_ASMR_ONE_ENRICH)
+            .toList()
+        if (candidates.isEmpty()) return recommendations
+
+        val semaphore = Semaphore(RECOMMENDATION_ASMR_ONE_ENRICH_CONCURRENCY)
+        val detailsByRj = coroutineScope {
+            candidates.map { rj ->
+                async(Dispatchers.IO) {
+                    semaphore.withPermit {
+                        val asmr = runCatching { asmrOneCrawler.getDetails(rj) }.getOrNull()
+                        rj to asmr
+                    }
+                }
+            }.mapNotNull { deferred ->
+                val (rj, details) = runCatching { deferred.await() }.getOrNull() ?: return@mapNotNull null
+                details?.let { rj to it }
+            }.toMap()
+        }
+        if (detailsByRj.isEmpty()) return recommendations
+
+        fun enrich(list: List<DlsiteRecommendedWork>): List<DlsiteRecommendedWork> {
+            return list.map { work ->
+                val asmr = detailsByRj[work.rjCode.trim().uppercase()] ?: return@map work
+                work.copy(
+                    title = asmr.title.ifBlank { work.title },
+                    coverUrl = asmr.mainCoverUrl.ifBlank { work.coverUrl }
                 )
             }
         }
@@ -1107,17 +1132,18 @@ class AlbumDetailViewModel @Inject constructor(
                     return@launch
                 }
                 val locale = dlsiteLocaleForLang(loadModel.dlsiteSelectedLang)
-                val (dlsiteWorkInfo, dlsiteRecommendationsFromV2, dlsiteTrialTracks) = coroutineScope {
-                    val infoDeferred = async { runCatching { dlsiteScraper.getWorkInfo(workno, locale = locale) }.getOrNull() }
+                val (dlsiteInitialDetail, dlsiteRecommendationsFromV2) = coroutineScope {
+                    val initialDeferred = async {
+                        runCatching { dlsiteScraper.getInitialWorkDetail(workno, locale = locale) }.getOrNull()
+                    }
                     val recDeferred = async {
                         runCatching { dlsiteScraper.getRecommendationsDetailV2(workno, locale = locale) }
                             .getOrDefault(DlsiteRecommendations())
                     }
-                    val tracksDeferred = async {
-                        runCatching { dlsiteScraper.getTracks(workno, locale = locale) }.getOrDefault(emptyList())
-                    }
-                    Triple(infoDeferred.await(), recDeferred.await(), tracksDeferred.await())
+                    initialDeferred.await() to recDeferred.await()
                 }
+                val dlsiteWorkInfo = dlsiteInitialDetail?.workInfo
+                val dlsiteTrialTracks = dlsiteInitialDetail?.trialTracks.orEmpty()
 
                 val dlsiteInfo = dlsiteWorkInfo?.album
                 val dlsiteGalleryUrls = dlsiteWorkInfo?.galleryUrls.orEmpty()
@@ -2594,5 +2620,10 @@ class AlbumDetailViewModel @Inject constructor(
     override fun onCleared() {
         cancelCloudSyncSelection()
         super.onCleared()
+    }
+
+    private companion object {
+        const val MAX_RECOMMENDATION_ASMR_ONE_ENRICH = 12
+        const val RECOMMENDATION_ASMR_ONE_ENRICH_CONCURRENCY = 4
     }
 }

--- a/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailDlsiteTabs.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailDlsiteTabs.kt
@@ -692,6 +692,7 @@ internal fun AlbumDlsiteInfoBreadcrumbTabV2(
     trialTracks: List<Track>,
     trialDownloadEnabled: Boolean,
     isLoading: Boolean,
+    isAwaitingInitialLoad: Boolean,
     asmrOneTree: List<AsmrOneTrackNodeResponse>,
     isLoadingAsmrOne: Boolean,
     isLoadingTrial: Boolean,
@@ -761,7 +762,8 @@ internal fun AlbumDlsiteInfoBreadcrumbTabV2(
     LaunchedEffect(currentPath, treeStateKey) {
         onPersistCurrentPath(currentPath)
     }
-    val isInitialDlsiteLoading = dlsiteInfo == null && isLoading
+    val isInitialDlsiteLoading = dlsiteInfo == null && (isLoading || isAwaitingInitialLoad)
+    val isAsmrOnePending = isAwaitingInitialLoad || isLoadingAsmrOne
 
     LazyColumn(
         modifier = Modifier
@@ -838,7 +840,9 @@ internal fun AlbumDlsiteInfoBreadcrumbTabV2(
                 style = MaterialTheme.typography.titleMedium,
                 fontWeight = FontWeight.Bold
             )
-            if (galleryUrls.isEmpty()) {
+            if (galleryUrls.isEmpty() && isInitialDlsiteLoading) {
+                DlsiteGalleryLoadingRow()
+            } else if (galleryUrls.isEmpty()) {
                 DlsiteSectionEmptyState(
                     text = "暂无样图",
                     artworkKind = DlsiteEmptyArtworkKind.Gallery,
@@ -1028,7 +1032,7 @@ internal fun AlbumDlsiteInfoBreadcrumbTabV2(
                     )
                 }
             }
-        } else if (isLoadingAsmrOne || (asmrOneTree.isNotEmpty() && browser == null)) {
+        } else if (isAsmrOnePending || (asmrOneTree.isNotEmpty() && browser == null)) {
             item(key = "dlsite-one-content") {
                 Box(modifier = dlsiteAnimatedSectionModifier(Modifier.fillMaxWidth(), animateIntro)) {
                     DlsiteDirectoryLoadingPanel()


### PR DESCRIPTION
## 概述
优化专辑详情页在线加载体验，并修复信息行展开动画的抖动问题。

## 改动
- **专辑详情页加载优化**：改进在线专辑封面与元数据加载逻辑。
- **信息行展开动画优化**：
  - 调小 cv 行与 tags 行之间的间距（12dp → 6dp），与行内换行间距保持一致。
  - 修复网络数据返回瞬间按钮行先下沉抖动再平移的问题：去掉外层 Column 的 `spacedBy`，将行间距改为信息行自身的底部 padding，使间距随 `expandVertically` 一起从 0 平滑增长，下方按钮行全程平滑下移而非瞬间跳变。

## 测试
- `./gradlew :app:compileDebugKotlin` 编译通过。
- 动画行为需在真机/模拟器上观感验证。
