### PR TITLE
fix: optimize bottom nav scroll-to-top

### DIFF
--- a/app/src/main/java/com/asmr/player/ui/common/LazyListSmoothScroll.kt
+++ b/app/src/main/java/com/asmr/player/ui/common/LazyListSmoothScroll.kt
@@ -1,17 +1,91 @@
+@file:OptIn(ExperimentalFoundationApi::class)
+
 package com.asmr.player.ui.common
 
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.foundation.lazy.staggeredgrid.LazyStaggeredGridState
+import kotlin.math.abs
+import kotlinx.coroutines.CancellationException
+
+private const val MaxAnimatedScrollItems = 10
 
 suspend fun LazyListState.smoothScrollToIndex(
     index: Int,
-    anchorOffsetPx: Int
+    anchorOffsetPx: Int = 0,
+    maxAnimatedItems: Int = MaxAnimatedScrollItems
 ) {
     if (index < 0) return
-    runCatching {
-        // 直接使用内置动画，避免重复调用和自定义不支持的参数
-        this.animateScrollToItem(index, anchorOffsetPx)
-    }.onFailure {
-        // 如果动画被打断，直接跳转到位
+    if (firstVisibleItemIndex == index && firstVisibleItemScrollOffset == anchorOffsetPx) return
+
+    try {
+        jumpNearTargetIfNeeded(
+            targetIndex = index,
+            anchorOffsetPx = anchorOffsetPx,
+            maxAnimatedItems = maxAnimatedItems.coerceAtLeast(1)
+        )
+        animateScrollToItem(index, anchorOffsetPx)
+    } catch (cancelled: CancellationException) {
+        throw cancelled
+    } catch (_: Throwable) {
         runCatching { scrollToItem(index, anchorOffsetPx) }
+    }
+}
+
+suspend fun LazyListState.smoothScrollToTop(anchorOffsetPx: Int = 0) {
+    smoothScrollToIndex(index = 0, anchorOffsetPx = anchorOffsetPx)
+}
+
+suspend fun LazyStaggeredGridState.smoothScrollToIndex(
+    index: Int,
+    anchorOffsetPx: Int = 0,
+    maxAnimatedItems: Int = MaxAnimatedScrollItems
+) {
+    if (index < 0) return
+    if (firstVisibleItemIndex == index && firstVisibleItemScrollOffset == anchorOffsetPx) return
+
+    try {
+        jumpNearTargetIfNeeded(
+            targetIndex = index,
+            anchorOffsetPx = anchorOffsetPx,
+            maxAnimatedItems = maxAnimatedItems.coerceAtLeast(1)
+        )
+        animateScrollToItem(index, anchorOffsetPx)
+    } catch (cancelled: CancellationException) {
+        throw cancelled
+    } catch (_: Throwable) {
+        runCatching { scrollToItem(index, anchorOffsetPx) }
+    }
+}
+
+suspend fun LazyStaggeredGridState.smoothScrollToTop(anchorOffsetPx: Int = 0) {
+    smoothScrollToIndex(index = 0, anchorOffsetPx = anchorOffsetPx)
+}
+
+private suspend fun LazyListState.jumpNearTargetIfNeeded(
+    targetIndex: Int,
+    anchorOffsetPx: Int,
+    maxAnimatedItems: Int
+) {
+    val currentIndex = firstVisibleItemIndex
+    if (abs(currentIndex - targetIndex) <= maxAnimatedItems) return
+    scrollToItem(currentIndex.nearTarget(targetIndex, maxAnimatedItems), anchorOffsetPx)
+}
+
+private suspend fun LazyStaggeredGridState.jumpNearTargetIfNeeded(
+    targetIndex: Int,
+    anchorOffsetPx: Int,
+    maxAnimatedItems: Int
+) {
+    val currentIndex = firstVisibleItemIndex
+    if (abs(currentIndex - targetIndex) <= maxAnimatedItems) return
+    scrollToItem(currentIndex.nearTarget(targetIndex, maxAnimatedItems), anchorOffsetPx)
+}
+
+private fun Int.nearTarget(targetIndex: Int, maxAnimatedItems: Int): Int {
+    return if (this > targetIndex) {
+        targetIndex + maxAnimatedItems
+    } else {
+        (targetIndex - maxAnimatedItems).coerceAtLeast(this)
     }
 }

--- a/app/src/main/java/com/asmr/player/ui/downloads/DownloadsScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/downloads/DownloadsScreen.kt
@@ -72,6 +72,7 @@ import com.asmr.player.ui.common.FlatActionDialog
 import com.asmr.player.ui.common.FlatDialogAction
 import com.asmr.player.ui.common.FlatDialogActionTone
 import com.asmr.player.ui.common.LocalBottomOverlayPadding
+import com.asmr.player.ui.common.smoothScrollToTop
 import com.asmr.player.ui.common.thinScrollbar
 import com.asmr.player.ui.theme.AsmrTheme
 import com.asmr.player.util.Formatting
@@ -98,7 +99,7 @@ fun DownloadsScreen(
 
     LaunchedEffect(scrollToTopSignal) {
         if (scrollToTopSignal == 0L) return@LaunchedEffect
-        runCatching { listState.animateScrollToItem(0) }
+        listState.smoothScrollToTop()
     }
 
     val isCompact = windowSizeClass.widthSizeClass == WindowWidthSizeClass.Compact

--- a/app/src/main/java/com/asmr/player/ui/groups/AlbumGroupDetailScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/groups/AlbumGroupDetailScreen.kt
@@ -78,6 +78,7 @@ import com.asmr.player.ui.common.queryTrackFileSize
 import com.asmr.player.ui.common.rememberAudioMeta
 import com.asmr.player.ui.common.rememberAudioMetaText
 import com.asmr.player.ui.common.SubtitleStamp
+import com.asmr.player.ui.common.smoothScrollToTop
 import com.asmr.player.ui.common.thinScrollbar
 import com.asmr.player.ui.common.rememberTrackMetaLine
 import com.asmr.player.ui.common.reorderable.ItemPosition
@@ -207,7 +208,7 @@ internal fun AlbumGroupDetailContent(
     }
     LaunchedEffect(scrollToTopSignal) {
         if (scrollToTopSignal == 0L) return@LaunchedEffect
-        runCatching { listState.animateScrollToItem(0) }
+        listState.smoothScrollToTop()
     }
 
     Box(

--- a/app/src/main/java/com/asmr/player/ui/groups/AlbumGroupsScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/groups/AlbumGroupsScreen.kt
@@ -60,6 +60,7 @@ import com.asmr.player.ui.common.FlatDialogActionTone
 import com.asmr.player.ui.common.FlatTextFieldDialog
 import com.asmr.player.ui.common.LocalBottomOverlayPadding
 import com.asmr.player.ui.common.StableWindowInsets
+import com.asmr.player.ui.common.smoothScrollToTop
 import com.asmr.player.ui.common.thinScrollbar
 import com.asmr.player.ui.common.withAddedBottomPadding
 import com.asmr.player.ui.theme.AsmrTheme
@@ -88,7 +89,7 @@ fun AlbumGroupsScreen(
     ) { padding ->
         LaunchedEffect(scrollToTopSignal) {
             if (scrollToTopSignal == 0L) return@LaunchedEffect
-            runCatching { listState.animateScrollToItem(0) }
+            listState.smoothScrollToTop()
         }
         Box(
             modifier = Modifier

--- a/app/src/main/java/com/asmr/player/ui/hotlistening/HotListeningScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/hotlistening/HotListeningScreen.kt
@@ -48,6 +48,7 @@ import com.asmr.player.hotlistening.HotListeningSortMode
 import com.asmr.player.ui.common.EaraBrandedEmptyState
 import com.asmr.player.ui.common.EaraLogoLoadingIndicator
 import com.asmr.player.ui.common.LocalBottomOverlayPadding
+import com.asmr.player.ui.common.smoothScrollToTop
 import com.asmr.player.ui.common.thinScrollbar
 import com.asmr.player.ui.common.withAddedBottomPadding
 import com.asmr.player.ui.library.AlbumGridItem
@@ -129,8 +130,8 @@ fun HotListeningScreen(
         if (scrollToTopSignal == 0L) return@LaunchedEffect
         viewModel.resetScrollPosition()
         when (viewMode) {
-            0 -> runCatching { listState.animateScrollToItem(0) }
-            else -> runCatching { gridState.animateScrollToItem(0) }
+            0 -> listState.smoothScrollToTop()
+            else -> gridState.smoothScrollToTop()
         }
     }
 

--- a/app/src/main/java/com/asmr/player/ui/library/LibraryScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/LibraryScreen.kt
@@ -65,6 +65,7 @@ import com.asmr.player.ui.common.StableWindowInsets
 import com.asmr.player.ui.common.rememberAudioMeta
 import com.asmr.player.ui.common.rememberAudioMetaText
 import com.asmr.player.ui.common.rememberTrackMetaLine
+import com.asmr.player.ui.common.smoothScrollToTop
 import com.asmr.player.ui.common.withAddedBottomPadding
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.ListItem
@@ -335,8 +336,8 @@ fun LibraryScreen(
     LaunchedEffect(scrollToTopSignal) {
         if (scrollToTopSignal == 0L) return@LaunchedEffect
         when (mode) {
-            1 -> runCatching { gridState.animateScrollToItem(0) }
-            else -> runCatching { listState.animateScrollToItem(0) }
+            1 -> gridState.smoothScrollToTop()
+            else -> listState.smoothScrollToTop()
         }
         chromeState.expand()
     }

--- a/app/src/main/java/com/asmr/player/ui/playlists/PlaylistDetailScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/playlists/PlaylistDetailScreen.kt
@@ -68,6 +68,7 @@ import com.asmr.player.ui.common.LocalBottomOverlayPadding
 import com.asmr.player.ui.common.StableWindowInsets
 import com.asmr.player.ui.common.rememberAudioMeta
 import com.asmr.player.ui.common.SubtitleStamp
+import com.asmr.player.ui.common.smoothScrollToTop
 import com.asmr.player.ui.common.thinScrollbar
 import com.asmr.player.ui.common.rememberAudioMetaText
 import com.asmr.player.ui.common.reorderable.ItemPosition
@@ -153,7 +154,7 @@ internal fun PlaylistDetailContent(
     }
     LaunchedEffect(scrollToTopSignal) {
         if (scrollToTopSignal == 0L) return@LaunchedEffect
-        runCatching { listState.animateScrollToItem(0) }
+        listState.smoothScrollToTop()
     }
 
     val playItems = localItems.map { item -> item.toPlaybackEntity() }

--- a/app/src/main/java/com/asmr/player/ui/playlists/PlaylistsScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/playlists/PlaylistsScreen.kt
@@ -56,6 +56,7 @@ import com.asmr.player.ui.common.FlatDialogActionTone
 import com.asmr.player.ui.common.FlatTextFieldDialog
 import com.asmr.player.ui.common.LocalBottomOverlayPadding
 import com.asmr.player.ui.common.StableWindowInsets
+import com.asmr.player.ui.common.smoothScrollToTop
 import com.asmr.player.ui.common.EaraBrandedEmptyState
 import com.asmr.player.ui.common.thinScrollbar
 import com.asmr.player.ui.common.withAddedBottomPadding
@@ -87,7 +88,7 @@ fun PlaylistsScreen(
     ) { padding ->
         LaunchedEffect(scrollToTopSignal) {
             if (scrollToTopSignal == 0L) return@LaunchedEffect
-            runCatching { listState.animateScrollToItem(0) }
+            listState.smoothScrollToTop()
         }
         Box(
             modifier = Modifier

--- a/app/src/main/java/com/asmr/player/ui/search/SearchScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/search/SearchScreen.kt
@@ -108,6 +108,7 @@ import com.asmr.player.ui.common.StableWindowInsets
 import com.asmr.player.ui.common.clearFocusOnTapOutside
 import com.asmr.player.ui.common.collapsibleHeaderUiState
 import com.asmr.player.ui.common.rememberCollapsibleHeaderState
+import com.asmr.player.ui.common.smoothScrollToTop
 import com.asmr.player.ui.common.thinScrollbar
 import com.asmr.player.ui.common.withAddedBottomPadding
 import com.asmr.player.ui.library.AlbumGridItem
@@ -577,8 +578,8 @@ fun SearchScreen(
         if (scrollToTopSignal == 0L) return@LaunchedEffect
         pullNextPageDragPx = 0f
         when (viewMode) {
-            0 -> runCatching { listState.animateScrollToItem(0) }
-            else -> runCatching { gridState.animateScrollToItem(0) }
+            0 -> listState.smoothScrollToTop()
+            else -> gridState.smoothScrollToTop()
         }
         chromeState.expand()
     }

--- a/app/src/main/java/com/asmr/player/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/settings/SettingsScreen.kt
@@ -69,6 +69,7 @@ import com.asmr.player.ui.common.FlatDialogActionTone
 import com.asmr.player.ui.theme.AsmrTheme
 import com.asmr.player.ui.common.LocalBottomOverlayPadding
 import com.asmr.player.ui.common.StableWindowInsets
+import com.asmr.player.ui.common.smoothScrollToTop
 import com.asmr.player.ui.common.thinScrollbar
 import com.asmr.player.ui.common.withAddedBottomPadding
 import com.asmr.player.ui.update.launchDownloadedApkInstall
@@ -155,7 +156,7 @@ fun SettingsScreen(
     ) { padding ->
         LaunchedEffect(scrollToTopSignal) {
             if (scrollToTopSignal == 0L) return@LaunchedEffect
-            runCatching { listState.animateScrollToItem(0) }
+            listState.smoothScrollToTop()
         }
         Box(
             modifier = Modifier


### PR DESCRIPTION
Optimize repeated bottom-navigation scroll-to-top behavior by switching long-distance jumps to a near-target jump plus short animation, and reuse the helper across library/search/hot listening/playlists/groups/downloads/settings pages.