### PR TITLE
Fix album detail CV reveal and device id header

### DIFF
--- a/app/src/main/java/com/asmr/player/data/local/DeviceIdentityStore.kt
+++ b/app/src/main/java/com/asmr/player/data/local/DeviceIdentityStore.kt
@@ -1,0 +1,44 @@
+package com.asmr.player.data.local
+
+import android.content.Context
+import dagger.hilt.android.qualifiers.ApplicationContext
+import java.util.UUID
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class DeviceIdentityStore @Inject constructor(
+    @ApplicationContext context: Context
+) {
+    private val prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+
+    @Volatile
+    private var cachedDeviceId: String? = null
+
+    fun getOrCreateDeviceId(): String {
+        cachedDeviceId?.let { return it }
+        return synchronized(this) {
+            cachedDeviceId?.let { return@synchronized it }
+            val deviceId = prefs.getString(KEY_DEVICE_ID, null)
+                ?.takeIf(::isValidDeviceId)
+                ?: createAndStoreDeviceId()
+            cachedDeviceId = deviceId
+            deviceId
+        }
+    }
+
+    private fun createAndStoreDeviceId(): String {
+        val deviceId = UUID.randomUUID().toString()
+        prefs.edit().putString(KEY_DEVICE_ID, deviceId).commit()
+        return deviceId
+    }
+
+    private companion object {
+        const val PREFS_NAME = "device_identity"
+        const val KEY_DEVICE_ID = "device_id"
+
+        fun isValidDeviceId(value: String): Boolean {
+            return runCatching { UUID.fromString(value) }.isSuccess
+        }
+    }
+}

--- a/app/src/main/java/com/asmr/player/data/remote/NetworkHeaders.kt
+++ b/app/src/main/java/com/asmr/player/data/remote/NetworkHeaders.kt
@@ -6,6 +6,7 @@ object NetworkHeaders {
     const val USER_AGENT = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
     const val REFERER_DLSITE = "https://www.dlsite.com/"
     const val HEADER_SILENT_IO_ERROR = "X-Silent-IO-Error"
+    const val HEADER_EARA_DEVICE_ID = "X-Eara-Device-Id"
     const val SILENT_IO_ERROR_ON = "1"
 
     val ACCEPT_LANGUAGE: String

--- a/app/src/main/java/com/asmr/player/data/remote/scraper/DLSiteScraper.kt
+++ b/app/src/main/java/com/asmr/player/data/remote/scraper/DLSiteScraper.kt
@@ -131,6 +131,34 @@ data class DlsiteSearchResult(
     val canGoNext: Boolean
 )
 
+internal fun parseCvNames(doc: Document): List<String> {
+    val outline = doc.selectFirst("#work_outline") ?: return emptyList()
+    return outline.select("tr")
+        .filter { row ->
+            val th = row.selectFirst("th")?.text()?.trim().orEmpty()
+            th.contains("声优") ||
+                th.contains("声優") ||
+                th.contains("聲優") ||
+                th.contains("CV", ignoreCase = true)
+        }
+        .flatMap { row ->
+            val anchors = row.select("td a")
+                .map { it.text().trim() }
+                .filter { it.isNotBlank() }
+            if (anchors.isNotEmpty()) {
+                anchors
+            } else {
+                row.selectFirst("td")
+                    ?.text()
+                    .orEmpty()
+                    .split("/", "／", ",", "，", "、")
+                    .map { it.trim() }
+            }
+        }
+        .filter { it.isNotBlank() }
+        .distinct()
+}
+
 @Singleton
 class DLSiteScraper @Inject constructor(
     @ApplicationContext context: Context
@@ -459,16 +487,39 @@ class DLSiteScraper @Inject constructor(
     }
 
     suspend fun getWorkInfo(workId: String, locale: String? = null): DlsiteWorkInfo? = withContext(Dispatchers.IO) {
-        val doc = fetchWorkDocument(workId, locale = locale) ?: return@withContext null
-        parseWorkInfo(workId, doc)
+        val clean = workId.trim().uppercase()
+        val doc = fetchWorkDocument(clean, locale = locale) ?: return@withContext null
+        val parsed = parseWorkInfo(clean, doc) ?: return@withContext null
+        withJapaneseCvFallback(clean, locale, parsed)
+    }
+
+    private suspend fun withJapaneseCvFallback(
+        workId: String,
+        locale: String?,
+        parsed: DlsiteWorkInfo
+    ): DlsiteWorkInfo {
+        if (parsed.album.cv.isNotBlank() || locale?.startsWith("ja", ignoreCase = true) == true) {
+            return parsed
+        }
+
+        val japaneseCv = fetchWorkDocument(workId, locale = "ja_JP")
+            ?.let { japaneseDoc -> parseCvNames(japaneseDoc).joinToString(", ") }
+            .orEmpty()
+        return if (japaneseCv.isBlank()) {
+            parsed
+        } else {
+            parsed.copy(album = parsed.album.copy(cv = japaneseCv))
+        }
     }
 
     suspend fun getInitialWorkDetail(workId: String, locale: String? = null): DlsiteWorkInitialDetail = withContext(Dispatchers.IO) {
         val clean = workId.trim().uppercase()
         if (clean.isBlank()) return@withContext DlsiteWorkInitialDetail(workInfo = null)
         val doc = fetchWorkDocument(clean, locale = locale) ?: return@withContext DlsiteWorkInitialDetail(workInfo = null)
+        val workInfo = parseWorkInfo(clean, doc)
+            ?.let { withJapaneseCvFallback(clean, locale, it) }
         DlsiteWorkInitialDetail(
-            workInfo = parseWorkInfo(clean, doc),
+            workInfo = workInfo,
             trialTracks = parseTracksFromWorkDocument(clean, locale, doc, allowFallback = true)
         )
     }
@@ -477,14 +528,11 @@ class DLSiteScraper @Inject constructor(
         val title = doc.selectFirst("#work_name")?.text()?.trim() ?: return null
         val circle = doc.selectFirst(".maker_name a")?.text()?.trim() ?: ""
         
-        val cvNames = mutableListOf<String>()
+        val cvNames = parseCvNames(doc)
         val outline = doc.selectFirst("#work_outline")
         var releaseDate = ""
         outline?.select("tr")?.forEach { row ->
             val th = row.selectFirst("th")?.text() ?: ""
-            if (th.contains("声优") || th.contains("声優") || th.contains("CV")) {
-                cvNames.addAll(row.select("td a").map { it.text().trim() })
-            }
             if (releaseDate.isBlank() && (th.contains("販売日") || th.contains("発売日") || th.contains("发售日") || th.contains("發售日"))) {
                 val txt = row.selectFirst("td")?.text()?.trim().orEmpty()
                 val m = Regex("""(\d{4})\D+(\d{1,2})\D+(\d{1,2})""").find(txt)

--- a/app/src/main/java/com/asmr/player/di/networkmodule.kt
+++ b/app/src/main/java/com/asmr/player/di/networkmodule.kt
@@ -1,5 +1,7 @@
 package com.asmr.player.di
 
+import com.asmr.player.BuildConfig
+import com.asmr.player.data.local.DeviceIdentityStore
 import com.asmr.player.data.remote.api.AsmrOneApi
 import com.asmr.player.data.remote.api.Asmr200Api
 import com.asmr.player.data.remote.api.Asmr100Api
@@ -12,6 +14,7 @@ import okhttp3.Dispatcher
 import okhttp3.OkHttpClient
 import okhttp3.Interceptor
 import okhttp3.logging.HttpLoggingInterceptor
+import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
 import javax.inject.Singleton
@@ -36,7 +39,8 @@ object NetworkModule {
     @Singleton
     fun provideOkHttpClient(
         messageManager: MessageManager,
-        trafficStatsInterceptor: TrafficStatsInterceptor
+        trafficStatsInterceptor: TrafficStatsInterceptor,
+        deviceIdentityStore: DeviceIdentityStore
     ): OkHttpClient {
         val logging = HttpLoggingInterceptor().apply {
             level = HttpLoggingInterceptor.Level.BASIC
@@ -49,6 +53,10 @@ object NetworkModule {
             
             val builder = request.newBuilder()
                 .header("User-Agent", NetworkHeaders.USER_AGENT)
+
+            if (isEaraBackendHost(host)) {
+                builder.header(NetworkHeaders.HEADER_EARA_DEVICE_ID, deviceIdentityStore.getOrCreateDeviceId())
+            }
 
             if (suppressAutoErrorMessage) {
                 builder.removeHeader(NetworkHeaders.HEADER_SILENT_IO_ERROR)
@@ -102,7 +110,8 @@ object NetworkModule {
     @Singleton
     @Named("image")
     fun provideImageOkHttpClient(
-        trafficStatsInterceptor: TrafficStatsInterceptor
+        trafficStatsInterceptor: TrafficStatsInterceptor,
+        deviceIdentityStore: DeviceIdentityStore
     ): OkHttpClient {
         val logging = HttpLoggingInterceptor().apply {
             level = HttpLoggingInterceptor.Level.BASIC
@@ -113,6 +122,10 @@ object NetworkModule {
 
             val builder = request.newBuilder()
                 .header("User-Agent", NetworkHeaders.USER_AGENT)
+
+            if (isEaraBackendHost(host)) {
+                builder.header(NetworkHeaders.HEADER_EARA_DEVICE_ID, deviceIdentityStore.getOrCreateDeviceId())
+            }
 
             if (host.contains("asmr.one")) {
                 builder.header("Origin", "https://www.asmr.one")
@@ -190,5 +203,15 @@ object NetworkModule {
             .addConverterFactory(GsonConverterFactory.create())
             .build()
         return retrofit.create(Asmr300Api::class.java)
+    }
+
+    private val earaBackendHost: String?
+        get() = BuildConfig.LISTEN_TOGETHER_BASE_URL
+            .toHttpUrlOrNull()
+            ?.host
+            ?.lowercase()
+
+    private fun isEaraBackendHost(host: String): Boolean {
+        return earaBackendHost?.let { host == it } == true
     }
 }

--- a/app/src/main/java/com/asmr/player/main/MainContainer.kt
+++ b/app/src/main/java/com/asmr/player/main/MainContainer.kt
@@ -1505,6 +1505,7 @@ fun MainContainer(
                                                         rjCode = album.rjCode.ifBlank { album.workId },
                                                         title = album.title,
                                                         circle = album.circle,
+                                                        cv = album.cv,
                                                         coverUrl = album.coverUrl
                                                     )
                                                     navigator.openAlbumDetail(
@@ -1553,6 +1554,7 @@ fun MainContainer(
                                                         rjCode = album.rjCode.ifBlank { album.workId },
                                                         title = album.title,
                                                         circle = album.circle,
+                                                        cv = album.cv,
                                                         coverUrl = album.coverUrl
                                                     )
                                                     openAlbumDetailFromSearch(
@@ -1575,6 +1577,7 @@ fun MainContainer(
                                                         rjCode = album.rjCode.ifBlank { album.workId },
                                                         title = album.title,
                                                         circle = album.circle,
+                                                        cv = album.cv,
                                                         coverUrl = album.coverUrl
                                                     )
                                                     navigator.openAlbumDetailByRj(album.rjCode.ifBlank { album.workId })

--- a/app/src/main/java/com/asmr/player/ui/library/AlbumDetailScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/AlbumDetailScreen.kt
@@ -219,6 +219,13 @@ internal fun dlsiteElasticItemModifier(
     }
 }
 
+internal fun shouldExpandAlbumHeaderMetaReveal(
+    deferMetaRevealExpected: Boolean,
+    presentInitially: Boolean
+): Boolean {
+    return deferMetaRevealExpected || !presentInitially
+}
+
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalFoundationApi::class)
 @Composable
 fun AlbumDetailScreen(
@@ -1407,10 +1414,12 @@ private fun AlbumHeader(
     }
 
     // 记录“首帧时各信息块是否已存在”：本地库专辑进入时 cv/tags 已就绪，应直接淡入不撑开（消除下沉抖动）；
-    // 在线专辑进入时 cv/tags 为空，待网络返回后由信息行自身执行展开动画。
+    // 在线专辑即使从列表 hint 拿到了 cv，也仍按延迟元信息处理，保留平移撑开的进入节奏。
     val cvPresentInitially = remember(headerAnimationScopeKey) { album.cv.isNotBlank() }
     val tagsPresentInitially = remember(headerAnimationScopeKey) { album.tags.isNotEmpty() }
-    val headerHasDeferredMeta = deferMetaRevealExpected && (!cvPresentInitially || !tagsPresentInitially)
+    val cvExpandLayout = shouldExpandAlbumHeaderMetaReveal(deferMetaRevealExpected, cvPresentInitially)
+    val tagsExpandLayout = shouldExpandAlbumHeaderMetaReveal(deferMetaRevealExpected, tagsPresentInitially)
+    val headerHasDeferredMeta = deferMetaRevealExpected
 
     val headerContainerModifier = Modifier
         .fillMaxWidth()
@@ -1447,7 +1456,7 @@ private fun AlbumHeader(
                         revealKey = "$headerAnimationScopeKey:cv",
                         delayMillis = AlbumDetailCvRevealDelayMs,
                         enabled = animateIntro,
-                        expandLayout = !cvPresentInitially
+                        expandLayout = cvExpandLayout
                     ) {
                         Box(modifier = Modifier.padding(bottom = if (album.tags.isNotEmpty()) 6.dp else 12.dp)) {
                             AlbumCvChipsFlow(
@@ -1466,7 +1475,7 @@ private fun AlbumHeader(
                         revealKey = "$headerAnimationScopeKey:tags",
                         delayMillis = AlbumDetailTagsRevealDelayMs,
                         enabled = animateIntro,
-                        expandLayout = !tagsPresentInitially
+                        expandLayout = tagsExpandLayout
                     ) {
                         Box(modifier = Modifier.padding(bottom = 12.dp)) {
                             AlbumTagsFlow(

--- a/app/src/main/java/com/asmr/player/ui/library/AlbumDetailViewModel.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/AlbumDetailViewModel.kt
@@ -1109,6 +1109,7 @@ class AlbumDetailViewModel @Inject constructor(
                             localAlbum = latestResolved.localAlbum,
                             dlsiteInfo = latestResolved.dlsiteInfo,
                             asmrOneWorkId = latestResolved.asmrOneWorkId,
+                            fallbackCv = latestResolved.displayAlbum.cv,
                             fallbackCoverUrl = latestResolved.displayAlbum.coverUrl
                         ),
                         dlsiteWorkno = resolvedTarget.workno,
@@ -1184,7 +1185,14 @@ class AlbumDetailViewModel @Inject constructor(
                 )
                 val updated = (_uiState.value as? AlbumDetailUiState.Success)?.model ?: return@launch
                 if (token != dlsiteLoadToken) return@launch
-                val displayAlbum = buildDisplayAlbum(updated.rjCode, updated.localAlbum, dlsiteInfo, updated.asmrOneWorkId, updated.displayAlbum.coverUrl)
+                val displayAlbum = buildDisplayAlbum(
+                    rjCode = updated.rjCode,
+                    localAlbum = updated.localAlbum,
+                    dlsiteInfo = dlsiteInfo,
+                    asmrOneWorkId = updated.asmrOneWorkId,
+                    fallbackCv = updated.displayAlbum.cv,
+                    fallbackCoverUrl = updated.displayAlbum.coverUrl
+                )
                 _uiState.value = AlbumDetailUiState.Success(
                     model = updated.copy(
                         displayAlbum = displayAlbum,
@@ -1250,6 +1258,7 @@ class AlbumDetailViewModel @Inject constructor(
                     localAlbum = current.model.localAlbum,
                     dlsiteInfo = null,
                     asmrOneWorkId = null,
+                    fallbackCv = current.model.displayAlbum.cv,
                     fallbackCoverUrl = current.model.displayAlbum.coverUrl
                 ),
                 dlsiteInfo = null,
@@ -1279,7 +1288,14 @@ class AlbumDetailViewModel @Inject constructor(
             }
             val updated = (_uiState.value as? AlbumDetailUiState.Success)?.model ?: return@launch
             if (!updated.rjCode.equals(workno, ignoreCase = true)) return@launch
-            val displayAlbum = buildDisplayAlbum(updated.rjCode, local, updated.dlsiteInfo, updated.asmrOneWorkId, updated.displayAlbum.coverUrl)
+            val displayAlbum = buildDisplayAlbum(
+                rjCode = updated.rjCode,
+                localAlbum = local,
+                dlsiteInfo = updated.dlsiteInfo,
+                asmrOneWorkId = updated.asmrOneWorkId,
+                fallbackCv = updated.displayAlbum.cv,
+                fallbackCoverUrl = updated.displayAlbum.coverUrl
+            )
             _uiState.value = AlbumDetailUiState.Success(
                 model = updated.copy(
                     localAlbum = local,
@@ -1481,7 +1497,14 @@ class AlbumDetailViewModel @Inject constructor(
                     }
                     return@launch
                 }
-                val displayAlbum = buildDisplayAlbum(updated.rjCode, updated.localAlbum, updated.dlsiteInfo, workId, updated.displayAlbum.coverUrl)
+                val displayAlbum = buildDisplayAlbum(
+                    rjCode = updated.rjCode,
+                    localAlbum = updated.localAlbum,
+                    dlsiteInfo = updated.dlsiteInfo,
+                    asmrOneWorkId = workId,
+                    fallbackCv = updated.displayAlbum.cv,
+                    fallbackCoverUrl = updated.displayAlbum.coverUrl
+                )
                 _uiState.value = AlbumDetailUiState.Success(
                     model = updated.copy(
                         displayAlbum = displayAlbum,
@@ -1633,22 +1656,6 @@ class AlbumDetailViewModel @Inject constructor(
         return Triple(null, null, emptyList())
     }
 
-    private fun buildDisplayAlbum(
-        rjCode: String,
-        localAlbum: Album?,
-        dlsiteInfo: Album?,
-        asmrOneWorkId: String?,
-        fallbackCoverUrl: String = ""
-    ): Album {
-        val base = dlsiteInfo ?: localAlbum ?: Album(title = rjCode.ifBlank { "专辑" }, path = "")
-        return base.copy(
-            workId = asmrOneWorkId?.takeIf { it.isNotBlank() } ?: base.workId,
-            rjCode = rjCode.ifBlank { base.rjCode.ifBlank { base.workId } },
-            // 网络解析尚未返回封面时，保留列表种入/上一帧的 coverUrl，避免 hero 先空白再加载。
-            coverUrl = base.coverUrl.ifBlank { fallbackCoverUrl }
-        )
-    }
-
     private fun albumFromInitialHint(rj: String, hint: AlbumCoverHint?): Album {
         val normalizedRj = rj.ifBlank { hint?.rjCode.orEmpty() }
         return Album(
@@ -1657,6 +1664,7 @@ class AlbumDetailViewModel @Inject constructor(
             workId = normalizedRj,
             rjCode = normalizedRj,
             circle = hint?.circle.orEmpty(),
+            cv = hint?.cv.orEmpty(),
             coverUrl = hint?.coverUrl.orEmpty()
         )
     }

--- a/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailViewModelSupport.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailViewModelSupport.kt
@@ -169,6 +169,24 @@ data class AlbumDetailModel(
     val isLoadingDlsitePlay: Boolean
 )
 
+internal fun buildDisplayAlbum(
+    rjCode: String,
+    localAlbum: Album?,
+    dlsiteInfo: Album?,
+    asmrOneWorkId: String?,
+    fallbackCv: String = "",
+    fallbackCoverUrl: String = ""
+): Album {
+    val base = dlsiteInfo ?: localAlbum ?: Album(title = rjCode.ifBlank { "专辑" }, path = "")
+    return base.copy(
+        workId = asmrOneWorkId?.takeIf { it.isNotBlank() } ?: base.workId,
+        rjCode = rjCode.ifBlank { base.rjCode.ifBlank { base.workId } },
+        cv = base.cv.ifBlank { fallbackCv },
+        // 网络解析尚未返回封面时，保留列表种入/上一帧的 coverUrl，避免 hero 先空白再加载。
+        coverUrl = base.coverUrl.ifBlank { fallbackCoverUrl }
+    )
+}
+
 internal enum class DlsiteChinesePreference {
     None,
     Hans,

--- a/app/src/main/java/com/asmr/player/ui/nav/AlbumCoverHintStore.kt
+++ b/app/src/main/java/com/asmr/player/ui/nav/AlbumCoverHintStore.kt
@@ -2,7 +2,7 @@ package com.asmr.player.ui.nav
 
 /**
  * 轻量内存存储：在列表点击进入专辑详情时，记录列表已知的首屏信息，
- * 供详情页在网络解析完成前先种入标题、RJ、社团与封面。
+ * 供详情页在网络解析完成前先种入标题、RJ、社团、CV 与封面。
  *
  * 这样 hero 封面与列表卡片使用完全相同的图片 model（同一 coverUrl + 同一 keyTag），
  * 跨尺寸缓存复用（peekAnySize）即可命中，避免重复发起网络请求。
@@ -22,15 +22,28 @@ object AlbumCoverHintStore {
             rjCode = rjCode,
             title = null,
             circle = null,
+            cv = null,
             coverUrl = coverUrl
         )
     }
 
     fun record(albumId: Long?, rjCode: String?, title: String?, circle: String?, coverUrl: String?) {
+        record(
+            albumId = albumId,
+            rjCode = rjCode,
+            title = title,
+            circle = circle,
+            cv = null,
+            coverUrl = coverUrl
+        )
+    }
+
+    fun record(albumId: Long?, rjCode: String?, title: String?, circle: String?, cv: String?, coverUrl: String?) {
         val hint = AlbumCoverHint(
             title = title?.trim().orEmpty(),
             rjCode = rjCode?.trim().orEmpty().uppercase(),
             circle = circle?.trim().orEmpty(),
+            cv = cv?.trim().orEmpty(),
             coverUrl = coverUrl?.trim().orEmpty().takeIf { it.startsWith("http", ignoreCase = true) }.orEmpty()
         )
         if (hint.isBlank()) return
@@ -61,9 +74,10 @@ data class AlbumCoverHint(
     val title: String,
     val rjCode: String,
     val circle: String,
+    val cv: String,
     val coverUrl: String
 ) {
     fun isBlank(): Boolean {
-        return title.isBlank() && rjCode.isBlank() && circle.isBlank() && coverUrl.isBlank()
+        return title.isBlank() && rjCode.isBlank() && circle.isBlank() && cv.isBlank() && coverUrl.isBlank()
     }
 }

--- a/app/src/test/java/com/asmr/player/data/local/DeviceIdentityStoreTest.kt
+++ b/app/src/test/java/com/asmr/player/data/local/DeviceIdentityStoreTest.kt
@@ -1,0 +1,52 @@
+package com.asmr.player.data.local
+
+import android.content.Context
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import java.util.UUID
+
+@RunWith(RobolectricTestRunner::class)
+class DeviceIdentityStoreTest {
+    private val context = RuntimeEnvironment.getApplication()
+    private val prefs = context.getSharedPreferences("device_identity", Context.MODE_PRIVATE)
+
+    @Before
+    fun setUp() {
+        prefs.edit().clear().commit()
+    }
+
+    @After
+    fun tearDown() {
+        prefs.edit().clear().commit()
+    }
+
+    @Test
+    fun getOrCreateDeviceId_reusesStoredId() {
+        val firstStore = DeviceIdentityStore(context)
+        val firstId = firstStore.getOrCreateDeviceId()
+        UUID.fromString(firstId)
+
+        val secondStore = DeviceIdentityStore(context)
+        val secondId = secondStore.getOrCreateDeviceId()
+
+        assertEquals(firstId, secondId)
+        assertEquals(firstId, prefs.getString("device_id", null))
+    }
+
+    @Test
+    fun getOrCreateDeviceId_replacesInvalidStoredId() {
+        prefs.edit().putString("device_id", "broken").commit()
+
+        val deviceId = DeviceIdentityStore(context).getOrCreateDeviceId()
+        UUID.fromString(deviceId)
+
+        assertNotEquals("broken", deviceId)
+        assertEquals(deviceId, prefs.getString("device_id", null))
+    }
+}

--- a/app/src/test/java/com/asmr/player/data/remote/scraper/DLSiteScraperCvParserTest.kt
+++ b/app/src/test/java/com/asmr/player/data/remote/scraper/DLSiteScraperCvParserTest.kt
@@ -1,0 +1,37 @@
+package com.asmr.player.data.remote.scraper
+
+import org.jsoup.Jsoup
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class DLSiteScraperCvParserTest {
+    @Test
+    fun parseCvNames_supportsTraditionalChineseVoiceActorLabel() {
+        val doc = Jsoup.parse(
+            """
+            <div id="work_outline">
+                <table>
+                    <tr><th>聲優</th><td><a>かの仔</a></td></tr>
+                </table>
+            </div>
+            """.trimIndent()
+        )
+
+        assertEquals(listOf("かの仔"), parseCvNames(doc))
+    }
+
+    @Test
+    fun parseCvNames_supportsPlainTextNames() {
+        val doc = Jsoup.parse(
+            """
+            <div id="work_outline">
+                <table>
+                    <tr><th>声優</th><td>かの仔、別名義</td></tr>
+                </table>
+            </div>
+            """.trimIndent()
+        )
+
+        assertEquals(listOf("かの仔", "別名義"), parseCvNames(doc))
+    }
+}

--- a/app/src/test/java/com/asmr/player/ui/library/AlbumDetailViewModelSupportTest.kt
+++ b/app/src/test/java/com/asmr/player/ui/library/AlbumDetailViewModelSupportTest.kt
@@ -1,0 +1,31 @@
+package com.asmr.player.ui.library
+
+import com.asmr.player.domain.model.Album
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class AlbumDetailViewModelSupportTest {
+    @Test
+    fun buildDisplayAlbum_keepsFallbackCvWhenDlsiteInfoHasNoCv() {
+        val localAlbum = Album(
+            title = "作品",
+            path = "",
+            cv = "かの仔",
+            workId = "RJ01572724",
+            rjCode = "RJ01572724"
+        )
+
+        val result = buildDisplayAlbum(
+            rjCode = "RJ01572724",
+            localAlbum = localAlbum,
+            dlsiteInfo = localAlbum.copy(cv = ""),
+            asmrOneWorkId = null,
+            fallbackCv = "かの仔",
+            fallbackCoverUrl = ""
+        )
+
+        assertEquals("かの仔", result.cv)
+        assertTrue(result.rjCode.isNotBlank())
+    }
+}

--- a/app/src/test/java/com/asmr/player/ui/library/AlbumHeaderMetaRevealTest.kt
+++ b/app/src/test/java/com/asmr/player/ui/library/AlbumHeaderMetaRevealTest.kt
@@ -1,0 +1,37 @@
+package com.asmr.player.ui.library
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class AlbumHeaderMetaRevealTest {
+    @Test
+    fun shouldExpandAlbumHeaderMetaReveal_expandsOnlineHintMeta() {
+        assertTrue(
+            shouldExpandAlbumHeaderMetaReveal(
+                deferMetaRevealExpected = true,
+                presentInitially = true
+            )
+        )
+    }
+
+    @Test
+    fun shouldExpandAlbumHeaderMetaReveal_keepsLocalInitialMetaStable() {
+        assertFalse(
+            shouldExpandAlbumHeaderMetaReveal(
+                deferMetaRevealExpected = false,
+                presentInitially = true
+            )
+        )
+    }
+
+    @Test
+    fun shouldExpandAlbumHeaderMetaReveal_expandsLateMeta() {
+        assertTrue(
+            shouldExpandAlbumHeaderMetaReveal(
+                deferMetaRevealExpected = false,
+                presentInitially = false
+            )
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- Preserve CV from online search hints in album detail
- Keep header reveal animation smooth when CV arrives from online data
- Add persistent per-device id and attach it to backend requests

## Validation
- ./gradlew.bat :app:compileDebugKotlin
- ./gradlew.bat :app:compileDebugUnitTestKotlin
- ./gradlew.bat :app:assembleRelease --no-build-cache
- ./gradlew.bat :app:installRelease --no-build-cache