### PR TITLE
fix: optimize bottom nav page transitions

### DIFF
--- a/app/src/main/java/com/asmr/player/main/MainContainer.kt
+++ b/app/src/main/java/com/asmr/player/main/MainContainer.kt
@@ -206,6 +206,7 @@ import com.asmr.player.ui.common.AudioOutputRouteIcon
 import com.asmr.player.ui.common.DismissOutsideBoundsOverlay
 import com.asmr.player.service.AudioOutputRouteKind
 import javax.inject.Inject
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.withTimeoutOrNull
 import kotlinx.coroutines.flow.distinctUntilChanged
@@ -611,17 +612,48 @@ fun MainContainer(
         label = "nowPlayingBackdropAlpha"
     )
     val currentPrimaryRouteState = rememberUpdatedState(currentPrimaryRoute)
+    val pendingPrimaryNavigationRouteState = rememberUpdatedState(pendingPrimaryNavigationRoute)
+    var primaryNavigationJob by remember { mutableStateOf<Job?>(null) }
+    var primaryNavigationRequestId by remember { mutableLongStateOf(0L) }
+    DisposableEffect(Unit) {
+        onDispose {
+            primaryNavigationJob?.cancel()
+        }
+    }
+
     fun openPrimaryRoute(route: String, pagerRoutes: List<String> = primaryPagerRoutes) {
         val targetPage = pagerRoutes.indexOf(route)
+        primaryNavigationJob?.cancel()
+        primaryNavigationRequestId += 1L
+        val requestId = primaryNavigationRequestId
         if (targetPage >= 0 && currentPrimaryRoute != null) {
-            scope.launch {
-                pendingPrimaryNavigationRoute = route
-                primaryPagerState.animateScrollToPage(targetPage)
-                if (currentPrimaryRouteState.value != route) {
-                    navController.navigatePrimaryRoute(route)
+            pendingPrimaryNavigationRoute = route
+            primaryNavigationJob = scope.launch {
+                var completed = false
+                try {
+                    val currentPage = primaryPagerState.currentPage
+                    resolvePrimaryPagerApproachPage(
+                        currentPage = currentPage,
+                        targetPage = targetPage
+                    )?.let { approachPage ->
+                        primaryPagerState.scrollToPage(approachPage)
+                    }
+                    primaryPagerState.animateScrollToPage(targetPage)
+                    if (currentPrimaryRouteState.value != route) {
+                        navController.navigatePrimaryRoute(route)
+                    }
+                    completed = true
+                } finally {
+                    if (primaryNavigationRequestId == requestId) {
+                        primaryNavigationJob = null
+                        if (!completed && pendingPrimaryNavigationRouteState.value == route) {
+                            pendingPrimaryNavigationRoute = null
+                        }
+                    }
                 }
             }
         } else {
+            primaryNavigationJob = null
             pendingPrimaryNavigationRoute = null
             navController.navigatePrimaryRoute(route)
         }
@@ -737,16 +769,18 @@ fun MainContainer(
         }
     }
 
-    LaunchedEffect(currentPrimaryRoute, primaryPagerRoutes, pendingPrimaryNavigationRoute) {
+    LaunchedEffect(currentPrimaryRoute, primaryPagerRoutes, pendingPrimaryNavigationRoute, primaryNavigationJob) {
         val route = currentPrimaryRoute ?: return@LaunchedEffect
         val pendingRoute = pendingPrimaryNavigationRoute
-        if (pendingRoute != null && route != pendingRoute) return@LaunchedEffect
+        if (pendingRoute != null) {
+            if (route == pendingRoute && primaryNavigationJob == null) {
+                pendingPrimaryNavigationRoute = null
+            }
+            return@LaunchedEffect
+        }
         val targetPage = primaryPagerRoutes.indexOf(route)
         if (targetPage >= 0 && primaryPagerState.currentPage != targetPage) {
             primaryPagerState.scrollToPage(targetPage)
-        }
-        if (pendingRoute == route) {
-            pendingPrimaryNavigationRoute = null
         }
     }
 
@@ -758,6 +792,7 @@ fun MainContainer(
                     keyboardController?.hide()
                     return@collect
                 }
+                if (pendingPrimaryNavigationRouteState.value != null) return@collect
                 val page = primaryPagerState.currentPage
                 val currentPrimary = currentPrimaryRouteState.value ?: return@collect
                 val targetRoute = primaryPagerRoutes.getOrNull(page) ?: return@collect
@@ -1489,6 +1524,7 @@ fun MainContainer(
                                     modifier = Modifier
                                         .fillMaxSize()
                                         .padding(top = pagerTopContentPadding),
+                                    beyondBoundsPageCount = 1,
                                     userScrollEnabled = !primaryPagerScrollLocked && !hasOverlayRoute,
                                     key = { primaryPagerRoutes[it] }
                                 ) { page ->
@@ -2144,7 +2180,7 @@ fun MainContainer(
                         },
                         onOpenQueue = onShowQueue,
                         onNavigate = { route ->
-                            if (shouldScrollPrimaryRouteToTop(
+                            if (pendingPrimaryNavigationRoute == null && shouldScrollPrimaryRouteToTop(
                                     requestedRoute = route,
                                     activePrimaryRoute = activePrimaryRoute,
                                     currentPrimaryRoute = currentPrimaryRoute

--- a/app/src/main/java/com/asmr/player/main/MainNavigationSupport.kt
+++ b/app/src/main/java/com/asmr/player/main/MainNavigationSupport.kt
@@ -251,6 +251,14 @@ internal fun resolvePrimaryNavVisualRoute(
     return pendingRoute?.takeIf { it in pagerRoutes } ?: activeRoute
 }
 
+internal fun resolvePrimaryPagerApproachPage(
+    currentPage: Int,
+    targetPage: Int
+): Int? {
+    if (kotlin.math.abs(targetPage - currentPage) <= 1) return null
+    return targetPage + if (targetPage > currentPage) -1 else 1
+}
+
 internal fun resolveCurrentPrimaryDestinationRoute(
     currentRoute: String?,
     playlistSystemType: String? = null

--- a/app/src/test/java/com/asmr/player/MainNavigationSupportTest.kt
+++ b/app/src/test/java/com/asmr/player/MainNavigationSupportTest.kt
@@ -57,6 +57,13 @@ class MainNavigationSupportTest {
     }
 
     @Test
+    fun resolvePrimaryPagerApproachPage_onlySkipsLongProgrammaticJumps() {
+        assertEquals(null, resolvePrimaryPagerApproachPage(currentPage = 1, targetPage = 2))
+        assertEquals(2, resolvePrimaryPagerApproachPage(currentPage = 0, targetPage = 3))
+        assertEquals(1, resolvePrimaryPagerApproachPage(currentPage = 4, targetPage = 0))
+    }
+
+    @Test
     fun resolveCurrentPrimaryDestinationRoute_handlesFavoritesSystemPlaylist() {
         assertEquals(
             "playlist_system/favorites",


### PR DESCRIPTION
## Summary\n- make bottom navigation page transitions interruptible\n- reduce long-distance pager jump stutter by approaching the target page first\n- keep the pager precomposed around neighboring pages\n\n## Verification\n- .\\gradlew.bat :app:compileDebugKotlin\n- .\\gradlew.bat :app:compileDebugUnitTestKotlin