### PR TITLE
Adjust inactive lyric contrast on lyrics page

### DIFF
--- a/app/src/main/java/com/asmr/player/ui/player/LyricReadableColors.kt
+++ b/app/src/main/java/com/asmr/player/ui/player/LyricReadableColors.kt
@@ -65,7 +65,7 @@ private fun inactiveLyricTextColor(
     fallback: Color
 ): Color {
     val lightGrayCandidate = Color(0xFFD7DCE4)
-    val darkGrayCandidate = Color(0xFF58606C)
+    val darkGrayCandidate = Color(0xFF3E4651)
     return if (activeText.luminance() > 0.5f) {
         lightGrayCandidate
     } else if (activeText.luminance() < 0.2f) {


### PR DESCRIPTION
## Summary
- darken the inactive lyric color used when the active lyric is rendered in a near-black tone
- keep the change scoped to the readable lyric color helper so only the light-page inactive lyric contrast is affected

## Verification
- .\\gradlew-local.bat :app:installRelease
