### PR TITLE
feat: add search blocked keywords

### DIFF
--- a/app/src/main/java/com/asmr/player/data/settings/SettingsDataStore.kt
+++ b/app/src/main/java/com/asmr/player/data/settings/SettingsDataStore.kt
@@ -20,6 +20,7 @@ object SettingsKeys {
     val SEARCH_VIEW_MODE = intPreferencesKey("search_view_mode")
     val HOT_LISTENING_VIEW_MODE = intPreferencesKey("hot_listening_view_mode")
     val HOT_LISTENING_SORT_MODE = stringPreferencesKey("hot_listening_sort_mode")
+    val SEARCH_BLOCKED_KEYWORDS = stringPreferencesKey("search_blocked_keywords")
 
     val PLAY_MODE = intPreferencesKey("play_mode")
 

--- a/app/src/main/java/com/asmr/player/data/settings/SettingsRepository.kt
+++ b/app/src/main/java/com/asmr/player/data/settings/SettingsRepository.kt
@@ -12,6 +12,7 @@ import androidx.datastore.preferences.core.edit
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.withContext
+import java.util.Locale
 
 data class PlaybackRuntimeSettings(
     val pauseOnOutputDisconnect: Boolean = true,
@@ -40,6 +41,10 @@ class SettingsRepository @Inject constructor(
 
     val searchViewMode: Flow<Int> = context.settingsDataStore.data.map { prefs ->
         prefs[SettingsKeys.SEARCH_VIEW_MODE] ?: 1 // Default to Grid (1)
+    }
+
+    val searchBlockedKeywords: Flow<List<String>> = context.settingsDataStore.data.map { prefs ->
+        decodeSearchBlockedKeywords(prefs[SettingsKeys.SEARCH_BLOCKED_KEYWORDS])
     }
 
     val hotListeningViewMode: Flow<Int> = context.settingsDataStore.data.map { prefs ->
@@ -357,6 +362,35 @@ class SettingsRepository @Inject constructor(
         }
     }
 
+    suspend fun addSearchBlockedKeyword(keyword: String) {
+        val normalizedKeyword = keyword.trim()
+        if (normalizedKeyword.isBlank()) return
+        withContext(Dispatchers.IO) {
+            context.settingsDataStore.edit { prefs ->
+                val current = decodeSearchBlockedKeywords(prefs[SettingsKeys.SEARCH_BLOCKED_KEYWORDS])
+                val next = normalizeSearchBlockedKeywords(current + normalizedKeyword)
+                prefs[SettingsKeys.SEARCH_BLOCKED_KEYWORDS] = encodeSearchBlockedKeywords(next)
+            }
+        }
+    }
+
+    suspend fun removeSearchBlockedKeyword(keyword: String) {
+        val normalizedKeyword = keyword.trim()
+        if (normalizedKeyword.isBlank()) return
+        withContext(Dispatchers.IO) {
+            context.settingsDataStore.edit { prefs ->
+                val normalizedTarget = normalizedKeyword.lowercase(Locale.ROOT)
+                val next = decodeSearchBlockedKeywords(prefs[SettingsKeys.SEARCH_BLOCKED_KEYWORDS])
+                    .filterNot { it.lowercase(Locale.ROOT) == normalizedTarget }
+                if (next.isEmpty()) {
+                    prefs.remove(SettingsKeys.SEARCH_BLOCKED_KEYWORDS)
+                } else {
+                    prefs[SettingsKeys.SEARCH_BLOCKED_KEYWORDS] = encodeSearchBlockedKeywords(next)
+                }
+            }
+        }
+    }
+
     suspend fun setHotListeningViewMode(mode: Int) {
         withContext(Dispatchers.IO) {
             context.settingsDataStore.edit { it[SettingsKeys.HOT_LISTENING_VIEW_MODE] = mode }
@@ -442,4 +476,27 @@ class SettingsRepository @Inject constructor(
         }
     }
 
+}
+
+private fun decodeSearchBlockedKeywords(raw: String?): List<String> {
+    if (raw.isNullOrBlank()) return emptyList()
+    return normalizeSearchBlockedKeywords(raw.split('\n'))
+}
+
+private fun encodeSearchBlockedKeywords(keywords: List<String>): String {
+    return normalizeSearchBlockedKeywords(keywords).joinToString(separator = "\n")
+}
+
+private fun normalizeSearchBlockedKeywords(keywords: List<String>): List<String> {
+    val seen = linkedSetOf<String>()
+    val result = mutableListOf<String>()
+    keywords.forEach { keyword ->
+        val trimmed = keyword.trim()
+        if (trimmed.isBlank()) return@forEach
+        val key = trimmed.lowercase(Locale.ROOT)
+        if (seen.add(key)) {
+            result += trimmed
+        }
+    }
+    return result
 }

--- a/app/src/main/java/com/asmr/player/ui/search/SearchViewModel.kt
+++ b/app/src/main/java/com/asmr/player/ui/search/SearchViewModel.kt
@@ -27,6 +27,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
@@ -37,6 +38,7 @@ import org.jsoup.HttpStatusException
 import retrofit2.HttpException
 import java.io.IOException
 import java.net.SocketTimeoutException
+import java.util.Locale
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicBoolean
 import javax.inject.Inject
@@ -430,9 +432,13 @@ class SearchViewModel @Inject constructor(
             val resp = dlsitePlayLibraryClient.searchPurchased(keyword, page, pageSize)
             return SearchPageResult(items = resp.items, canGoNext = resp.canGoNext)
         }
+        val keywordWithBlockedTerms = appendBlockedKeywordsForOnlineSearch(
+            keyword = keyword,
+            blockedKeywords = settingsRepository.searchBlockedKeywords.first()
+        )
         if (collectedOnly) {
             val offset = (page.coerceAtLeast(1) - 1) * pageSize
-            val resp = asmrOneAvailabilityApi.search(keyword, pageSize, offset, collectedSort.backendSort)
+            val resp = asmrOneAvailabilityApi.search(keywordWithBlockedTerms, pageSize, offset, collectedSort.backendSort)
             val items = resp.items.orEmpty().map { it.toCollectedAlbum() }
             val total = resp.total.coerceAtLeast(0)
             val responseOffset = resp.offset.coerceAtLeast(offset)
@@ -443,7 +449,13 @@ class SearchViewModel @Inject constructor(
         }
         val normalizedKeyword = keyword.trim()
         val normalizedRj = normalizedKeyword.uppercase()
-        if (!presaleOnly && !chineseTranslatedOnly && page == 1 && Regex("""RJ\d{6,}""").matches(normalizedRj)) {
+        if (
+            keywordWithBlockedTerms == normalizedKeyword &&
+            !presaleOnly &&
+            !chineseTranslatedOnly &&
+            page == 1 &&
+            Regex("""RJ\d{6,}""").matches(normalizedRj)
+        ) {
             val preferred = currentLocale
             val info = when {
                 !preferred.isNullOrBlank() -> {
@@ -465,7 +477,7 @@ class SearchViewModel @Inject constructor(
             }
         }
         val result = dlsiteScraper.search(
-            keyword = keyword,
+            keyword = keywordWithBlockedTerms,
             page = page,
             order = order.dlsiteOrder,
             locale = currentLocale,
@@ -839,6 +851,27 @@ private data class SearchPageResult(
     val items: List<Album>,
     val canGoNext: Boolean
 )
+
+internal fun appendBlockedKeywordsForOnlineSearch(
+    keyword: String,
+    blockedKeywords: List<String>
+): String {
+    val base = keyword.trim()
+    val exclusions = blockedKeywords
+        .map { it.trim() }
+        .map { it.removePrefix("-").trim() }
+        .filter { it.isNotBlank() }
+        .distinctBy { it.lowercase(Locale.ROOT) }
+    if (exclusions.isEmpty()) return base
+    return buildString {
+        if (base.isNotBlank()) append(base)
+        exclusions.forEach { blocked ->
+            if (isNotEmpty()) append(' ')
+            append('-')
+            append(blocked)
+        }
+    }
+}
 
 sealed class SearchUiState {
     object Idle : SearchUiState()

--- a/app/src/main/java/com/asmr/player/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/settings/SettingsScreen.kt
@@ -19,6 +19,7 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.rounded.FormatAlignLeft
 import androidx.compose.material.icons.automirrored.rounded.FormatAlignRight
@@ -30,6 +31,7 @@ import androidx.compose.material.icons.rounded.FormatAlignLeft
 import androidx.compose.material.icons.rounded.FormatAlignRight
 import androidx.compose.material.icons.rounded.Info
 import androidx.compose.material.icons.rounded.Refresh
+import androidx.compose.material.icons.rounded.VisibilityOff
 import androidx.compose.material.icons.rounded.Sync
 import androidx.compose.material3.*
 import androidx.compose.material3.windowsizeclass.WindowSizeClass
@@ -40,13 +42,16 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.layout.SubcomposeLayout
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.Constraints
 import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -104,6 +109,7 @@ fun SettingsScreen(
     val pauseFadeOutMs by viewModel.pauseFadeOutMs.collectAsState()
     val sfwHideSystemControls by viewModel.sfwHideSystemControls.collectAsState()
     val showMiniPlayerBar by viewModel.showMiniPlayerBar.collectAsState()
+    val searchBlockedKeywords by viewModel.searchBlockedKeywords.collectAsState()
     val updateState by viewModel.updateState.collectAsState()
     val autoUpdateCheckEnabled by viewModel.autoUpdateCheckEnabled.collectAsState()
     val scanRoots by libraryViewModel.scanRoots.collectAsState()
@@ -123,6 +129,7 @@ fun SettingsScreen(
     
     var overlayGranted by remember { mutableStateOf(Settings.canDrawOverlays(context)) }
     var activeTipKey by remember { mutableStateOf<String?>(null) }
+    var searchBlockedKeywordInput by rememberSaveable { mutableStateOf("") }
     DisposableEffect(onHorizontalControlInteractionChanged) {
         onDispose { onHorizontalControlInteractionChanged(false) }
     }
@@ -310,6 +317,24 @@ fun SettingsScreen(
                 }
             }
         }
+
+                item(key = "group:block_words") {
+                    SettingsGroup(title = "屏蔽词") {
+                        SearchBlockedKeywordsSection(
+                            input = searchBlockedKeywordInput,
+                            keywords = searchBlockedKeywords,
+                            onInputChange = { searchBlockedKeywordInput = it },
+                            onAddKeyword = {
+                                val keyword = searchBlockedKeywordInput.trim()
+                                if (keyword.isNotBlank()) {
+                                    viewModel.addSearchBlockedKeyword(keyword)
+                                    searchBlockedKeywordInput = ""
+                                }
+                            },
+                            onRemoveKeyword = viewModel::removeSearchBlockedKeyword
+                        )
+                    }
+                }
 
                 item(key = "group:appearance") {
                     SettingsGroup(title = "外观") {
@@ -933,6 +958,310 @@ private fun formatTreeRootLabel(uriString: String): String {
     if (treeId.isBlank()) return uriString
     val doc = treeId.substringAfterLast(':', treeId)
     return doc.ifBlank { treeId }
+}
+
+@Composable
+private fun SearchBlockedKeywordsSection(
+    input: String,
+    keywords: List<String>,
+    onInputChange: (String) -> Unit,
+    onAddKeyword: () -> Unit,
+    onRemoveKeyword: (String) -> Unit
+) {
+    val colorScheme = AsmrTheme.colorScheme
+    val isDark = colorScheme.isDark
+    val addButtonColors = ButtonDefaults.filledTonalButtonColors(
+        containerColor = colorScheme.primarySoft,
+        contentColor = if (isDark) colorScheme.onPrimaryContainer else colorScheme.primaryStrong
+    )
+    var showHelp by remember { mutableStateOf(false) }
+    Column(
+        modifier = Modifier.fillMaxWidth(),
+        verticalArrangement = Arrangement.spacedBy(10.dp)
+    ) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                text = "屏蔽关键词",
+                style = MaterialTheme.typography.bodyMedium,
+                fontWeight = FontWeight.SemiBold,
+                color = colorScheme.textPrimary,
+                modifier = Modifier.weight(1f)
+            )
+            IconButton(
+                onClick = { showHelp = true },
+                modifier = Modifier.size(28.dp)
+            ) {
+                Icon(
+                    imageVector = Icons.Rounded.Info,
+                    contentDescription = "搜索高级用法",
+                    tint = colorScheme.textSecondary,
+                    modifier = Modifier.size(18.dp)
+                )
+            }
+        }
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            SearchBlockedKeywordInputField(
+                value = input,
+                onValueChange = onInputChange,
+                modifier = Modifier
+                    .weight(1f)
+                    .height(44.dp)
+            )
+            FilledTonalButton(
+                onClick = onAddKeyword,
+                enabled = input.isNotBlank(),
+                colors = addButtonColors,
+                shape = RoundedCornerShape(10.dp),
+                contentPadding = PaddingValues(horizontal = 16.dp, vertical = 0.dp)
+            ) {
+                Text("添加")
+            }
+        }
+
+        if (keywords.isEmpty()) {
+            Text(
+                text = "暂无屏蔽关键词",
+                style = MaterialTheme.typography.bodySmall,
+                color = colorScheme.textSecondary
+            )
+        } else {
+            SearchBlockedKeywordsChips(
+                keywords = keywords,
+                onRemoveKeyword = onRemoveKeyword
+            )
+        }
+    }
+    if (showHelp) {
+        SearchBlockedKeywordsHelpDialog(onDismissRequest = { showHelp = false })
+    }
+}
+
+@Composable
+private fun SearchBlockedKeywordsHelpDialog(
+    onDismissRequest: () -> Unit
+) {
+    FlatActionDialog(
+        message = "搜索高级用法",
+        onDismissRequest = onDismissRequest,
+        actions = listOf(
+            FlatDialogAction(
+                text = "知道了",
+                tone = FlatDialogActionTone.Primary,
+                onClick = onDismissRequest
+            )
+        )
+    ) {
+        Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+            SearchHelpText("和 搜索(空格分割)：「学校 制服」，表示同时包含指定关键词")
+            SearchHelpText("或 搜索(英文竖线分割)：「学校|制服」，表示包含一个或多个指定关键词均可")
+            SearchHelpText("排除 搜索(空格与减号)：「学校 -制服」，表示排除指定关键词")
+            SearchHelpText("完整 搜索(英文双引号包裹)：「\"【简体中文】 舔耳\"」，表示将多个词当做完整词组搜索")
+        }
+    }
+}
+
+@Composable
+private fun SearchHelpText(text: String) {
+    Text(
+        text = text,
+        style = MaterialTheme.typography.bodySmall,
+        color = AsmrTheme.colorScheme.textSecondary
+    )
+}
+
+@Composable
+private fun SearchBlockedKeywordsChips(
+    keywords: List<String>,
+    onRemoveKeyword: (String) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val horizontalSpacing = 8.dp
+    val verticalSpacing = 4.dp
+    SubcomposeLayout(modifier = modifier.fillMaxWidth()) { constraints ->
+        val itemSpacingPx = horizontalSpacing.roundToPx()
+        val lineSpacingPx = verticalSpacing.roundToPx()
+        val looseConstraints = Constraints()
+
+        val keywordPlaceables = keywords.mapIndexed { index, keyword ->
+            subcompose("keyword:$index:$keyword") {
+                SearchBlockedKeywordChip(
+                    keyword = keyword,
+                    onRemoveKeyword = onRemoveKeyword
+                )
+            }.first().measure(looseConstraints)
+        }
+
+        val naturalSingleLineWidth = keywordPlaceables.sumOf { it.width } +
+            itemSpacingPx * (keywordPlaceables.size - 1).coerceAtLeast(0)
+
+        val contentFitsSingleLine = naturalSingleLineWidth <= constraints.maxWidth
+        if (contentFitsSingleLine) {
+            val rowHeight = keywordPlaceables.maxOfOrNull { it.height } ?: 0
+            return@SubcomposeLayout layout(constraints.maxWidth, rowHeight) {
+                var x = 0
+                keywordPlaceables.forEachIndexed { index, placeable ->
+                    placeable.placeRelative(
+                        x,
+                        (rowHeight - placeable.height) / 2
+                    )
+                    x += placeable.width
+                    if (index < keywordPlaceables.lastIndex) {
+                        x += itemSpacingPx
+                    }
+                }
+            }
+        }
+        val lines = mutableListOf<MutableList<Int>>()
+        val lineHeights = mutableListOf<Int>()
+        var currentLine = mutableListOf<Int>()
+        var currentWidth = 0
+        var currentHeight = 0
+
+        fun commitLine() {
+            if (currentLine.isEmpty()) return
+            lines += currentLine
+            lineHeights += currentHeight
+            currentLine = mutableListOf()
+            currentWidth = 0
+            currentHeight = 0
+        }
+
+        keywordPlaceables.forEachIndexed { index, placeable ->
+            val nextWidth = if (currentLine.isEmpty()) {
+                placeable.width
+            } else {
+                currentWidth + itemSpacingPx + placeable.width
+            }
+            if (currentLine.isNotEmpty() && nextWidth > constraints.maxWidth) {
+                commitLine()
+            }
+            currentWidth = if (currentLine.isEmpty()) {
+                placeable.width
+            } else {
+                currentWidth + itemSpacingPx + placeable.width
+            }
+            currentHeight = maxOf(currentHeight, placeable.height)
+            currentLine += index
+        }
+        commitLine()
+
+        val layoutHeight = lineHeights.sum() +
+            lineSpacingPx * (lineHeights.size - 1).coerceAtLeast(0)
+
+        layout(constraints.maxWidth, layoutHeight) {
+            var y = 0
+            lines.forEachIndexed { lineIndex, line ->
+                val lineHeight = lineHeights[lineIndex]
+                var x = 0
+                line.forEachIndexed { itemIndex, placeableIndex ->
+                    val placeable = keywordPlaceables[placeableIndex]
+                    placeable.placeRelative(
+                        x,
+                        y + (lineHeight - placeable.height) / 2
+                    )
+                    x += placeable.width
+                    if (itemIndex < line.lastIndex) {
+                        x += itemSpacingPx
+                    }
+                }
+                y += lineHeight + lineSpacingPx
+            }
+        }
+    }
+}
+
+@Composable
+private fun SearchBlockedKeywordInputField(
+    value: String,
+    onValueChange: (String) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val colorScheme = AsmrTheme.colorScheme
+    val shape = RoundedCornerShape(12.dp)
+    BasicTextField(
+        value = value,
+        onValueChange = onValueChange,
+        modifier = modifier,
+        singleLine = true,
+        textStyle = MaterialTheme.typography.bodyMedium.copy(color = colorScheme.textPrimary),
+        cursorBrush = SolidColor(colorScheme.primary),
+        decorationBox = { innerTextField ->
+            Surface(
+                modifier = Modifier.fillMaxSize(),
+                shape = shape,
+                color = colorScheme.surface.copy(alpha = 0.38f),
+                border = androidx.compose.foundation.BorderStroke(
+                    width = 1.dp,
+                    color = MaterialTheme.colorScheme.outline.copy(alpha = 0.32f)
+                )
+            ) {
+                Row(
+                    modifier = Modifier.padding(horizontal = 12.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(8.dp)
+                ) {
+                    Icon(
+                        imageVector = Icons.Rounded.VisibilityOff,
+                        contentDescription = null,
+                        tint = colorScheme.textSecondary,
+                        modifier = Modifier.size(18.dp)
+                    )
+                    Box(
+                        modifier = Modifier.weight(1f),
+                        contentAlignment = Alignment.CenterStart
+                    ) {
+                        if (value.isEmpty()) {
+                            Text(
+                                text = "屏蔽关键词，例如：NTR",
+                                style = MaterialTheme.typography.bodyMedium,
+                                color = colorScheme.textTertiary,
+                                maxLines = 1,
+                                overflow = TextOverflow.Ellipsis
+                            )
+                        }
+                        innerTextField()
+                    }
+                }
+            }
+        }
+    )
+}
+
+@Composable
+@OptIn(ExperimentalMaterial3Api::class)
+private fun SearchBlockedKeywordChip(
+    keyword: String,
+    onRemoveKeyword: (String) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    CompositionLocalProvider(LocalMinimumInteractiveComponentEnforcement provides false) {
+        InputChip(
+            selected = false,
+            onClick = { onRemoveKeyword(keyword) },
+            modifier = modifier,
+            label = {
+                Text(
+                    text = keyword,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
+            },
+            trailingIcon = {
+                Icon(
+                    imageVector = Icons.Rounded.Delete,
+                    contentDescription = "删除 $keyword",
+                    modifier = Modifier.size(16.dp)
+                )
+            }
+        )
+    }
 }
 
 @Composable

--- a/app/src/main/java/com/asmr/player/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/asmr/player/ui/settings/SettingsViewModel.kt
@@ -132,6 +132,9 @@ class SettingsViewModel @Inject constructor(
     val showMiniPlayerBar: StateFlow<Boolean> = settingsRepository.showMiniPlayerBar
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), true)
 
+    val searchBlockedKeywords: StateFlow<List<String>> = settingsRepository.searchBlockedKeywords
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyList())
+
     private val updateClient = GitHubUpdateClient(okHttpClient)
     private val _updateState = MutableStateFlow<AppUpdateState>(AppUpdateState.Idle)
     val updateState = _updateState.asStateFlow()
@@ -200,6 +203,14 @@ class SettingsViewModel @Inject constructor(
 
     fun setShowMiniPlayerBar(enabled: Boolean) {
         viewModelScope.launch { settingsRepository.setShowMiniPlayerBar(enabled) }
+    }
+
+    fun addSearchBlockedKeyword(keyword: String) {
+        viewModelScope.launch { settingsRepository.addSearchBlockedKeyword(keyword) }
+    }
+
+    fun removeSearchBlockedKeyword(keyword: String) {
+        viewModelScope.launch { settingsRepository.removeSearchBlockedKeyword(keyword) }
     }
 
     fun setAutoUpdateCheckEnabled(enabled: Boolean) {

--- a/app/src/test/java/com/asmr/player/data/settings/SettingsRepositoryTest.kt
+++ b/app/src/test/java/com/asmr/player/data/settings/SettingsRepositoryTest.kt
@@ -117,6 +117,32 @@ class SettingsRepositoryTest {
         assertEquals(false, stored.sceneEffectExpanded)
     }
 
+    @Test
+    fun searchBlockedKeywords_defaultToEmptyList() = runBlocking {
+        assertEquals(emptyList<String>(), repository.searchBlockedKeywords.first())
+    }
+
+    @Test
+    fun addSearchBlockedKeyword_trimsIgnoresBlankAndDeduplicatesIgnoringCase() = runBlocking {
+        repository.addSearchBlockedKeyword("  言语侵犯  ")
+        repository.addSearchBlockedKeyword("")
+        repository.addSearchBlockedKeyword("言语侵犯")
+        repository.addSearchBlockedKeyword("VOICE")
+        repository.addSearchBlockedKeyword("voice")
+
+        assertEquals(listOf("言语侵犯", "VOICE"), repository.searchBlockedKeywords.first())
+    }
+
+    @Test
+    fun removeSearchBlockedKeyword_removesIgnoringCase() = runBlocking {
+        repository.addSearchBlockedKeyword("言语侵犯")
+        repository.addSearchBlockedKeyword("VOICE")
+
+        repository.removeSearchBlockedKeyword("voice")
+
+        assertEquals(listOf("言语侵犯"), repository.searchBlockedKeywords.first())
+    }
+
     private suspend fun SettingsRepository.appVolumePercentValue(): Int {
         return appVolumePercent.first()
     }

--- a/app/src/test/java/com/asmr/player/ui/search/SearchBlockedKeywordQueryTest.kt
+++ b/app/src/test/java/com/asmr/player/ui/search/SearchBlockedKeywordQueryTest.kt
@@ -1,0 +1,46 @@
+package com.asmr.player.ui.search
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class SearchBlockedKeywordQueryTest {
+    @Test
+    fun appendBlockedKeywordsForOnlineSearch_appendsExclusionsAfterKeyword() {
+        val query = appendBlockedKeywordsForOnlineSearch(
+            keyword = "校园",
+            blockedKeywords = listOf("猫娘", "言语侵犯")
+        )
+
+        assertEquals("校园 -猫娘 -言语侵犯", query)
+    }
+
+    @Test
+    fun appendBlockedKeywordsForOnlineSearch_supportsBlankBaseKeyword() {
+        val query = appendBlockedKeywordsForOnlineSearch(
+            keyword = " ",
+            blockedKeywords = listOf("猫娘")
+        )
+
+        assertEquals("-猫娘", query)
+    }
+
+    @Test
+    fun appendBlockedKeywordsForOnlineSearch_trimsIgnoresBlankAndDeduplicates() {
+        val query = appendBlockedKeywordsForOnlineSearch(
+            keyword = "校园",
+            blockedKeywords = listOf("  猫娘  ", "", "猫娘", "VOICE", "voice")
+        )
+
+        assertEquals("校园 -猫娘 -VOICE", query)
+    }
+
+    @Test
+    fun appendBlockedKeywordsForOnlineSearch_normalizesLeadingMinus() {
+        val query = appendBlockedKeywordsForOnlineSearch(
+            keyword = "校园",
+            blockedKeywords = listOf("-猫娘", "-", " - ")
+        )
+
+        assertEquals("校园 -猫娘", query)
+    }
+}


### PR DESCRIPTION
## Summary
- add settings storage and UI for search blocked keywords
- append blocked keywords as online search exclusions
- keep the blocked keyword chip list fully expanded with compact spacing
- add repository and query-building tests

## Verification
- PASS: `./gradlew.bat :app:compileDebugKotlin`