### PR TITLE
Fix album detail tap-through

### DIFF
--- a/app/src/main/java/com/asmr/player/ui/common/Modifiers.kt
+++ b/app/src/main/java/com/asmr/player/ui/common/Modifiers.kt
@@ -59,6 +59,16 @@ fun Modifier.glassMenu(
     .background(color = baseColor, shape = shape)
     .clip(shape)
 
+fun Modifier.consumeTapThrough(): Modifier =
+    pointerInput(Unit) {
+        awaitEachGesture {
+            do {
+                val event = awaitPointerEvent()
+                event.changes.forEach { change -> change.consume() }
+            } while (event.changes.any { it.pressed })
+        }
+    }
+
 @Composable
 fun Modifier.clearFocusOnTapOutside(): Modifier {
     val focusManager = LocalFocusManager.current

--- a/app/src/main/java/com/asmr/player/ui/library/AlbumDetailScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/AlbumDetailScreen.kt
@@ -140,6 +140,7 @@ import com.asmr.player.ui.common.EaraLogoLoadingIndicator
 import com.asmr.player.ui.common.ImagePreviewDialog
 import com.asmr.player.ui.common.ImagePreviewRequest
 import com.asmr.player.ui.common.collapsibleHeaderUiState
+import com.asmr.player.ui.common.consumeTapThrough
 import com.asmr.player.ui.common.rememberCollapsibleHeaderState
 import com.asmr.player.ui.playlists.PlaylistPickerScreen
 import com.asmr.player.ui.theme.AsmrTheme
@@ -627,6 +628,12 @@ fun AlbumDetailScreen(
                                 .clipToBounds()
                                 .zIndex(0f)
                         ) {
+                            Box(
+                                modifier = Modifier
+                                    .matchParentSize()
+                                    .consumeTapThrough()
+                            )
+
                             AlbumDetailHeroBackground(
                                 album = activeHeroAlbum,
                                 coverSessionKey = screenKey,
@@ -1053,6 +1060,11 @@ private fun AlbumDetailHeroBackground(
             }
             .clipToBounds()
     ) {
+        Box(
+            modifier = Modifier
+                .matchParentSize()
+                .consumeTapThrough()
+        )
         AsmrAsyncImage(
             model = imageModel,
             contentDescription = null,

--- a/app/src/main/java/com/asmr/player/ui/nav/BottomChrome.kt
+++ b/app/src/main/java/com/asmr/player/ui/nav/BottomChrome.kt
@@ -11,7 +11,6 @@ import androidx.compose.animation.fadeOut
 import androidx.compose.animation.scaleIn
 import androidx.compose.animation.scaleOut
 import androidx.compose.animation.togetherWith
-import androidx.compose.foundation.gestures.awaitEachGesture
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
@@ -69,7 +68,6 @@ import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.lerp
 import androidx.compose.ui.graphics.vector.ImageVector
-import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.boundsInParent
 import androidx.compose.ui.layout.boundsInRoot
 import androidx.compose.ui.layout.onGloballyPositioned
@@ -81,6 +79,7 @@ import androidx.compose.ui.semantics.stateDescription
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
+import com.asmr.player.ui.common.consumeTapThrough
 import com.asmr.player.ui.player.MiniPlayer
 import com.asmr.player.ui.player.MiniPlayerDisplayMode
 import com.asmr.player.ui.theme.AsmrTheme
@@ -553,16 +552,6 @@ private fun computeBottomNavEntryVisibility(
     return ((visibleWidth - fadeThreshold) / (entryWidth.value - fadeThreshold))
         .coerceIn(0f, 1f)
 }
-
-private fun Modifier.consumeTapThrough(): Modifier =
-    pointerInput(Unit) {
-        awaitEachGesture {
-            do {
-                val event = awaitPointerEvent()
-                event.changes.forEach { change -> change.consume() }
-            } while (event.changes.any { it.pressed })
-        }
-    }
 
 @Composable
 fun BottomChrome(

--- a/app/src/main/java/com/asmr/player/ui/search/SearchScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/search/SearchScreen.kt
@@ -108,6 +108,7 @@ import com.asmr.player.ui.common.LocalBottomOverlayPadding
 import com.asmr.player.ui.common.StableWindowInsets
 import com.asmr.player.ui.common.clearFocusOnTapOutside
 import com.asmr.player.ui.common.collapsibleHeaderUiState
+import com.asmr.player.ui.common.consumeTapThrough
 import com.asmr.player.ui.common.rememberCollapsibleHeaderState
 import com.asmr.player.ui.common.smoothScrollToTop
 import com.asmr.player.ui.common.thinScrollbar
@@ -186,16 +187,6 @@ internal fun resolveSearchChromeLockState(uiState: SearchUiState): SearchChromeL
         showSearchSpinner = interactionLocked
     )
 }
-
-private fun Modifier.consumeTapThrough(): Modifier =
-    pointerInput(Unit) {
-        awaitEachGesture {
-            do {
-                val event = awaitPointerEvent()
-                event.changes.forEach { change -> change.consume() }
-            } while (event.changes.any { it.pressed })
-        }
-    }
 
 @Composable
 private fun SearchFilterIconView(


### PR DESCRIPTION
## Summary
- add a shared tap-through consuming modifier for transparent overlay surfaces
- prevent album detail hero/background gaps from passing taps to underlying pages
- reuse the shared modifier in existing search pagination and bottom chrome overlays

## Verification
- .\\gradlew-local.bat :app:installRelease