### PR TITLE
Add asmr.one backend track tree support

### DIFF
--- a/app/src/main/java/com/asmr/player/data/remote/api/AsmrOneAvailabilityApi.kt
+++ b/app/src/main/java/com/asmr/player/data/remote/api/AsmrOneAvailabilityApi.kt
@@ -6,6 +6,7 @@ import com.asmr.player.data.remote.NetworkHeaders
 import com.asmr.player.data.remote.withSearchTimeouts
 import com.asmr.player.listentogether.XxHash64
 import com.google.gson.Gson
+import com.google.gson.reflect.TypeToken
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import okhttp3.MediaType.Companion.toMediaType
@@ -14,6 +15,7 @@ import okhttp3.Request
 import okhttp3.RequestBody.Companion.toRequestBody
 import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 import java.io.IOException
+import java.util.concurrent.TimeUnit
 import java.util.UUID
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -70,11 +72,21 @@ class AsmrOneAvailabilityApi @Inject constructor(
     private val okHttpClient: OkHttpClient,
     private val gson: Gson
 ) {
+    internal constructor(
+        okHttpClient: OkHttpClient,
+        gson: Gson,
+        baseUrlProvider: () -> String
+    ) : this(okHttpClient, gson) {
+        this.baseUrlProvider = baseUrlProvider
+    }
+
+    private var baseUrlProvider: () -> String = { BuildConfig.LISTEN_TOGETHER_BASE_URL }
     private val clientSessionId = UUID.randomUUID().toString()
     private val appHeaderValue = "com.asmr.player/${BuildConfig.VERSION_NAME} (${BuildConfig.VERSION_CODE})"
     private val deviceFingerprint = buildDeviceFingerprint()
     private val userAgent = buildUserAgent()
     private val requestClient by lazy { okHttpClient.withSearchTimeouts() }
+    private val trackTreeClient by lazy { okHttpClient.withBackendTrackTreeTimeouts() }
 
     suspend fun check(rjs: List<String>): Map<String, Boolean> {
         val normalized = rjs
@@ -84,7 +96,7 @@ class AsmrOneAvailabilityApi @Inject constructor(
             .distinct()
             .take(MAX_RJS)
             .toList()
-        if (normalized.isEmpty() || baseUrl.isBlank()) return emptyMap()
+        if (normalized.isEmpty() || backendBaseUrl.isBlank()) return emptyMap()
 
         return runCatching {
             withContext(Dispatchers.IO) {
@@ -102,14 +114,48 @@ class AsmrOneAvailabilityApi @Inject constructor(
                     val raw = response.body?.string().orEmpty()
                     if (raw.isBlank()) return@withContext emptyMap()
                     val parsed = gson.fromJson(raw, AsmrOneAvailabilityResponse::class.java)
-                    parsed.items.associate { it.rj.trim().uppercase() to it.collected }
+                    val requested = normalized.toSet()
+                    buildMap {
+                        parsed.items.forEach { item ->
+                            item.matchedRequestRjs(requested).forEach { rj ->
+                                put(rj, item.collected)
+                            }
+                        }
+                    }
                 }
             }
         }.getOrDefault(emptyMap())
     }
 
+    suspend fun findCollectedWorkId(rj: String): String? {
+        val normalized = rj.trim().uppercase()
+        if (!RJ_CODE_REGEX.matches(normalized) || backendBaseUrl.isBlank()) return null
+        return runCatching {
+            withContext(Dispatchers.IO) {
+                val request = Request.Builder()
+                    .url(resolveUrl("api/asmr-one/availability"))
+                    .header("User-Agent", userAgent)
+                    .header("X-Listen-Together-App", appHeaderValue)
+                    .header("X-Listen-Together-Client-Session-Id", clientSessionId)
+                    .header("X-Listen-Together-Device-Fingerprint", deviceFingerprint)
+                    .header(NetworkHeaders.HEADER_SILENT_IO_ERROR, NetworkHeaders.SILENT_IO_ERROR_ON)
+                    .post(gson.toJson(AsmrOneAvailabilityRequest(listOf(normalized))).toRequestBody(JSON_MEDIA_TYPE))
+                    .build()
+                requestClient.newCall(request).execute().use { response ->
+                    if (!response.isSuccessful) return@withContext null
+                    val raw = response.body?.string().orEmpty()
+                    if (raw.isBlank()) return@withContext null
+                    val parsed = gson.fromJson(raw, AsmrOneAvailabilityResponse::class.java)
+                    parsed.items.firstOrNull { item ->
+                        item.collected && item.matchedRequestRjs(setOf(normalized)).isNotEmpty()
+                    }?.workId?.takeIf { it > 0 }?.toString()
+                }
+            }
+        }.getOrNull()
+    }
+
     suspend fun search(keyword: String, limit: Int, offset: Int, sort: String): AsmrOneCollectedSearchResponse {
-        if (baseUrl.isBlank()) throw IOException("asmr.one backend is not configured")
+        if (backendBaseUrl.isBlank()) throw IOException("asmr.one backend is not configured")
         return withContext(Dispatchers.IO) {
             val url = resolveUrl("api/asmr-one/search")
                 .toHttpUrlOrNull()
@@ -141,19 +187,54 @@ class AsmrOneAvailabilityApi @Inject constructor(
         }
     }
 
+    suspend fun getTrackTree(workId: String): List<AsmrOneTrackNodeResponse> {
+        if (backendBaseUrl.isBlank()) throw IOException("asmr.one backend is not configured")
+        val normalizedId = workId.trim()
+        if (normalizedId.isBlank()) throw IOException("asmr.one work id is blank")
+        return withContext(Dispatchers.IO) {
+            val url = resolveUrl("api/asmr-one/tracks")
+                .toHttpUrlOrNull()
+                ?.newBuilder()
+                ?.addQueryParameter("workId", normalizedId)
+                ?.build()
+                ?: throw IOException("invalid asmr.one tracks backend url")
+            val request = Request.Builder()
+                .url(url)
+                .header("User-Agent", userAgent)
+                .header("X-Listen-Together-App", appHeaderValue)
+                .header("X-Listen-Together-Client-Session-Id", clientSessionId)
+                .header("X-Listen-Together-Device-Fingerprint", deviceFingerprint)
+                .header(NetworkHeaders.HEADER_SILENT_IO_ERROR, NetworkHeaders.SILENT_IO_ERROR_ON)
+                .get()
+                .build()
+            trackTreeClient.newCall(request).execute().use { response ->
+                if (!response.isSuccessful) {
+                    throw IOException("asmr.one tracks backend failed: HTTP ${response.code}")
+                }
+                val raw = response.body?.string().orEmpty()
+                if (raw.isBlank()) return@withContext emptyList()
+                val listType = object : TypeToken<List<AsmrOneTrackNodeResponse>>() {}.type
+                gson.fromJson<List<AsmrOneTrackNodeResponse>>(raw, listType).orEmpty()
+            }
+        }
+    }
+
     private fun resolveUrl(path: String): String {
-        val root = baseUrl.trimEnd('/')
+        val root = backendBaseUrl.trimEnd('/')
         val normalizedPath = path.trimStart('/')
         return "$root/$normalizedPath"
     }
 
+    private val backendBaseUrl: String
+        get() = baseUrlProvider().trim()
+
     private fun buildDeviceFingerprint(): String {
         val source = listOf(
-            Build.BRAND,
-            Build.MANUFACTURER,
-            Build.MODEL,
-            Build.DEVICE,
-            Build.PRODUCT,
+            Build.BRAND.orEmpty(),
+            Build.MANUFACTURER.orEmpty(),
+            Build.MODEL.orEmpty(),
+            Build.DEVICE.orEmpty(),
+            Build.PRODUCT.orEmpty(),
             Build.VERSION.SDK_INT.toString(),
             BuildConfig.APPLICATION_ID,
             BuildConfig.VERSION_NAME,
@@ -162,7 +243,7 @@ class AsmrOneAvailabilityApi @Inject constructor(
     }
 
     private fun buildUserAgent(): String {
-        val deviceModel = listOf(Build.MANUFACTURER, Build.MODEL)
+        val deviceModel = listOf(Build.MANUFACTURER.orEmpty(), Build.MODEL.orEmpty())
             .map { it.trim() }
             .filter { it.isNotBlank() }
             .joinToString(separator = " ")
@@ -174,7 +255,27 @@ class AsmrOneAvailabilityApi @Inject constructor(
         private val JSON_MEDIA_TYPE = "application/json; charset=utf-8".toMediaType()
         private val RJ_CODE_REGEX = Regex("""RJ\d{6,}""")
         private const val MAX_RJS = 100
-        private val baseUrl: String
-            get() = BuildConfig.LISTEN_TOGETHER_BASE_URL
     }
 }
+
+private fun AsmrOneAvailabilityItem.matchedRequestRjs(requested: Set<String>): List<String> {
+    if (requested.isEmpty()) return emptyList()
+    return buildList {
+        add(rj)
+        add(originalWorkno)
+        addAll(matchedRjs)
+    }
+        .asSequence()
+        .map { it.trim().uppercase() }
+        .filter { it in requested }
+        .distinct()
+        .toList()
+}
+
+private fun OkHttpClient.withBackendTrackTreeTimeouts(): OkHttpClient =
+    newBuilder()
+        .callTimeout(3, TimeUnit.SECONDS)
+        .connectTimeout(2, TimeUnit.SECONDS)
+        .readTimeout(3, TimeUnit.SECONDS)
+        .writeTimeout(3, TimeUnit.SECONDS)
+        .build()

--- a/app/src/main/java/com/asmr/player/main/MainContainer.kt
+++ b/app/src/main/java/com/asmr/player/main/MainContainer.kt
@@ -1709,6 +1709,7 @@ fun MainContainer(
                                                         dlCount = album.dlCount,
                                                         priceJpy = album.priceJpy,
                                                         hasAsmrOne = album.hasAsmrOne,
+                                                        asmrOneWorkId = album.workId.takeIf { album.hasAsmrOne },
                                                         description = album.description,
                                                         hasResolvedDlsiteInfo = hasResolvedDetail && !fromPurchasedOnly
                                                     )
@@ -1741,6 +1742,7 @@ fun MainContainer(
                                                         dlCount = album.dlCount,
                                                         priceJpy = album.priceJpy,
                                                         hasAsmrOne = album.hasAsmrOne,
+                                                        asmrOneWorkId = album.workId.takeIf { album.hasAsmrOne },
                                                         description = album.description,
                                                         hasResolvedDlsiteInfo = true
                                                     )

--- a/app/src/main/java/com/asmr/player/ui/library/AlbumDetailViewModel.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/AlbumDetailViewModel.kt
@@ -19,6 +19,7 @@ import com.asmr.player.data.local.db.entities.TagSource
 import com.asmr.player.data.local.db.entities.TrackTagEntity
 import com.asmr.player.data.remote.api.AsmrOneOtherLanguageEditionInDb
 import com.asmr.player.data.remote.api.AsmrOneTrackNodeResponse
+import com.asmr.player.data.remote.api.AsmrOneAvailabilityApi
 import com.asmr.player.data.remote.crawler.AsmrOneCrawler
 import com.asmr.player.data.remote.dlsite.DlsiteCloudSyncCandidate
 import com.asmr.player.data.remote.dlsite.DlsiteCloudSyncResolveResult
@@ -105,6 +106,7 @@ class AlbumDetailViewModel @Inject constructor(
     private val albumDao: AlbumDao,
     private val trackDao: TrackDao,
     private val asmrOneCrawler: AsmrOneCrawler,
+    private val asmrOneAvailabilityApi: AsmrOneAvailabilityApi,
     private val dlsiteScraper: DLSiteScraper,
     private val dlsiteProductInfoClient: DlsiteProductInfoClient,
     private val dlsitePlayWorkClient: DlsitePlayWorkClient,
@@ -291,15 +293,40 @@ class AlbumDetailViewModel @Inject constructor(
         val now = SystemClock.elapsedRealtime()
         val cached = asmrOneTracksCache[cacheKey]
         if (cached != null && (now - cached.first) <= 10 * 60_000L) return cached.second
-        val tree = runCatching {
-            if (site != null) asmrOneCrawler.getTracksFromSite(site, normalizedId) else asmrOneCrawler.getTracks(normalizedId)
-        }.getOrDefault(emptyList())
+        val tree = fetchAsmrOneTracksBackendFirst(
+            workId = normalizedId,
+            fetchBackend = { asmrOneAvailabilityApi.getTrackTree(it) },
+            fetchFallback = {
+                if (site != null) asmrOneCrawler.getTracksFromSite(site, normalizedId) else asmrOneCrawler.getTracks(normalizedId)
+            }
+        )
         asmrOneTracksCache[cacheKey] = now to tree
         if (asmrOneTracksCache.size > 200) {
             val firstKey = asmrOneTracksCache.entries.firstOrNull()?.key
             if (firstKey != null) asmrOneTracksCache.remove(firstKey)
         }
         return tree
+    }
+
+    private suspend fun resolveBackendAsmrOneWork(rj: String): Pair<String, List<AsmrOneTrackNodeResponse>>? {
+        val normalizedRj = rj.trim().uppercase()
+        if (!RJ_CODE_REGEX.matches(normalizedRj)) return null
+        val workId = runCatching { asmrOneAvailabilityApi.findCollectedWorkId(normalizedRj) }
+            .getOrNull()
+            ?.trim()
+            .orEmpty()
+        if (workId.isBlank()) return null
+        asmrOneCollectedCache[normalizedRj] = SystemClock.elapsedRealtime() to true
+        val tree = getAsmrOneTracksCached(site = null, workId = workId)
+        return workId to tree
+    }
+
+    private suspend fun resolveHintedBackendAsmrOneWork(workId: String?): Pair<String, List<AsmrOneTrackNodeResponse>>? {
+        val normalizedWorkId = workId?.trim().orEmpty()
+        if (!ASMR_ONE_WORK_ID_REGEX.matches(normalizedWorkId)) return null
+        val tree = getAsmrOneTracksCached(site = null, workId = normalizedWorkId)
+        if (tree.isEmpty()) return null
+        return normalizedWorkId to tree
     }
 
     fun getTreeExpanded(stateKey: String): List<String> {
@@ -1429,6 +1456,70 @@ class AlbumDetailViewModel @Inject constructor(
                     ?.uppercase()
                     .orEmpty()
                 val originalRj = jpnWorkno.ifBlank { latestBase.ifBlank { keyRj } }
+
+                val hintedBackend = resolveHintedBackendAsmrOneWork(latest.asmrOneWorkId ?: latest.displayAlbum.workId)
+                if (hintedBackend != null) {
+                    val (workId, tree) = hintedBackend
+                    val updated = (_uiState.value as? AlbumDetailUiState.Success)?.model ?: return@launch
+                    if (token != asmrOneLoadToken) {
+                        asmrOneAttemptedRj.remove(keyRj)
+                        if (updated.rjCode.trim().uppercase().equals(keyRj, ignoreCase = true) && updated.isLoadingAsmrOne) {
+                            _uiState.value = AlbumDetailUiState.Success(model = updated.copy(isLoadingAsmrOne = false))
+                        }
+                        return@launch
+                    }
+                    val displayAlbum = mergeDetailHeaderAlbum(
+                        currentDisplayAlbum = updated.displayAlbum,
+                        localAlbum = updated.localAlbum,
+                        fetchedDlsiteInfo = updated.dlsiteInfo,
+                        rjCode = updated.rjCode,
+                        asmrOneWorkId = workId,
+                        preserveHeaderAlbumMetadata = updated.preserveHeaderAlbumMetadata
+                    )
+                    _uiState.value = AlbumDetailUiState.Success(
+                        model = updated.copy(
+                            displayAlbum = displayAlbum,
+                            asmrOneWorkId = workId,
+                            asmrOneSite = null,
+                            asmrOneTree = tree,
+                            hasResolvedAsmrOneContent = true,
+                            isLoadingAsmrOne = false
+                        )
+                    )
+                    return@launch
+                }
+
+                val backendResolved = resolveBackendAsmrOneWork(originalRj)
+                if (backendResolved != null) {
+                    val (workId, tree) = backendResolved
+                    val updated = (_uiState.value as? AlbumDetailUiState.Success)?.model ?: return@launch
+                    if (token != asmrOneLoadToken) {
+                        asmrOneAttemptedRj.remove(keyRj)
+                        if (updated.rjCode.trim().uppercase().equals(keyRj, ignoreCase = true) && updated.isLoadingAsmrOne) {
+                            _uiState.value = AlbumDetailUiState.Success(model = updated.copy(isLoadingAsmrOne = false))
+                        }
+                        return@launch
+                    }
+                    val displayAlbum = mergeDetailHeaderAlbum(
+                        currentDisplayAlbum = updated.displayAlbum,
+                        localAlbum = updated.localAlbum,
+                        fetchedDlsiteInfo = updated.dlsiteInfo,
+                        rjCode = updated.rjCode,
+                        asmrOneWorkId = workId,
+                        preserveHeaderAlbumMetadata = updated.preserveHeaderAlbumMetadata
+                    )
+                    _uiState.value = AlbumDetailUiState.Success(
+                        model = updated.copy(
+                            displayAlbum = displayAlbum,
+                            asmrOneWorkId = workId,
+                            asmrOneSite = null,
+                            asmrOneTree = tree,
+                            hasResolvedAsmrOneContent = true,
+                            isLoadingAsmrOne = false
+                        )
+                    )
+                    return@launch
+                }
 
                 val collected = isAsmrOneCollected(originalRj, timeoutMs = 1_200L)
                 if (collected == false) {
@@ -2680,6 +2771,8 @@ class AlbumDetailViewModel @Inject constructor(
     }
 
     private companion object {
+        val RJ_CODE_REGEX = Regex("""RJ\d{6,}""")
+        val ASMR_ONE_WORK_ID_REGEX = Regex("""\d+""")
         const val MAX_RECOMMENDATION_ASMR_ONE_ENRICH = 12
         const val RECOMMENDATION_ASMR_ONE_ENRICH_CONCURRENCY = 4
     }

--- a/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailViewModelSupport.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailViewModelSupport.kt
@@ -321,6 +321,18 @@ internal data class AsmrOneLeafDownload(
     val duration: Double?
 )
 
+internal suspend fun fetchAsmrOneTracksBackendFirst(
+    workId: String,
+    fetchBackend: suspend (String) -> List<AsmrOneTrackNodeResponse>,
+    fetchFallback: suspend (String) -> List<AsmrOneTrackNodeResponse>
+): List<AsmrOneTrackNodeResponse> {
+    val normalizedId = workId.trim()
+    if (normalizedId.isBlank()) return emptyList()
+    val backendTree = runCatching { fetchBackend(normalizedId) }.getOrDefault(emptyList())
+    if (backendTree.isNotEmpty()) return backendTree
+    return runCatching { fetchFallback(normalizedId) }.getOrDefault(emptyList())
+}
+
 internal const val DlsiteTrialDownloadDirectoryName = "体验版"
 
 internal fun flattenAsmrOneTracks(tree: List<AsmrOneTrackNodeResponse>): List<Track> {

--- a/app/src/main/java/com/asmr/player/ui/nav/AlbumCoverHintStore.kt
+++ b/app/src/main/java/com/asmr/player/ui/nav/AlbumCoverHintStore.kt
@@ -56,6 +56,7 @@ object AlbumCoverHintStore {
         dlCount: Int = 0,
         priceJpy: Int = 0,
         hasAsmrOne: Boolean = false,
+        asmrOneWorkId: String? = null,
         description: String? = null,
         hasResolvedDlsiteInfo: Boolean = false
     ) {
@@ -75,6 +76,7 @@ object AlbumCoverHintStore {
             dlCount = dlCount.coerceAtLeast(0),
             priceJpy = priceJpy.coerceAtLeast(0),
             hasAsmrOne = hasAsmrOne,
+            asmrOneWorkId = asmrOneWorkId?.trim().orEmpty(),
             description = description?.trim().orEmpty(),
             hasResolvedDlsiteInfo = hasResolvedDlsiteInfo
         )
@@ -115,6 +117,7 @@ data class AlbumCoverHint(
     val dlCount: Int,
     val priceJpy: Int,
     val hasAsmrOne: Boolean,
+    val asmrOneWorkId: String,
     val description: String,
     val hasResolvedDlsiteInfo: Boolean
 ) {
@@ -131,6 +134,7 @@ data class AlbumCoverHint(
             dlCount <= 0 &&
             priceJpy <= 0 &&
             !hasAsmrOne &&
+            asmrOneWorkId.isBlank() &&
             description.isBlank()
     }
 }
@@ -140,7 +144,7 @@ internal fun albumFromCoverHint(rj: String, hint: AlbumCoverHint?): Album {
     return Album(
         title = hint?.title?.ifBlank { normalizedRj }.orEmpty().ifBlank { "专辑" },
         path = "",
-        workId = normalizedRj,
+        workId = hint?.asmrOneWorkId?.ifBlank { normalizedRj }.orEmpty().ifBlank { normalizedRj },
         rjCode = normalizedRj,
         circle = hint?.circle.orEmpty(),
         cv = hint?.cv.orEmpty(),

--- a/app/src/main/java/com/asmr/player/ui/search/SearchViewModel.kt
+++ b/app/src/main/java/com/asmr/player/ui/search/SearchViewModel.kt
@@ -691,7 +691,7 @@ class SearchViewModel @Inject constructor(
         return Album(
             title = title.trim().ifBlank { normalizedRj.ifBlank { "已收录作品" } },
             path = "",
-            workId = normalizedRj,
+            workId = workId.takeIf { it > 0 }?.toString().orEmpty().ifBlank { normalizedRj },
             rjCode = normalizedRj,
             circle = circle.trim(),
             cv = cvs.orEmpty()

--- a/app/src/test/java/com/asmr/player/data/remote/api/AsmrOneAvailabilityApiTest.kt
+++ b/app/src/test/java/com/asmr/player/data/remote/api/AsmrOneAvailabilityApiTest.kt
@@ -1,0 +1,115 @@
+package com.asmr.player.data.remote.api
+
+import com.asmr.player.data.remote.NetworkHeaders
+import com.google.gson.Gson
+import okhttp3.Interceptor
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.Protocol
+import okhttp3.Response
+import okhttp3.ResponseBody.Companion.toResponseBody
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.IOException
+
+class AsmrOneAvailabilityApiTest {
+    @Test
+    fun check_mapsMatchedRjsToRequestedWorkno() {
+        val api = AsmrOneAvailabilityApi(
+            okHttpClient = OkHttpClient.Builder()
+                .addInterceptor { chain ->
+                    response(
+                        chain,
+                        200,
+                        """{"items":[{"rj":"RJ000001","collected":true,"workId":1583603,"matchedRjs":["RJ01583603"]}]}"""
+                    )
+                }
+                .build(),
+            gson = Gson(),
+            baseUrlProvider = { "https://eara.test" }
+        )
+
+        val result = kotlinx.coroutines.runBlocking { api.check(listOf("RJ01583603")) }
+
+        assertEquals(true, result["RJ01583603"])
+    }
+
+    @Test
+    fun findCollectedWorkId_returnsBackendWorkIdFromMatchedRj() {
+        var requestedPath = ""
+        var hasSilentHeader = false
+        val api = AsmrOneAvailabilityApi(
+            okHttpClient = OkHttpClient.Builder()
+                .addInterceptor { chain ->
+                    requestedPath = chain.request().url.encodedPath
+                    hasSilentHeader = chain.request().header(NetworkHeaders.HEADER_SILENT_IO_ERROR) == NetworkHeaders.SILENT_IO_ERROR_ON
+                    response(
+                        chain,
+                        200,
+                        """{"items":[{"rj":"RJ000001","collected":true,"workId":1583603,"matchedRjs":["RJ01583603"]}]}"""
+                    )
+                }
+                .build(),
+            gson = Gson(),
+            baseUrlProvider = { "https://eara.test" }
+        )
+
+        val workId = kotlinx.coroutines.runBlocking { api.findCollectedWorkId("RJ01583603") }
+
+        assertEquals("/api/asmr-one/availability", requestedPath)
+        assertTrue(hasSilentHeader)
+        assertEquals("1583603", workId)
+    }
+
+    @Test
+    fun getTrackTree_returnsBackendTree() {
+        var requestedPath = ""
+        var requestedWorkId = ""
+        var hasSilentHeader = false
+        val api = AsmrOneAvailabilityApi(
+            okHttpClient = OkHttpClient.Builder()
+                .addInterceptor { chain ->
+                    requestedPath = chain.request().url.encodedPath
+                    requestedWorkId = chain.request().url.queryParameter("workId").orEmpty()
+                    hasSilentHeader = chain.request().header(NetworkHeaders.HEADER_SILENT_IO_ERROR) == NetworkHeaders.SILENT_IO_ERROR_ON
+                    response(chain, 200, """[{"title":"01.mp3","mediaDownloadUrl":"https://example.test/01.mp3"}]""")
+                }
+                .build(),
+            gson = Gson(),
+            baseUrlProvider = { "https://eara.test" }
+        )
+
+        val tree = kotlinx.coroutines.runBlocking { api.getTrackTree("1590748") }
+
+        assertEquals("/api/asmr-one/tracks", requestedPath)
+        assertEquals("1590748", requestedWorkId)
+        assertTrue(hasSilentHeader)
+        assertEquals(1, tree.size)
+        assertEquals("01.mp3", tree.first().title)
+        assertEquals("https://example.test/01.mp3", tree.first().mediaDownloadUrl)
+    }
+
+    @Test(expected = IOException::class)
+    fun getTrackTree_throwsOnBackendMiss() {
+        val api = AsmrOneAvailabilityApi(
+            okHttpClient = OkHttpClient.Builder()
+                .addInterceptor { chain -> response(chain, 404, """{"error":"not_found"}""") }
+                .build(),
+            gson = Gson(),
+            baseUrlProvider = { "https://eara.test" }
+        )
+
+        kotlinx.coroutines.runBlocking { api.getTrackTree("1590748") }
+    }
+
+    private fun response(chain: Interceptor.Chain, code: Int, body: String): Response {
+        return Response.Builder()
+            .request(chain.request())
+            .protocol(Protocol.HTTP_1_1)
+            .code(code)
+            .message(if (code in 200..299) "OK" else "Error")
+            .body(body.toResponseBody("application/json; charset=utf-8".toMediaType()))
+            .build()
+    }
+}

--- a/app/src/test/java/com/asmr/player/ui/library/AlbumDetailDirectorySupportTest.kt
+++ b/app/src/test/java/com/asmr/player/ui/library/AlbumDetailDirectorySupportTest.kt
@@ -201,4 +201,58 @@ class AlbumDetailDirectorySupportTest {
         val paths = flattened.entries.filterIsInstance<LocalTreeUiEntry.File>().map { it.path }.sorted()
         assertEquals(listOf("one/same.mp3", "体验版/same.mp3"), paths)
     }
+
+    @Test
+    fun fetchAsmrOneTracksBackendFirst_usesBackendTreeWithoutFallback() {
+        var fallbackCalls = 0
+        val backendTree = listOf(
+            AsmrOneTrackNodeResponse(
+                title = "backend.mp3",
+                mediaDownloadUrl = "https://backend.test/1.mp3"
+            )
+        )
+
+        val result = kotlinx.coroutines.runBlocking {
+            fetchAsmrOneTracksBackendFirst(
+                workId = " 1590748 ",
+                fetchBackend = { backendTree },
+                fetchFallback = {
+                    fallbackCalls++
+                    listOf(
+                        AsmrOneTrackNodeResponse(
+                            title = "fallback.mp3",
+                            mediaDownloadUrl = "https://fallback.test/1.mp3"
+                        )
+                    )
+                }
+            )
+        }
+
+        assertEquals("backend.mp3", result.single().title)
+        assertEquals(0, fallbackCalls)
+    }
+
+    @Test
+    fun fetchAsmrOneTracksBackendFirst_fallsBackWhenBackendFails() {
+        var fallbackWorkId = ""
+
+        val result = kotlinx.coroutines.runBlocking {
+            fetchAsmrOneTracksBackendFirst(
+                workId = "1590748",
+                fetchBackend = { error("backend down") },
+                fetchFallback = {
+                    fallbackWorkId = it
+                    listOf(
+                        AsmrOneTrackNodeResponse(
+                            title = "fallback.mp3",
+                            mediaDownloadUrl = "https://fallback.test/1.mp3"
+                        )
+                    )
+                }
+            )
+        }
+
+        assertEquals("1590748", fallbackWorkId)
+        assertEquals("fallback.mp3", result.single().title)
+    }
 }

--- a/app/src/test/java/com/asmr/player/ui/nav/AlbumCoverHintStoreTest.kt
+++ b/app/src/test/java/com/asmr/player/ui/nav/AlbumCoverHintStoreTest.kt
@@ -20,6 +20,7 @@ class AlbumCoverHintStoreTest {
             dlCount = 1200,
             priceJpy = 990,
             hasAsmrOne = true,
+            asmrOneWorkId = "1583603",
             description = "简介",
             hasResolvedDlsiteInfo = true
         )
@@ -27,6 +28,7 @@ class AlbumCoverHintStoreTest {
         val album = albumFromCoverHint("", hint)
 
         assertEquals("RJ123456", album.rjCode)
+        assertEquals("1583603", album.workId)
         assertEquals("Alice, Bob", album.cv)
         assertEquals(listOf("耳语", "安眠"), album.tags)
         assertEquals(4.8, album.ratingValue ?: 0.0, 0.0)


### PR DESCRIPTION
## Summary
- add backend asmr.one availability/work-id/track-tree calls
- prefer backend track tree before crawler fallback in album detail
- carry asmr.one work id through search and cover hints

## Verification
- .\gradlew-local.bat :app:testReleaseUnitTest was run