### PR TITLE
fix: cache bottom nav pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,4 @@ crash.txt
 
 Thumbs.db
 .DS_Store
+AGENTS.md

--- a/app/src/main/java/com/asmr/player/main/MainContainer.kt
+++ b/app/src/main/java/com/asmr/player/main/MainContainer.kt
@@ -538,6 +538,9 @@ fun MainContainer(
     )
     var miniPlayerDisplayMode by rememberSaveable { mutableStateOf(MiniPlayerDisplayMode.CoverOnly) }
     val primaryPagerRoutes = remember(bottomNavItems) { bottomNavItems.map { it.route } }
+    val primaryPagerBeyondBoundsPageCount = remember(primaryPagerRoutes) {
+        resolvePrimaryPagerBeyondBoundsPageCount(primaryPagerRoutes.size)
+    }
     val initialPrimaryPage = remember(initialDestination, primaryPagerRoutes) {
         primaryPagerRoutes.indexOf(initialDestination).takeIf { it >= 0 } ?: 0
     }
@@ -1624,7 +1627,7 @@ fun MainContainer(
                                     modifier = Modifier
                                         .fillMaxSize()
                                         .padding(top = pagerTopContentPadding),
-                                    beyondBoundsPageCount = 1,
+                                    beyondBoundsPageCount = primaryPagerBeyondBoundsPageCount,
                                     userScrollEnabled = !primaryPagerScrollLocked && !hasOverlayRoute,
                                     key = { primaryPagerRoutes[it] }
                                 ) { page ->

--- a/app/src/main/java/com/asmr/player/main/MainNavigationSupport.kt
+++ b/app/src/main/java/com/asmr/player/main/MainNavigationSupport.kt
@@ -259,6 +259,10 @@ internal fun resolvePrimaryPagerApproachPage(
     return targetPage + if (targetPage > currentPage) -1 else 1
 }
 
+internal fun resolvePrimaryPagerBeyondBoundsPageCount(pageCount: Int): Int {
+    return (pageCount - 1).coerceAtLeast(0)
+}
+
 internal fun resolveCurrentPrimaryDestinationRoute(
     currentRoute: String?,
     playlistSystemType: String? = null

--- a/app/src/test/java/com/asmr/player/MainNavigationSupportTest.kt
+++ b/app/src/test/java/com/asmr/player/MainNavigationSupportTest.kt
@@ -64,6 +64,13 @@ class MainNavigationSupportTest {
     }
 
     @Test
+    fun resolvePrimaryPagerBeyondBoundsPageCount_keepsAllPrimaryPagesComposed() {
+        assertEquals(0, resolvePrimaryPagerBeyondBoundsPageCount(0))
+        assertEquals(0, resolvePrimaryPagerBeyondBoundsPageCount(1))
+        assertEquals(7, resolvePrimaryPagerBeyondBoundsPageCount(8))
+    }
+
+    @Test
     fun resolveCurrentPrimaryDestinationRoute_handlesFavoritesSystemPlaylist() {
         assertEquals(
             "playlist_system/favorites",

--- a/gradle-clean-local-cache.bat
+++ b/gradle-clean-local-cache.bat
@@ -1,0 +1,23 @@
+@echo off
+setlocal
+
+set "PROJECT_DIR=%~dp0"
+set "BUILD_DIR=%PROJECT_DIR%.build_asmr_player_android"
+set "TEMP_DIR=%PROJECT_DIR%.gradle-temp"
+set "LOCAL_BUILD_CACHE=%PROJECT_DIR%.gradle-user-home\caches\build-cache-1"
+
+call "%PROJECT_DIR%gradlew-local.bat" --stop
+
+if exist "%BUILD_DIR%" (
+    rmdir /s /q "%BUILD_DIR%"
+)
+
+if exist "%TEMP_DIR%" (
+    rmdir /s /q "%TEMP_DIR%"
+)
+
+if exist "%LOCAL_BUILD_CACHE%" (
+    rmdir /s /q "%LOCAL_BUILD_CACHE%"
+)
+
+echo Local Gradle build artifacts and temporary cache cleaned.


### PR DESCRIPTION
## Summary
- keep all bottom navigation primary pages composed in the top-level pager
- add navigation support coverage for the pager cache window
- include current local Gradle cleanup/gitignore updates

## Verification
- .\\gradlew.bat :app:compileDebugKotlin :app:compileDebugUnitTestKotlin