### PR TITLE
fix: polish album detail transitions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,8 @@ keystore.properties
 
 .gradle/
 .gradle-home
+.gradle-user-home/
+.gradle-temp/
 **/build/
 .build_asmr_player_android/
 .debug_device_db/

--- a/app/src/main/java/com/asmr/player/benchmark/BenchmarkHarnessActivity.kt
+++ b/app/src/main/java/com/asmr/player/benchmark/BenchmarkHarnessActivity.kt
@@ -157,7 +157,7 @@ private fun BenchmarkScenarioScreen(
         BenchmarkScenario.SearchNetwork -> {
             SearchScreen(
                 windowSizeClass = windowSizeClass,
-                onAlbumClick = { _, _ -> }
+                onAlbumClick = { _, _, _ -> }
             )
         }
 

--- a/app/src/main/java/com/asmr/player/hotlistening/HotListeningApi.kt
+++ b/app/src/main/java/com/asmr/player/hotlistening/HotListeningApi.kt
@@ -40,7 +40,17 @@ data class HotListeningItem(
     val tags: String = "",
     val coverUrl: String = "",
     val playCount: Int = 0,
-    val listenDurationMs: Long = 0L
+    val listenDurationMs: Long = 0L,
+    val releaseDate: String = "",
+    val rateAverage2dp: Double? = null,
+    val ratingValue: Double? = null,
+    val rateCount: Int? = null,
+    val reviewCount: Int? = null,
+    val ratingCount: Int? = null,
+    val dlCount: Int = 0,
+    val price: Int? = null,
+    val priceJpy: Int? = null,
+    val description: String = ""
 ) {
     val cvList: List<String>
         get() = cv.split(",").map { it.trim() }.filter { it.isNotBlank() }

--- a/app/src/main/java/com/asmr/player/main/MainContainer.kt
+++ b/app/src/main/java/com/asmr/player/main/MainContainer.kt
@@ -1684,14 +1684,23 @@ fun MainContainer(
                                                     searchAssistInitialRequest = request
                                                     navController.navigateSingleTop(Routes.searchAssist(request.keyword))
                                                 },
-                                                onAlbumClick = { album, fromPurchasedOnly ->
+                                                onAlbumClick = { album, fromPurchasedOnly, hasResolvedDetail ->
                                                     AlbumCoverHintStore.record(
                                                         albumId = album.id,
                                                         rjCode = album.rjCode.ifBlank { album.workId },
                                                         title = album.title,
                                                         circle = album.circle,
                                                         cv = album.cv,
-                                                        coverUrl = album.coverUrl
+                                                        coverUrl = album.coverUrl,
+                                                        tags = album.tags,
+                                                        ratingValue = album.ratingValue,
+                                                        ratingCount = album.ratingCount,
+                                                        releaseDate = album.releaseDate,
+                                                        dlCount = album.dlCount,
+                                                        priceJpy = album.priceJpy,
+                                                        hasAsmrOne = album.hasAsmrOne,
+                                                        description = album.description,
+                                                        hasResolvedDlsiteInfo = hasResolvedDetail && !fromPurchasedOnly
                                                     )
                                                     openAlbumDetailFromSearch(
                                                         albumId = album.id,
@@ -1714,7 +1723,16 @@ fun MainContainer(
                                                         title = album.title,
                                                         circle = album.circle,
                                                         cv = album.cv,
-                                                        coverUrl = album.coverUrl
+                                                        coverUrl = album.coverUrl,
+                                                        tags = album.tags,
+                                                        ratingValue = album.ratingValue,
+                                                        ratingCount = album.ratingCount,
+                                                        releaseDate = album.releaseDate,
+                                                        dlCount = album.dlCount,
+                                                        priceJpy = album.priceJpy,
+                                                        hasAsmrOne = album.hasAsmrOne,
+                                                        description = album.description,
+                                                        hasResolvedDlsiteInfo = true
                                                     )
                                                     navigator.openAlbumDetailByRj(album.rjCode.ifBlank { album.workId })
                                                 },

--- a/app/src/main/java/com/asmr/player/ui/hotlistening/HotListeningViewModel.kt
+++ b/app/src/main/java/com/asmr/player/ui/hotlistening/HotListeningViewModel.kt
@@ -135,7 +135,13 @@ class HotListeningViewModel @Inject constructor(
                 cv = cv,
                 tags = tagList,
                 coverUrl = coverUrl,
-                rjCode = rj
+                rjCode = rj,
+                releaseDate = releaseDate.trim(),
+                ratingValue = ratingValue ?: rateAverage2dp,
+                ratingCount = (ratingCount ?: rateCount ?: reviewCount ?: 0).coerceAtLeast(0),
+                dlCount = dlCount.coerceAtLeast(0),
+                priceJpy = (priceJpy ?: price ?: 0).coerceAtLeast(0),
+                description = description.trim()
             ),
             playCount = playCount,
             listenDurationMs = listenDurationMs,

--- a/app/src/main/java/com/asmr/player/ui/library/AlbumDetailScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/AlbumDetailScreen.kt
@@ -12,7 +12,6 @@ import androidx.compose.animation.core.Spring
 import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.FastOutSlowInEasing
 import androidx.compose.animation.core.animateFloatAsState
-import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.animation.core.spring
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.expandVertically
@@ -154,9 +153,10 @@ import java.util.UUID
 import kotlin.math.abs
 import kotlin.math.roundToInt
 
-private enum class AlbumPrimaryAction {
-    Download,
-    Save
+private enum class AlbumHeaderButtonGroupState {
+    DownloadOnly,
+    Save,
+    Lossless
 }
 
 private enum class OnlineDownloadSource {
@@ -196,11 +196,22 @@ private const val AlbumDetailHeroMetaRevealDelayMs = 280
 private const val AlbumDetailCvRevealDelayMs = 220
 private const val AlbumDetailTagsRevealDelayMs = 360
 private const val AlbumDetailActionsRevealDelayMs = 500
+private const val AlbumDetailHeaderMotionSettleMs = 940L
 internal val AlbumDetailHorizontalPadding = 8.dp
 
 private val AlbumDetailHeroBounceBackSpec = spring<Float>(
     dampingRatio = Spring.DampingRatioNoBouncy,
     stiffness = Spring.StiffnessLow
+)
+
+private val AlbumHeaderEnterFloatSpec = spring<Float>(
+    dampingRatio = Spring.DampingRatioNoBouncy,
+    stiffness = Spring.StiffnessVeryLow
+)
+
+private val AlbumHeaderActionMorphSpec = spring<Float>(
+    dampingRatio = Spring.DampingRatioNoBouncy,
+    stiffness = Spring.StiffnessMediumLow
 )
 
 private val DlsiteElasticResizeSpring = spring<IntSize>(
@@ -736,12 +747,14 @@ fun AlbumDetailScreen(
                                     1 -> AlbumDlsiteInfoBreadcrumbTabV2(
                                         album = album,
                                         header = { headerContent(1) },
-                                        dlsiteInfo = model.dlsiteInfo,
                                         galleryUrls = model.dlsiteGalleryUrls,
                                         trialTracks = model.dlsiteTrialTracks,
                                         trialDownloadEnabled = trialDownloadTree.isNotEmpty(),
                                         isLoading = model.isLoadingDlsite,
-                                        isAwaitingInitialLoad = !model.hasResolvedInitialDlsiteTarget,
+                                        isAwaitingInitialLoad = !model.hasLoadedInitialDlsiteContent,
+                                        isAwaitingAsmrOneLoad = model.hasResolvedInitialDlsiteTarget &&
+                                            !model.hasResolvedAsmrOneContent &&
+                                            asmrOneTree.isEmpty(),
                                         asmrOneTree = asmrOneTree,
                                         isLoadingAsmrOne = model.isLoadingAsmrOne,
                                         isLoadingTrial = model.isLoadingDlsiteTrial,
@@ -1409,7 +1422,7 @@ private fun AlbumHeader(
             headerIntroPlayed = true
             return@LaunchedEffect
         }
-        delay(700)
+        delay(AlbumDetailActionsRevealDelayMs + AlbumDetailHeaderMotionSettleMs)
         headerIntroPlayed = true
     }
 
@@ -1450,7 +1463,7 @@ private fun AlbumHeader(
         // 会随展开动画一起从 0 平滑增长，按钮行始终被平滑下移而非瞬间跳变。
     ) {
                 // cv 行与 tags 行同属“信息行”，行间距与行内换行间距（6.dp）保持一致；
-                // 末尾信息行携带 12.dp 底部 padding 作为与下方按钮行的间距。
+                // 末尾信息行携带 8.dp 底部 padding 作为与下方按钮行的间距。
                 if (album.cv.isNotBlank()) {
                     AlbumHeaderInfoReveal(
                         revealKey = "$headerAnimationScopeKey:cv",
@@ -1458,7 +1471,7 @@ private fun AlbumHeader(
                         enabled = animateIntro,
                         expandLayout = cvExpandLayout
                     ) {
-                        Box(modifier = Modifier.padding(bottom = if (album.tags.isNotEmpty()) 6.dp else 12.dp)) {
+                        Box(modifier = Modifier.padding(bottom = if (album.tags.isNotEmpty()) 6.dp else 8.dp)) {
                             AlbumCvChipsFlow(
                                 cvText = album.cv,
                                 horizontalArrangement = Arrangement.spacedBy(8.dp),
@@ -1477,7 +1490,7 @@ private fun AlbumHeader(
                         enabled = animateIntro,
                         expandLayout = tagsExpandLayout
                     ) {
-                        Box(modifier = Modifier.padding(bottom = 12.dp)) {
+                        Box(modifier = Modifier.padding(bottom = 8.dp)) {
                             AlbumTagsFlow(
                                 tags = album.tags,
                                 horizontalArrangement = Arrangement.spacedBy(8.dp),
@@ -1498,7 +1511,6 @@ private fun AlbumHeader(
                     BoxWithConstraints(
                         modifier = Modifier
                             .fillMaxWidth()
-                            .padding(top = 4.dp)
                     ) {
                         val compact = maxWidth < 400.dp
                         val ultraCompact = maxWidth < 340.dp
@@ -1546,67 +1558,24 @@ private fun AlbumHeader(
                                     .height(36.dp)
                                     .weight(1f)
                             ) {
-                                val radius = 10.dp
-                                val hasSecondaryPrimaryAction = canSaveOnline || showDlsitePlayLossless
-                                val leftShape = if (hasSecondaryPrimaryAction) {
-                                    RoundedCornerShape(topStart = radius, bottomStart = radius, topEnd = 0.dp, bottomEnd = 0.dp)
-                                } else {
-                                    RoundedCornerShape(radius)
+                                val groupState = when {
+                                    showDlsitePlayLossless -> AlbumHeaderButtonGroupState.Lossless
+                                    canSaveOnline -> AlbumHeaderButtonGroupState.Save
+                                    else -> AlbumHeaderButtonGroupState.DownloadOnly
                                 }
-                                val rightShape = RoundedCornerShape(topStart = 0.dp, bottomStart = 0.dp, topEnd = radius, bottomEnd = radius)
-
-                                Button(
-                                    onClick = onDownloadClick,
-                                    enabled = downloadEnabled,
-                                    modifier = Modifier
-                                        .fillMaxHeight()
-                                        .weight(1f),
-                                    shape = leftShape,
-                                    contentPadding = PaddingValues(horizontal = primaryButtonPadding, vertical = 0.dp),
-                                    colors = ButtonDefaults.buttonColors(containerColor = colorScheme.primary)
-                                ) {
-                                    Icon(Icons.Rounded.Download, contentDescription = null, modifier = Modifier.size(primaryIconSize))
-                                    Spacer(modifier = Modifier.width(primaryIconGap))
-                                    Text("下载", style = MaterialTheme.typography.labelMedium, maxLines = 1)
-                                }
-
-                                if (showDlsitePlayLossless) {
-                                    Button(
-                                        onClick = onLosslessDownloadClick,
-                                        enabled = losslessDownloadEnabled,
-                                        modifier = Modifier
-                                            .fillMaxHeight()
-                                            .weight(1f),
-                                        shape = rightShape,
-                                        contentPadding = PaddingValues(horizontal = primaryButtonPadding, vertical = 0.dp),
-                                        colors = ButtonDefaults.buttonColors(
-                                            containerColor = colorScheme.primary.copy(alpha = 0.14f),
-                                            contentColor = colorScheme.primary
-                                        )
-                                    ) {
-                                        Icon(Icons.Rounded.LibraryMusic, contentDescription = null, modifier = Modifier.size(primaryIconSize))
-                                        Spacer(modifier = Modifier.width(primaryIconGap))
-                                        Text("无损下载", style = MaterialTheme.typography.labelMedium, maxLines = 1)
-                                    }
-                                } else if (canSaveOnline) {
-                                    Button(
-                                        onClick = onSaveClick,
-                                        enabled = saveEnabled,
-                                        modifier = Modifier
-                                            .fillMaxHeight()
-                                            .weight(1f),
-                                        shape = rightShape,
-                                        contentPadding = PaddingValues(horizontal = primaryButtonPadding, vertical = 0.dp),
-                                        colors = ButtonDefaults.buttonColors(
-                                            containerColor = colorScheme.primary.copy(alpha = 0.14f),
-                                            contentColor = colorScheme.primary
-                                        )
-                                    ) {
-                                        Icon(Icons.Rounded.Bookmark, contentDescription = null, modifier = Modifier.size(primaryIconSize))
-                                        Spacer(modifier = Modifier.width(primaryIconGap))
-                                        Text("保存", style = MaterialTheme.typography.labelMedium, maxLines = 1)
-                                    }
-                                }
+                                AlbumHeaderDownloadAction(
+                                    groupState = groupState,
+                                    onDownloadClick = onDownloadClick,
+                                    onSaveClick = onSaveClick,
+                                    onLosslessDownloadClick = onLosslessDownloadClick,
+                                    downloadEnabled = downloadEnabled,
+                                    saveEnabled = saveEnabled,
+                                    losslessDownloadEnabled = losslessDownloadEnabled,
+                                    horizontalPadding = primaryButtonPadding,
+                                    iconSize = primaryIconSize,
+                                    iconGap = primaryIconGap,
+                                    modifier = Modifier.fillMaxSize()
+                                )
                             }
 
                             if (showGroupButton) {
@@ -1635,12 +1604,25 @@ private fun AlbumHeader(
                             }
 
                             if (langCandidates.isNotEmpty()) {
+                                val languageSelectable = langCandidates.size > 1
+                                val languageContainerColor = colorScheme.primary.copy(
+                                    alpha = if (languageSelectable) {
+                                        if (colorScheme.isDark) 0.18f else 0.10f
+                                    } else {
+                                        if (colorScheme.isDark) 0.08f else 0.06f
+                                    }
+                                )
+                                val languageContentColor = if (languageSelectable) {
+                                    colorScheme.primary
+                                } else {
+                                    colorScheme.textSecondary
+                                }
                                 Box {
                                     OutlinedButton(
                                         onClick = {
-                                            if (langCandidates.size > 1) languageMenuExpanded = true
+                                            if (languageSelectable) languageMenuExpanded = true
                                         },
-                                        enabled = langCandidates.size > 1,
+                                        enabled = languageSelectable,
                                         modifier = Modifier
                                             .height(36.dp)
                                             .widthIn(min = selectorMinWidth, max = selectorMaxWidth),
@@ -1648,40 +1630,46 @@ private fun AlbumHeader(
                                         contentPadding = PaddingValues(horizontal = smallButtonPadding, vertical = 0.dp),
                                         border = androidx.compose.foundation.BorderStroke(
                                             1.dp,
-                                            colorScheme.primary.copy(alpha = if (langCandidates.size > 1) 0.3f else 0.16f)
+                                            colorScheme.primary.copy(alpha = if (languageSelectable) 0.34f else 0.16f)
                                         ),
                                         colors = ButtonDefaults.outlinedButtonColors(
-                                            disabledContentColor = colorScheme.textSecondary
+                                            containerColor = languageContainerColor,
+                                            contentColor = languageContentColor,
+                                            disabledContainerColor = languageContainerColor,
+                                            disabledContentColor = languageContentColor
                                         )
                                     ) {
+                                        Icon(
+                                            imageVector = Icons.Rounded.Translate,
+                                            contentDescription = null,
+                                            tint = languageContentColor,
+                                            modifier = Modifier.size(primaryIconSize)
+                                        )
+                                        Spacer(modifier = Modifier.width(primaryIconGap))
                                         Text(
                                             text = selectedLangLabel,
                                             style = MaterialTheme.typography.labelMedium,
-                                            color = if (langCandidates.size > 1) colorScheme.primary else colorScheme.textSecondary,
+                                            color = languageContentColor,
                                             maxLines = 1
                                         )
                                         Spacer(modifier = Modifier.width(if (compact) 2.dp else 4.dp))
                                         Icon(
                                             imageVector = Icons.Rounded.ArrowDropDown,
                                             contentDescription = null,
-                                            tint = if (langCandidates.size > 1) colorScheme.primary else colorScheme.textTertiary,
+                                            tint = if (languageSelectable) colorScheme.primary else colorScheme.textTertiary,
                                             modifier = Modifier.size(primaryIconSize)
                                         )
                                     }
-                                    DropdownMenu(
+                                    AlbumHeaderLanguageDropdownMenu(
                                         expanded = languageMenuExpanded,
-                                        onDismissRequest = { languageMenuExpanded = false }
-                                    ) {
-                                        langCandidates.forEach { edition ->
-                                            DropdownMenuItem(
-                                                text = { Text(dlsiteLanguageButtonLabel(edition.lang)) },
-                                                onClick = {
-                                                    languageMenuExpanded = false
-                                                    onDlsiteLangSelected(edition.lang)
-                                                }
-                                            )
+                                        candidates = langCandidates,
+                                        selectedLang = dlsiteSelectedLang,
+                                        onDismiss = { languageMenuExpanded = false },
+                                        onSelect = { lang ->
+                                            languageMenuExpanded = false
+                                            onDlsiteLangSelected(lang)
                                         }
-                                    }
+                                    )
                                 }
                             }
 
@@ -1723,6 +1711,230 @@ private fun dlsiteLanguageButtonLabel(lang: String): String {
 }
 
 @Composable
+private fun AlbumHeaderLanguageDropdownMenu(
+    expanded: Boolean,
+    candidates: List<DlsiteLanguageEdition>,
+    selectedLang: String,
+    onDismiss: () -> Unit,
+    onSelect: (String) -> Unit
+) {
+    val colorScheme = AsmrTheme.colorScheme
+    val materialColorScheme = MaterialTheme.colorScheme
+    val menuContainer = if (colorScheme.isDark) {
+        colorScheme.surfaceVariant.copy(alpha = 0.98f)
+    } else {
+        colorScheme.surface.copy(alpha = 0.98f)
+    }
+    MaterialTheme(
+        colorScheme = materialColorScheme.copy(
+            surface = menuContainer,
+            onSurface = colorScheme.textPrimary,
+            surfaceVariant = colorScheme.primary.copy(alpha = if (colorScheme.isDark) 0.22f else 0.12f),
+            onSurfaceVariant = colorScheme.textSecondary
+        )
+    ) {
+        DropdownMenu(
+            expanded = expanded,
+            onDismissRequest = onDismiss,
+            modifier = Modifier
+                .background(menuContainer, RoundedCornerShape(14.dp))
+                .border(
+                    width = 0.5.dp,
+                    color = colorScheme.primary.copy(alpha = if (colorScheme.isDark) 0.28f else 0.20f),
+                    shape = RoundedCornerShape(14.dp)
+                )
+        ) {
+            candidates.forEachIndexed { index, edition ->
+                val selected = edition.lang.equals(selectedLang, ignoreCase = true)
+                if (index > 0) {
+                    HorizontalDivider(
+                        modifier = Modifier.padding(horizontal = 10.dp),
+                        thickness = 0.5.dp,
+                        color = colorScheme.onSurfaceVariant.copy(alpha = if (colorScheme.isDark) 0.22f else 0.16f)
+                    )
+                }
+                DropdownMenuItem(
+                    text = {
+                        Text(
+                            text = dlsiteLanguageButtonLabel(edition.lang),
+                            style = MaterialTheme.typography.labelMedium,
+                            color = if (selected) colorScheme.primary else colorScheme.textPrimary,
+                            maxLines = 1
+                        )
+                    },
+                    onClick = { onSelect(edition.lang) },
+                    leadingIcon = {
+                        Icon(
+                            imageVector = if (selected) Icons.Rounded.CheckCircle else Icons.Rounded.Translate,
+                            contentDescription = null,
+                            modifier = Modifier.size(18.dp),
+                            tint = if (selected) colorScheme.primary else colorScheme.textSecondary
+                        )
+                    },
+                    trailingIcon = {
+                        if (selected) {
+                            Box(
+                                modifier = Modifier
+                                    .size(width = 22.dp, height = 6.dp)
+                                    .clip(RoundedCornerShape(999.dp))
+                                    .background(colorScheme.primary.copy(alpha = if (colorScheme.isDark) 0.46f else 0.30f))
+                            )
+                        }
+                    },
+                    colors = MenuDefaults.itemColors(
+                        textColor = colorScheme.textPrimary,
+                        leadingIconColor = colorScheme.textSecondary,
+                        trailingIconColor = colorScheme.primary,
+                        disabledTextColor = colorScheme.textTertiary,
+                        disabledLeadingIconColor = colorScheme.textTertiary,
+                        disabledTrailingIconColor = colorScheme.textTertiary
+                    )
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun AlbumHeaderDownloadAction(
+    groupState: AlbumHeaderButtonGroupState,
+    onDownloadClick: () -> Unit,
+    onSaveClick: () -> Unit,
+    onLosslessDownloadClick: () -> Unit,
+    downloadEnabled: Boolean,
+    saveEnabled: Boolean,
+    losslessDownloadEnabled: Boolean,
+    horizontalPadding: Dp,
+    iconSize: Dp,
+    iconGap: Dp,
+    modifier: Modifier = Modifier
+) {
+    val colorScheme = AsmrTheme.colorScheme
+    val hasSecondaryAction = groupState != AlbumHeaderButtonGroupState.DownloadOnly
+    var displayedSecondaryState by remember { mutableStateOf(groupState) }
+    LaunchedEffect(groupState) {
+        if (groupState != AlbumHeaderButtonGroupState.DownloadOnly) {
+            displayedSecondaryState = groupState
+        }
+    }
+    val morphProgress by animateFloatAsState(
+        targetValue = if (hasSecondaryAction) 1f else 0f,
+        animationSpec = AlbumHeaderActionMorphSpec,
+        label = "albumHeaderDownloadActionMorph",
+        finishedListener = { value ->
+            if (value == 0f && groupState == AlbumHeaderButtonGroupState.DownloadOnly) {
+                displayedSecondaryState = AlbumHeaderButtonGroupState.DownloadOnly
+            }
+        }
+    )
+    val enabledProgress by animateFloatAsState(
+        targetValue = if (downloadEnabled) 1f else 0f,
+        animationSpec = AlbumHeaderActionMorphSpec,
+        label = "albumHeaderDownloadActionEnabled"
+    )
+    val radius = 10.dp
+    val secondaryContentAlpha = ((morphProgress - 0.22f) / 0.78f).coerceIn(0f, 1f)
+    val mainEndRadius = radius * (1f - morphProgress)
+    val mainShape = RoundedCornerShape(
+        topStart = radius,
+        bottomStart = radius,
+        topEnd = mainEndRadius,
+        bottomEnd = mainEndRadius
+    )
+    val secondaryShape = RoundedCornerShape(
+        topStart = 0.dp,
+        bottomStart = 0.dp,
+        topEnd = radius,
+        bottomEnd = radius
+    )
+    val disabledContainer = colorScheme.surfaceVariant.copy(
+        alpha = if (colorScheme.isDark) 0.54f else 0.74f
+    )
+    val disabledContent = colorScheme.textTertiary.copy(alpha = if (colorScheme.isDark) 0.72f else 0.86f)
+    val primaryContainer = lerp(disabledContainer, colorScheme.primary, enabledProgress)
+    val primaryContent = lerp(disabledContent, colorScheme.onPrimary, enabledProgress)
+    val secondaryContainer = colorScheme.primary.copy(
+        alpha = if (colorScheme.isDark) 0.22f else 0.14f
+    )
+    val activeSecondaryState = if (hasSecondaryAction) groupState else displayedSecondaryState
+
+    Row(
+        modifier = modifier,
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Button(
+            onClick = onDownloadClick,
+            enabled = downloadEnabled,
+            modifier = Modifier
+                .fillMaxHeight()
+                .weight(1f),
+            shape = mainShape,
+            contentPadding = PaddingValues(horizontal = horizontalPadding, vertical = 0.dp),
+            colors = ButtonDefaults.buttonColors(
+                containerColor = primaryContainer,
+                contentColor = primaryContent,
+                disabledContainerColor = primaryContainer,
+                disabledContentColor = primaryContent
+            )
+        ) {
+            Icon(Icons.Rounded.Download, contentDescription = null, modifier = Modifier.size(iconSize))
+            Spacer(modifier = Modifier.width(iconGap))
+            Text("下载", style = MaterialTheme.typography.labelMedium, maxLines = 1)
+        }
+        Box(
+            modifier = Modifier
+                .fillMaxHeight()
+                .weight(morphProgress.coerceAtLeast(0.001f))
+                .graphicsLayer { alpha = morphProgress }
+        ) {
+            when (activeSecondaryState) {
+                AlbumHeaderButtonGroupState.Save -> Button(
+                    onClick = onSaveClick,
+                    enabled = saveEnabled && secondaryContentAlpha > 0.92f,
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .graphicsLayer { alpha = secondaryContentAlpha },
+                    shape = secondaryShape,
+                    contentPadding = PaddingValues(horizontal = horizontalPadding, vertical = 0.dp),
+                    colors = ButtonDefaults.buttonColors(
+                        containerColor = secondaryContainer,
+                        contentColor = colorScheme.primary,
+                        disabledContainerColor = secondaryContainer,
+                        disabledContentColor = colorScheme.primary.copy(alpha = 0.72f)
+                    )
+                ) {
+                    Icon(Icons.Rounded.Bookmark, contentDescription = null, modifier = Modifier.size(iconSize))
+                    Spacer(modifier = Modifier.width(iconGap))
+                    Text("保存", style = MaterialTheme.typography.labelMedium, maxLines = 1)
+                }
+
+                AlbumHeaderButtonGroupState.Lossless -> Button(
+                    onClick = onLosslessDownloadClick,
+                    enabled = losslessDownloadEnabled && secondaryContentAlpha > 0.92f,
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .graphicsLayer { alpha = secondaryContentAlpha },
+                    shape = secondaryShape,
+                    contentPadding = PaddingValues(horizontal = horizontalPadding, vertical = 0.dp),
+                    colors = ButtonDefaults.buttonColors(
+                        containerColor = secondaryContainer,
+                        contentColor = colorScheme.primary,
+                        disabledContainerColor = secondaryContainer,
+                        disabledContentColor = colorScheme.primary.copy(alpha = 0.72f)
+                    )
+                ) {
+                    Icon(Icons.Rounded.LibraryMusic, contentDescription = null, modifier = Modifier.size(iconSize))
+                    Spacer(modifier = Modifier.width(iconGap))
+                    Text("无损下载", style = MaterialTheme.typography.labelMedium, maxLines = 1)
+                }
+
+                AlbumHeaderButtonGroupState.DownloadOnly -> Unit
+            }
+        }
+    }
+}
+
+@Composable
 private fun AlbumHeaderInfoReveal(
     revealKey: String,
     delayMillis: Int = 0,
@@ -1758,28 +1970,23 @@ private fun AlbumHeaderInfoReveal(
     }
     val alpha by animateFloatAsState(
         targetValue = if (visible) 1f else 0f,
-        animationSpec = spring(
-            dampingRatio = Spring.DampingRatioNoBouncy,
-            stiffness = Spring.StiffnessLow
-        ),
+        animationSpec = AlbumHeaderEnterFloatSpec,
         label = "albumHeaderInfoAlpha"
     )
-    val offsetY by animateDpAsState(
-        targetValue = if (visible) 0.dp else 14.dp,
-        animationSpec = spring(
-            dampingRatio = Spring.DampingRatioNoBouncy,
-            stiffness = Spring.StiffnessLow
-        ),
+    val offsetYProgress by animateFloatAsState(
+        targetValue = if (visible) 0f else 1f,
+        animationSpec = AlbumHeaderEnterFloatSpec,
         label = "albumHeaderInfoOffsetY"
     )
     val density = LocalDensity.current
+    val offsetYPx = with(density) { 14.dp.toPx() } * offsetYProgress
     if (!expandLayout) {
         // 进入时就已存在的内容（本地库 cv/tags、按钮行）：只做淡入 + 轻微上移，
         // 不改变布局高度，避免从 0 高度展开把下方列表先推下再回弹（“下沉”抖动）。
         Box(
             modifier = Modifier.graphicsLayer {
                 this.alpha = alpha
-                translationY = with(density) { offsetY.toPx() }
+                translationY = offsetYPx
             }
         ) {
             content()
@@ -1808,7 +2015,7 @@ private fun AlbumHeaderInfoReveal(
         Box(
             modifier = Modifier.graphicsLayer {
                 this.alpha = alpha
-                translationY = with(density) { offsetY.toPx() }
+                translationY = offsetYPx
             }
         ) {
             content()

--- a/app/src/main/java/com/asmr/player/ui/library/AlbumDetailViewModel.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/AlbumDetailViewModel.kt
@@ -48,6 +48,7 @@ import com.asmr.player.listentogether.ListenTogetherRepository
 import com.asmr.player.ui.common.queryTrackFileSize
 import com.asmr.player.ui.nav.AlbumCoverHint
 import com.asmr.player.ui.nav.AlbumCoverHintStore
+import com.asmr.player.ui.nav.albumFromCoverHint
 import com.asmr.player.util.OnlineLyricsStore
 import com.asmr.player.util.RemoteSubtitleSource
 import com.asmr.player.util.SubtitleMatchSupport
@@ -555,10 +556,13 @@ class AlbumDetailViewModel @Inject constructor(
         lastAlbumKey = key
         val initialHint = AlbumCoverHintStore.peekHint(albumId, normalizedRj)
         val initialRj = normalizedRj.ifBlank { initialHint?.rjCode.orEmpty() }
+        val initialHintAlbum = albumFromInitialHint(initialRj, initialHint)
         _uiState.value = AlbumDetailUiState.Success(
             model = createInitialAlbumDetailModel(
                 rj = initialRj,
-                displayAlbum = albumFromInitialHint(initialRj, initialHint)
+                displayAlbum = initialHintAlbum,
+                dlsiteInfo = initialHintAlbum.takeIf { initialHint?.hasResolvedDlsiteInfo == true },
+                preserveHeaderAlbumMetadata = initialHint != null
             )
         )
         viewModelScope.launch {
@@ -576,21 +580,18 @@ class AlbumDetailViewModel @Inject constructor(
                 }.uppercase()
 
                 val hint = AlbumCoverHintStore.peekHint(albumId, rj) ?: initialHint
-                val displayAlbum = localAlbum ?: Album(
-                    title = hint?.title?.ifBlank { rj }.orEmpty().ifBlank { "专辑" },
-                    path = "",
-                    workId = rj,
-                    rjCode = hint?.rjCode?.ifBlank { rj }.orEmpty().ifBlank { rj },
-                    circle = hint?.circle.orEmpty(),
-                    // 种入列表点击时记录的封面 URL：让 hero 与列表卡片使用相同图片 model，
-                    // 在网络解析完成前即可命中跨尺寸内存缓存，避免重复请求封面。
-                    coverUrl = hint?.coverUrl.orEmpty()
-                )
+                val hintAlbum = albumFromInitialHint(rj, hint)
+                val dlsiteInfo = hintAlbum.takeIf { hint?.hasResolvedDlsiteInfo == true }
+                // 种入列表点击时记录的封面与元信息：让 hero 与列表卡片使用相同图片 model，
+                // 在网络解析完成前即可命中跨尺寸内存缓存，避免重复请求封面。
+                val displayAlbum = if (hint != null) hintAlbum else localAlbum ?: hintAlbum
                 _uiState.value = AlbumDetailUiState.Success(
                     model = createInitialAlbumDetailModel(
                         rj = rj,
                         displayAlbum = displayAlbum,
-                        localAlbum = localAlbum
+                        localAlbum = localAlbum,
+                        dlsiteInfo = dlsiteInfo,
+                        preserveHeaderAlbumMetadata = hint != null
                     )
                 )
                 localTracksObserveJob?.cancel()
@@ -1084,6 +1085,7 @@ class AlbumDetailViewModel @Inject constructor(
 
     fun ensureDlsiteLoaded() {
         val current = _uiState.value as? AlbumDetailUiState.Success ?: return
+        if (current.model.hasLoadedInitialDlsiteContent) return
         if (current.model.isLoadingDlsite) return
         
         // 如果还没有拉取过多语言列表，先拉取一次
@@ -1104,13 +1106,13 @@ class AlbumDetailViewModel @Inject constructor(
                     if (token != dlsiteLoadToken) return@launch
                     loadModel = latestResolved.copy(
                         rjCode = resolvedTarget.workno,
-                        displayAlbum = buildDisplayAlbum(
-                            rjCode = resolvedTarget.workno,
+                        displayAlbum = mergeDetailHeaderAlbum(
+                            currentDisplayAlbum = latestResolved.displayAlbum,
                             localAlbum = latestResolved.localAlbum,
-                            dlsiteInfo = latestResolved.dlsiteInfo,
+                            fetchedDlsiteInfo = latestResolved.dlsiteInfo,
+                            rjCode = resolvedTarget.workno,
                             asmrOneWorkId = latestResolved.asmrOneWorkId,
-                            fallbackCv = latestResolved.displayAlbum.cv,
-                            fallbackCoverUrl = latestResolved.displayAlbum.coverUrl
+                            preserveHeaderAlbumMetadata = latestResolved.preserveHeaderAlbumMetadata
                         ),
                         dlsiteWorkno = resolvedTarget.workno,
                         dlsiteEditions = resolvedTarget.editions,
@@ -1123,13 +1125,26 @@ class AlbumDetailViewModel @Inject constructor(
                 }
 
                 if (loadModel.dlsiteInfo != null) {
-                    _uiState.value = AlbumDetailUiState.Success(model = loadModel.copy(isLoadingDlsite = false))
-                    return@launch
+                    val workno = loadModel.dlsiteWorkno.trim().uppercase().ifBlank { loadModel.rjCode.trim().uppercase() }
+                    if (workno.isBlank()) {
+                        _uiState.value = AlbumDetailUiState.Success(
+                            model = loadModel.copy(
+                                hasLoadedInitialDlsiteContent = true,
+                                isLoadingDlsite = false
+                            )
+                        )
+                        return@launch
+                    }
                 }
 
                 val workno = loadModel.dlsiteWorkno.trim().uppercase().ifBlank { loadModel.rjCode.trim().uppercase() }
                 if (workno.isBlank()) {
-                    _uiState.value = AlbumDetailUiState.Success(model = loadModel.copy(isLoadingDlsite = false))
+                    _uiState.value = AlbumDetailUiState.Success(
+                        model = loadModel.copy(
+                            hasLoadedInitialDlsiteContent = true,
+                            isLoadingDlsite = false
+                        )
+                    )
                     return@launch
                 }
                 val locale = dlsiteLocaleForLang(loadModel.dlsiteSelectedLang)
@@ -1185,21 +1200,22 @@ class AlbumDetailViewModel @Inject constructor(
                 )
                 val updated = (_uiState.value as? AlbumDetailUiState.Success)?.model ?: return@launch
                 if (token != dlsiteLoadToken) return@launch
-                val displayAlbum = buildDisplayAlbum(
-                    rjCode = updated.rjCode,
+                val displayAlbum = mergeDetailHeaderAlbum(
+                    currentDisplayAlbum = updated.displayAlbum,
                     localAlbum = updated.localAlbum,
-                    dlsiteInfo = dlsiteInfo,
+                    fetchedDlsiteInfo = dlsiteInfo,
+                    rjCode = updated.rjCode,
                     asmrOneWorkId = updated.asmrOneWorkId,
-                    fallbackCv = updated.displayAlbum.cv,
-                    fallbackCoverUrl = updated.displayAlbum.coverUrl
+                    preserveHeaderAlbumMetadata = updated.preserveHeaderAlbumMetadata
                 )
                 _uiState.value = AlbumDetailUiState.Success(
                     model = updated.copy(
                         displayAlbum = displayAlbum,
-                        dlsiteInfo = dlsiteInfo,
+                        dlsiteInfo = if (updated.preserveHeaderAlbumMetadata) updated.dlsiteInfo else dlsiteInfo,
                         dlsiteGalleryUrls = dlsiteGalleryUrls,
                         dlsiteTrialTracks = dlsiteTrialTracks,
                         dlsiteRecommendations = dlsiteRecommendationsRaw,
+                        hasLoadedInitialDlsiteContent = true,
                         isLoadingDlsite = false
                     )
                 )
@@ -1253,19 +1269,21 @@ class AlbumDetailViewModel @Inject constructor(
                 dlsiteWorkno = workno,
                 dlsitePlayWorkno = "",
                 rjCode = workno,
-                displayAlbum = buildDisplayAlbum(
-                    rjCode = workno,
+                displayAlbum = mergeDetailHeaderAlbum(
+                    currentDisplayAlbum = current.model.displayAlbum,
                     localAlbum = current.model.localAlbum,
-                    dlsiteInfo = null,
+                    fetchedDlsiteInfo = null,
+                    rjCode = workno,
                     asmrOneWorkId = null,
-                    fallbackCv = current.model.displayAlbum.cv,
-                    fallbackCoverUrl = current.model.displayAlbum.coverUrl
+                    preserveHeaderAlbumMetadata = current.model.preserveHeaderAlbumMetadata
                 ),
                 dlsiteInfo = null,
                 dlsiteGalleryUrls = emptyList(),
                 dlsiteTrialTracks = emptyList(),
                 dlsiteRecommendations = DlsiteRecommendations(),
                 hasResolvedInitialDlsiteTarget = true,
+                hasLoadedInitialDlsiteContent = false,
+                hasResolvedAsmrOneContent = false,
                 isDlsiteLanguageUserSelected = current.model.isDlsiteLanguageUserSelected || isUserSelection,
                 asmrOneWorkId = null,
                 asmrOneSite = null,
@@ -1288,13 +1306,13 @@ class AlbumDetailViewModel @Inject constructor(
             }
             val updated = (_uiState.value as? AlbumDetailUiState.Success)?.model ?: return@launch
             if (!updated.rjCode.equals(workno, ignoreCase = true)) return@launch
-            val displayAlbum = buildDisplayAlbum(
-                rjCode = updated.rjCode,
+            val displayAlbum = mergeDetailHeaderAlbum(
+                currentDisplayAlbum = updated.displayAlbum,
                 localAlbum = local,
-                dlsiteInfo = updated.dlsiteInfo,
+                fetchedDlsiteInfo = updated.dlsiteInfo,
+                rjCode = updated.rjCode,
                 asmrOneWorkId = updated.asmrOneWorkId,
-                fallbackCv = updated.displayAlbum.cv,
-                fallbackCoverUrl = updated.displayAlbum.coverUrl
+                preserveHeaderAlbumMetadata = updated.preserveHeaderAlbumMetadata
             )
             _uiState.value = AlbumDetailUiState.Success(
                 model = updated.copy(
@@ -1327,6 +1345,7 @@ class AlbumDetailViewModel @Inject constructor(
                 asmrOneWorkId = null,
                 asmrOneSite = null,
                 asmrOneTree = emptyList(),
+                hasResolvedAsmrOneContent = false,
                 isLoadingAsmrOne = false
             )
         )
@@ -1370,10 +1389,18 @@ class AlbumDetailViewModel @Inject constructor(
     fun ensureAsmrOneLoaded() {
         val current = _uiState.value as? AlbumDetailUiState.Success ?: return
         val keyRj = current.model.rjCode.trim().uppercase()
+        if (current.model.asmrOneTree.isNotEmpty()) {
+            if (!current.model.hasResolvedAsmrOneContent) {
+                _uiState.value = AlbumDetailUiState.Success(
+                    model = current.model.copy(hasResolvedAsmrOneContent = true)
+                )
+            }
+            return
+        }
         if (
             keyRj.isBlank() ||
             !current.model.hasResolvedInitialDlsiteTarget ||
-            current.model.asmrOneTree.isNotEmpty() ||
+            current.model.hasResolvedAsmrOneContent ||
             current.model.isLoadingAsmrOne ||
             asmrOneAttemptedRj.contains(keyRj)
         ) return
@@ -1386,7 +1413,12 @@ class AlbumDetailViewModel @Inject constructor(
                 asmrOneAttemptedRj.remove(keyRj)
                 return@launch
             }
-            _uiState.value = AlbumDetailUiState.Success(model = latestBefore.model.copy(isLoadingAsmrOne = true))
+            _uiState.value = AlbumDetailUiState.Success(
+                model = latestBefore.model.copy(
+                    isLoadingAsmrOne = true,
+                    hasResolvedAsmrOneContent = false
+                )
+            )
             try {
                 val latest = (_uiState.value as? AlbumDetailUiState.Success)?.model ?: return@launch
                 val selectedLang = latest.dlsiteSelectedLang.trim().uppercase().ifBlank { "JPN" }
@@ -1440,7 +1472,12 @@ class AlbumDetailViewModel @Inject constructor(
                     val updated = (_uiState.value as? AlbumDetailUiState.Success)?.model ?: return@launch
                     val updatedKey = updated.rjCode.trim().uppercase()
                     if (updatedKey.equals(keyRj, ignoreCase = true) && updated.isLoadingAsmrOne) {
-                        _uiState.value = AlbumDetailUiState.Success(model = updated.copy(isLoadingAsmrOne = false))
+                        _uiState.value = AlbumDetailUiState.Success(
+                            model = updated.copy(
+                                isLoadingAsmrOne = false,
+                                hasResolvedAsmrOneContent = true
+                            )
+                        )
                     }
                     return@launch
                 }
@@ -1452,7 +1489,12 @@ class AlbumDetailViewModel @Inject constructor(
                         if (token != asmrOneLoadToken) return@launch
                         asmrOneAttemptedRj.remove(keyRj)
                         if (updated.rjCode.trim().uppercase().equals(keyRj, ignoreCase = true) && updated.isLoadingAsmrOne) {
-                            _uiState.value = AlbumDetailUiState.Success(model = updated.copy(isLoadingAsmrOne = false))
+                            _uiState.value = AlbumDetailUiState.Success(
+                                model = updated.copy(
+                                    isLoadingAsmrOne = false,
+                                    hasResolvedAsmrOneContent = true
+                                )
+                            )
                         }
                         return@launch
                     }
@@ -1493,17 +1535,22 @@ class AlbumDetailViewModel @Inject constructor(
                     asmrOneAttemptedRj.remove(keyRj)
                     val updatedKey = updated.rjCode.trim().uppercase()
                     if (updatedKey.equals(keyRj, ignoreCase = true) && updated.isLoadingAsmrOne) {
-                        _uiState.value = AlbumDetailUiState.Success(model = updated.copy(isLoadingAsmrOne = false))
+                        _uiState.value = AlbumDetailUiState.Success(
+                            model = updated.copy(
+                                isLoadingAsmrOne = false,
+                                hasResolvedAsmrOneContent = true
+                            )
+                        )
                     }
                     return@launch
                 }
-                val displayAlbum = buildDisplayAlbum(
-                    rjCode = updated.rjCode,
+                val displayAlbum = mergeDetailHeaderAlbum(
+                    currentDisplayAlbum = updated.displayAlbum,
                     localAlbum = updated.localAlbum,
-                    dlsiteInfo = updated.dlsiteInfo,
+                    fetchedDlsiteInfo = updated.dlsiteInfo,
+                    rjCode = updated.rjCode,
                     asmrOneWorkId = workId,
-                    fallbackCv = updated.displayAlbum.cv,
-                    fallbackCoverUrl = updated.displayAlbum.coverUrl
+                    preserveHeaderAlbumMetadata = updated.preserveHeaderAlbumMetadata
                 )
                 _uiState.value = AlbumDetailUiState.Success(
                     model = updated.copy(
@@ -1511,6 +1558,7 @@ class AlbumDetailViewModel @Inject constructor(
                         asmrOneWorkId = workId,
                         asmrOneSite = site,
                         asmrOneTree = tree,
+                        hasResolvedAsmrOneContent = true,
                         isLoadingAsmrOne = false
                     )
                 )
@@ -1530,7 +1578,12 @@ class AlbumDetailViewModel @Inject constructor(
                         messageManager.showError("在线资源加载失败，请稍后重试")
                     }
                     if (updated.isLoadingAsmrOne) {
-                        _uiState.value = AlbumDetailUiState.Success(model = updated.copy(isLoadingAsmrOne = false))
+                        _uiState.value = AlbumDetailUiState.Success(
+                            model = updated.copy(
+                                isLoadingAsmrOne = false,
+                                hasResolvedAsmrOneContent = true
+                            )
+                        )
                     }
                 } else if (updated.isLoadingAsmrOne) {
                     _uiState.value = AlbumDetailUiState.Success(model = updated.copy(isLoadingAsmrOne = false))
@@ -1657,22 +1710,15 @@ class AlbumDetailViewModel @Inject constructor(
     }
 
     private fun albumFromInitialHint(rj: String, hint: AlbumCoverHint?): Album {
-        val normalizedRj = rj.ifBlank { hint?.rjCode.orEmpty() }
-        return Album(
-            title = hint?.title?.ifBlank { normalizedRj }.orEmpty().ifBlank { "专辑" },
-            path = "",
-            workId = normalizedRj,
-            rjCode = normalizedRj,
-            circle = hint?.circle.orEmpty(),
-            cv = hint?.cv.orEmpty(),
-            coverUrl = hint?.coverUrl.orEmpty()
-        )
+        return albumFromCoverHint(rj, hint)
     }
 
     private fun createInitialAlbumDetailModel(
         rj: String,
         displayAlbum: Album,
-        localAlbum: Album? = null
+        localAlbum: Album? = null,
+        dlsiteInfo: Album? = null,
+        preserveHeaderAlbumMetadata: Boolean = false
     ): AlbumDetailModel {
         return AlbumDetailModel(
             baseRjCode = rj,
@@ -1680,7 +1726,7 @@ class AlbumDetailViewModel @Inject constructor(
             listenTogetherRjListenerCount = null,
             displayAlbum = displayAlbum,
             localAlbum = localAlbum,
-            dlsiteInfo = null,
+            dlsiteInfo = dlsiteInfo,
             dlsiteGalleryUrls = emptyList(),
             dlsiteTrialTracks = emptyList(),
             dlsiteRecommendations = DlsiteRecommendations(),
@@ -1689,6 +1735,9 @@ class AlbumDetailViewModel @Inject constructor(
             dlsiteEditions = defaultDlsiteEditions(rj),
             dlsiteSelectedLang = "JPN",
             hasResolvedInitialDlsiteTarget = false,
+            hasLoadedInitialDlsiteContent = false,
+            hasResolvedAsmrOneContent = false,
+            preserveHeaderAlbumMetadata = preserveHeaderAlbumMetadata,
             isDlsiteLanguageUserSelected = false,
             asmrOneWorkId = null,
             asmrOneSite = null,

--- a/app/src/main/java/com/asmr/player/ui/library/AlbumItem.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/AlbumItem.kt
@@ -97,6 +97,7 @@ fun AlbumItem(
     onTagClick: ((String) -> Unit)? = null,
     coverBadge: AlbumCoverBadge? = null,
     onlineDetailLoading: Boolean = false,
+    onlineCvLoading: Boolean = onlineDetailLoading,
 ) {
     val colorScheme = AsmrTheme.colorScheme
     val shape = remember { RoundedCornerShape(AlbumListItemCornerRadius) }
@@ -229,8 +230,8 @@ fun AlbumItem(
                     )
 
                     AlbumOnlineDetailAnimatedLine(
-                        content = album.cv,
-                        loading = onlineDetailLoading
+                        content = if (onlineCvLoading) "" else album.cv,
+                        loading = onlineCvLoading
                     ) {
                         AlbumCvChipsSingleLine(
                             cvText = album.cv,
@@ -338,6 +339,7 @@ fun AlbumGridItem(
     onTagClick: ((String) -> Unit)? = null,
     coverBadge: AlbumCoverBadge? = null,
     onlineDetailLoading: Boolean = false,
+    onlineCvLoading: Boolean = onlineDetailLoading,
 ) {
     val colorScheme = AsmrTheme.colorScheme
     val shape = remember { RoundedCornerShape(AlbumGridItemCornerRadius) }
@@ -462,8 +464,8 @@ fun AlbumGridItem(
             )
 
             AlbumOnlineDetailAnimatedLine(
-                content = album.cv,
-                loading = onlineDetailLoading,
+                content = if (onlineCvLoading) "" else album.cv,
+                loading = onlineCvLoading,
                 loadingContent = {
                     AlbumDetailSkeletonLine(widthFraction = 0.72f)
                 }

--- a/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailDlsiteTabs.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailDlsiteTabs.kt
@@ -683,16 +683,27 @@ private fun LazyItemScope.dlsiteAnimatedSectionModifier(
     )
 }
 
+internal fun shouldShowAsmrOneDirectoryLoading(
+    isAwaitingAsmrOneLoad: Boolean,
+    isLoadingAsmrOne: Boolean,
+    hasAsmrOneTree: Boolean,
+    hasDirectoryBrowser: Boolean
+): Boolean {
+    return isAwaitingAsmrOneLoad ||
+        isLoadingAsmrOne ||
+        (hasAsmrOneTree && !hasDirectoryBrowser)
+}
+
 @Composable
 internal fun AlbumDlsiteInfoBreadcrumbTabV2(
     album: Album,
     header: @Composable () -> Unit,
-    dlsiteInfo: Album?,
     galleryUrls: List<String>,
     trialTracks: List<Track>,
     trialDownloadEnabled: Boolean,
     isLoading: Boolean,
     isAwaitingInitialLoad: Boolean,
+    isAwaitingAsmrOneLoad: Boolean,
     asmrOneTree: List<AsmrOneTrackNodeResponse>,
     isLoadingAsmrOne: Boolean,
     isLoadingTrial: Boolean,
@@ -766,8 +777,13 @@ internal fun AlbumDlsiteInfoBreadcrumbTabV2(
     LaunchedEffect(currentPath, treeStateKey) {
         onPersistCurrentPath(currentPath)
     }
-    val isInitialDlsiteLoading = dlsiteInfo == null && (isLoading || isAwaitingInitialLoad)
-    val isAsmrOnePending = isAwaitingInitialLoad || isLoadingAsmrOne
+    val isInitialDlsiteLoading = isLoading || isAwaitingInitialLoad
+    val isAsmrOnePending = shouldShowAsmrOneDirectoryLoading(
+        isAwaitingAsmrOneLoad = isAwaitingAsmrOneLoad,
+        isLoadingAsmrOne = isLoadingAsmrOne,
+        hasAsmrOneTree = asmrOneTree.isNotEmpty(),
+        hasDirectoryBrowser = browser != null
+    )
 
     LazyColumn(
         modifier = Modifier
@@ -1036,7 +1052,7 @@ internal fun AlbumDlsiteInfoBreadcrumbTabV2(
                     )
                 }
             }
-        } else if (isAsmrOnePending || (asmrOneTree.isNotEmpty() && browser == null)) {
+        } else if (isAsmrOnePending) {
             item(key = "dlsite-one-content") {
                 Box(modifier = dlsiteAnimatedSectionModifier(Modifier.fillMaxWidth(), animateIntro)) {
                     DlsiteDirectoryLoadingPanel()

--- a/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailViewModelSupport.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailViewModelSupport.kt
@@ -158,6 +158,9 @@ data class AlbumDetailModel(
     val dlsiteEditions: List<DlsiteLanguageEdition>,
     val dlsiteSelectedLang: String,
     val hasResolvedInitialDlsiteTarget: Boolean,
+    val hasLoadedInitialDlsiteContent: Boolean,
+    val hasResolvedAsmrOneContent: Boolean,
+    val preserveHeaderAlbumMetadata: Boolean,
     val isDlsiteLanguageUserSelected: Boolean,
     val asmrOneWorkId: String?,
     val asmrOneSite: Int?,
@@ -185,6 +188,47 @@ internal fun buildDisplayAlbum(
         // 网络解析尚未返回封面时，保留列表种入/上一帧的 coverUrl，避免 hero 先空白再加载。
         coverUrl = base.coverUrl.ifBlank { fallbackCoverUrl }
     )
+}
+
+internal fun Album.withResolvedWorkIdentity(
+    rjCode: String,
+    asmrOneWorkId: String?
+): Album {
+    return copy(
+        workId = asmrOneWorkId?.takeIf { it.isNotBlank() } ?: workId,
+        rjCode = rjCode.ifBlank { this.rjCode.ifBlank { workId } }
+    )
+}
+
+internal fun mergeDetailHeaderAlbum(
+    currentDisplayAlbum: Album,
+    localAlbum: Album?,
+    fetchedDlsiteInfo: Album?,
+    rjCode: String,
+    asmrOneWorkId: String?,
+    preserveHeaderAlbumMetadata: Boolean
+): Album {
+    if (preserveHeaderAlbumMetadata) {
+        return currentDisplayAlbum.withResolvedWorkIdentity(
+            rjCode = rjCode,
+            asmrOneWorkId = asmrOneWorkId
+        )
+    }
+    return if (fetchedDlsiteInfo != null) {
+        buildDisplayAlbum(
+            rjCode = rjCode,
+            localAlbum = localAlbum,
+            dlsiteInfo = fetchedDlsiteInfo,
+            asmrOneWorkId = asmrOneWorkId,
+            fallbackCv = currentDisplayAlbum.cv,
+            fallbackCoverUrl = currentDisplayAlbum.coverUrl
+        )
+    } else {
+        currentDisplayAlbum.withResolvedWorkIdentity(
+            rjCode = rjCode,
+            asmrOneWorkId = asmrOneWorkId
+        )
+    }
 }
 
 internal enum class DlsiteChinesePreference {

--- a/app/src/main/java/com/asmr/player/ui/nav/AlbumCoverHintStore.kt
+++ b/app/src/main/java/com/asmr/player/ui/nav/AlbumCoverHintStore.kt
@@ -1,8 +1,10 @@
 package com.asmr.player.ui.nav
 
+import com.asmr.player.domain.model.Album
+
 /**
  * 轻量内存存储：在列表点击进入专辑详情时，记录列表已知的首屏信息，
- * 供详情页在网络解析完成前先种入标题、RJ、社团、CV 与封面。
+ * 供详情页在网络解析完成前先种入标题、RJ、社团、CV、标签、评分与封面。
  *
  * 这样 hero 封面与列表卡片使用完全相同的图片 model（同一 coverUrl + 同一 keyTag），
  * 跨尺寸缓存复用（peekAnySize）即可命中，避免重复发起网络请求。
@@ -23,6 +25,7 @@ object AlbumCoverHintStore {
             title = null,
             circle = null,
             cv = null,
+            tags = emptyList(),
             coverUrl = coverUrl
         )
     }
@@ -34,17 +37,46 @@ object AlbumCoverHintStore {
             title = title,
             circle = circle,
             cv = null,
+            tags = emptyList(),
             coverUrl = coverUrl
         )
     }
 
-    fun record(albumId: Long?, rjCode: String?, title: String?, circle: String?, cv: String?, coverUrl: String?) {
+    fun record(
+        albumId: Long?,
+        rjCode: String?,
+        title: String?,
+        circle: String?,
+        cv: String?,
+        coverUrl: String?,
+        tags: List<String> = emptyList(),
+        ratingValue: Double? = null,
+        ratingCount: Int = 0,
+        releaseDate: String? = null,
+        dlCount: Int = 0,
+        priceJpy: Int = 0,
+        hasAsmrOne: Boolean = false,
+        description: String? = null,
+        hasResolvedDlsiteInfo: Boolean = false
+    ) {
         val hint = AlbumCoverHint(
             title = title?.trim().orEmpty(),
             rjCode = rjCode?.trim().orEmpty().uppercase(),
             circle = circle?.trim().orEmpty(),
             cv = cv?.trim().orEmpty(),
-            coverUrl = coverUrl?.trim().orEmpty().takeIf { it.startsWith("http", ignoreCase = true) }.orEmpty()
+            tags = tags
+                .map { it.trim() }
+                .filter { it.isNotBlank() }
+                .distinct(),
+            coverUrl = coverUrl?.trim().orEmpty().takeIf { it.startsWith("http", ignoreCase = true) }.orEmpty(),
+            ratingValue = ratingValue?.takeIf { it > 0.0 },
+            ratingCount = ratingCount.coerceAtLeast(0),
+            releaseDate = releaseDate?.trim().orEmpty(),
+            dlCount = dlCount.coerceAtLeast(0),
+            priceJpy = priceJpy.coerceAtLeast(0),
+            hasAsmrOne = hasAsmrOne,
+            description = description?.trim().orEmpty(),
+            hasResolvedDlsiteInfo = hasResolvedDlsiteInfo
         )
         if (hint.isBlank()) return
         val rj = hint.rjCode
@@ -75,9 +107,51 @@ data class AlbumCoverHint(
     val rjCode: String,
     val circle: String,
     val cv: String,
-    val coverUrl: String
+    val tags: List<String>,
+    val coverUrl: String,
+    val ratingValue: Double?,
+    val ratingCount: Int,
+    val releaseDate: String,
+    val dlCount: Int,
+    val priceJpy: Int,
+    val hasAsmrOne: Boolean,
+    val description: String,
+    val hasResolvedDlsiteInfo: Boolean
 ) {
     fun isBlank(): Boolean {
-        return title.isBlank() && rjCode.isBlank() && circle.isBlank() && cv.isBlank() && coverUrl.isBlank()
+        return title.isBlank() &&
+            rjCode.isBlank() &&
+            circle.isBlank() &&
+            cv.isBlank() &&
+            tags.isEmpty() &&
+            coverUrl.isBlank() &&
+            ratingValue == null &&
+            ratingCount <= 0 &&
+            releaseDate.isBlank() &&
+            dlCount <= 0 &&
+            priceJpy <= 0 &&
+            !hasAsmrOne &&
+            description.isBlank()
     }
+}
+
+internal fun albumFromCoverHint(rj: String, hint: AlbumCoverHint?): Album {
+    val normalizedRj = rj.ifBlank { hint?.rjCode.orEmpty() }
+    return Album(
+        title = hint?.title?.ifBlank { normalizedRj }.orEmpty().ifBlank { "专辑" },
+        path = "",
+        workId = normalizedRj,
+        rjCode = normalizedRj,
+        circle = hint?.circle.orEmpty(),
+        cv = hint?.cv.orEmpty(),
+        tags = hint?.tags.orEmpty(),
+        coverUrl = hint?.coverUrl.orEmpty(),
+        ratingValue = hint?.ratingValue,
+        ratingCount = hint?.ratingCount ?: 0,
+        releaseDate = hint?.releaseDate.orEmpty(),
+        dlCount = hint?.dlCount ?: 0,
+        priceJpy = hint?.priceJpy ?: 0,
+        hasAsmrOne = hint?.hasAsmrOne == true,
+        description = hint?.description.orEmpty()
+    )
 }

--- a/app/src/main/java/com/asmr/player/ui/search/SearchScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/search/SearchScreen.kt
@@ -224,7 +224,7 @@ private fun SearchFilterIconView(
 @Composable
 fun SearchScreen(
     windowSizeClass: WindowSizeClass,
-    onAlbumClick: (Album, Boolean) -> Unit,
+    onAlbumClick: (Album, Boolean, Boolean) -> Unit,
     onOpenSearchAssist: (SearchAssistSearchRequest) -> Unit = {},
     submittedSearchKeyword: String = "",
     submittedSearchOrderName: String = SearchSortOption.Trend.name,
@@ -623,6 +623,7 @@ fun SearchScreen(
                                 downloadPath = album.downloadPath,
                                 circle = album.circle,
                                 cv = album.cv,
+                                tags = album.tags.split(",").map { it.trim() }.filter { it.isNotBlank() },
                                 coverUrl = album.coverUrl,
                                 coverPath = album.coverPath,
                                 coverThumbPath = album.coverThumbPath,
@@ -630,6 +631,7 @@ fun SearchScreen(
                                 rjCode = album.rjCode,
                                 description = album.description
                             ),
+                            false,
                             false
                         )
                     },
@@ -751,12 +753,15 @@ fun SearchScreen(
                                             contentType = { _, _ -> "album" }
                                         ) { _, album ->
                                             val onlineDetailLoading = onlineDetailLoadingFor(album, state)
+                                            val rj = album.rjCode.ifBlank { album.workId }.trim().uppercase()
+                                            val hasResolvedDetail = rj.isNotBlank() && rj in state.enrichedDetailRjCodes
                                             AlbumItem(
                                                 album = album,
-                                                onClick = { onAlbumClick(album, state.purchasedOnly) },
+                                                onClick = { onAlbumClick(album, state.purchasedOnly, hasResolvedDetail) },
                                                 modifier = Modifier.animateItemPlacement(SearchResultPlacementSpring),
                                                 emptyCoverUseShimmer = true,
                                                 onlineDetailLoading = onlineDetailLoading,
+                                                onlineCvLoading = onlineDetailLoading,
                                                 onRjClick = { copyMeta("RJ", it) },
                                                 onCircleClick = { copyMeta("社团", it) },
                                                 onCvClick = { copyMeta("CV", it) },
@@ -788,12 +793,15 @@ fun SearchScreen(
                                         ) { index ->
                                             val album = state.results[index]
                                             val onlineDetailLoading = onlineDetailLoadingFor(album, state)
+                                            val rj = album.rjCode.ifBlank { album.workId }.trim().uppercase()
+                                            val hasResolvedDetail = rj.isNotBlank() && rj in state.enrichedDetailRjCodes
                                             AlbumGridItem(
                                                 album = album,
-                                                onClick = { onAlbumClick(album, state.purchasedOnly) },
+                                                onClick = { onAlbumClick(album, state.purchasedOnly, hasResolvedDetail) },
                                                 modifier = Modifier.animateItemPlacement(SearchResultPlacementSpring),
                                                 emptyCoverUseShimmer = true,
                                                 onlineDetailLoading = onlineDetailLoading,
+                                                onlineCvLoading = onlineDetailLoading,
                                                 onRjClick = { copyMeta("RJ", it) },
                                                 onCircleClick = { copyMeta("社团", it) },
                                                 onCvClick = { copyMeta("CV", it) },

--- a/app/src/main/java/com/asmr/player/ui/search/SearchViewModel.kt
+++ b/app/src/main/java/com/asmr/player/ui/search/SearchViewModel.kt
@@ -338,6 +338,7 @@ class SearchViewModel @Inject constructor(
                     visitedPages = buildVisitedPages(previousSuccess, requestKind, page),
                     isEnriching = false,
                     enrichingRjCodes = emptySet(),
+                    enrichedDetailRjCodes = pageResult.resolvedDetailRjCodes,
                     isAsmrOneChecking = false,
                     asmrOneChecked = 0,
                     asmrOneTotal = 0
@@ -444,7 +445,10 @@ class SearchViewModel @Inject constructor(
             val responseOffset = resp.offset.coerceAtLeast(offset)
             return SearchPageResult(
                 items = items,
-                canGoNext = responseOffset + items.size < total
+                canGoNext = responseOffset + items.size < total,
+                resolvedDetailRjCodes = items
+                    .mapNotNull { it.rjCode.ifBlank { it.workId }.trim().uppercase().takeIf(String::isNotBlank) }
+                    .toSet()
             )
         }
         val normalizedKeyword = keyword.trim()
@@ -473,7 +477,11 @@ class SearchViewModel @Inject constructor(
             }
             if (info != null) {
                 val album = info.album.copy(workId = normalizedRj, rjCode = normalizedRj)
-                return SearchPageResult(items = listOf(album), canGoNext = false)
+                return SearchPageResult(
+                    items = listOf(album),
+                    canGoNext = false,
+                    resolvedDetailRjCodes = setOf(normalizedRj)
+                )
             }
         }
         val result = dlsiteScraper.search(
@@ -532,11 +540,16 @@ class SearchViewModel @Inject constructor(
                     if (cur.keyword != keyword || cur.page != page || cur.purchasedOnly || cur.collectedOnly) return@forEach
                     val list = cur.results.toMutableList()
                     if (detail != null && idx in list.indices) {
-                        list[idx] = mergeAlbum(list[idx], detail)
+                        list[idx] = mergeSearchAlbumDetail(list[idx], detail)
                     }
                     _uiState.value = cur.copy(
                         results = list,
-                        enrichingRjCodes = cur.enrichingRjCodes - rj
+                        enrichingRjCodes = cur.enrichingRjCodes - rj,
+                        enrichedDetailRjCodes = if (detail != null) {
+                            cur.enrichedDetailRjCodes + rj
+                        } else {
+                            cur.enrichedDetailRjCodes
+                        }
                     )
                     if (detail != null) scheduleCacheWrite()
                 }
@@ -602,6 +615,13 @@ class SearchViewModel @Inject constructor(
             visitedPages = listOf(page),
             isEnriching = false,
             enrichingRjCodes = emptySet(),
+            enrichedDetailRjCodes = if (filters.collectedOnly && !filters.purchasedOnly) {
+                cached.results
+                    .mapNotNull { it.rjCode.ifBlank { it.workId }.trim().uppercase().takeIf(String::isNotBlank) }
+                    .toSet()
+            } else {
+                emptySet()
+            },
             isAsmrOneChecking = false,
             asmrOneChecked = 0,
             asmrOneTotal = 0
@@ -663,21 +683,6 @@ class SearchViewModel @Inject constructor(
 
             else -> "搜索失败，请稍后重试"
         }
-    }
-
-    private fun mergeAlbum(base: Album, detail: Album): Album {
-        return base.copy(
-            title = base.title.ifBlank { detail.title },
-            circle = base.circle.ifBlank { detail.circle },
-            cv = base.cv.ifBlank { detail.cv },
-            tags = if (base.tags.isEmpty()) detail.tags else base.tags,
-            coverUrl = base.coverUrl.ifBlank { detail.coverUrl },
-            ratingValue = detail.ratingValue ?: base.ratingValue,
-            ratingCount = maxOf(base.ratingCount, detail.ratingCount),
-            releaseDate = base.releaseDate.ifBlank { detail.releaseDate },
-            dlCount = maxOf(base.dlCount, detail.dlCount),
-            priceJpy = if (base.priceJpy > 0) base.priceJpy else detail.priceJpy
-        )
     }
 
     private fun AsmrOneCollectedSearchItem.toCollectedAlbum(): Album {
@@ -849,8 +854,24 @@ private data class SearchFilterFlags(
 
 private data class SearchPageResult(
     val items: List<Album>,
-    val canGoNext: Boolean
+    val canGoNext: Boolean,
+    val resolvedDetailRjCodes: Set<String> = emptySet()
 )
+
+internal fun mergeSearchAlbumDetail(base: Album, detail: Album): Album {
+    return base.copy(
+        title = base.title.ifBlank { detail.title },
+        circle = base.circle.ifBlank { detail.circle },
+        cv = detail.cv.ifBlank { base.cv },
+        tags = if (base.tags.isEmpty()) detail.tags else base.tags,
+        coverUrl = base.coverUrl.ifBlank { detail.coverUrl },
+        ratingValue = detail.ratingValue ?: base.ratingValue,
+        ratingCount = maxOf(base.ratingCount, detail.ratingCount),
+        releaseDate = base.releaseDate.ifBlank { detail.releaseDate },
+        dlCount = maxOf(base.dlCount, detail.dlCount),
+        priceJpy = if (base.priceJpy > 0) base.priceJpy else detail.priceJpy
+    )
+}
 
 internal fun appendBlockedKeywordsForOnlineSearch(
     keyword: String,
@@ -894,6 +915,7 @@ sealed class SearchUiState {
         val visitedPages: List<Int> = listOf(page),
         val isEnriching: Boolean = false,
         val enrichingRjCodes: Set<String> = emptySet(),
+        val enrichedDetailRjCodes: Set<String> = emptySet(),
         val isAsmrOneChecking: Boolean = false,
         val asmrOneChecked: Int = 0,
         val asmrOneTotal: Int = 0

--- a/app/src/test/java/com/asmr/player/ui/library/AlbumDetailOneStateTest.kt
+++ b/app/src/test/java/com/asmr/player/ui/library/AlbumDetailOneStateTest.kt
@@ -1,0 +1,35 @@
+package com.asmr.player.ui.library
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class AlbumDetailOneStateTest {
+    @Test
+    fun shouldShowAsmrOneDirectoryLoading_dependsOnOneStateOnly() {
+        assertTrue(
+            shouldShowAsmrOneDirectoryLoading(
+                isAwaitingAsmrOneLoad = true,
+                isLoadingAsmrOne = false,
+                hasAsmrOneTree = false,
+                hasDirectoryBrowser = false
+            )
+        )
+        assertTrue(
+            shouldShowAsmrOneDirectoryLoading(
+                isAwaitingAsmrOneLoad = false,
+                isLoadingAsmrOne = false,
+                hasAsmrOneTree = true,
+                hasDirectoryBrowser = false
+            )
+        )
+        assertFalse(
+            shouldShowAsmrOneDirectoryLoading(
+                isAwaitingAsmrOneLoad = false,
+                isLoadingAsmrOne = false,
+                hasAsmrOneTree = false,
+                hasDirectoryBrowser = false
+            )
+        )
+    }
+}

--- a/app/src/test/java/com/asmr/player/ui/library/AlbumDetailViewModelSupportTest.kt
+++ b/app/src/test/java/com/asmr/player/ui/library/AlbumDetailViewModelSupportTest.kt
@@ -28,4 +28,65 @@ class AlbumDetailViewModelSupportTest {
         assertEquals("かの仔", result.cv)
         assertTrue(result.rjCode.isNotBlank())
     }
+    @Test
+    fun mergeDetailHeaderAlbum_preservesListMetadataWhenRequested() {
+        val listAlbum = Album(
+            title = "列表标题",
+            path = "",
+            rjCode = "RJ123456",
+            cv = "列表CV A, 列表CV B",
+            tags = listOf("列表标签"),
+            coverUrl = "https://example.com/list.jpg"
+        )
+        val fetched = listAlbum.copy(
+            title = "抓取标题",
+            cv = "抓取CV",
+            tags = listOf("抓取标签"),
+            coverUrl = "https://example.com/fetched.jpg"
+        )
+
+        val result = mergeDetailHeaderAlbum(
+            currentDisplayAlbum = listAlbum,
+            localAlbum = null,
+            fetchedDlsiteInfo = fetched,
+            rjCode = "RJ123456",
+            asmrOneWorkId = "789",
+            preserveHeaderAlbumMetadata = true
+        )
+
+        assertEquals("列表标题", result.title)
+        assertEquals("列表CV A, 列表CV B", result.cv)
+        assertEquals(listOf("列表标签"), result.tags)
+        assertEquals("https://example.com/list.jpg", result.coverUrl)
+        assertEquals("789", result.workId)
+    }
+
+    @Test
+    fun mergeDetailHeaderAlbum_allowsFetchedMetadataWhenNotPreserved() {
+        val current = Album(
+            title = "RJ123456",
+            path = "",
+            rjCode = "RJ123456",
+            cv = "",
+            tags = emptyList()
+        )
+        val fetched = current.copy(
+            title = "抓取标题",
+            cv = "抓取CV",
+            tags = listOf("抓取标签")
+        )
+
+        val result = mergeDetailHeaderAlbum(
+            currentDisplayAlbum = current,
+            localAlbum = null,
+            fetchedDlsiteInfo = fetched,
+            rjCode = "RJ123456",
+            asmrOneWorkId = null,
+            preserveHeaderAlbumMetadata = false
+        )
+
+        assertEquals("抓取标题", result.title)
+        assertEquals("抓取CV", result.cv)
+        assertEquals(listOf("抓取标签"), result.tags)
+    }
 }

--- a/app/src/test/java/com/asmr/player/ui/nav/AlbumCoverHintStoreTest.kt
+++ b/app/src/test/java/com/asmr/player/ui/nav/AlbumCoverHintStoreTest.kt
@@ -1,0 +1,37 @@
+package com.asmr.player.ui.nav
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class AlbumCoverHintStoreTest {
+    @Test
+    fun albumFromCoverHint_keepsResolvedListMetadataForDetailHeader() {
+        val hint = AlbumCoverHint(
+            title = "作品",
+            rjCode = "RJ123456",
+            circle = "社团",
+            cv = "Alice, Bob",
+            tags = listOf("耳语", "安眠"),
+            coverUrl = "https://example.com/cover.jpg",
+            ratingValue = 4.8,
+            ratingCount = 42,
+            releaseDate = "2026-06-19",
+            dlCount = 1200,
+            priceJpy = 990,
+            hasAsmrOne = true,
+            description = "简介",
+            hasResolvedDlsiteInfo = true
+        )
+
+        val album = albumFromCoverHint("", hint)
+
+        assertEquals("RJ123456", album.rjCode)
+        assertEquals("Alice, Bob", album.cv)
+        assertEquals(listOf("耳语", "安眠"), album.tags)
+        assertEquals(4.8, album.ratingValue ?: 0.0, 0.0)
+        assertEquals(42, album.ratingCount)
+        assertEquals("2026-06-19", album.releaseDate)
+        assertTrue(album.hasAsmrOne)
+    }
+}

--- a/app/src/test/java/com/asmr/player/ui/search/SearchAlbumDetailMergeTest.kt
+++ b/app/src/test/java/com/asmr/player/ui/search/SearchAlbumDetailMergeTest.kt
@@ -1,0 +1,33 @@
+package com.asmr.player.ui.search
+
+import com.asmr.player.domain.model.Album
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class SearchAlbumDetailMergeTest {
+    @Test
+    fun mergeSearchAlbumDetail_prefersCompleteDetailCvOverPartialListCv() {
+        val base = Album(
+            title = "作品",
+            path = "",
+            rjCode = "RJ123456",
+            cv = "Alice",
+            tags = listOf("耳语")
+        )
+        val detail = base.copy(
+            cv = "Alice, Bob",
+            tags = listOf("耳语", "安眠"),
+            ratingValue = 4.8,
+            ratingCount = 42,
+            releaseDate = "2026-06-19"
+        )
+
+        val merged = mergeSearchAlbumDetail(base, detail)
+
+        assertEquals("Alice, Bob", merged.cv)
+        assertEquals(listOf("耳语"), merged.tags)
+        assertEquals(4.8, merged.ratingValue ?: 0.0, 0.0)
+        assertEquals(42, merged.ratingCount)
+        assertEquals("2026-06-19", merged.releaseDate)
+    }
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,5 +9,7 @@ org.gradle.workers.max=1
 org.gradle.parallel=false
 
 org.gradle.caching=true
-gradle.user.home=D:/Android_sdk/.gradle
 kotlin.compiler.execution.strategy=in-process
+
+# Gradle user home is chosen before project gradle.properties is read, so setting
+# it here is ineffective. Use gradlew-local.bat or set GRADLE_USER_HOME instead.

--- a/gradlew-local.bat
+++ b/gradlew-local.bat
@@ -1,0 +1,13 @@
+@echo off
+setlocal
+
+set "PROJECT_DIR=%~dp0"
+set "GRADLE_USER_HOME=%PROJECT_DIR%.gradle-user-home"
+set "TEMP=%PROJECT_DIR%.gradle-temp"
+set "TMP=%PROJECT_DIR%.gradle-temp"
+
+if not exist "%GRADLE_USER_HOME%" mkdir "%GRADLE_USER_HOME%"
+if not exist "%TEMP%" mkdir "%TEMP%"
+
+call "%PROJECT_DIR%gradlew.bat" %*
+exit /b %ERRORLEVEL%


### PR DESCRIPTION
## Summary
- smooth album detail header download action transition and language selector styling
- include current search/detail prefetch and release support changes from this branch
- add focused regression coverage for album detail/search/nav support

## Verification
- .\\gradlew.bat :app:compileDebugKotlin