### PR TITLE
Optimize app navigation and list rendering performance

### DIFF
--- a/app/src/main/java/com/asmr/player/main/MainContainer.kt
+++ b/app/src/main/java/com/asmr/player/main/MainContainer.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.pager.HorizontalPager
+import androidx.compose.foundation.pager.PagerState
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
@@ -127,6 +128,7 @@ import com.asmr.player.ui.drawer.SiteStatusType
 import com.asmr.player.ui.nav.AlbumCoverHintStore
 import com.asmr.player.ui.nav.AppNavigator
 import com.asmr.player.ui.nav.BottomChrome
+import com.asmr.player.ui.nav.BottomChromeNavItem
 import com.asmr.player.ui.nav.Routes
 import com.asmr.player.ui.nav.bottomChromeNavItems
 import com.asmr.player.ui.nav.bottomChromeOverlayHeight
@@ -435,6 +437,56 @@ private fun restoreMainContainerSystemUi(
 }
 
 @Composable
+@OptIn(ExperimentalFoundationApi::class)
+private fun PrimaryBottomChrome(
+    activeRoute: String,
+    pagerState: PagerState,
+    pagerRoutes: List<String>,
+    fallbackRoute: String,
+    lockedRoute: String?,
+    miniPlayerVisible: Boolean,
+    miniPlayerDisplayMode: MiniPlayerDisplayMode,
+    onMiniPlayerDisplayModeChange: (MiniPlayerDisplayMode) -> Unit,
+    onOpenNowPlaying: () -> Unit,
+    onOpenQueue: () -> Unit,
+    onNavigate: (String) -> Unit,
+    largeLayout: Boolean = false,
+    modifier: Modifier = Modifier,
+    navItems: List<BottomChromeNavItem> = bottomChromeNavItems()
+) {
+    val selectionProgresses by remember(
+        pagerState,
+        pagerRoutes,
+        fallbackRoute,
+        lockedRoute
+    ) {
+        derivedStateOf {
+            computePrimaryNavSelectionProgresses(
+                pagerRoutes = pagerRoutes,
+                currentPage = pagerState.currentPage,
+                currentPageOffsetFraction = pagerState.currentPageOffsetFraction,
+                fallbackRoute = fallbackRoute,
+                lockedRoute = lockedRoute
+            )
+        }
+    }
+
+    BottomChrome(
+        activeRoute = activeRoute,
+        selectionProgresses = selectionProgresses,
+        miniPlayerVisible = miniPlayerVisible,
+        miniPlayerDisplayMode = miniPlayerDisplayMode,
+        onMiniPlayerDisplayModeChange = onMiniPlayerDisplayModeChange,
+        onOpenNowPlaying = onOpenNowPlaying,
+        onOpenQueue = onOpenQueue,
+        onNavigate = onNavigate,
+        largeLayout = largeLayout,
+        modifier = modifier,
+        navItems = navItems
+    )
+}
+
+@Composable
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalComposeUiApi::class, ExperimentalFoundationApi::class)
 @androidx.annotation.OptIn(UnstableApi::class)
 fun MainContainer(
@@ -504,22 +556,6 @@ fun MainContainer(
             pendingRoute = pendingPrimaryNavigationRoute,
             pagerRoutes = primaryPagerRoutes
         )
-    }
-    val primaryNavSelectionProgresses by remember(
-        primaryPagerState,
-        primaryPagerRoutes,
-        activePrimaryRoute,
-        pendingPrimaryNavigationRoute
-    ) {
-        derivedStateOf {
-            computePrimaryNavSelectionProgresses(
-                pagerRoutes = primaryPagerRoutes,
-                currentPage = primaryPagerState.currentPage,
-                currentPageOffsetFraction = primaryPagerState.currentPageOffsetFraction,
-                fallbackRoute = activePrimaryRoute,
-                lockedRoute = pendingPrimaryNavigationRoute
-            )
-        }
     }
     LaunchedEffect(Unit) {
         withFrameNanos { }
@@ -2226,9 +2262,12 @@ fun MainContainer(
                         .padding(start = bottomChromeHorizontalPadding, bottom = 24.dp)
                         .width(chromeWidth)
                 ) {
-                    BottomChrome(
+                    PrimaryBottomChrome(
                         activeRoute = visualPrimaryRoute,
-                        selectionProgresses = primaryNavSelectionProgresses,
+                        pagerState = primaryPagerState,
+                        pagerRoutes = primaryPagerRoutes,
+                        fallbackRoute = activePrimaryRoute,
+                        lockedRoute = pendingPrimaryNavigationRoute,
                         miniPlayerVisible = miniPlayerVisible,
                         miniPlayerDisplayMode = miniPlayerDisplayMode,
                         largeLayout = useLargeBottomChrome,
@@ -2250,7 +2289,7 @@ fun MainContainer(
                                     currentPrimaryRoute = currentPrimaryRoute
                                 )) {
                                 triggerPrimaryRouteScrollToTop(route)
-                                return@BottomChrome
+                                return@PrimaryBottomChrome
                             }
                             openPrimaryRoute(route)
                         }

--- a/app/src/main/java/com/asmr/player/ui/common/AlbumCarousel.kt
+++ b/app/src/main/java/com/asmr/player/ui/common/AlbumCarousel.kt
@@ -74,7 +74,6 @@ fun AlbumCarousel(
                     modifier = Modifier.fillMaxSize(),
                     contentScale = ContentScale.Crop,
                     placeholderCornerRadius = 16,
-                    loadAtOriginalSize = coverData.startsWith("http", ignoreCase = true),
                 )
                 Surface(
                     modifier = Modifier

--- a/app/src/main/java/com/asmr/player/ui/common/AsmrAsyncImage.kt
+++ b/app/src/main/java/com/asmr/player/ui/common/AsmrAsyncImage.kt
@@ -4,6 +4,7 @@ import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.MutableState
@@ -79,9 +80,10 @@ fun AsmrAsyncImage(
         }
     val loadedSize: MutableState<IntSize?> = remember(normalizedModel) { mutableStateOf(null) }
     val crossfade = remember(normalizedModel) { Animatable(if (seededPainter != null) 1f else 0f) }
-    val sizedModifier = modifier.onSizeChanged { sz ->
+    val containerModifier = modifier.onSizeChanged { sz ->
         if (sz.width > 0 && sz.height > 0) measuredSize.value = IntSize(sz.width, sz.height)
     }
+    val contentModifier = Modifier.fillMaxSize()
 
     LaunchedEffect(normalizedModel, measuredSize.value) {
         val initialSize = measuredSize.value ?: return@LaunchedEffect
@@ -142,41 +144,38 @@ fun AsmrAsyncImage(
     }
 
     val p = painter.value
-    if (state.value == AsmrAsyncImageState.Error) {
-        placeholder(sizedModifier)
-        return
-    }
+    val currentState = state.value
     val progress = crossfade.value.coerceIn(0f, 1f)
-    Box {
-        // Keep a measurable anchor even when loading/empty UI intentionally renders nothing.
-        Box(
-            modifier = sizedModifier.graphicsLayer {
-                this.alpha = 0f
-                compositingStrategy = CompositingStrategy.ModulateAlpha
+    Box(modifier = containerModifier) {
+        when {
+            currentState == AsmrAsyncImageState.Error -> {
+                placeholder(contentModifier)
             }
-        )
-        if (state.value == AsmrAsyncImageState.Loading || (fadeIn && progress < 1f)) {
-            val loadingAlpha = if (state.value == AsmrAsyncImageState.Loading) 1f else (1f - progress)
-            val loadingModifier = if (loadingAlpha >= 0.999f) {
-                sizedModifier
-            } else {
-                sizedModifier.graphicsLayer {
-                    this.alpha = loadingAlpha
-                    compositingStrategy = CompositingStrategy.ModulateAlpha
+            else -> {
+                if (currentState == AsmrAsyncImageState.Loading || (fadeIn && progress < 1f)) {
+                    val loadingAlpha = if (currentState == AsmrAsyncImageState.Loading) 1f else (1f - progress)
+                    val loadingModifier = if (loadingAlpha >= 0.999f) {
+                        contentModifier
+                    } else {
+                        contentModifier.graphicsLayer {
+                            this.alpha = loadingAlpha
+                            compositingStrategy = CompositingStrategy.ModulateAlpha
+                        }
+                    }
+                    loading(loadingModifier)
+                }
+                if (p != null) {
+                    Image(
+                        painter = p,
+                        contentDescription = contentDescription,
+                        modifier = contentModifier,
+                        contentScale = contentScale,
+                        alignment = alignment,
+                        alpha = if (fadeIn) alpha * progress else alpha,
+                        colorFilter = colorFilter
+                    )
                 }
             }
-            loading(loadingModifier)
-        }
-        if (p != null) {
-            Image(
-                painter = p,
-                contentDescription = contentDescription,
-                modifier = sizedModifier,
-                contentScale = contentScale,
-                alignment = alignment,
-                alpha = if (fadeIn) alpha * progress else alpha,
-                colorFilter = colorFilter
-            )
         }
     }
 }

--- a/app/src/main/java/com/asmr/player/ui/common/ThinScrollbar.kt
+++ b/app/src/main/java/com/asmr/player/ui/common/ThinScrollbar.kt
@@ -31,20 +31,16 @@ fun Modifier.thinScrollbar(
     bottomPadding: Dp = 8.dp,
     minThumbLength: Dp = 32.dp,
 ): Modifier {
-    val metrics = state.thinScrollbarMetrics()
-    val canScroll = state.canScrollBackward || state.canScrollForward
     val scrollbarColor = AsmrTheme.colorScheme.textSecondary
     val alpha by animateFloatAsState(
-        targetValue = when {
-            metrics == null || !canScroll -> 0f
-            state.isScrollInProgress -> 0.72f
-            else -> 0.34f
-        },
+        targetValue = if (state.isScrollInProgress) 0.72f else 0.34f,
         animationSpec = tween(durationMillis = 180),
         label = "lazyListThinScrollbarAlpha"
     )
     return drawThinScrollbar(
-        metrics = metrics,
+        metricsProvider = {
+            if (!state.canScrollBackward && !state.canScrollForward) null else state.thinScrollbarMetrics()
+        },
         color = scrollbarColor,
         alpha = alpha,
         thickness = thickness,
@@ -64,20 +60,16 @@ fun Modifier.thinScrollbar(
     bottomPadding: Dp = 8.dp,
     minThumbLength: Dp = 32.dp,
 ): Modifier {
-    val metrics = state.thinScrollbarMetrics()
-    val canScroll = state.canScrollBackward || state.canScrollForward
     val scrollbarColor = AsmrTheme.colorScheme.textSecondary
     val alpha by animateFloatAsState(
-        targetValue = when {
-            metrics == null || !canScroll -> 0f
-            state.isScrollInProgress -> 0.72f
-            else -> 0.34f
-        },
+        targetValue = if (state.isScrollInProgress) 0.72f else 0.34f,
         animationSpec = tween(durationMillis = 180),
         label = "lazyGridThinScrollbarAlpha"
     )
     return drawThinScrollbar(
-        metrics = metrics,
+        metricsProvider = {
+            if (!state.canScrollBackward && !state.canScrollForward) null else state.thinScrollbarMetrics()
+        },
         color = scrollbarColor,
         alpha = alpha,
         thickness = thickness,
@@ -97,20 +89,16 @@ fun Modifier.thinScrollbar(
     bottomPadding: Dp = 8.dp,
     minThumbLength: Dp = 32.dp,
 ): Modifier {
-    val metrics = state.thinScrollbarMetrics()
-    val canScroll = state.canScrollBackward || state.canScrollForward
     val scrollbarColor = AsmrTheme.colorScheme.textSecondary
     val alpha by animateFloatAsState(
-        targetValue = when {
-            metrics == null || !canScroll -> 0f
-            state.isScrollInProgress -> 0.72f
-            else -> 0.34f
-        },
+        targetValue = if (state.isScrollInProgress) 0.72f else 0.34f,
         animationSpec = tween(durationMillis = 180),
         label = "scrollStateThinScrollbarAlpha"
     )
     return drawThinScrollbar(
-        metrics = metrics,
+        metricsProvider = {
+            if (!state.canScrollBackward && !state.canScrollForward) null else state.thinScrollbarMetrics()
+        },
         color = scrollbarColor,
         alpha = alpha,
         thickness = thickness,
@@ -122,7 +110,7 @@ fun Modifier.thinScrollbar(
 }
 
 private fun Modifier.drawThinScrollbar(
-    metrics: ThinScrollbarMetrics?,
+    metricsProvider: () -> ThinScrollbarMetrics?,
     color: androidx.compose.ui.graphics.Color,
     alpha: Float,
     thickness: Dp,
@@ -134,7 +122,7 @@ private fun Modifier.drawThinScrollbar(
     return then(
         Modifier.drawWithContent {
             drawContent()
-            val resolvedMetrics = metrics ?: return@drawWithContent
+            val resolvedMetrics = metricsProvider() ?: return@drawWithContent
             if (alpha <= 0f) return@drawWithContent
 
             val resolvedColor = color.copy(alpha = alpha)

--- a/app/src/main/java/com/asmr/player/ui/hotlistening/HotListeningScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/hotlistening/HotListeningScreen.kt
@@ -34,6 +34,7 @@ import androidx.compose.material3.TextButton
 import androidx.compose.material3.windowsizeclass.WindowSizeClass
 import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -63,6 +64,9 @@ import com.asmr.player.ui.library.AlbumItem
 import com.asmr.player.ui.library.rememberAlbumMetaCopyAction
 import com.asmr.player.ui.theme.AsmrTheme
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.map
 import kotlin.math.absoluteValue
 
 private fun stableAlbumKey(album: Album): String {
@@ -119,17 +123,36 @@ fun HotListeningScreen(
     }
 
     LaunchedEffect(listState) {
-        snapshotFlow { listState.firstVisibleItemIndex to listState.firstVisibleItemScrollOffset }
+        snapshotFlow { listState.isScrollInProgress }
+            .filter { scrolling -> !scrolling }
+            .map { listState.firstVisibleItemIndex to listState.firstVisibleItemScrollOffset }
+            .distinctUntilChanged()
             .collect { (index, offset) ->
                 viewModel.updateListScrollPosition(index, offset)
             }
     }
 
     LaunchedEffect(gridState) {
-        snapshotFlow { gridState.firstVisibleItemIndex to gridState.firstVisibleItemScrollOffset }
+        snapshotFlow { gridState.isScrollInProgress }
+            .filter { scrolling -> !scrolling }
+            .map { gridState.firstVisibleItemIndex to gridState.firstVisibleItemScrollOffset }
+            .distinctUntilChanged()
             .collect { (index, offset) ->
                 viewModel.updateGridScrollPosition(index, offset)
             }
+    }
+
+    DisposableEffect(listState, gridState, viewModel) {
+        onDispose {
+            viewModel.updateListScrollPosition(
+                listState.firstVisibleItemIndex,
+                listState.firstVisibleItemScrollOffset
+            )
+            viewModel.updateGridScrollPosition(
+                gridState.firstVisibleItemIndex,
+                gridState.firstVisibleItemScrollOffset
+            )
+        }
     }
 
     LaunchedEffect(scrollToTopSignal) {

--- a/app/src/main/java/com/asmr/player/ui/library/AlbumItem.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/AlbumItem.kt
@@ -98,9 +98,6 @@ fun AlbumItem(
         val headers = if (data.startsWith("http", ignoreCase = true)) DlsiteAntiHotlink.headersForImageUrl(data) else emptyMap()
         if (headers.isEmpty()) data else CacheImageModel(data = data, headers = headers, keyTag = "dlsite")
     }
-    // 在线封面按原尺寸加载并缓存：缓存 key 与显示尺寸无关，详情页 hero 用相同 model 即可命中此缓存，
-    // 不再二次网络请求、不再低分辨率占位。本地文件封面保持按尺寸加载，避免缩略图占用过多内存。
-    val loadCoverAtOriginalSize = remember(data) { data.startsWith("http", ignoreCase = true) }
     val screenWidthDp = LocalConfiguration.current.screenWidthDp
     val listItemHeight = (screenWidthDp.dp * 0.24f).coerceIn(112.dp, 140.dp)
     val coverSize = listItemHeight
@@ -136,7 +133,6 @@ fun AlbumItem(
                             contentDescription = null,
                             contentScale = ContentScale.Crop,
                             placeholderCornerRadius = 0,
-                            loadAtOriginalSize = loadCoverAtOriginalSize,
                             modifier = Modifier.fillMaxSize().clip(coverShape),
                             empty = { m -> AsmrShimmerPlaceholder(modifier = m, cornerRadius = 0) },
                         )
@@ -146,7 +142,6 @@ fun AlbumItem(
                             contentDescription = null,
                             contentScale = ContentScale.Crop,
                             placeholderCornerRadius = 0,
-                            loadAtOriginalSize = loadCoverAtOriginalSize,
                             modifier = Modifier.fillMaxSize().clip(coverShape),
                         )
                     }
@@ -343,9 +338,6 @@ fun AlbumGridItem(
         val headers = if (data.startsWith("http", ignoreCase = true)) DlsiteAntiHotlink.headersForImageUrl(data) else emptyMap()
         if (headers.isEmpty()) data else CacheImageModel(data = data, headers = headers, keyTag = "dlsite")
     }
-    // 在线封面按原尺寸加载并缓存，详情页 hero 用相同 model 直接命中（见 AlbumItem 同名说明）。
-    val loadCoverAtOriginalSize = remember(data) { data.startsWith("http", ignoreCase = true) }
-
     Column(
         modifier = modifier
             .clip(shape)
@@ -362,7 +354,6 @@ fun AlbumGridItem(
                     contentDescription = null,
                     contentScale = ContentScale.Crop,
                     placeholderCornerRadius = 0,
-                    loadAtOriginalSize = loadCoverAtOriginalSize,
                     modifier = Modifier.fillMaxSize().clip(coverShape),
                     empty = { m -> AsmrShimmerPlaceholder(modifier = m, cornerRadius = 0) },
                 )
@@ -372,7 +363,6 @@ fun AlbumGridItem(
                     contentDescription = null,
                     contentScale = ContentScale.Crop,
                     placeholderCornerRadius = 0,
-                    loadAtOriginalSize = loadCoverAtOriginalSize,
                     modifier = Modifier.fillMaxSize().clip(coverShape),
                 )
             }

--- a/app/src/main/java/com/asmr/player/ui/library/LibraryScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/LibraryScreen.kt
@@ -131,6 +131,7 @@ import com.asmr.player.ui.sidepanel.LandscapeRightPanelHost
 import com.asmr.player.ui.sidepanel.RecentAlbumsPanel
 import com.asmr.player.cache.ImageCacheEntryPoint
 import com.asmr.player.cache.LazyListPreloader
+import com.asmr.player.cache.CacheImageModel
 import dagger.hilt.android.EntryPointAccessors
 
 import androidx.compose.foundation.combinedClickable
@@ -155,6 +156,7 @@ import androidx.paging.compose.collectAsLazyPagingItems
 import com.asmr.player.ui.theme.dynamicPageContainerColor
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import androidx.compose.ui.graphics.graphicsLayer
@@ -169,6 +171,7 @@ import com.asmr.player.ui.common.collapsibleHeaderUiState
 import com.asmr.player.ui.common.rememberCollapsibleHeaderState
 import com.asmr.player.ui.common.thinScrollbar
 import com.asmr.player.playback.MediaItemFactory
+import com.asmr.player.util.DlsiteAntiHotlink
 
 internal const val LIBRARY_CHROME_TAG = "library_chrome"
 internal const val LIBRARY_SEARCH_INPUT_TAG = "library_search_input"
@@ -186,6 +189,34 @@ private val LibraryAlbumGridInfoVerticalPadding = 8.dp
 private fun Album.withUserTags(userTags: List<String>): Album {
     if (userTags.isEmpty()) return this
     return copy(tags = (tags + userTags).distinct())
+}
+
+private fun albumCoverData(
+    coverThumbPath: String,
+    coverPath: String,
+    coverUrl: String
+): String? {
+    return coverThumbPath.takeIf { it.isNotBlank() && it.contains("_v2") }
+        ?: coverPath.takeIf { it.isNotBlank() }
+        ?: coverUrl.takeIf { it.isNotBlank() }
+}
+
+private fun albumCoverImageModel(
+    coverThumbPath: String,
+    coverPath: String,
+    coverUrl: String
+): Any? {
+    val data = albumCoverData(
+        coverThumbPath = coverThumbPath,
+        coverPath = coverPath,
+        coverUrl = coverUrl
+    ) ?: return null
+    val headers = if (data.startsWith("http", ignoreCase = true)) {
+        DlsiteAntiHotlink.headersForImageUrl(data)
+    } else {
+        emptyMap()
+    }
+    return if (headers.isEmpty()) data else CacheImageModel(data = data, headers = headers, keyTag = "dlsite")
 }
 
 @Composable
@@ -317,21 +348,25 @@ fun LibraryScreen(
             lastChromeResetMode = mode
         }
     }
-    LaunchedEffect(listState.firstVisibleItemIndex, listState.firstVisibleItemScrollOffset, mode) {
-        if ((mode == 0 || mode == 2) &&
-            listState.firstVisibleItemIndex == 0 &&
-            listState.firstVisibleItemScrollOffset == 0
-        ) {
-            chromeState.expand()
+    LaunchedEffect(listState, mode) {
+        if (mode != 0 && mode != 2) return@LaunchedEffect
+        snapshotFlow {
+            listState.firstVisibleItemIndex == 0 && listState.firstVisibleItemScrollOffset == 0
         }
+            .distinctUntilChanged()
+            .collect { atTop ->
+                if (atTop) chromeState.expand()
+            }
     }
-    LaunchedEffect(gridState.firstVisibleItemIndex, gridState.firstVisibleItemScrollOffset, mode) {
-        if (mode == 1 &&
-            gridState.firstVisibleItemIndex == 0 &&
-            gridState.firstVisibleItemScrollOffset == 0
-        ) {
-            chromeState.expand()
+    LaunchedEffect(gridState, mode) {
+        if (mode != 1) return@LaunchedEffect
+        snapshotFlow {
+            gridState.firstVisibleItemIndex == 0 && gridState.firstVisibleItemScrollOffset == 0
         }
+            .distinctUntilChanged()
+            .collect { atTop ->
+                if (atTop) chromeState.expand()
+            }
     }
     LaunchedEffect(scrollToTopSignal) {
         if (scrollToTopSignal == 0L) return@LaunchedEffect
@@ -591,8 +626,11 @@ fun LibraryScreen(
                                                         totalDurationSeconds = header.totalDuration,
                                                         totalSizeBytes = header.totalSizeBytes.takeIf { it > 0L }
                                                             ?: rememberAlbumTrackListTotalSizeBytes(rows),
-                                                        coverModel = header.coverPath.takeIf { it.isNotBlank() }.takeIf { it != "null" }
-                                                            ?: header.coverUrl.takeIf { it.isNotBlank() },
+                                                        coverModel = albumCoverImageModel(
+                                                            coverThumbPath = "",
+                                                            coverPath = header.coverPath.takeIf { it != "null" }.orEmpty(),
+                                                            coverUrl = header.coverUrl
+                                                        ),
                                                         expanded = expanded,
                                                         isFirstInList = isFirstAlbumHeader,
                                                         isLastInList = isLastAlbumHeader,
@@ -761,9 +799,11 @@ fun LibraryScreen(
                                             if (a == null) {
                                                 null
                                             } else {
-                                                a.coverThumbPath.takeIf { it.isNotBlank() && it.contains("_v2") }
-                                                    ?: a.coverPath.takeIf { it.isNotBlank() }
-                                                    ?: a.coverUrl.takeIf { it.isNotBlank() }
+                                                albumCoverImageModel(
+                                                    coverThumbPath = a.coverThumbPath,
+                                                    coverPath = a.coverPath,
+                                                    coverUrl = a.coverUrl
+                                                )
                                             }
                                         }
                                     )
@@ -1357,15 +1397,17 @@ private fun AlbumGridItem(
     ) {
         Box(modifier = Modifier.fillMaxWidth().aspectRatio(1f)) {
             val coverModel = remember(album.coverThumbPath, album.coverPath, album.coverUrl) {
-                val thumb = album.coverThumbPath.trim().takeIf { it.isNotBlank() && it.contains("_v2") }.orEmpty()
-                thumb.ifBlank { album.coverPath }.ifBlank { album.coverUrl }.trim().ifBlank { null }
+                albumCoverImageModel(
+                    coverThumbPath = album.coverThumbPath,
+                    coverPath = album.coverPath,
+                    coverUrl = album.coverUrl
+                )
             }
             AsmrAsyncImage(
                 model = coverModel,
                 contentDescription = null,
                 contentScale = ContentScale.Crop,
                 placeholderCornerRadius = 0,
-                loadAtOriginalSize = coverModel?.startsWith("http", ignoreCase = true) == true,
                 modifier = Modifier.fillMaxSize().clip(coverShape),
             )
             
@@ -1545,15 +1587,17 @@ private fun AlbumItem(
                         .fillMaxSize()
                 ) {
                     val coverModel = remember(album.coverThumbPath, album.coverPath, album.coverUrl) {
-                        val thumb = album.coverThumbPath.trim().takeIf { it.isNotBlank() && it.contains("_v2") }.orEmpty()
-                        thumb.ifBlank { album.coverPath }.ifBlank { album.coverUrl }.trim().ifBlank { null }
+                        albumCoverImageModel(
+                            coverThumbPath = album.coverThumbPath,
+                            coverPath = album.coverPath,
+                            coverUrl = album.coverUrl
+                        )
                     }
                     AsmrAsyncImage(
                         model = coverModel,
                         contentDescription = null,
                         contentScale = ContentScale.Crop,
                         placeholderCornerRadius = 0,
-                        loadAtOriginalSize = coverModel?.startsWith("http", ignoreCase = true) == true,
                         modifier = Modifier.fillMaxSize().clip(coverShape),
                     )
                     

--- a/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailDlsiteTabs.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailDlsiteTabs.kt
@@ -754,10 +754,14 @@ internal fun AlbumDlsiteInfoBreadcrumbTabV2(
             .distinctUntilChanged()
             .collect { (idx, off) -> onPersistScroll(idx, off) }
     }
-    LaunchedEffect(listState.firstVisibleItemIndex, listState.firstVisibleItemScrollOffset) {
-        if (listState.firstVisibleItemIndex == 0 && listState.firstVisibleItemScrollOffset == 0) {
-            chromeState.expand()
+    LaunchedEffect(listState, treeStateKey) {
+        snapshotFlow {
+            listState.firstVisibleItemIndex == 0 && listState.firstVisibleItemScrollOffset == 0
         }
+            .distinctUntilChanged()
+            .collect { atTop ->
+                if (atTop) chromeState.expand()
+            }
     }
     LaunchedEffect(currentPath, treeStateKey) {
         onPersistCurrentPath(currentPath)
@@ -1215,10 +1219,14 @@ internal fun AlbumDlsitePlayBreadcrumbTabV2(
                 onPersistScroll(persistedIndex, off)
             }
     }
-    LaunchedEffect(listState.firstVisibleItemIndex, listState.firstVisibleItemScrollOffset) {
-        if (listState.firstVisibleItemIndex == 0 && listState.firstVisibleItemScrollOffset == 0) {
-            chromeState.expand()
+    LaunchedEffect(listState, treeStateKey) {
+        snapshotFlow {
+            listState.firstVisibleItemIndex == 0 && listState.firstVisibleItemScrollOffset == 0
         }
+            .distinctUntilChanged()
+            .collect { atTop ->
+                if (atTop) chromeState.expand()
+            }
     }
 
     val rj = rjCode.trim().uppercase()

--- a/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailLocalTab.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailLocalTab.kt
@@ -181,10 +181,14 @@ internal fun AlbumLocalBreadcrumbTabV2(
             .distinctUntilChanged()
             .collect { (idx, off) -> onPersistScroll(idx, off) }
     }
-    LaunchedEffect(listState.firstVisibleItemIndex, listState.firstVisibleItemScrollOffset) {
-        if (listState.firstVisibleItemIndex == 0 && listState.firstVisibleItemScrollOffset == 0) {
-            chromeState.expand()
+    LaunchedEffect(listState, stateKey) {
+        snapshotFlow {
+            listState.firstVisibleItemIndex == 0 && listState.firstVisibleItemScrollOffset == 0
         }
+            .distinctUntilChanged()
+            .collect { atTop ->
+                if (atTop) chromeState.expand()
+            }
     }
     LaunchedEffect(currentPath, stateKey) {
         onPersistCurrentPath(currentPath)

--- a/app/src/main/java/com/asmr/player/ui/nav/BottomChrome.kt
+++ b/app/src/main/java/com/asmr/player/ui/nav/BottomChrome.kt
@@ -56,8 +56,10 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.geometry.CornerRadius
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.geometry.RoundRect
+import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Path
 import androidx.compose.ui.graphics.StrokeCap
@@ -921,31 +923,53 @@ private fun BottomNavigationPillSurface(
             }
             .graphicsLayer { clip = false }
             .drawBehind {
-                val outline = buildBottomNavContainerPath(
-                    width = size.width,
-                    height = size.height,
-                    barHeight = metrics.barHeight.toPx(),
-                    barRadius = metrics.barCornerRadius.toPx(),
-                    overflowAnchorX = overflowPanelCenterPx,
-                    overflowHeadroom = overflowHeadroomPx,
-                    overflowPanelWidth = overflowPanelWidthPx,
-                    overflowTopCapHeight = metrics.overflowTopCapHeight.toPx(),
-                    overflowShoulderLift = metrics.overflowShoulderLift.toPx(),
-                    overflowNeckBottomOffset = metrics.overflowNeckBottomOffset.toPx(),
-                    leftShoulderReach = metrics.overflowLeftShoulderReach.toPx(),
-                    rightShoulderReach = metrics.overflowRightShoulderReach.toPx(),
-                    overflowShapeProgress = overflowOutlineProgress
+                val drawBarHeightPx = metrics.barHeight.toPx()
+                val drawBarRadiusPx = metrics.barCornerRadius.toPx()
+                val borderStroke = Stroke(
+                    width = BottomNavBorderWidth.toPx(),
+                    join = StrokeJoin.Round,
+                    cap = StrokeCap.Round
                 )
-                drawPath(path = outline, color = containerColor)
-                drawPath(
-                    path = outline,
-                    color = borderColor,
-                    style = Stroke(
-                        width = BottomNavBorderWidth.toPx(),
-                        join = StrokeJoin.Round,
-                        cap = StrokeCap.Round
+                if (overflowOutlineProgress <= 0.001f || !overflowPanelCenterPx.isFinite()) {
+                    val topLeft = Offset(0f, size.height - drawBarHeightPx)
+                    val barSize = Size(size.width, drawBarHeightPx)
+                    val cornerRadius = CornerRadius(drawBarRadiusPx, drawBarRadiusPx)
+                    drawRoundRect(
+                        color = containerColor,
+                        topLeft = topLeft,
+                        size = barSize,
+                        cornerRadius = cornerRadius
                     )
-                )
+                    drawRoundRect(
+                        color = borderColor,
+                        topLeft = topLeft,
+                        size = barSize,
+                        cornerRadius = cornerRadius,
+                        style = borderStroke
+                    )
+                } else {
+                    val outline = buildBottomNavContainerPath(
+                        width = size.width,
+                        height = size.height,
+                        barHeight = drawBarHeightPx,
+                        barRadius = drawBarRadiusPx,
+                        overflowAnchorX = overflowPanelCenterPx,
+                        overflowHeadroom = overflowHeadroomPx,
+                        overflowPanelWidth = overflowPanelWidthPx,
+                        overflowTopCapHeight = metrics.overflowTopCapHeight.toPx(),
+                        overflowShoulderLift = metrics.overflowShoulderLift.toPx(),
+                        overflowNeckBottomOffset = metrics.overflowNeckBottomOffset.toPx(),
+                        leftShoulderReach = metrics.overflowLeftShoulderReach.toPx(),
+                        rightShoulderReach = metrics.overflowRightShoulderReach.toPx(),
+                        overflowShapeProgress = overflowOutlineProgress
+                    )
+                    drawPath(path = outline, color = containerColor)
+                    drawPath(
+                        path = outline,
+                        color = borderColor,
+                        style = borderStroke
+                    )
+                }
             }
     ) {
         Box(

--- a/app/src/main/java/com/asmr/player/ui/search/SearchAssistScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/search/SearchAssistScreen.kt
@@ -43,6 +43,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.runtime.withFrameNanos
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -76,6 +77,7 @@ import com.asmr.player.ui.common.thinScrollbar
 import com.asmr.player.ui.common.withAddedBottomPadding
 import com.asmr.player.ui.theme.AsmrTheme
 import com.asmr.player.util.DlsiteAntiHotlink
+import kotlinx.coroutines.flow.distinctUntilChanged
 
 internal const val SEARCH_ASSIST_INPUT_TAG = "search_assist_input"
 internal const val SEARCH_ASSIST_SUBMIT_TAG = "search_assist_submit"
@@ -257,10 +259,14 @@ internal fun SearchAssistContent(
         )
     }
 
-    LaunchedEffect(listState.firstVisibleItemIndex, listState.firstVisibleItemScrollOffset) {
-        if (listState.firstVisibleItemIndex == 0 && listState.firstVisibleItemScrollOffset == 0) {
-            chromeState.expand()
+    LaunchedEffect(listState) {
+        snapshotFlow {
+            listState.firstVisibleItemIndex == 0 && listState.firstVisibleItemScrollOffset == 0
         }
+            .distinctUntilChanged()
+            .collect { atTop ->
+                if (atTop) chromeState.expand()
+            }
     }
 
     LaunchedEffect(inputFocusRequester) {
@@ -801,8 +807,6 @@ private fun SearchAssistWorkChip(
         }
         if (headers.isEmpty()) coverData else CacheImageModel(data = coverData, headers = headers, keyTag = "dlsite")
     }
-    // 在线封面按原尺寸加载并缓存，详情页 hero 用相同 model 直接命中、不再二次网络请求。
-    val loadCoverAtOriginalSize = remember(coverData) { coverData.startsWith("http", ignoreCase = true) }
     val containerColor = colorScheme.surface.copy(alpha = if (colorScheme.isDark) 0.72f else 0.82f)
         .compositeOver(colorScheme.background)
     val meta = listOf(album.cv, album.circle)
@@ -829,7 +833,6 @@ private fun SearchAssistWorkChip(
             contentDescription = null,
             contentScale = ContentScale.Crop,
             placeholderCornerRadius = 0,
-            loadAtOriginalSize = loadCoverAtOriginalSize,
             modifier = Modifier
                 .aspectRatio(1f)
                 .height(if (compact) 76.dp else 84.dp)

--- a/app/src/main/java/com/asmr/player/ui/search/SearchScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/search/SearchScreen.kt
@@ -119,6 +119,8 @@ import com.asmr.player.ui.sidepanel.LandscapeRightPanelHost
 import com.asmr.player.ui.sidepanel.RecentAlbumsPanel
 import com.asmr.player.ui.theme.AsmrTheme
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.flow.distinctUntilChanged
+import androidx.compose.runtime.snapshotFlow
 import kotlin.math.absoluteValue
 import kotlin.math.roundToInt
 
@@ -564,15 +566,25 @@ fun SearchScreen(
             lastChromeResetKey = chromeResetKey
         }
     }
-    LaunchedEffect(listState.firstVisibleItemIndex, listState.firstVisibleItemScrollOffset, viewMode) {
-        if (viewMode == 0 && listState.firstVisibleItemIndex == 0 && listState.firstVisibleItemScrollOffset == 0) {
-            chromeState.expand()
+    LaunchedEffect(listState, viewMode) {
+        if (viewMode != 0) return@LaunchedEffect
+        snapshotFlow {
+            listState.firstVisibleItemIndex == 0 && listState.firstVisibleItemScrollOffset == 0
         }
+            .distinctUntilChanged()
+            .collect { atTop ->
+                if (atTop) chromeState.expand()
+            }
     }
-    LaunchedEffect(gridState.firstVisibleItemIndex, gridState.firstVisibleItemScrollOffset, viewMode) {
-        if (viewMode != 0 && gridState.firstVisibleItemIndex == 0 && gridState.firstVisibleItemScrollOffset == 0) {
-            chromeState.expand()
+    LaunchedEffect(gridState, viewMode) {
+        if (viewMode == 0) return@LaunchedEffect
+        snapshotFlow {
+            gridState.firstVisibleItemIndex == 0 && gridState.firstVisibleItemScrollOffset == 0
         }
+            .distinctUntilChanged()
+            .collect { atTop ->
+                if (atTop) chromeState.expand()
+            }
     }
     LaunchedEffect(scrollToTopSignal) {
         if (scrollToTopSignal == 0L) return@LaunchedEffect
@@ -806,32 +818,6 @@ fun SearchScreen(
                                     }
                                 }
                             )
-                                /* modifier = Modifier
-                                    .fillMaxSize()
-                                    .verticalScroll(rememberScrollState())
-                                    .padding(top = topPadding),
-                                horizontalAlignment = Alignment.CenterHorizontally,
-                                verticalArrangement = Arrangement.Center
-                            ) {
-                                Icon(
-                                    imageVector = Icons.Rounded.WifiOff,
-                                    contentDescription = null,
-                                    tint = colorScheme.textSecondary.copy(alpha = 0.6f),
-                                    modifier = Modifier.size(92.dp)
-                                )
-                                Spacer(modifier = Modifier.height(12.dp))
-                                Text(text = "网络错误", color = colorScheme.textSecondary)
-                                Spacer(modifier = Modifier.height(16.dp))
-                                FilledTonalButton(
-                                    onClick = { viewModel.retry() },
-                                    colors = ButtonDefaults.filledTonalButtonColors(
-                                        containerColor = colorScheme.primaryContainer,
-                                        contentColor = colorScheme.onPrimaryContainer
-                                    )
-                                ) {
-                                    Text("刷新")
-                                }
-                            } */
 
                             else -> Column(
                                 modifier = Modifier


### PR DESCRIPTION
## Summary
- Reduce broad Compose recomposition during bottom navigation pager animations by isolating pager offset reads into the bottom chrome layer.
- Make bottom navigation background drawing lighter while preserving the existing shape/animation behavior.
- Reduce list/detail scroll overhead by moving high-frequency scroll reads and persistence paths out of composition where possible.
- Avoid unnecessary original-size image work in scrolling cover/card paths, while keeping detail/full preview behavior intact.
- Keep DLsite image header/cache-key handling consistent between preload and render paths.

## Performance Context
Manual measurements were recorded on a real installed release APK while operating the app, instead of relying on synthetic local gestures. Representative optimized-release samples:
- 本地库 30s: 117.34 FPS, FrameTimeline jank 0%, p50/p90/p95/p99 22/34/36/48ms
- 在线搜索页面列表滚动 30s: 119.55 FPS, FrameTimeline jank 0%, p50/p90/p95/p99 22/24/25/29ms
- 热门收听页面列表滚动 30s: 119.37 FPS, FrameTimeline jank 0%, p50/p90/p95/p99 18/27/28/36ms
- 点击底部导航栏触发页面切换 30s: 93.42 FPS, FrameTimeline jank 0%, p50/p90/p95/p99 24/53/69/129ms

## Validation
- `./gradlew.bat :app:compileDebugKotlin :app:compileReleaseKotlin`
- `./gradlew.bat :app:assembleRelease`
- `git diff --check` passed with only existing CRLF/LF conversion warnings