### PR TITLE
fix: optimize video playback scrolling performance

### DIFF
--- a/app/src/androidTest/java/com/asmr/player/ui/player/CoverArtworkBackgroundStyleAndroidTest.kt
+++ b/app/src/androidTest/java/com/asmr/player/ui/player/CoverArtworkBackgroundStyleAndroidTest.kt
@@ -11,7 +11,7 @@ class CoverArtworkBackgroundStyleAndroidTest {
 
     @Test
     fun clarity100_hasNoBlur_andLowerOverlayTint() {
-        val lowClarity = coverArtworkBackdropStyle(clarity = 0f, isDark = true)
+        val lowClarity = coverArtworkBackdropStyle(clarity = 0.05f, isDark = true)
         val highClarity = coverArtworkBackdropStyle(clarity = 1f, isDark = true)
 
         assertEquals(0f, highClarity.blurDp.value, 0.001f)
@@ -22,28 +22,41 @@ class CoverArtworkBackgroundStyleAndroidTest {
 
     @Test
     fun artworkVisibility_increasesAsClarityIncreases() {
-        val lowClarity = coverArtworkBackdropStyle(clarity = 0f, isDark = false)
+        val hiddenClarity = coverArtworkBackdropStyle(clarity = 0f, isDark = false)
+        val lowClarity = coverArtworkBackdropStyle(clarity = 0.05f, isDark = false)
         val midClarity = coverArtworkBackdropStyle(clarity = 0.5f, isDark = false)
         val highClarity = coverArtworkBackdropStyle(clarity = 1f, isDark = false)
 
+        assertEquals(0f, hiddenClarity.artworkAlpha, 0.0001f)
         assertTrue(lowClarity.artworkAlpha < midClarity.artworkAlpha)
         assertTrue(midClarity.artworkAlpha < highClarity.artworkAlpha)
     }
 
     @Test
-    fun lowClarity_keepsBackdropTintVisible_inDarkMode() {
+    fun zeroClarity_hidesArtworkButKeepsThemeBackdrop() {
         val style = coverArtworkBackdropStyle(clarity = 0f, isDark = true)
 
+        assertEquals(0f, style.artworkAlpha, 0.0001f)
         assertTrue(style.baseTintAlpha >= 0.9f)
-        assertTrue(style.scrimAlpha <= 0.01f)
         assertTrue(style.tintAlpha >= 0.26f)
+        assertTrue(style.overlayAlpha <= 0.04f)
+        assertTrue(style.scrimAlpha <= 0.01f)
+    }
+
+    @Test
+    fun lowClarity_keepsBackdropTintVisible_inDarkMode() {
+        val style = coverArtworkBackdropStyle(clarity = 0.05f, isDark = true)
+
+        assertTrue(style.baseTintAlpha >= 0.89f)
+        assertTrue(style.scrimAlpha <= 0.01f)
+        assertTrue(style.tintAlpha >= 0.25f)
     }
 
     @Test
     fun lowClarity_avoidsWhiteWash_inLightMode() {
-        val style = coverArtworkBackdropStyle(clarity = 0f, isDark = false)
+        val style = coverArtworkBackdropStyle(clarity = 0.05f, isDark = false)
 
-        assertTrue(style.baseTintAlpha >= 0.82f)
+        assertTrue(style.baseTintAlpha >= 0.81f)
         assertTrue(style.overlayAlpha <= 0.02f)
         assertEquals(0f, style.scrimAlpha, 0.0001f)
     }

--- a/app/src/main/java/com/asmr/player/MainActivity.kt
+++ b/app/src/main/java/com/asmr/player/MainActivity.kt
@@ -259,7 +259,11 @@ class MainActivity : ComponentActivity() {
                     .map { it.currentMediaItem.toThemeMediaSource() }
                     .distinctUntilChanged()
             }.collectAsState(initial = ThemeMediaSource())
-            val playbackSnapshot by playerViewModel.playback.collectAsState()
+            val playbackRestoreResolved by remember(playerViewModel) {
+                playerViewModel.playback
+                    .map { it.startupRestoreResolved }
+                    .distinctUntilChanged()
+            }.collectAsState(initial = false)
             val systemDark = isSystemInDarkTheme()
             val themePref = themeBootstrap.theme
             val mode = resolveThemeMode(themePref = themePref, systemDark = systemDark)
@@ -315,14 +319,14 @@ class MainActivity : ComponentActivity() {
             }
             val bootstrapDynamicHueSeedArgb = remember(
                 globalDynamicHueEnabled,
-                playbackSnapshot.startupRestoreResolved,
+                playbackRestoreResolved,
                 activeSourceKey,
                 themeBootstrap.lastDynamicHueSourceKey,
                 themeBootstrap.lastDynamicHueSeedArgb
             ) {
                 resolveBootstrapDynamicHueSeedArgb(
                     dynamicHueEnabled = globalDynamicHueEnabled,
-                    playbackRestoreResolved = playbackSnapshot.startupRestoreResolved,
+                    playbackRestoreResolved = playbackRestoreResolved,
                     currentSourceKey = activeSourceKey,
                     persistedSourceKey = themeBootstrap.lastDynamicHueSourceKey,
                     persistedSeedArgb = themeBootstrap.lastDynamicHueSeedArgb
@@ -349,16 +353,18 @@ class MainActivity : ComponentActivity() {
             val dynamicFallbackHue = remember(baseStaticHue, bootstrapDynamicHue) {
                 bootstrapDynamicHue ?: baseStaticHue
             }
-            if (isVideo && artworkUri == null) {
-                PrewarmDynamicHuePaletteFromVideoFrame(
-                    videoUri = videoUri,
-                    fallbackHue = dynamicFallbackHue
-                )
-            } else {
-                PrewarmDynamicHuePalette(
-                    artworkModel = artworkUri,
-                    fallbackHue = dynamicFallbackHue
-                )
+            if (globalDynamicHueEnabled) {
+                if (isVideo && artworkUri == null) {
+                    PrewarmDynamicHuePaletteFromVideoFrame(
+                        videoUri = videoUri,
+                        fallbackHue = dynamicFallbackHue
+                    )
+                } else {
+                    PrewarmDynamicHuePalette(
+                        artworkModel = artworkUri,
+                        fallbackHue = dynamicFallbackHue
+                    )
+                }
             }
             val globalHue = if (globalDynamicHueEnabled) {
                 val state = if (isVideo && artworkUri == null) {
@@ -409,7 +415,7 @@ class MainActivity : ComponentActivity() {
 
             LaunchedEffect(
                 globalDynamicHueEnabled,
-                playbackSnapshot.startupRestoreResolved,
+                playbackRestoreResolved,
                 activeSourceKey,
                 themeBootstrap.lastDynamicHueSourceKey,
                 themeBootstrap.lastDynamicHueSeedArgb
@@ -417,7 +423,7 @@ class MainActivity : ComponentActivity() {
                 if (
                     shouldClearPersistedDynamicHueSeed(
                         dynamicHueEnabled = globalDynamicHueEnabled,
-                        playbackRestoreResolved = playbackSnapshot.startupRestoreResolved,
+                        playbackRestoreResolved = playbackRestoreResolved,
                         currentSourceKey = activeSourceKey,
                         persistedSourceKey = themeBootstrap.lastDynamicHueSourceKey,
                         persistedSeedArgb = themeBootstrap.lastDynamicHueSeedArgb

--- a/app/src/main/java/com/asmr/player/hotlistening/ListeningTracker.kt
+++ b/app/src/main/java/com/asmr/player/hotlistening/ListeningTracker.kt
@@ -6,16 +6,19 @@ import com.asmr.player.ui.player.isOnlineMedia
 import com.asmr.player.util.DlsiteWorkNo
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.sample
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
+@OptIn(FlowPreview::class)
 class ListeningTracker @Inject constructor(
     private val hotListeningApi: HotListeningApi
 ) {
@@ -28,6 +31,7 @@ class ListeningTracker @Inject constructor(
         stop()
         observationJob = scope.launch {
             playback
+                .sample(TrackerObservationIntervalMs)
                 .map { snapshot ->
                     val item = snapshot.currentMediaItem
                     val mediaId = item?.mediaId ?: ""
@@ -166,6 +170,7 @@ class ListeningTracker @Inject constructor(
 
     private companion object {
         private const val REPORT_THRESHOLD_MS = 30_000L
+        private const val TrackerObservationIntervalMs = 1_000L
     }
 }
 

--- a/app/src/main/java/com/asmr/player/main/MainContainer.kt
+++ b/app/src/main/java/com/asmr/player/main/MainContainer.kt
@@ -610,7 +610,15 @@ fun MainContainer(
             .map { it.currentMediaItem != null }
             .distinctUntilChanged()
     }.collectAsState(initial = false)
-    val sharedPlayerPlayback by playerViewModel.playback.collectAsState()
+    val sharedPlayerItem by remember(playerViewModel) {
+        playerViewModel.playback
+            .map { it.currentMediaItem }
+            .distinctUntilChanged { old, new ->
+                old?.mediaId == new?.mediaId &&
+                    old?.localConfiguration?.uri == new?.localConfiguration?.uri &&
+                    old?.mediaMetadata?.artworkUri == new?.mediaMetadata?.artworkUri
+            }
+    }.collectAsState(initial = null)
     val drawerStatusViewModel: DrawerStatusViewModel = hiltViewModel()
     val statisticsViewModel: StatisticsViewModel = hiltViewModel()
     val bulkProgress by libraryViewModel.bulkProgress.collectAsState()
@@ -687,7 +695,6 @@ fun MainContainer(
         nowPlayingVisible = false
     }
     val playerBackdropVisible = nowPlayingVisible
-    val sharedPlayerItem = sharedPlayerPlayback.currentMediaItem
     val sharedPlayerUriText = sharedPlayerItem?.localConfiguration?.uri?.toString().orEmpty()
     val sharedPlayerMimeType = sharedPlayerItem?.localConfiguration?.mimeType.orEmpty()
     val sharedPlayerExt = sharedPlayerUriText
@@ -2352,7 +2359,7 @@ fun MainContainer(
                         .graphicsLayer { alpha = nowPlayingBackdropAlpha }
                 ) {
                     PlayerSharedBackdrop(
-                        playback = sharedPlayerPlayback,
+                        mediaItem = sharedPlayerItem,
                         enabled = coverBackgroundEnabled,
                         clarity = coverBackgroundClarity,
                         artworkAlignment = sharedPlayerBackdropAlignment

--- a/app/src/main/java/com/asmr/player/playback/PlayerConnection.kt
+++ b/app/src/main/java/com/asmr/player/playback/PlayerConnection.kt
@@ -96,6 +96,7 @@ class PlayerConnection @Inject constructor(
     private val meteredWarnedMediaIds = LinkedHashSet<String>()
     private var lastMeteredWarnAtMs: Long = 0L
     private val connectMutex = Mutex()
+    private var videoSurfaceVisible: Boolean = false
     @Volatile private var reconnecting = false
 
     val appVolumePercent: StateFlow<Int> = settingsRepository.appVolumePercent
@@ -160,7 +161,7 @@ class PlayerConnection @Inject constructor(
                         }
                     }
 
-                    _snapshot.value = _snapshot.value.copy(
+                    updateSnapshotIfChanged(
                         positionMs = c.currentPosition.coerceAtLeast(0L),
                         durationMs = duration,
                         audioSessionId = sessionId,
@@ -170,7 +171,7 @@ class PlayerConnection @Inject constructor(
 
                     applySliceLoopIfNeeded(c)
                 }
-                delay(250)
+                delay(resolvePositionPollIntervalMs())
             }
         }
         scope.launch {
@@ -731,6 +732,14 @@ class PlayerConnection @Inject constructor(
         sendCustomCommand("RELOAD_LYRICS", android.os.Bundle.EMPTY)
     }
 
+    fun setVideoSurfaceVisible(visible: Boolean) {
+        videoSurfaceVisible = visible
+        sendCustomCommand(
+            "SET_VIDEO_SURFACE_VISIBLE",
+            android.os.Bundle().apply { putBoolean("visible", visible) }
+        )
+    }
+
     fun setAppVolumePercent(percent: Int) {
         scope.launch {
             settingsRepository.setAppVolumePercent(percent)
@@ -746,6 +755,45 @@ class PlayerConnection @Inject constructor(
     private fun updateQueue() {
         val c = controller ?: return
         _queue.value = (0 until c.mediaItemCount).map { idx -> c.getMediaItemAt(idx) }
+    }
+
+    private fun updateSnapshotIfChanged(
+        positionMs: Long,
+        durationMs: Long,
+        audioSessionId: Int,
+        playbackSpeed: Float,
+        playbackPitch: Float
+    ) {
+        val current = _snapshot.value
+        if (
+            current.positionMs == positionMs &&
+            current.durationMs == durationMs &&
+            current.audioSessionId == audioSessionId &&
+            current.playbackSpeed == playbackSpeed &&
+            current.playbackPitch == playbackPitch
+        ) {
+            return
+        }
+
+        _snapshot.value = current.copy(
+            positionMs = positionMs,
+            durationMs = durationMs,
+            audioSessionId = audioSessionId,
+            playbackSpeed = playbackSpeed,
+            playbackPitch = playbackPitch
+        )
+    }
+
+    private fun resolvePositionPollIntervalMs(): Long {
+        val snapshot = _snapshot.value
+        if (slicePlaybackController.sliceModeEnabled.value || slicePlaybackController.previewSlice.value != null) {
+            return 250L
+        }
+        return if (snapshot.currentMediaItem.isVideoMediaItem() && !videoSurfaceVisible) {
+            1_000L
+        } else {
+            250L
+        }
     }
 
     private fun applySliceLoopIfNeeded(c: MediaController) {
@@ -811,6 +859,20 @@ private fun Player.toSnapshot(
         durationMs = duration.coerceAtLeast(0L),
         audioSessionId = audioSessionId
     )
+}
+
+private fun MediaItem?.isVideoMediaItem(): Boolean {
+    val item = this ?: return false
+    val uriString = item.localConfiguration?.uri?.toString().orEmpty()
+    val mime = item.localConfiguration?.mimeType.orEmpty()
+    val ext = uriString
+        .substringBefore('#')
+        .substringBefore('?')
+        .substringAfterLast('.', "")
+        .lowercase()
+    return item.mediaMetadata.extras?.getBoolean("is_video") == true ||
+        mime.startsWith("video/") ||
+        ext in setOf("mp4", "m4v", "webm", "mkv", "mov")
 }
 
 private data class PlaybackStateKey(

--- a/app/src/main/java/com/asmr/player/playback/StereoSpectrumBus.kt
+++ b/app/src/main/java/com/asmr/player/playback/StereoSpectrumBus.kt
@@ -8,4 +8,21 @@ object StereoSpectrumBus {
     val store: StereoSpectrumStore = StereoSpectrumStore(DefaultBinCount)
     @Volatile
     var playbackActive: Boolean = false
+    @Volatile
+    var captureActive: Boolean = false
+        private set
+
+    private var captureConsumerCount: Int = 0
+
+    @Synchronized
+    fun registerCaptureConsumer() {
+        captureConsumerCount += 1
+        captureActive = true
+    }
+
+    @Synchronized
+    fun unregisterCaptureConsumer() {
+        captureConsumerCount = (captureConsumerCount - 1).coerceAtLeast(0)
+        captureActive = captureConsumerCount > 0
+    }
 }

--- a/app/src/main/java/com/asmr/player/playback/StereoSpectrumTapAudioProcessor.kt
+++ b/app/src/main/java/com/asmr/player/playback/StereoSpectrumTapAudioProcessor.kt
@@ -27,7 +27,7 @@ class StereoSpectrumTapAudioProcessor(
     override fun queueInput(inputBuffer: ByteBuffer) {
         if (!inputBuffer.hasRemaining()) return
 
-        if (tapEnabled) {
+        if (tapEnabled && StereoSpectrumBus.captureActive) {
             val start = inputBuffer.position()
             val end = inputBuffer.limit()
 

--- a/app/src/main/java/com/asmr/player/service/PlaybackService.kt
+++ b/app/src/main/java/com/asmr/player/service/PlaybackService.kt
@@ -20,6 +20,7 @@ import android.util.Log
 import androidx.core.app.TaskStackBuilder
 import androidx.media3.common.AudioAttributes
 import androidx.media3.common.C
+import androidx.media3.common.MediaItem
 import androidx.media3.common.Player
 import androidx.media3.common.util.UnstableApi
 import androidx.media3.exoplayer.ExoPlayer
@@ -136,6 +137,7 @@ class PlaybackService : MediaSessionService() {
     private var hasAudioFocus: Boolean = false
     private var notificationProvider: LyricMediaNotificationProvider? = null
     private var sfwHideSystemControlsEnabled: Boolean = false
+    private var videoSurfaceVisible: Boolean = false
 
     private val audioFocusChangeListener = AudioManager.OnAudioFocusChangeListener { focusChange ->
         when (focusChange) {
@@ -316,6 +318,7 @@ class PlaybackService : MediaSessionService() {
             )
             .setHandleAudioBecomingNoisy(true)
             .build()
+        applyVideoSurfaceVisibility()
 
         spectrumAnalyzer.start()
 
@@ -354,6 +357,7 @@ class PlaybackService : MediaSessionService() {
             override fun onMediaItemTransition(mediaItem: androidx.media3.common.MediaItem?, reason: Int) {
                 serviceScope.launch { updateArtworkForCurrentMedia() }
                 serviceScope.launch { loadLyricsForCurrentMedia() }
+                applyVideoSurfaceVisibility()
                 if (exoPlayer.isPlaying) {
                     markCurrentAlbumPlayed()
                 }
@@ -765,6 +769,7 @@ class PlaybackService : MediaSessionService() {
                             .add(androidx.media3.session.SessionCommand("GET_AUDIO_SESSION_ID", android.os.Bundle.EMPTY))
                             .add(androidx.media3.session.SessionCommand("UPDATE_SESSION_EQ", android.os.Bundle.EMPTY))
                             .add(androidx.media3.session.SessionCommand("RELOAD_LYRICS", android.os.Bundle.EMPTY))
+                            .add(androidx.media3.session.SessionCommand("SET_VIDEO_SURFACE_VISIBLE", android.os.Bundle.EMPTY))
                             .build()
                     }
                     val playerCommands = if (
@@ -868,11 +873,50 @@ class PlaybackService : MediaSessionService() {
                                 androidx.media3.session.SessionResult(androidx.media3.session.SessionResult.RESULT_SUCCESS, android.os.Bundle.EMPTY)
                             )
                         }
+
+                        "SET_VIDEO_SURFACE_VISIBLE" -> {
+                            setVideoSurfaceVisible(args.getBoolean("visible", false))
+                            return com.google.common.util.concurrent.Futures.immediateFuture(
+                                androidx.media3.session.SessionResult(androidx.media3.session.SessionResult.RESULT_SUCCESS, android.os.Bundle.EMPTY)
+                            )
+                        }
                     }
                     return super.onCustomCommand(session, controller, customCommand, args)
                 }
             })
             .build()
+    }
+
+    private fun setVideoSurfaceVisible(visible: Boolean) {
+        if (videoSurfaceVisible == visible) return
+        videoSurfaceVisible = visible
+        applyVideoSurfaceVisibility()
+    }
+
+    private fun applyVideoSurfaceVisibility() {
+        val item = exoPlayer.currentMediaItem
+        val videoActive = videoSurfaceVisible && item.isVideoMediaItem()
+        val params = exoPlayer.trackSelectionParameters
+        val updated = params.buildUpon()
+            .setTrackTypeDisabled(C.TRACK_TYPE_VIDEO, !videoActive)
+            .build()
+        if (updated != params) {
+            exoPlayer.trackSelectionParameters = updated
+        }
+    }
+
+    private fun MediaItem?.isVideoMediaItem(): Boolean {
+        val item = this ?: return false
+        val uriString = item.localConfiguration?.uri?.toString().orEmpty()
+        val mime = item.localConfiguration?.mimeType.orEmpty()
+        val ext = uriString
+            .substringBefore('#')
+            .substringBefore('?')
+            .substringAfterLast('.', "")
+            .lowercase()
+        return item.mediaMetadata.extras?.getBoolean("is_video") == true ||
+            mime.startsWith("video/") ||
+            ext in setOf("mp4", "m4v", "webm", "mkv", "mov")
     }
 
     private fun refreshMediaNotificationControllerRegistration() {

--- a/app/src/main/java/com/asmr/player/ui/library/AlbumDetailScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/AlbumDetailScreen.kt
@@ -10,6 +10,7 @@ import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.animateContentSize
 import androidx.compose.animation.core.Spring
 import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.FastOutLinearInEasing
 import androidx.compose.animation.core.FastOutSlowInEasing
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.spring
@@ -190,13 +191,13 @@ private const val AlbumDetailHeroFlingOvershootPortion = 0.24f
 private const val AlbumDetailHeroFlingOvershootMaxPortion = 0.14f
 private const val AlbumDetailHeroFlingApproachMillis = 560
 private const val AlbumDetailHeroFlingSettleMillis = 980
-private const val AlbumDetailRevealSettleMs = 760L
+private const val AlbumDetailRevealSettleMs = 420L
 private const val AlbumDetailHeroTitleRevealDelayMs = 120
 private const val AlbumDetailHeroMetaRevealDelayMs = 280
 private const val AlbumDetailCvRevealDelayMs = 220
 private const val AlbumDetailTagsRevealDelayMs = 360
 private const val AlbumDetailActionsRevealDelayMs = 500
-private const val AlbumDetailHeaderMotionSettleMs = 940L
+private const val AlbumDetailHeaderMotionSettleMs = 520L
 internal val AlbumDetailHorizontalPadding = 8.dp
 
 private val AlbumDetailHeroBounceBackSpec = spring<Float>(
@@ -204,9 +205,14 @@ private val AlbumDetailHeroBounceBackSpec = spring<Float>(
     stiffness = Spring.StiffnessLow
 )
 
-private val AlbumHeaderEnterFloatSpec = spring<Float>(
-    dampingRatio = Spring.DampingRatioNoBouncy,
-    stiffness = Spring.StiffnessVeryLow
+private val AlbumHeaderEnterTweenSpec = tween<Float>(
+    durationMillis = 320,
+    easing = FastOutLinearInEasing
+)
+
+private val AlbumHeaderExpandTweenSpec = tween<IntSize>(
+    durationMillis = 320,
+    easing = FastOutLinearInEasing
 )
 
 private val AlbumHeaderActionMorphSpec = spring<Float>(
@@ -214,17 +220,17 @@ private val AlbumHeaderActionMorphSpec = spring<Float>(
     stiffness = Spring.StiffnessMediumLow
 )
 
-private val DlsiteElasticResizeSpring = spring<IntSize>(
-    dampingRatio = Spring.DampingRatioLowBouncy,
-    stiffness = Spring.StiffnessLow
+private val DlsiteSectionResizeTweenSpec = tween<IntSize>(
+    durationMillis = 280,
+    easing = FastOutSlowInEasing
 )
 
-internal fun dlsiteElasticItemModifier(
+internal fun dlsiteSectionRevealModifier(
     modifier: Modifier = Modifier,
     enabled: Boolean = true
 ): Modifier {
     return if (enabled) {
-        modifier.animateContentSize(animationSpec = DlsiteElasticResizeSpring)
+        modifier.animateContentSize(animationSpec = DlsiteSectionResizeTweenSpec)
     } else {
         modifier
     }
@@ -1451,7 +1457,7 @@ private fun AlbumHeader(
     var languageMenuExpanded by rememberSaveable { mutableStateOf(false) }
 
     Column(
-        modifier = dlsiteElasticItemModifier(
+        modifier = dlsiteSectionRevealModifier(
             modifier = headerContainerModifier,
             enabled = animateIntro && !headerIntroPlayed && !headerHasDeferredMeta
         )
@@ -1970,12 +1976,12 @@ private fun AlbumHeaderInfoReveal(
     }
     val alpha by animateFloatAsState(
         targetValue = if (visible) 1f else 0f,
-        animationSpec = AlbumHeaderEnterFloatSpec,
+        animationSpec = AlbumHeaderEnterTweenSpec,
         label = "albumHeaderInfoAlpha"
     )
     val offsetYProgress by animateFloatAsState(
         targetValue = if (visible) 0f else 1f,
-        animationSpec = AlbumHeaderEnterFloatSpec,
+        animationSpec = AlbumHeaderEnterTweenSpec,
         label = "albumHeaderInfoOffsetY"
     )
     val density = LocalDensity.current
@@ -1997,18 +2003,12 @@ private fun AlbumHeaderInfoReveal(
     // 但避免再叠加父级 animateContentSize，减少同一尺寸变化被双重动画驱动。
     AnimatedVisibility(
         visible = visible,
-        enter = fadeIn(animationSpec = tween(durationMillis = 420)) + expandVertically(
-            animationSpec = spring(
-                dampingRatio = Spring.DampingRatioNoBouncy,
-                stiffness = Spring.StiffnessLow
-            ),
+        enter = fadeIn(animationSpec = AlbumHeaderEnterTweenSpec) + expandVertically(
+            animationSpec = AlbumHeaderExpandTweenSpec,
             expandFrom = Alignment.Top
         ),
         exit = fadeOut(animationSpec = tween(durationMillis = 120)) + shrinkVertically(
-            animationSpec = spring(
-                dampingRatio = Spring.DampingRatioNoBouncy,
-                stiffness = Spring.StiffnessMediumLow
-            ),
+            animationSpec = tween(durationMillis = 160, easing = FastOutLinearInEasing),
             shrinkTowards = Alignment.Top
         )
     ) {

--- a/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailDirectorySupport.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailDirectorySupport.kt
@@ -1822,7 +1822,7 @@ internal fun DirectoryBrowserPanel(
         shape = RoundedCornerShape(18.dp),
         tonalElevation = 1.dp,
         color = AsmrTheme.colorScheme.surface.copy(alpha = 0.44f),
-        modifier = dlsiteElasticItemModifier(
+        modifier = dlsiteSectionRevealModifier(
             Modifier
                 .fillMaxWidth()
                 .padding(horizontal = 16.dp, vertical = 8.dp)
@@ -2701,7 +2701,7 @@ internal fun DirectoryBrowserPanelV4(
                 color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.18f)
             )
             Row(
-                modifier = dlsiteElasticItemModifier(
+                modifier = dlsiteSectionRevealModifier(
                     modifier = Modifier
                         .fillMaxWidth()
                         .padding(horizontal = 12.dp, vertical = 8.dp),

--- a/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailDlsiteTabs.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailDlsiteTabs.kt
@@ -8,10 +8,10 @@ import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.animateContentSize
-import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.FastOutSlowInEasing
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.animateDpAsState
-import androidx.compose.animation.core.spring
+import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.slideInHorizontally
@@ -666,9 +666,9 @@ private fun DlsiteRecommendationsLoadingBlocks() {
     }
 }
 
-private val DlsiteSectionPlacementSpring = spring<IntOffset>(
-    dampingRatio = Spring.DampingRatioLowBouncy,
-    stiffness = Spring.StiffnessLow
+private val DlsiteSectionPlacementTweenSpec = tween<IntOffset>(
+    durationMillis = 280,
+    easing = FastOutSlowInEasing
 )
 
 @OptIn(ExperimentalFoundationApi::class)
@@ -677,8 +677,8 @@ private fun LazyItemScope.dlsiteAnimatedSectionModifier(
     animateIntro: Boolean = true
 ): Modifier {
     if (!animateIntro) return modifier
-    return dlsiteElasticItemModifier(
-        modifier = modifier.animateItemPlacement(animationSpec = DlsiteSectionPlacementSpring),
+    return dlsiteSectionRevealModifier(
+        modifier = modifier.animateItemPlacement(animationSpec = DlsiteSectionPlacementTweenSpec),
         enabled = true
     )
 }

--- a/app/src/main/java/com/asmr/player/ui/player/ChannelSpectrumView.kt
+++ b/app/src/main/java/com/asmr/player/ui/player/ChannelSpectrumView.kt
@@ -211,11 +211,13 @@ class ChannelSpectrumView @JvmOverloads constructor(
     override fun onAttachedToWindow() {
         super.onAttachedToWindow()
         (parent as? android.view.ViewGroup)?.clipChildren = false
+        StereoSpectrumBus.registerCaptureConsumer()
         start()
     }
 
     override fun onDetachedFromWindow() {
         stop()
+        StereoSpectrumBus.unregisterCaptureConsumer()
         super.onDetachedFromWindow()
     }
 

--- a/app/src/main/java/com/asmr/player/ui/player/CoverArtworkBackground.kt
+++ b/app/src/main/java/com/asmr/player/ui/player/CoverArtworkBackground.kt
@@ -37,11 +37,15 @@ fun CoverArtworkBackground(
         coverArtworkBackdropStyle(clarity = clarity, isDark = isDark)
     }
 
+    Box(modifier = Modifier.fillMaxSize().background(overlayBaseColor))
+
     // Keep the backdrop anchored to the extracted cover hue, but keep the base veil lighter.
     val baseBackdropColor = remember(style.baseTintAlpha, overlayBaseColor, tintBaseColor) {
         tintBaseColor.copy(alpha = style.baseTintAlpha).compositeOver(overlayBaseColor)
     }
-    Box(modifier = Modifier.fillMaxSize().background(baseBackdropColor))
+    if (style.baseTintAlpha > 0f) {
+        Box(modifier = Modifier.fillMaxSize().background(baseBackdropColor))
+    }
 
     val artworkModifier = remember(style.blurDp) {
         if (style.blurDp.value <= 0f) {
@@ -58,7 +62,7 @@ fun CoverArtworkBackground(
         }
     }
 
-    if (artworkModel != null) {
+    if (artworkModel != null && style.artworkAlpha > 0f) {
         AsmrAsyncImage(
             model = artworkModel,
             contentDescription = null,
@@ -70,8 +74,12 @@ fun CoverArtworkBackground(
         )
     }
 
-    Box(modifier = Modifier.fillMaxSize().background(overlayBaseColor.copy(alpha = style.overlayAlpha)))
-    Box(modifier = Modifier.fillMaxSize().background(tintBaseColor.copy(alpha = style.tintAlpha)))
+    if (style.overlayAlpha > 0f) {
+        Box(modifier = Modifier.fillMaxSize().background(overlayBaseColor.copy(alpha = style.overlayAlpha)))
+    }
+    if (style.tintAlpha > 0f) {
+        Box(modifier = Modifier.fillMaxSize().background(tintBaseColor.copy(alpha = style.tintAlpha)))
+    }
 
     if (style.scrimAlpha > 0f) {
         Box(modifier = Modifier.fillMaxSize().background(Color.Black.copy(alpha = style.scrimAlpha)))
@@ -109,7 +117,7 @@ internal fun coverArtworkBackdropStyle(
             start = if (isDark) 0.10f else 0.08f,
             end = if (isDark) 0.98f else 0.99f,
             fraction = reveal
-        ),
+        ).takeIf { normalized > 0f } ?: 0f,
         overlayAlpha = lerpFloat(
             start = if (isDark) 0.04f else 0.02f,
             end = if (isDark) 0f else 0f,

--- a/app/src/main/java/com/asmr/player/ui/player/MiniPlayer.kt
+++ b/app/src/main/java/com/asmr/player/ui/player/MiniPlayer.kt
@@ -63,13 +63,39 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.media3.common.MediaItem
 import com.asmr.player.ui.common.AsmrAsyncImage
 import com.asmr.player.ui.theme.AsmrTheme
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.map
 
 enum class MiniPlayerDisplayMode {
     CoverOnly,
     Expanded
+}
+
+private data class MiniPlayerProgress(
+    val positionMs: Long = 0L,
+    val durationMs: Long = 0L
+) {
+    val fraction: Float
+        get() = if (durationMs > 0L) {
+            (positionMs.toDouble() / durationMs.toDouble()).toFloat().coerceIn(0f, 1f)
+        } else {
+            0f
+        }
+}
+
+private fun sameMiniPlayerMediaItem(old: MediaItem?, new: MediaItem?): Boolean {
+    if (old === new) return true
+    if (old == null || new == null) return false
+    return old.mediaId == new.mediaId &&
+        old.localConfiguration?.uri == new.localConfiguration?.uri &&
+        old.mediaMetadata.artworkUri == new.mediaMetadata.artworkUri &&
+        old.mediaMetadata.title?.toString() == new.mediaMetadata.title?.toString() &&
+        old.mediaMetadata.artist?.toString() == new.mediaMetadata.artist?.toString()
 }
 
 @Composable
@@ -83,9 +109,27 @@ fun MiniPlayer(
     modifier: Modifier = Modifier,
     viewModel: PlayerViewModel = hiltViewModel()
 ) {
-    val playback by viewModel.playback.collectAsState()
+    val currentItemState by remember(viewModel) {
+        viewModel.playback
+            .map { it.currentMediaItem }
+            .distinctUntilChanged(::sameMiniPlayerMediaItem)
+    }.collectAsState(initial = null)
+    val isPlaying by remember(viewModel) {
+        viewModel.playback
+            .map { it.isPlaying }
+            .distinctUntilChanged()
+    }.collectAsState(initial = false)
+    val progressState by remember(viewModel, displayMode) {
+        if (displayMode == MiniPlayerDisplayMode.Expanded) {
+            viewModel.playback
+                .map { MiniPlayerProgress(it.positionMs, it.durationMs) }
+                .distinctUntilChanged()
+        } else {
+            flowOf(MiniPlayerProgress())
+        }
+    }.collectAsState(initial = MiniPlayerProgress())
     val isFavorite by viewModel.isFavorite.collectAsState()
-    val item = playback.currentMediaItem ?: return
+    val item = currentItemState ?: return
     val metadata = item.mediaMetadata
     val colorScheme = AsmrTheme.colorScheme
     val currentMediaId = item.mediaId
@@ -100,7 +144,7 @@ fun MiniPlayer(
 
     var optimisticIsPlaying by remember { mutableStateOf<Boolean?>(null) }
     var stableMediaId by remember { mutableStateOf(currentMediaId) }
-    val isPlayingEffective = optimisticIsPlaying ?: playback.isPlaying
+    val isPlayingEffective = optimisticIsPlaying ?: isPlaying
 
     LaunchedEffect(currentMediaId) {
         if (currentMediaId != stableMediaId) {
@@ -116,11 +160,7 @@ fun MiniPlayer(
         }
     }
 
-    val progress = if (playback.durationMs > 0) {
-        (playback.positionMs.toDouble() / playback.durationMs.toDouble()).toFloat().coerceIn(0f, 1f)
-    } else {
-        0f
-    }
+    val progress = progressState.fraction
 
     AnimatedContent(
         targetState = displayMode,
@@ -248,7 +288,7 @@ fun MiniPlayer(
                                 }
                                     IconButton(
                                         onClick = {
-                                            optimisticIsPlaying = !(optimisticIsPlaying ?: playback.isPlaying)
+                                            optimisticIsPlaying = !(optimisticIsPlaying ?: isPlaying)
                                             viewModel.togglePlayPause()
                                         },
                                         modifier = Modifier.size(controlsButtonSize)

--- a/app/src/main/java/com/asmr/player/ui/player/NowPlayingScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/player/NowPlayingScreen.kt
@@ -63,6 +63,7 @@ import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.layout.boundsInRoot
+import androidx.compose.ui.layout.layout
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.platform.LocalConfiguration
@@ -116,11 +117,140 @@ import kotlin.math.roundToInt
 import kotlin.math.roundToLong
 
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 
 private enum class NowPlayingSurfaceMode {
     PLAYER,
     LYRICS
+}
+
+private const val VideoProgressUiTickMs = 1_000L
+
+private data class NowPlayingStaticPlayback(
+    val isConnected: Boolean,
+    val startupRestoreResolved: Boolean,
+    val isPlaying: Boolean,
+    val playbackState: Int,
+    val repeatMode: Int,
+    val shuffleEnabled: Boolean,
+    val playbackSpeed: Float,
+    val playbackPitch: Float,
+    val currentMediaItem: MediaItem?,
+    val durationMs: Long,
+    val audioSessionId: Int
+) {
+    fun toSnapshot(positionMs: Long): PlaybackSnapshot {
+        return PlaybackSnapshot(
+            isConnected = isConnected,
+            startupRestoreResolved = startupRestoreResolved,
+            isPlaying = isPlaying,
+            playbackState = playbackState,
+            repeatMode = repeatMode,
+            shuffleEnabled = shuffleEnabled,
+            playbackSpeed = playbackSpeed,
+            playbackPitch = playbackPitch,
+            currentMediaItem = currentMediaItem,
+            positionMs = positionMs,
+            durationMs = durationMs,
+            audioSessionId = audioSessionId
+        )
+    }
+}
+
+private data class NowPlayingProgressState(
+    val positionMs: Long = 0L,
+    val durationMs: Long = 0L
+)
+
+private fun PlaybackSnapshot.toStaticPlayback(): NowPlayingStaticPlayback {
+    return NowPlayingStaticPlayback(
+        isConnected = isConnected,
+        startupRestoreResolved = startupRestoreResolved,
+        isPlaying = isPlaying,
+        playbackState = playbackState,
+        repeatMode = repeatMode,
+        shuffleEnabled = shuffleEnabled,
+        playbackSpeed = playbackSpeed,
+        playbackPitch = playbackPitch,
+        currentMediaItem = currentMediaItem,
+        durationMs = durationMs,
+        audioSessionId = audioSessionId
+    )
+}
+
+@Composable
+private fun PlaybackProgressContent(
+    viewModel: PlayerViewModel,
+    isVideo: Boolean,
+    content: @Composable (NowPlayingProgressState) -> Unit
+) {
+    val progressState by remember(viewModel, isVideo) {
+        viewModel.playback
+            .map { snapshot ->
+                val positionMs = if (isVideo) {
+                    (snapshot.positionMs / VideoProgressUiTickMs) * VideoProgressUiTickMs
+                } else {
+                    snapshot.positionMs
+                }
+                NowPlayingProgressState(positionMs, snapshot.durationMs)
+            }
+            .distinctUntilChanged()
+    }.collectAsState(initial = NowPlayingProgressState())
+
+    content(progressState)
+}
+
+private fun Modifier.fitVideoPreviewAspectRatio(
+    aspectRatio: Float,
+    maxWidth: Dp = Dp.Unspecified
+): Modifier {
+    val boundedModifier = if (maxWidth != Dp.Unspecified) {
+        this.widthIn(max = maxWidth)
+    } else {
+        this
+    }
+    return boundedModifier.layout { measurable, constraints ->
+        val ratio = aspectRatio
+            .takeIf { it.isFinite() && it > 0f }
+            ?.coerceIn(0.5f, 3f)
+            ?: (16f / 9f)
+        val hasBoundedWidth = constraints.maxWidth != androidx.compose.ui.unit.Constraints.Infinity
+        val hasBoundedHeight = constraints.maxHeight != androidx.compose.ui.unit.Constraints.Infinity
+        if (!hasBoundedWidth && !hasBoundedHeight) {
+            val placeable = measurable.measure(constraints)
+            return@layout layout(placeable.width, placeable.height) { placeable.place(0, 0) }
+        }
+
+        val availableWidth = when {
+            hasBoundedWidth -> constraints.maxWidth
+            hasBoundedHeight -> (constraints.maxHeight * ratio).roundToInt()
+            else -> constraints.minWidth
+        }.coerceAtLeast(1)
+        val availableHeight = when {
+            hasBoundedHeight -> constraints.maxHeight
+            hasBoundedWidth -> (constraints.maxWidth / ratio).roundToInt()
+            else -> constraints.minHeight
+        }.coerceAtLeast(1)
+
+        var width = availableWidth
+        var height = (width / ratio).roundToInt().coerceAtLeast(1)
+        if (height > availableHeight) {
+            height = availableHeight
+            width = (height * ratio).roundToInt().coerceAtLeast(1)
+        }
+
+        val placeable = measurable.measure(
+            androidx.compose.ui.unit.Constraints.fixed(
+                width = width.coerceAtMost(availableWidth),
+                height = height.coerceAtMost(availableHeight)
+            )
+        )
+        layout(placeable.width, placeable.height) {
+            placeable.place(0, 0)
+        }
+    }
 }
 
 private fun AnimatedContentTransitionScope<NowPlayingSurfaceMode>.nowPlayingSurfaceTransform(): ContentTransform {
@@ -414,7 +544,12 @@ internal fun NowPlayingScreen(
     enableStaggeredRouteEntry: Boolean = true,
     lyricsViewModel: LyricsViewModel = hiltViewModel()
 ) {
-    val playback by viewModel.playback.collectAsState()
+    val staticPlayback by remember(viewModel) {
+        viewModel.playback
+            .map { it.toStaticPlayback() }
+            .distinctUntilChanged()
+    }.collectAsState(initial = PlaybackSnapshot().toStaticPlayback())
+    val playback = staticPlayback.toSnapshot(positionMs = 0L)
     val resolvedDurationMs by viewModel.resolvedDurationMs.collectAsState()
     val sliceUiState by viewModel.sliceUiState.collectAsState()
     val isFavorite by viewModel.isFavorite.collectAsState()
@@ -439,16 +574,18 @@ internal fun NowPlayingScreen(
     val tagViewModel: NowPlayingTagViewModel = hiltViewModel()
     val tagDialog by tagViewModel.dialogState.collectAsState()
     val availableTags by tagViewModel.availableTags.collectAsState()
+    val playerArtworkBackdropEnabled = coverBackgroundEnabled && !isVideo
     val playerThemeColors = rememberPlayerThemeColors(
         mediaItem = item,
         colorScheme = colorScheme,
-        coverBackgroundEnabled = coverBackgroundEnabled
+        coverBackgroundEnabled = coverBackgroundEnabled,
+        artworkBackdropEnabled = playerArtworkBackdropEnabled
     )
     val accentColor = playerThemeColors.accentColor
     val lyricColors = rememberLyricReadableColors(
         accentColor = accentColor,
         backdropTintColor = playerThemeColors.backdropTintColor,
-        coverBackgroundEnabled = coverBackgroundEnabled,
+        coverBackgroundEnabled = playerArtworkBackdropEnabled,
         coverBackgroundClarity = coverBackgroundClarity
     )
     val onAccentColor = playerThemeColors.onAccentColor
@@ -534,12 +671,6 @@ internal fun NowPlayingScreen(
     val toggleSelectedSlice = { sliceId: Long ->
         viewModel.selectSlice(if (sliceUiState.selectedSliceId == sliceId) null else sliceId)
     }
-    val highlightedPlaybackSliceId = currentSliceIdForPosition(
-        positionMs = playback.positionMs,
-        slices = sliceUiState.slices,
-        sliceModeEnabled = sliceUiState.sliceModeEnabled
-    )
-    
     val configuration = LocalConfiguration.current
     val isLandscape = configuration.orientation == Configuration.ORIENTATION_LANDSCAPE
     val widthClass = windowSizeClass.widthSizeClass
@@ -817,22 +948,43 @@ internal fun NowPlayingScreen(
                     ) {
                         Box(
                             modifier = Modifier
-                                .widthIn(max = 420.dp)
-                                .aspectRatio(if (isVideo) videoAspectRatio else 1f)
-                                .then(coverMotion)
+                                .then(
+                                    if (isVideo) {
+                                        Modifier
+                                            .fillMaxWidth()
+                                            .weight(1f)
+                                    } else {
+                                        Modifier
+                                            .widthIn(max = 420.dp)
+                                            .aspectRatio(1f)
+                                    }
+                                )
+                                .then(coverMotion),
+                            contentAlignment = Alignment.Center
                         ) {
-                            ArtworkBox(
-                                isVideo = isVideo,
-                                metadata = metadata,
-                                viewModel = viewModel,
-                                onOpenLyrics = showLyricsSurface,
-                                edgeBlendEnabled = false,
-                                edgeBlendColor = if (coverBackgroundEnabled) playerThemeColors.backdropTintColor else colorScheme.background,
-                                videoBackdropColor = videoBackdropColor,
-                                artworkAlignment = coverPreviewAlignment,
-                                dragPreviewEnabled = useDragPreview,
-                                dragPreviewState = coverDragPreviewState
-                            )
+                            Box(
+                                modifier = if (isVideo) {
+                                    Modifier.fitVideoPreviewAspectRatio(
+                                        aspectRatio = videoAspectRatio,
+                                        maxWidth = 420.dp
+                                    )
+                                } else {
+                                    Modifier.fillMaxSize()
+                                }
+                            ) {
+                                ArtworkBox(
+                                    isVideo = isVideo,
+                                    metadata = metadata,
+                                    viewModel = viewModel,
+                                    onOpenLyrics = showLyricsSurface,
+                                    edgeBlendEnabled = false,
+                                    edgeBlendColor = if (playerArtworkBackdropEnabled) playerThemeColors.backdropTintColor else colorScheme.background,
+                                    videoBackdropColor = videoBackdropColor,
+                                    artworkAlignment = coverPreviewAlignment,
+                                    dragPreviewEnabled = useDragPreview,
+                                    dragPreviewState = coverDragPreviewState
+                                )
+                            }
                         }
                         
                         key(item?.mediaId) {
@@ -841,24 +993,26 @@ internal fun NowPlayingScreen(
                                     .fillMaxWidth()
                                     .then(progressMotion)
                             ) {
-                                PlayerProgress(
-                                    positionMs = playback.positionMs,
-                                    durationMs = progressDurationMs,
-                                    sliceUiState = sliceUiState,
-                                    onSeekTo = { viewModel.seekTo(it) },
-                                    onCutPressed = { viewModel.onCutPressed(progressDurationMs) },
-                                    onScrubbingChanged = { viewModel.setUserScrubbing(it) },
-                                    onSelectSlice = { viewModel.selectSlice(it) },
-                                    onLongPressSlice = {
-                                        viewModel.selectSlice(it)
-                                        showSliceSheet = true
-                                    },
-                                    onUpdateSliceRange = { sliceId, startMs, endMs ->
-                                        viewModel.updateSliceRange(sliceId, startMs, endMs, progressDurationMs)
-                                    },
-                                    activeColor = accentColor,
-                                    inactiveColor = accentColor.copy(alpha = 0.2f)
-                                )
+                                PlaybackProgressContent(viewModel, isVideo) { progress ->
+                                    PlayerProgress(
+                                        positionMs = progress.positionMs,
+                                        durationMs = progressDurationMs,
+                                        sliceUiState = sliceUiState,
+                                        onSeekTo = { viewModel.seekTo(it) },
+                                        onCutPressed = { viewModel.onCutPressed(progressDurationMs) },
+                                        onScrubbingChanged = { viewModel.setUserScrubbing(it) },
+                                        onSelectSlice = { viewModel.selectSlice(it) },
+                                        onLongPressSlice = {
+                                            viewModel.selectSlice(it)
+                                            showSliceSheet = true
+                                        },
+                                        onUpdateSliceRange = { sliceId, startMs, endMs ->
+                                            viewModel.updateSliceRange(sliceId, startMs, endMs, progressDurationMs)
+                                        },
+                                        activeColor = accentColor,
+                                        inactiveColor = accentColor.copy(alpha = 0.2f)
+                                    )
+                                }
                             }
                         }
                     }
@@ -905,17 +1059,23 @@ internal fun NowPlayingScreen(
                                     }
                                 )
 
-                                AppleLyricsView(
-                                    lyrics = lyricsState.lyrics,
-                                    currentPosition = playback.positionMs,
-                                    onSeekTo = { viewModel.seekTo(it) },
-                                    onOpenLyrics = showLyricsSurface,
-                                    colors = lyricColors,
+                                Box(
                                     modifier = Modifier
                                         .weight(0.70f)
-                                        .fillMaxHeight(),
-                                    isLandscape = true
-                                )
+                                        .fillMaxHeight()
+                                ) {
+                                    PlaybackProgressContent(viewModel, isVideo) { progress ->
+                                        AppleLyricsView(
+                                            lyrics = lyricsState.lyrics,
+                                            currentPosition = progress.positionMs,
+                                            onSeekTo = { viewModel.seekTo(it) },
+                                            onOpenLyrics = showLyricsSurface,
+                                            colors = lyricColors,
+                                            modifier = Modifier.fillMaxSize(),
+                                            isLandscape = true
+                                        )
+                                    }
+                                }
 
                                 AndroidView(
                                     modifier = Modifier
@@ -1039,22 +1199,29 @@ internal fun NowPlayingScreen(
                         Box(
                             modifier = Modifier
                                 .weight(1f)
-                                .aspectRatio(if (isVideo) videoAspectRatio else 1f)
                                 .then(coverMotion),
                             contentAlignment = Alignment.Center
                         ) {
-                            ArtworkBox(
-                                isVideo = isVideo,
-                                metadata = metadata,
-                                viewModel = viewModel,
-                                onOpenLyrics = showLyricsSurface,
-                                edgeBlendEnabled = false,
-                                edgeBlendColor = if (coverBackgroundEnabled) playerThemeColors.backdropTintColor else colorScheme.background,
-                                videoBackdropColor = videoBackdropColor,
-                                artworkAlignment = coverPreviewAlignment,
-                                dragPreviewEnabled = useDragPreview,
-                                dragPreviewState = coverDragPreviewState
-                            )
+                            Box(
+                                modifier = if (isVideo) {
+                                    Modifier.fitVideoPreviewAspectRatio(videoAspectRatio)
+                                } else {
+                                    Modifier.aspectRatio(1f)
+                                }
+                            ) {
+                                ArtworkBox(
+                                    isVideo = isVideo,
+                                    metadata = metadata,
+                                    viewModel = viewModel,
+                                    onOpenLyrics = showLyricsSurface,
+                                    edgeBlendEnabled = false,
+                                    edgeBlendColor = if (playerArtworkBackdropEnabled) playerThemeColors.backdropTintColor else colorScheme.background,
+                                    videoBackdropColor = videoBackdropColor,
+                                    artworkAlignment = coverPreviewAlignment,
+                                    dragPreviewEnabled = useDragPreview,
+                                    dragPreviewState = coverDragPreviewState
+                                )
+                            }
                         }
 
                         key(item?.mediaId) {
@@ -1063,24 +1230,26 @@ internal fun NowPlayingScreen(
                                     .fillMaxWidth()
                                     .then(progressMotion)
                             ) {
-                                PlayerProgress(
-                                    positionMs = playback.positionMs,
-                                    durationMs = progressDurationMs,
-                                    sliceUiState = sliceUiState,
-                                    onSeekTo = { viewModel.seekTo(it) },
-                                    onCutPressed = { viewModel.onCutPressed(progressDurationMs) },
-                                    onScrubbingChanged = { viewModel.setUserScrubbing(it) },
-                                    onSelectSlice = { viewModel.selectSlice(it) },
-                                    onLongPressSlice = {
-                                        viewModel.selectSlice(it)
-                                        showSliceSheet = true
-                                    },
-                                    onUpdateSliceRange = { sliceId, startMs, endMs ->
-                                        viewModel.updateSliceRange(sliceId, startMs, endMs, progressDurationMs)
-                                    },
-                                    activeColor = accentColor,
-                                    inactiveColor = accentColor.copy(alpha = 0.2f)
-                                )
+                                PlaybackProgressContent(viewModel, isVideo) { progress ->
+                                    PlayerProgress(
+                                        positionMs = progress.positionMs,
+                                        durationMs = progressDurationMs,
+                                        sliceUiState = sliceUiState,
+                                        onSeekTo = { viewModel.seekTo(it) },
+                                        onCutPressed = { viewModel.onCutPressed(progressDurationMs) },
+                                        onScrubbingChanged = { viewModel.setUserScrubbing(it) },
+                                        onSelectSlice = { viewModel.selectSlice(it) },
+                                        onLongPressSlice = {
+                                            viewModel.selectSlice(it)
+                                            showSliceSheet = true
+                                        },
+                                        onUpdateSliceRange = { sliceId, startMs, endMs ->
+                                            viewModel.updateSliceRange(sliceId, startMs, endMs, progressDurationMs)
+                                        },
+                                        activeColor = accentColor,
+                                        inactiveColor = accentColor.copy(alpha = 0.2f)
+                                    )
+                                }
                             }
                         }
                     }
@@ -1116,17 +1285,23 @@ internal fun NowPlayingScreen(
                                     }
                                 )
 
-                                AppleLyricsView(
-                                    lyrics = lyricsState.lyrics,
-                                    currentPosition = playback.positionMs,
-                                    onSeekTo = { viewModel.seekTo(it) },
-                                    onOpenLyrics = showLyricsSurface,
-                                    colors = lyricColors,
+                                Box(
                                     modifier = Modifier
                                         .weight(0.72f)
-                                        .fillMaxHeight(),
-                                    isLandscape = true
-                                )
+                                        .fillMaxHeight()
+                                ) {
+                                    PlaybackProgressContent(viewModel, isVideo) { progress ->
+                                        AppleLyricsView(
+                                            lyrics = lyricsState.lyrics,
+                                            currentPosition = progress.positionMs,
+                                            onSeekTo = { viewModel.seekTo(it) },
+                                            onOpenLyrics = showLyricsSurface,
+                                            colors = lyricColors,
+                                            modifier = Modifier.fillMaxSize(),
+                                            isLandscape = true
+                                        )
+                                    }
+                                }
 
                                 AndroidView(
                                     modifier = Modifier
@@ -1293,8 +1468,7 @@ internal fun NowPlayingScreen(
                                     if (isVideo) {
                                         Modifier
                                             .widthIn(max = if (widthClass == WindowWidthSizeClass.Compact) 1000.dp else 400.dp)
-                                            .fillMaxWidth()
-                                            .aspectRatio(videoAspectRatio)
+                                            .fitVideoPreviewAspectRatio(videoAspectRatio)
                                     } else {
                                         Modifier
                                             .fillMaxHeight()
@@ -1309,7 +1483,7 @@ internal fun NowPlayingScreen(
                                 viewModel = viewModel,
                                 onOpenLyrics = showLyricsSurface,
                                 edgeBlendEnabled = false,
-                                edgeBlendColor = if (coverBackgroundEnabled) playerThemeColors.backdropTintColor else colorScheme.background,
+                                edgeBlendColor = if (playerArtworkBackdropEnabled) playerThemeColors.backdropTintColor else colorScheme.background,
                                 videoBackdropColor = videoBackdropColor,
                                 artworkAlignment = coverPreviewAlignment,
                                 dragPreviewEnabled = useDragPreview,
@@ -1319,15 +1493,17 @@ internal fun NowPlayingScreen(
                     }
 
                     if (!isVideo) {
-                        SingleLineLyrics(
-                            lyrics = lyricsState.lyrics,
-                            currentPosition = playback.positionMs,
-                            onOpenLyrics = showLyricsSurface,
-                            colors = lyricColors,
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .then(lyricsMotion)
-                        )
+                        PlaybackProgressContent(viewModel, isVideo) { progress ->
+                            SingleLineLyrics(
+                                lyrics = lyricsState.lyrics,
+                                currentPosition = progress.positionMs,
+                                onOpenLyrics = showLyricsSurface,
+                                colors = lyricColors,
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .then(lyricsMotion)
+                            )
+                        }
                     }
 
                     key(item?.mediaId) {
@@ -1336,24 +1512,26 @@ internal fun NowPlayingScreen(
                                 .fillMaxWidth()
                                 .then(progressMotion)
                         ) {
-                            PlayerProgress(
-                                positionMs = playback.positionMs,
-                                durationMs = progressDurationMs,
-                                sliceUiState = sliceUiState,
-                                onSeekTo = { viewModel.seekTo(it) },
-                                onCutPressed = { viewModel.onCutPressed(progressDurationMs) },
-                                onScrubbingChanged = { viewModel.setUserScrubbing(it) },
-                                onSelectSlice = { viewModel.selectSlice(it) },
-                                onLongPressSlice = {
-                                    viewModel.selectSlice(it)
-                                    showSliceSheet = true
-                                },
-                                onUpdateSliceRange = { sliceId, startMs, endMs ->
-                                    viewModel.updateSliceRange(sliceId, startMs, endMs, progressDurationMs)
-                                },
-                                activeColor = accentColor,
-                                inactiveColor = accentColor.copy(alpha = 0.2f)
-                            )
+                            PlaybackProgressContent(viewModel, isVideo) { progress ->
+                                PlayerProgress(
+                                    positionMs = progress.positionMs,
+                                    durationMs = progressDurationMs,
+                                    sliceUiState = sliceUiState,
+                                    onSeekTo = { viewModel.seekTo(it) },
+                                    onCutPressed = { viewModel.onCutPressed(progressDurationMs) },
+                                    onScrubbingChanged = { viewModel.setUserScrubbing(it) },
+                                    onSelectSlice = { viewModel.selectSlice(it) },
+                                    onLongPressSlice = {
+                                        viewModel.selectSlice(it)
+                                        showSliceSheet = true
+                                    },
+                                    onUpdateSliceRange = { sliceId, startMs, endMs ->
+                                        viewModel.updateSliceRange(sliceId, startMs, endMs, progressDurationMs)
+                                    },
+                                    activeColor = accentColor,
+                                    inactiveColor = accentColor.copy(alpha = 0.2f)
+                                )
+                            }
                         }
                     }
 
@@ -1398,18 +1576,20 @@ internal fun NowPlayingScreen(
             }
             }
             } else {
-                NowPlayingLyricsSurface(
-                    isLandscape = isLandscape,
-                    playbackPositionMs = playback.positionMs,
-                    lyrics = lyricsState.lyrics,
-                    lyricColors = lyricColors,
-                    lyricsPageSettings = lyricsPageSettings,
-                    onSeekTo = { viewModel.seekTo(it) },
-                    onAddLyrics = openManualLyricsAction,
-                    modifier = Modifier
-                        .fillMaxSize()
-                        .then(routeTransition.nowPlayingMotionModifier(currentMotionLayout, NowPlayingMotionSlot.COVER))
-                )
+                PlaybackProgressContent(viewModel, isVideo) { progress ->
+                    NowPlayingLyricsSurface(
+                        isLandscape = isLandscape,
+                        playbackPositionMs = progress.positionMs,
+                        lyrics = lyricsState.lyrics,
+                        lyricColors = lyricColors,
+                        lyricsPageSettings = lyricsPageSettings,
+                        onSeekTo = { viewModel.seekTo(it) },
+                        onAddLyrics = openManualLyricsAction,
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .then(routeTransition.nowPlayingMotionModifier(currentMotionLayout, NowPlayingMotionSlot.COVER))
+                    )
+                }
             }
                 }
             }
@@ -1458,22 +1638,29 @@ internal fun NowPlayingScreen(
 
                     Spacer(modifier = Modifier.height(10.dp))
 
-                    SliceOverviewBar(
-                        positionMs = playback.positionMs,
-                        durationMs = progressDurationMs,
-                        slices = sliceUiState.slices,
-                        highlightedSliceId = highlightedPlaybackSliceId,
-                        selectedSliceId = sliceUiState.selectedSliceId,
-                        activeColor = accentColor,
-                        inactiveColor = accentColor.copy(alpha = 0.18f),
-                        onSeekTo = { viewModel.seekTo(it) },
-                        onSelectSlice = { id ->
-                            if (id == null) viewModel.selectSlice(null) else toggleSelectedSlice(id)
-                        },
-                        onLongPressSlice = { id ->
-                            toggleSelectedSlice(id)
-                        }
-                    )
+                    PlaybackProgressContent(viewModel, isVideo) { progress ->
+                        val highlightedPlaybackSliceId = currentSliceIdForPosition(
+                            positionMs = progress.positionMs,
+                            slices = sliceUiState.slices,
+                            sliceModeEnabled = sliceUiState.sliceModeEnabled
+                        )
+                        SliceOverviewBar(
+                            positionMs = progress.positionMs,
+                            durationMs = progressDurationMs,
+                            slices = sliceUiState.slices,
+                            highlightedSliceId = highlightedPlaybackSliceId,
+                            selectedSliceId = sliceUiState.selectedSliceId,
+                            activeColor = accentColor,
+                            inactiveColor = accentColor.copy(alpha = 0.18f),
+                            onSeekTo = { viewModel.seekTo(it) },
+                            onSelectSlice = { id ->
+                                if (id == null) viewModel.selectSlice(null) else toggleSelectedSlice(id)
+                            },
+                            onLongPressSlice = { id ->
+                                toggleSelectedSlice(id)
+                            }
+                        )
+                    }
 
                     Spacer(modifier = Modifier.height(10.dp))
 
@@ -1568,21 +1755,23 @@ internal fun NowPlayingScreen(
         if (edit != null) {
             val slice = sliceUiState.slices.firstOrNull { it.id == edit.first }
             if (slice != null) {
-                SliceTimeEditDialog(
-                    title = if (edit.second) "修改起点" else "修改终点",
-                    durationMs = progressDurationMs,
-                    currentMs = playback.positionMs,
-                    initialMs = if (edit.second) slice.startMs else slice.endMs,
-                    onDismiss = { timeEditTarget = null },
-                    onConfirm = { newMs ->
-                        if (edit.second) {
-                            viewModel.updateSliceRange(slice.id, newMs, slice.endMs, progressDurationMs)
-                        } else {
-                            viewModel.updateSliceRange(slice.id, slice.startMs, newMs, progressDurationMs)
+                PlaybackProgressContent(viewModel, isVideo) { progress ->
+                    SliceTimeEditDialog(
+                        title = if (edit.second) "修改起点" else "修改终点",
+                        durationMs = progressDurationMs,
+                        currentMs = progress.positionMs,
+                        initialMs = if (edit.second) slice.startMs else slice.endMs,
+                        onDismiss = { timeEditTarget = null },
+                        onConfirm = { newMs ->
+                            if (edit.second) {
+                                viewModel.updateSliceRange(slice.id, newMs, slice.endMs, progressDurationMs)
+                            } else {
+                                viewModel.updateSliceRange(slice.id, slice.startMs, newMs, progressDurationMs)
+                            }
+                            timeEditTarget = null
                         }
-                        timeEditTarget = null
-                    }
-                )
+                    )
+                }
             } else {
                 timeEditTarget = null
             }

--- a/app/src/main/java/com/asmr/player/ui/player/PlayerDynamicHue.kt
+++ b/app/src/main/java/com/asmr/player/ui/player/PlayerDynamicHue.kt
@@ -5,9 +5,7 @@ import androidx.compose.runtime.State
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.toArgb
 import androidx.media3.common.MediaItem
-import androidx.core.graphics.ColorUtils
 import com.asmr.player.toThemeMediaSource
 import com.asmr.player.ui.theme.AsmrColorScheme
 import com.asmr.player.ui.theme.HuePalette
@@ -16,6 +14,9 @@ import com.asmr.player.ui.theme.deriveHuePalette
 import com.asmr.player.ui.theme.neutralPaletteForMode
 import com.asmr.player.ui.theme.rememberDynamicHuePalette
 import com.asmr.player.ui.theme.rememberDynamicHuePaletteFromVideoFrame
+import kotlin.math.abs
+import kotlin.math.max
+import kotlin.math.min
 
 @Composable
 internal fun rememberPlayerDynamicHuePalette(
@@ -74,6 +75,7 @@ internal fun rememberPlayerThemeColors(
     mediaItem: MediaItem?,
     colorScheme: AsmrColorScheme,
     coverBackgroundEnabled: Boolean,
+    artworkBackdropEnabled: Boolean = coverBackgroundEnabled,
     transitionDurationMs: Int = 1000,
     cachedTransitionDurationMs: Int = 260
 ): PlayerThemeColors {
@@ -84,11 +86,12 @@ internal fun rememberPlayerThemeColors(
         cachedTransitionDurationMs = cachedTransitionDurationMs
     )
 
-    return remember(dynamicHue, colorScheme, coverBackgroundEnabled) {
+    return remember(dynamicHue, colorScheme, coverBackgroundEnabled, artworkBackdropEnabled) {
         resolvePlayerThemeColors(
             dynamicHue = dynamicHue,
             colorScheme = colorScheme,
-            coverBackgroundEnabled = coverBackgroundEnabled
+            coverBackgroundEnabled = coverBackgroundEnabled,
+            artworkBackdropEnabled = artworkBackdropEnabled
         )
     }
 }
@@ -96,7 +99,8 @@ internal fun rememberPlayerThemeColors(
 internal fun resolvePlayerThemeColors(
     dynamicHue: HuePalette,
     colorScheme: AsmrColorScheme,
-    coverBackgroundEnabled: Boolean
+    coverBackgroundEnabled: Boolean,
+    artworkBackdropEnabled: Boolean = coverBackgroundEnabled
 ): PlayerThemeColors {
     val accentColor = if (coverBackgroundEnabled) {
         dynamicHue.primaryStrong
@@ -108,21 +112,32 @@ internal fun resolvePlayerThemeColors(
     } else {
         colorScheme.onPrimary
     }
-    val backdropTintColor = if (coverBackgroundEnabled) {
+    val dynamicBackdropTintColor = derivePlayerBackdropTintColor(
+        primary = dynamicHue.primary,
+        primarySoft = dynamicHue.primarySoft,
+        background = colorScheme.background,
+        mode = colorScheme.mode
+    )
+    val backdropTintColor = if (artworkBackdropEnabled) {
+        dynamicBackdropTintColor
+    } else {
+        colorScheme.background
+    }
+    val videoBackdropColor = if (coverBackgroundEnabled) {
+        dynamicBackdropTintColor
+    } else {
         derivePlayerBackdropTintColor(
-            primary = dynamicHue.primary,
-            primarySoft = dynamicHue.primarySoft,
+            primary = colorScheme.primary,
+            primarySoft = colorScheme.primarySoft,
             background = colorScheme.background,
             mode = colorScheme.mode
         )
-    } else {
-        colorScheme.background
     }
     return PlayerThemeColors(
         accentColor = accentColor,
         onAccentColor = onAccentColor,
         backdropTintColor = backdropTintColor,
-        videoBackdropColor = backdropTintColor
+        videoBackdropColor = videoBackdropColor
     )
 }
 
@@ -132,30 +147,25 @@ internal fun derivePlayerBackdropTintColor(
     background: Color,
     mode: ThemeMode
 ): Color {
-    val seedMixed = Color(
-        ColorUtils.blendARGB(
-            primarySoft.toArgb(),
-            primary.toArgb(),
-            when (mode) {
-                ThemeMode.Light -> 0.52f
-                ThemeMode.Dark -> 0.72f
-                ThemeMode.SoftDark -> 0.64f
-            }
-        )
+    val seedMixed = blendSrgbColors(
+        start = primarySoft,
+        end = primary,
+        fraction = when (mode) {
+            ThemeMode.Light -> 0.52f
+            ThemeMode.Dark -> 0.72f
+            ThemeMode.SoftDark -> 0.64f
+        }
     )
-    val mixed = Color(
-        ColorUtils.blendARGB(
-            background.toArgb(),
-            seedMixed.toArgb(),
-            when (mode) {
-                ThemeMode.Light -> 0.86f
-                ThemeMode.Dark -> 0.88f
-                ThemeMode.SoftDark -> 0.86f
-            }
-        )
+    val mixed = blendSrgbColors(
+        start = background,
+        end = seedMixed,
+        fraction = when (mode) {
+            ThemeMode.Light -> 0.86f
+            ThemeMode.Dark -> 0.88f
+            ThemeMode.SoftDark -> 0.86f
+        }
     )
-    val hsl = FloatArray(3)
-    ColorUtils.colorToHSL(mixed.toArgb(), hsl)
+    val hsl = mixed.toHsl()
 
     when (mode) {
         ThemeMode.Light -> {
@@ -172,5 +182,81 @@ internal fun derivePlayerBackdropTintColor(
         }
     }
 
-    return Color(ColorUtils.HSLToColor(hsl))
+    return hslToColor(hsl)
+}
+
+private fun blendSrgbColors(
+    start: Color,
+    end: Color,
+    fraction: Float
+): Color {
+    val t = fraction.coerceIn(0f, 1f)
+    return Color(
+        red = start.red + (end.red - start.red) * t,
+        green = start.green + (end.green - start.green) * t,
+        blue = start.blue + (end.blue - start.blue) * t,
+        alpha = start.alpha + (end.alpha - start.alpha) * t
+    )
+}
+
+private fun Color.toHsl(): FloatArray {
+    val maxComponent = max(red, max(green, blue))
+    val minComponent = min(red, min(green, blue))
+    val lightness = (maxComponent + minComponent) / 2f
+    if (abs(maxComponent - minComponent) < 0.00001f) {
+        return floatArrayOf(0f, 0f, lightness)
+    }
+
+    val delta = maxComponent - minComponent
+    val saturation = if (lightness > 0.5f) {
+        delta / (2f - maxComponent - minComponent)
+    } else {
+        delta / (maxComponent + minComponent)
+    }
+    val hue = when (maxComponent) {
+        red -> ((green - blue) / delta + if (green < blue) 6f else 0f) * 60f
+        green -> ((blue - red) / delta + 2f) * 60f
+        else -> ((red - green) / delta + 4f) * 60f
+    }
+    return floatArrayOf(hue, saturation, lightness)
+}
+
+private fun hslToColor(hsl: FloatArray): Color {
+    val hue = ((hsl[0] % 360f) + 360f) % 360f
+    val saturation = hsl[1].coerceIn(0f, 1f)
+    val lightness = hsl[2].coerceIn(0f, 1f)
+    if (saturation <= 0f) {
+        return Color(lightness, lightness, lightness)
+    }
+
+    val q = if (lightness < 0.5f) {
+        lightness * (1f + saturation)
+    } else {
+        lightness + saturation - lightness * saturation
+    }
+    val p = 2f * lightness - q
+    val hk = hue / 360f
+    return Color(
+        red = hueToRgb(p, q, hk + 1f / 3f),
+        green = hueToRgb(p, q, hk),
+        blue = hueToRgb(p, q, hk - 1f / 3f)
+    )
+}
+
+private fun hueToRgb(
+    p: Float,
+    q: Float,
+    hue: Float
+): Float {
+    val t = when {
+        hue < 0f -> hue + 1f
+        hue > 1f -> hue - 1f
+        else -> hue
+    }
+    return when {
+        t < 1f / 6f -> p + (q - p) * 6f * t
+        t < 1f / 2f -> q
+        t < 2f / 3f -> p + (q - p) * (2f / 3f - t) * 6f
+        else -> p
+    }.coerceIn(0f, 1f)
 }

--- a/app/src/main/java/com/asmr/player/ui/player/PlayerSharedBackdrop.kt
+++ b/app/src/main/java/com/asmr/player/ui/player/PlayerSharedBackdrop.kt
@@ -4,12 +4,12 @@ import android.net.Uri
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
-import com.asmr.player.playback.PlaybackSnapshot
+import androidx.media3.common.MediaItem
 import com.asmr.player.ui.theme.AsmrTheme
 
 @Composable
 internal fun PlayerSharedBackdrop(
-    playback: PlaybackSnapshot,
+    mediaItem: MediaItem?,
     enabled: Boolean,
     clarity: Float,
     artworkAlignment: Alignment
@@ -17,22 +17,19 @@ internal fun PlayerSharedBackdrop(
     if (!enabled) return
 
     val colorScheme = AsmrTheme.colorScheme
-    val item = playback.currentMediaItem
-    val metadata = item?.mediaMetadata
-    val uriText = item?.localConfiguration?.uri?.toString().orEmpty()
-    val mimeType = item?.localConfiguration?.mimeType.orEmpty()
+    val metadata = mediaItem?.mediaMetadata
+    val uriText = mediaItem?.localConfiguration?.uri?.toString().orEmpty()
+    val mimeType = mediaItem?.localConfiguration?.mimeType.orEmpty()
     val ext = uriText.substringBefore('#').substringBefore('?').substringAfterLast('.', "").lowercase()
     val isVideo = metadata?.extras?.getBoolean("is_video") == true ||
         mimeType.startsWith("video/") ||
         ext in setOf("mp4", "m4v", "webm", "mkv", "mov")
 
-    if (isVideo) return
-
     val artworkModel = remember(metadata?.artworkUri) {
         sanitizeBackdropArtworkModel(metadata?.artworkUri)
     }
     val playerThemeColors = rememberPlayerThemeColors(
-        mediaItem = item,
+        mediaItem = mediaItem,
         colorScheme = colorScheme,
         coverBackgroundEnabled = enabled,
         transitionDurationMs = 0,
@@ -44,7 +41,7 @@ internal fun PlayerSharedBackdrop(
         enabled = enabled,
         clarity = clarity,
         overlayBaseColor = colorScheme.background,
-        tintBaseColor = playerThemeColors.backdropTintColor,
+        tintBaseColor = if (isVideo) playerThemeColors.videoBackdropColor else playerThemeColors.backdropTintColor,
         artworkAlignment = artworkAlignment,
         isDark = colorScheme.isDark
     )

--- a/app/src/main/java/com/asmr/player/ui/player/nowplaying/NowPlayingSurfaceComponents.kt
+++ b/app/src/main/java/com/asmr/player/ui/player/nowplaying/NowPlayingSurfaceComponents.kt
@@ -253,6 +253,12 @@ internal fun ArtworkBox(
 ) {
     val shape = RoundedCornerShape(28.dp)
     val hasArtwork = metadata?.artworkUri != null
+    val videoSurfaceHandle = remember(viewModel) {
+        VideoSurfaceVisibilityHandle { visible -> viewModel.setVideoSurfaceVisible(visible) }
+    }
+    DisposableEffect(videoSurfaceHandle) {
+        onDispose { videoSurfaceHandle.releaseAll() }
+    }
     Box(
         modifier = modifier
             .fillMaxSize()
@@ -271,6 +277,8 @@ internal fun ArtworkBox(
             if (!fullscreen) {
                 NowPlayingVideoPlayer(
                     player = player,
+                    onSurfaceVisible = videoSurfaceHandle::acquire,
+                    onSurfaceHidden = videoSurfaceHandle::release,
                     fullscreen = false,
                     onToggleFullscreen = { fullscreen = true },
                     viewKey = "inline",
@@ -288,6 +296,8 @@ internal fun ArtworkBox(
                 ) {
                     NowPlayingVideoPlayer(
                         player = player,
+                        onSurfaceVisible = videoSurfaceHandle::acquire,
+                        onSurfaceHidden = videoSurfaceHandle::release,
                         fullscreen = true,
                         onToggleFullscreen = { fullscreen = false },
                         viewKey = "fullscreen",
@@ -336,6 +346,8 @@ internal fun ArtworkBox(
 @Composable
 private fun NowPlayingVideoPlayer(
     player: Player?,
+    onSurfaceVisible: () -> Unit,
+    onSurfaceHidden: () -> Unit,
     fullscreen: Boolean,
     onToggleFullscreen: () -> Unit,
     viewKey: String,
@@ -343,10 +355,12 @@ private fun NowPlayingVideoPlayer(
     modifier: Modifier = Modifier
 ) {
     var playerView by remember { mutableStateOf<PlayerView?>(null) }
-    DisposableEffect(viewKey) {
+    DisposableEffect(viewKey, player) {
+        if (player != null) onSurfaceVisible()
         onDispose {
             playerView?.player = null
             playerView = null
+            if (player != null) onSurfaceHidden()
         }
     }
 
@@ -364,12 +378,15 @@ private fun NowPlayingVideoPlayer(
                         pv.useController = false
                         pv.player = player
                         pv.resizeMode = androidx.media3.ui.AspectRatioFrameLayout.RESIZE_MODE_FIT
+                        pv.setBackgroundColor(backdropColor.toArgb())
                         pv.setShutterBackgroundColor(backdropColor.toArgb())
                         playerView = pv
                     }
                 },
                 update = { view ->
                     if (view.player !== player) view.player = player
+                    view.setBackgroundColor(backdropColor.toArgb())
+                    view.setShutterBackgroundColor(backdropColor.toArgb())
                 }
             )
         }
@@ -387,6 +404,29 @@ private fun NowPlayingVideoPlayer(
                 tint = Color.White
             )
         }
+    }
+}
+
+private class VideoSurfaceVisibilityHandle(
+    private val onVisibleChanged: (Boolean) -> Unit
+) {
+    private var visibleCount = 0
+
+    fun acquire() {
+        visibleCount += 1
+        if (visibleCount == 1) onVisibleChanged(true)
+    }
+
+    fun release() {
+        if (visibleCount <= 0) return
+        visibleCount -= 1
+        if (visibleCount == 0) onVisibleChanged(false)
+    }
+
+    fun releaseAll() {
+        if (visibleCount == 0) return
+        visibleCount = 0
+        onVisibleChanged(false)
     }
 }
 

--- a/app/src/main/java/com/asmr/player/ui/player/playerviewmodel.kt
+++ b/app/src/main/java/com/asmr/player/ui/player/playerviewmodel.kt
@@ -70,7 +70,7 @@ import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
 
-private const val ONLINE_MANUAL_LYRICS_MESSAGE = "\u5728\u7ebf\u97f3\u9891\u5982\u9700\u66ff\u6362\u6b4c\u8bcd\uff0c\u8bf7\u5148\u4e0b\u8f7d\u97f3\u9891\u5230\u672c\u5730"
+private const val ONLINE_MANUAL_LYRICS_MESSAGE = "在线音频如需替换歌词，请先下载音频到本地"
 
 @HiltViewModel
 @OptIn(FlowPreview::class)
@@ -257,15 +257,16 @@ class PlayerViewModel @Inject constructor(
         }
 
         viewModelScope.launch {
-            trackMediaIdFlow.collect { }
+            playback
+                .map { it.currentMediaItem }
+                .distinctUntilChanged { old, new -> old?.mediaId == new?.mediaId }
+                .collect { item ->
+                    handleListenTogetherState(
+                        mediaId = item?.mediaId?.takeIf { id -> id.isNotBlank() },
+                        item = item
+                    )
+                }
         }
-
-        viewModelScope.launch {
-            playback.collect { snapshot ->
-                handleListenTogetherState(snapshot)
-            }
-        }
-
     }
 
     @OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
@@ -394,7 +395,6 @@ class PlayerViewModel @Inject constructor(
     fun setPlaybackSpeed(speed: Float) = playerConnection.setPlaybackSpeed(speed)
     fun setPlaybackPitch(pitch: Float) = playerConnection.setPlaybackPitch(pitch)
     fun setPlaybackParameters(speed: Float, pitch: Float) = playerConnection.setPlaybackParameters(speed, pitch)
-
     fun setUserScrubbing(scrubbing: Boolean) {
         slicePlaybackController.setUserScrubbing(scrubbing)
     }
@@ -772,6 +772,10 @@ class PlayerViewModel @Inject constructor(
 
     fun playerOrNull(): Player? = playerConnection.getControllerOrNull()
 
+    fun setVideoSurfaceVisible(visible: Boolean) {
+        playerConnection.setVideoSurfaceVisible(visible)
+    }
+
     override fun onCleared() {
         listenTogetherSyncJob?.cancel()
         val identity = activeListenTogetherIdentity
@@ -810,8 +814,7 @@ class PlayerViewModel @Inject constructor(
         }
     }
 
-    private suspend fun handleListenTogetherState(snapshot: PlaybackSnapshot) {
-        val item = snapshot.currentMediaItem
+    private suspend fun handleListenTogetherState(mediaId: String?, item: MediaItem?) {
         if (item == null) {
             stopListenTogether(clearCount = true)
             listenTogetherLastFailedMediaId = null
@@ -827,7 +830,8 @@ class PlayerViewModel @Inject constructor(
         }
 
         val currentIdentity = activeListenTogetherIdentity
-        if (currentIdentity != null && currentIdentity.mediaId == item.mediaId) {
+        val itemMediaId = mediaId.orEmpty().ifBlank { item.mediaId }
+        if (currentIdentity != null && currentIdentity.mediaId == itemMediaId) {
             _listenTogetherUiState.value = _listenTogetherUiState.value.copy(
                 syncing = listenTogetherRepository.isBackendConfigured,
                 backendConfigured = listenTogetherRepository.isBackendConfigured,
@@ -840,7 +844,7 @@ class PlayerViewModel @Inject constructor(
             return
         }
 
-        if (item.mediaId == listenTogetherLastFailedMediaId) {
+        if (itemMediaId == listenTogetherLastFailedMediaId) {
             _listenTogetherUiState.value = ListenTogetherUiState(
                 available = false,
                 listenerCount = null,
@@ -871,7 +875,7 @@ class PlayerViewModel @Inject constructor(
         }.getOrNull()
 
         if (identity == null) {
-            listenTogetherLastFailedMediaId = item.mediaId
+            listenTogetherLastFailedMediaId = itemMediaId
             _listenTogetherUiState.value = ListenTogetherUiState(
                 available = false,
                 listenerCount = null,

--- a/app/src/main/res/layout/view_now_playing_video_player.xml
+++ b/app/src/main/res/layout/view_now_playing_video_player.xml
@@ -4,5 +4,5 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     app:resize_mode="fit"
-    app:surface_type="texture_view"
+    app:surface_type="surface_view"
     app:use_controller="false" />

--- a/app/src/test/java/com/asmr/player/ui/player/PlayerDynamicHueTest.kt
+++ b/app/src/test/java/com/asmr/player/ui/player/PlayerDynamicHueTest.kt
@@ -53,7 +53,7 @@ class PlayerDynamicHueTest {
     }
 
     @Test
-    fun playerThemeColors_fallsBackToThemeAccent_whenCoverBackgroundDisabled() {
+    fun playerThemeColors_fallsBackToThemeAccentAndTintedVideoBackdrop_whenCoverBackgroundDisabled() {
         val dynamicHue = com.asmr.player.ui.theme.HuePalette(
             primary = Color(0xFF3A6EA5),
             primarySoft = Color(0xFFD7E3F4),
@@ -83,7 +83,58 @@ class PlayerDynamicHueTest {
         assertEquals(colorScheme.primary, result.accentColor)
         assertEquals(colorScheme.onPrimary, result.onAccentColor)
         assertEquals(colorScheme.background, result.backdropTintColor)
-        assertEquals(colorScheme.background, result.videoBackdropColor)
+        assertEquals(
+            derivePlayerBackdropTintColor(
+                primary = colorScheme.primary,
+                primarySoft = colorScheme.primarySoft,
+                background = colorScheme.background,
+                mode = colorScheme.mode
+            ),
+            result.videoBackdropColor
+        )
+    }
+
+    @Test
+    fun playerThemeColors_keepsDynamicAccentForVideoWhenArtworkBackdropDisabled() {
+        val dynamicHue = com.asmr.player.ui.theme.HuePalette(
+            primary = Color(0xFFB8576A),
+            primarySoft = Color(0xFFF6D4DB),
+            primaryStrong = Color(0xFF8D3044),
+            onPrimary = Color.White,
+            secondary = Color(0xFFB07182),
+            onPrimaryContainer = Color(0xFF351019),
+            onSecondary = Color.White,
+            background = Color(0xFFFFF7F8),
+            onBackground = Color(0xFF24191B),
+            surface = Color.White,
+            onSurface = Color(0xFF24191B),
+            surfaceVariant = Color(0xFFF3E4E7),
+            onSurfaceVariant = Color(0xFF6C5960),
+            textPrimary = Color(0xFF24191B),
+            textSecondary = Color(0xFF6C5960),
+            textTertiary = Color(0xFF917D84)
+        )
+        val colorScheme = testColorScheme()
+
+        val result = resolvePlayerThemeColors(
+            dynamicHue = dynamicHue,
+            colorScheme = colorScheme,
+            coverBackgroundEnabled = true,
+            artworkBackdropEnabled = false
+        )
+
+        assertEquals(dynamicHue.primaryStrong, result.accentColor)
+        assertEquals(dynamicHue.onPrimary, result.onAccentColor)
+        assertEquals(colorScheme.background, result.backdropTintColor)
+        assertEquals(
+            derivePlayerBackdropTintColor(
+                primary = dynamicHue.primary,
+                primarySoft = dynamicHue.primarySoft,
+                background = colorScheme.background,
+                mode = colorScheme.mode
+            ),
+            result.videoBackdropColor
+        )
     }
 
     @Test


### PR DESCRIPTION
## Summary
- optimize video playback rendering so video tracks are disabled while the video surface is not visible
- reduce playback snapshot churn and isolate progress-driven recomposition in the player UI
- refine dynamic player backdrop/video presentation paths and related tests

## Verification
- .\\gradlew-local.bat :app:compileReleaseKotlin
- .\\gradlew-local.bat :app:installRelease