### PR TITLE
Filter hot listening blocked works

### DIFF
--- a/app/src/main/java/com/asmr/player/ui/hotlistening/HotListeningScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/hotlistening/HotListeningScreen.kt
@@ -8,17 +8,21 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.itemsIndexed as lazyItemsIndexed
 import androidx.compose.foundation.lazy.staggeredgrid.LazyStaggeredGridState
 import androidx.compose.foundation.lazy.staggeredgrid.LazyVerticalStaggeredGrid
 import androidx.compose.foundation.lazy.staggeredgrid.StaggeredGridCells
+import androidx.compose.foundation.lazy.staggeredgrid.StaggeredGridItemSpan
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.AccessTime
 import androidx.compose.material.icons.rounded.FilterList
+import androidx.compose.material.icons.rounded.KeyboardArrowDown
+import androidx.compose.material.icons.rounded.KeyboardArrowUp
 import androidx.compose.material.icons.rounded.PlayArrow
 import androidx.compose.material.icons.rounded.Whatshot
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -33,15 +37,16 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import androidx.compose.foundation.layout.size
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.asmr.player.domain.model.Album
 import com.asmr.player.hotlistening.HotListeningSortMode
@@ -67,8 +72,8 @@ private fun stableAlbumKey(album: Album): String {
     return "h${seed.hashCode().absoluteValue}"
 }
 
-private fun hotListeningItemKey(index: Int, album: Album): String {
-    return "hot-listening:${stableAlbumKey(album)}:$index"
+private fun hotListeningItemKey(section: String, index: Int, album: Album): String {
+    return "hot-listening:$section:${stableAlbumKey(album)}:$index"
 }
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -87,6 +92,7 @@ fun HotListeningScreen(
     val copyMeta = rememberAlbumMetaCopyAction(viewModel.messageManager)
     val scope = rememberCoroutineScope()
     val isCompactWidth = windowSizeClass.widthSizeClass == WindowWidthSizeClass.Compact
+    var showBlockedEntries by rememberSaveable { mutableStateOf(false) }
 
     val savedScrollPosition = viewModel.scrollPosition
     val listState = rememberSaveable(saver = LazyListState.Saver) {
@@ -216,7 +222,11 @@ fun HotListeningScreen(
             )
 
             is HotListeningUiState.Success -> {
-                if (state.entries.isEmpty()) {
+                LaunchedEffect(state.period, state.sortMode) {
+                    showBlockedEntries = false
+                }
+
+                if (state.entries.isEmpty() && state.blockedEntries.isEmpty()) {
                     EaraBrandedEmptyState(
                         sectionTitle = "热门收听",
                         headline = "暂无排行数据",
@@ -235,20 +245,39 @@ fun HotListeningScreen(
                     ) {
                         lazyItemsIndexed(
                             items = state.entries,
-                            key = { index, entry -> hotListeningItemKey(index, entry.album) },
+                            key = { index, entry -> hotListeningItemKey("visible", index, entry.album) },
                             contentType = { _, _ -> "album" }
                         ) { _, entry ->
-                            val album = entry.album
-                            AlbumItem(
-                                album = album,
-                                onClick = { onAlbumClick(album) },
-                                emptyCoverUseShimmer = true,
-                                coverBadge = entry.toCoverBadge(),
-                                onRjClick = { copyMeta("RJ", it) },
-                                onCircleClick = { copyMeta("社团", it) },
-                                onCvClick = { copyMeta("CV", it) },
-                                onTagClick = { copyMeta("标签", it) },
+                            HotListeningListItem(
+                                entry = entry,
+                                onAlbumClick = onAlbumClick,
+                                copyMeta = copyMeta
                             )
+                        }
+                        if (state.blockedEntries.isNotEmpty()) {
+                            item(
+                                key = "blocked-footer",
+                                contentType = "blockedFooter"
+                            ) {
+                                BlockedHotListeningFooter(
+                                    blockedCount = state.blockedEntries.size,
+                                    expanded = showBlockedEntries,
+                                    onToggle = { showBlockedEntries = !showBlockedEntries }
+                                )
+                            }
+                            if (showBlockedEntries) {
+                                lazyItemsIndexed(
+                                    items = state.blockedEntries,
+                                    key = { index, entry -> hotListeningItemKey("blocked", index, entry.album) },
+                                    contentType = { _, _ -> "album" }
+                                ) { _, entry ->
+                                    HotListeningListItem(
+                                        entry = entry,
+                                        onAlbumClick = onAlbumClick,
+                                        copyMeta = copyMeta
+                                    )
+                                }
+                            }
                         }
                     }
                 } else {
@@ -269,25 +298,117 @@ fun HotListeningScreen(
                     ) {
                         items(
                             state.entries.size,
-                            key = { index -> hotListeningItemKey(index, state.entries[index].album) },
+                            key = { index -> hotListeningItemKey("visible", index, state.entries[index].album) },
                             contentType = { "albumGrid" }
                         ) { index ->
-                            val entry = state.entries[index]
-                            val album = entry.album
-                            AlbumGridItem(
-                                album = album,
-                                onClick = { onAlbumClick(album) },
-                                emptyCoverUseShimmer = true,
-                                coverBadge = entry.toCoverBadge(),
-                                onRjClick = { copyMeta("RJ", it) },
-                                onCircleClick = { copyMeta("社团", it) },
-                                onCvClick = { copyMeta("CV", it) },
-                                onTagClick = { copyMeta("标签", it) },
+                            HotListeningGridItem(
+                                entry = state.entries[index],
+                                onAlbumClick = onAlbumClick,
+                                copyMeta = copyMeta
                             )
+                        }
+                        if (state.blockedEntries.isNotEmpty()) {
+                            item(
+                                key = "blocked-footer",
+                                contentType = "blockedFooter",
+                                span = StaggeredGridItemSpan.FullLine
+                            ) {
+                                BlockedHotListeningFooter(
+                                    blockedCount = state.blockedEntries.size,
+                                    expanded = showBlockedEntries,
+                                    onToggle = { showBlockedEntries = !showBlockedEntries }
+                                )
+                            }
+                            if (showBlockedEntries) {
+                                items(
+                                    state.blockedEntries.size,
+                                    key = { index ->
+                                        hotListeningItemKey("blocked", index, state.blockedEntries[index].album)
+                                    },
+                                    contentType = { "albumGrid" }
+                                ) { index ->
+                                    HotListeningGridItem(
+                                        entry = state.blockedEntries[index],
+                                        onAlbumClick = onAlbumClick,
+                                        copyMeta = copyMeta
+                                    )
+                                }
+                            }
                         }
                     }
                 }
             }
+        }
+    }
+}
+
+@Composable
+private fun HotListeningListItem(
+    entry: HotListeningEntry,
+    onAlbumClick: (Album) -> Unit,
+    copyMeta: (String, String) -> Unit
+) {
+    val album = entry.album
+    AlbumItem(
+        album = album,
+        onClick = { onAlbumClick(album) },
+        emptyCoverUseShimmer = true,
+        coverBadge = entry.toCoverBadge(),
+        onRjClick = { copyMeta("RJ", it) },
+        onCircleClick = { copyMeta("社团", it) },
+        onCvClick = { copyMeta("CV", it) },
+        onTagClick = { copyMeta("标签", it) },
+    )
+}
+
+@Composable
+private fun HotListeningGridItem(
+    entry: HotListeningEntry,
+    onAlbumClick: (Album) -> Unit,
+    copyMeta: (String, String) -> Unit
+) {
+    val album = entry.album
+    AlbumGridItem(
+        album = album,
+        onClick = { onAlbumClick(album) },
+        emptyCoverUseShimmer = true,
+        coverBadge = entry.toCoverBadge(),
+        onRjClick = { copyMeta("RJ", it) },
+        onCircleClick = { copyMeta("社团", it) },
+        onCvClick = { copyMeta("CV", it) },
+        onTagClick = { copyMeta("标签", it) },
+    )
+}
+
+@Composable
+private fun BlockedHotListeningFooter(
+    blockedCount: Int,
+    expanded: Boolean,
+    onToggle: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val colorScheme = AsmrTheme.colorScheme
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 10.dp),
+        horizontalArrangement = Arrangement.Center,
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Text(
+            text = "$blockedCount 个作品被屏蔽",
+            style = androidx.compose.material3.MaterialTheme.typography.bodyMedium,
+            color = colorScheme.textSecondary
+        )
+        TextButton(onClick = onToggle) {
+            Icon(
+                imageVector = if (expanded) Icons.Rounded.KeyboardArrowUp else Icons.Rounded.KeyboardArrowDown,
+                contentDescription = null,
+                modifier = Modifier
+                    .padding(end = 2.dp)
+                    .size(18.dp)
+            )
+            Text(if (expanded) "折叠" else "展开")
         }
     }
 }

--- a/app/src/main/java/com/asmr/player/ui/hotlistening/HotListeningViewModel.kt
+++ b/app/src/main/java/com/asmr/player/ui/hotlistening/HotListeningViewModel.kt
@@ -18,6 +18,7 @@ import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import java.util.Locale
 import javax.inject.Inject
 
 @HiltViewModel
@@ -27,8 +28,13 @@ class HotListeningViewModel @Inject constructor(
     val messageManager: MessageManager,
 ) : ViewModel() {
 
-    private val _uiState = MutableStateFlow<HotListeningUiState>(HotListeningUiState.Loading)
-    val uiState: StateFlow<HotListeningUiState> = _uiState.asStateFlow()
+    private val _rawUiState = MutableStateFlow<HotListeningRawUiState>(HotListeningRawUiState.Loading)
+    val uiState: StateFlow<HotListeningUiState> = combine(
+        _rawUiState,
+        settingsRepository.searchBlockedKeywords
+    ) { rawState, blockedKeywords ->
+        rawState.toUiState(blockedKeywords)
+    }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), HotListeningUiState.Loading)
 
     private val _selectedPeriod = MutableStateFlow("day")
     val selectedPeriod: StateFlow<String> = _selectedPeriod.asStateFlow()
@@ -95,27 +101,27 @@ class HotListeningViewModel @Inject constructor(
 
     private suspend fun loadTopListings(period: String, sortMode: HotListeningSortMode) {
         if (!hotListeningApi.isBackendConfigured) {
-            _uiState.update { HotListeningUiState.Error("后端未配置") }
+            _rawUiState.update { HotListeningRawUiState.Error("后端未配置") }
             return
         }
-        _uiState.update { HotListeningUiState.Loading }
+        _rawUiState.update { HotListeningRawUiState.Loading }
         runCatching {
             val items = hotListeningApi.getTopListings(period, sortMode)
             if (items == null) {
-                _uiState.update { HotListeningUiState.Error("请求失败") }
+                _rawUiState.update { HotListeningRawUiState.Error("请求失败") }
                 return
             }
             val entries = items.map { it.toEntry(sortMode) }
-            _uiState.update {
-                HotListeningUiState.Success(
+            _rawUiState.update {
+                HotListeningRawUiState.Success(
                     entries = entries,
                     period = period,
                     sortMode = sortMode
                 )
             }
         }.onFailure { error ->
-            _uiState.update {
-                HotListeningUiState.Error(error.message ?: "加载失败")
+            _rawUiState.update {
+                HotListeningRawUiState.Error(error.message ?: "加载失败")
             }
         }
     }
@@ -136,6 +142,16 @@ class HotListeningViewModel @Inject constructor(
             sortMode = sortMode
         )
     }
+}
+
+private sealed class HotListeningRawUiState {
+    data object Loading : HotListeningRawUiState()
+    data class Success(
+        val entries: List<HotListeningEntry>,
+        val period: String,
+        val sortMode: HotListeningSortMode
+    ) : HotListeningRawUiState()
+    data class Error(val message: String) : HotListeningRawUiState()
 }
 
 data class HotListeningScrollPosition(
@@ -195,8 +211,71 @@ sealed class HotListeningUiState {
     data object Loading : HotListeningUiState()
     data class Success(
         val entries: List<HotListeningEntry>,
+        val blockedEntries: List<HotListeningEntry>,
         val period: String,
         val sortMode: HotListeningSortMode
     ) : HotListeningUiState()
     data class Error(val message: String) : HotListeningUiState()
+}
+
+internal data class HotListeningBlockedEntries(
+    val visibleEntries: List<HotListeningEntry>,
+    val blockedEntries: List<HotListeningEntry>
+)
+
+private fun HotListeningRawUiState.toUiState(blockedKeywords: List<String>): HotListeningUiState {
+    return when (this) {
+        HotListeningRawUiState.Loading -> HotListeningUiState.Loading
+        is HotListeningRawUiState.Error -> HotListeningUiState.Error(message)
+        is HotListeningRawUiState.Success -> {
+            val filtered = filterHotListeningEntries(entries, blockedKeywords)
+            HotListeningUiState.Success(
+                entries = filtered.visibleEntries,
+                blockedEntries = filtered.blockedEntries,
+                period = period,
+                sortMode = sortMode
+            )
+        }
+    }
+}
+
+internal fun filterHotListeningEntries(
+    entries: List<HotListeningEntry>,
+    blockedKeywords: List<String>
+): HotListeningBlockedEntries {
+    val normalizedKeywords = normalizeHotListeningBlockedKeywords(blockedKeywords)
+    if (normalizedKeywords.isEmpty()) {
+        return HotListeningBlockedEntries(
+            visibleEntries = entries,
+            blockedEntries = emptyList()
+        )
+    }
+    val (blockedEntries, visibleEntries) = entries.partition { entry ->
+        val searchableText = entry.album.toBlockedKeywordSearchText()
+        normalizedKeywords.any { keyword -> searchableText.contains(keyword) }
+    }
+    return HotListeningBlockedEntries(
+        visibleEntries = visibleEntries,
+        blockedEntries = blockedEntries
+    )
+}
+
+private fun normalizeHotListeningBlockedKeywords(keywords: List<String>): List<String> {
+    return keywords
+        .map { it.trim() }
+        .map { it.removePrefix("-").trim() }
+        .filter { it.isNotBlank() }
+        .distinctBy { it.lowercase(Locale.ROOT) }
+        .map { it.lowercase(Locale.ROOT) }
+}
+
+private fun Album.toBlockedKeywordSearchText(): String {
+    return buildString {
+        appendLine(title)
+        appendLine(circle)
+        appendLine(cv)
+        appendLine(rjCode)
+        appendLine(workId)
+        tags.forEach { appendLine(it) }
+    }.lowercase(Locale.ROOT)
 }

--- a/app/src/test/java/com/asmr/player/ui/hotlistening/HotListeningBlockedKeywordFilterTest.kt
+++ b/app/src/test/java/com/asmr/player/ui/hotlistening/HotListeningBlockedKeywordFilterTest.kt
@@ -1,0 +1,88 @@
+package com.asmr.player.ui.hotlistening
+
+import com.asmr.player.domain.model.Album
+import com.asmr.player.hotlistening.HotListeningSortMode
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class HotListeningBlockedKeywordFilterTest {
+    @Test
+    fun filterHotListeningEntries_keepsAllEntriesWhenBlockedKeywordsAreBlank() {
+        val entries = listOf(
+            entry(title = "雨音诊所", rjCode = "RJ100001"),
+            entry(title = "深夜耳语", rjCode = "RJ100002")
+        )
+
+        val result = filterHotListeningEntries(
+            entries = entries,
+            blockedKeywords = listOf("", " - ")
+        )
+
+        assertEquals(entries, result.visibleEntries)
+        assertEquals(emptyList<HotListeningEntry>(), result.blockedEntries)
+    }
+
+    @Test
+    fun filterHotListeningEntries_blocksByAlbumMetadataIgnoringCase() {
+        val visible = entry(title = "雨音诊所", circle = "青空工房", rjCode = "RJ100001")
+        val blockedByTitle = entry(title = "猫娘咖啡厅", rjCode = "RJ100002")
+        val blockedByCircle = entry(title = "深夜散步", circle = "Voice Lab", rjCode = "RJ100003")
+        val blockedByCv = entry(title = "耳语练习", cv = "小铃", rjCode = "RJ100004")
+        val blockedByTag = entry(title = "安眠向导", tags = listOf("催眠"), rjCode = "RJ100005")
+        val blockedByRj = entry(title = "夏日回声", rjCode = "RJ999999")
+
+        val result = filterHotListeningEntries(
+            entries = listOf(
+                visible,
+                blockedByTitle,
+                blockedByCircle,
+                blockedByCv,
+                blockedByTag,
+                blockedByRj
+            ),
+            blockedKeywords = listOf("猫娘", "voice", "小铃", "催眠", "rj999999")
+        )
+
+        assertEquals(listOf(visible), result.visibleEntries)
+        assertEquals(
+            listOf(blockedByTitle, blockedByCircle, blockedByCv, blockedByTag, blockedByRj),
+            result.blockedEntries
+        )
+    }
+
+    @Test
+    fun filterHotListeningEntries_trimsDeduplicatesAndNormalizesLeadingMinus() {
+        val visible = entry(title = "雨音诊所", rjCode = "RJ100001")
+        val blocked = entry(title = "猫娘咖啡厅", rjCode = "RJ100002")
+
+        val result = filterHotListeningEntries(
+            entries = listOf(visible, blocked),
+            blockedKeywords = listOf("  -猫娘  ", "猫娘", "CAT")
+        )
+
+        assertEquals(listOf(visible), result.visibleEntries)
+        assertEquals(listOf(blocked), result.blockedEntries)
+    }
+
+    private fun entry(
+        title: String,
+        circle: String = "",
+        cv: String = "",
+        tags: List<String> = emptyList(),
+        rjCode: String = ""
+    ): HotListeningEntry {
+        return HotListeningEntry(
+            album = Album(
+                title = title,
+                path = "",
+                circle = circle,
+                cv = cv,
+                tags = tags,
+                rjCode = rjCode
+            ),
+            playCount = 10,
+            listenDurationMs = 60_000L,
+            sortMode = HotListeningSortMode.PlayCount
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- filter hot listening rankings with user search blocked keywords before display
- show a collapsed footer with the number of blocked works and allow expanding them
- add unit coverage for hot listening blocked keyword matching

## Verification
- .\gradlew.bat :app:compileDebugKotlin :app:compileDebugUnitTestKotlin
