### PR TITLE
Decouple ONE tree loading from DLsite

### DIFF
--- a/app/src/main/java/com/asmr/player/data/remote/api/AsmrOneAvailabilityApi.kt
+++ b/app/src/main/java/com/asmr/player/data/remote/api/AsmrOneAvailabilityApi.kt
@@ -6,6 +6,7 @@ import com.asmr.player.data.remote.NetworkHeaders
 import com.asmr.player.data.remote.withSearchTimeouts
 import com.asmr.player.listentogether.XxHash64
 import com.google.gson.Gson
+import com.google.gson.reflect.TypeToken
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import okhttp3.MediaType.Companion.toMediaType
@@ -14,6 +15,7 @@ import okhttp3.Request
 import okhttp3.RequestBody.Companion.toRequestBody
 import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 import java.io.IOException
+import java.util.concurrent.TimeUnit
 import java.util.UUID
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -65,16 +67,36 @@ data class AsmrOneCollectedSearchItem(
     val rateAverage2dp: Double? = null
 )
 
+data class AsmrOneBackendTrackTreeResponse(
+    val rj: String = "",
+    val workId: Int = 0,
+    val sourceIdDigits: String = "",
+    val trackTree: List<AsmrOneTrackNodeResponse>? = emptyList(),
+    val fetchedAt: String = "",
+    val lastError: String = "",
+    val serverTimeEpochMs: Long = 0L
+)
+
 @Singleton
 class AsmrOneAvailabilityApi @Inject constructor(
     private val okHttpClient: OkHttpClient,
     private val gson: Gson
 ) {
+    internal constructor(
+        okHttpClient: OkHttpClient,
+        gson: Gson,
+        baseUrlProvider: () -> String
+    ) : this(okHttpClient, gson) {
+        this.baseUrlProvider = baseUrlProvider
+    }
+
+    private var baseUrlProvider: () -> String = { BuildConfig.LISTEN_TOGETHER_BASE_URL }
     private val clientSessionId = UUID.randomUUID().toString()
     private val appHeaderValue = "com.asmr.player/${BuildConfig.VERSION_NAME} (${BuildConfig.VERSION_CODE})"
     private val deviceFingerprint = buildDeviceFingerprint()
     private val userAgent = buildUserAgent()
     private val requestClient by lazy { okHttpClient.withSearchTimeouts() }
+    private val trackTreeClient by lazy { okHttpClient.withBackendTrackTreeTimeouts() }
 
     suspend fun check(rjs: List<String>): Map<String, Boolean> {
         val normalized = rjs
@@ -84,7 +106,7 @@ class AsmrOneAvailabilityApi @Inject constructor(
             .distinct()
             .take(MAX_RJS)
             .toList()
-        if (normalized.isEmpty() || baseUrl.isBlank()) return emptyMap()
+        if (normalized.isEmpty() || backendBaseUrl.isBlank()) return emptyMap()
 
         return runCatching {
             withContext(Dispatchers.IO) {
@@ -102,14 +124,21 @@ class AsmrOneAvailabilityApi @Inject constructor(
                     val raw = response.body?.string().orEmpty()
                     if (raw.isBlank()) return@withContext emptyMap()
                     val parsed = gson.fromJson(raw, AsmrOneAvailabilityResponse::class.java)
-                    parsed.items.associate { it.rj.trim().uppercase() to it.collected }
+                    val requested = normalized.toSet()
+                    buildMap {
+                        parsed.items.forEach { item ->
+                            item.matchedRequestRjs(requested).forEach { rj ->
+                                put(rj, item.collected)
+                            }
+                        }
+                    }
                 }
             }
         }.getOrDefault(emptyMap())
     }
 
     suspend fun search(keyword: String, limit: Int, offset: Int, sort: String): AsmrOneCollectedSearchResponse {
-        if (baseUrl.isBlank()) throw IOException("asmr.one backend is not configured")
+        if (backendBaseUrl.isBlank()) throw IOException("asmr.one backend is not configured")
         return withContext(Dispatchers.IO) {
             val url = resolveUrl("api/asmr-one/search")
                 .toHttpUrlOrNull()
@@ -141,19 +170,58 @@ class AsmrOneAvailabilityApi @Inject constructor(
         }
     }
 
+    suspend fun getTrackTreeByRj(rj: String): AsmrOneBackendTrackTreeResponse {
+        if (backendBaseUrl.isBlank()) throw IOException("asmr.one backend is not configured")
+        val normalizedRj = rj.trim().uppercase()
+        if (!RJ_CODE_REGEX.matches(normalizedRj)) throw IOException("asmr.one tracks RJ is invalid")
+        return withContext(Dispatchers.IO) {
+            val url = resolveUrl("api/asmr-one/tracks")
+                .toHttpUrlOrNull()
+                ?.newBuilder()
+                ?.addQueryParameter("rj", normalizedRj)
+                ?.build()
+                ?: throw IOException("invalid asmr.one tracks backend url")
+            val request = Request.Builder()
+                .url(url)
+                .header("User-Agent", userAgent)
+                .header("X-Listen-Together-App", appHeaderValue)
+                .header("X-Listen-Together-Client-Session-Id", clientSessionId)
+                .header("X-Listen-Together-Device-Fingerprint", deviceFingerprint)
+                .header(NetworkHeaders.HEADER_SILENT_IO_ERROR, NetworkHeaders.SILENT_IO_ERROR_ON)
+                .get()
+                .build()
+            trackTreeClient.newCall(request).execute().use { response ->
+                val raw = response.body?.string().orEmpty()
+                if (response.code == 404 && raw.contains("\"tracks_not_found\"", ignoreCase = true)) {
+                    throw IOException("asmr.one tracks backend not found")
+                }
+                if (!response.isSuccessful) {
+                    throw IOException("asmr.one tracks backend failed: HTTP ${response.code}")
+                }
+                if (raw.isBlank()) return@withContext AsmrOneBackendTrackTreeResponse(rj = normalizedRj)
+                val responseType = object : TypeToken<AsmrOneBackendTrackTreeResponse>() {}.type
+                gson.fromJson<AsmrOneBackendTrackTreeResponse>(raw, responseType)
+                    ?: AsmrOneBackendTrackTreeResponse(rj = normalizedRj)
+            }
+        }
+    }
+
     private fun resolveUrl(path: String): String {
-        val root = baseUrl.trimEnd('/')
+        val root = backendBaseUrl.trimEnd('/')
         val normalizedPath = path.trimStart('/')
         return "$root/$normalizedPath"
     }
 
+    private val backendBaseUrl: String
+        get() = baseUrlProvider().trim()
+
     private fun buildDeviceFingerprint(): String {
         val source = listOf(
-            Build.BRAND,
-            Build.MANUFACTURER,
-            Build.MODEL,
-            Build.DEVICE,
-            Build.PRODUCT,
+            Build.BRAND.orEmpty(),
+            Build.MANUFACTURER.orEmpty(),
+            Build.MODEL.orEmpty(),
+            Build.DEVICE.orEmpty(),
+            Build.PRODUCT.orEmpty(),
             Build.VERSION.SDK_INT.toString(),
             BuildConfig.APPLICATION_ID,
             BuildConfig.VERSION_NAME,
@@ -162,7 +230,7 @@ class AsmrOneAvailabilityApi @Inject constructor(
     }
 
     private fun buildUserAgent(): String {
-        val deviceModel = listOf(Build.MANUFACTURER, Build.MODEL)
+        val deviceModel = listOf(Build.MANUFACTURER.orEmpty(), Build.MODEL.orEmpty())
             .map { it.trim() }
             .filter { it.isNotBlank() }
             .joinToString(separator = " ")
@@ -174,7 +242,27 @@ class AsmrOneAvailabilityApi @Inject constructor(
         private val JSON_MEDIA_TYPE = "application/json; charset=utf-8".toMediaType()
         private val RJ_CODE_REGEX = Regex("""RJ\d{6,}""")
         private const val MAX_RJS = 100
-        private val baseUrl: String
-            get() = BuildConfig.LISTEN_TOGETHER_BASE_URL
     }
 }
+
+private fun AsmrOneAvailabilityItem.matchedRequestRjs(requested: Set<String>): List<String> {
+    if (requested.isEmpty()) return emptyList()
+    return buildList {
+        add(rj)
+        add(originalWorkno)
+        addAll(matchedRjs)
+    }
+        .asSequence()
+        .map { it.trim().uppercase() }
+        .filter { it in requested }
+        .distinct()
+        .toList()
+}
+
+private fun OkHttpClient.withBackendTrackTreeTimeouts(): OkHttpClient =
+    newBuilder()
+        .callTimeout(3, TimeUnit.SECONDS)
+        .connectTimeout(2, TimeUnit.SECONDS)
+        .readTimeout(3, TimeUnit.SECONDS)
+        .writeTimeout(3, TimeUnit.SECONDS)
+        .build()

--- a/app/src/main/java/com/asmr/player/ui/library/AlbumDetailScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/AlbumDetailScreen.kt
@@ -654,8 +654,7 @@ fun AlbumDetailScreen(
                             LaunchedEffect(
                                 selectedTab,
                                 model.rjCode,
-                                model.dlsiteWorkno,
-                                model.hasResolvedInitialDlsiteTarget
+                                model.dlsiteWorkno
                             ) {
                                 when (selectedTab) {
                                     1 -> {
@@ -765,8 +764,7 @@ fun AlbumDetailScreen(
                                         trialDownloadEnabled = trialDownloadTree.isNotEmpty(),
                                         isLoading = model.isLoadingDlsite,
                                         isAwaitingInitialLoad = !model.hasLoadedInitialDlsiteContent,
-                                        isAwaitingAsmrOneLoad = model.hasResolvedInitialDlsiteTarget &&
-                                            !model.hasResolvedAsmrOneContent &&
+                                        isAwaitingAsmrOneLoad = !model.hasResolvedAsmrOneContent &&
                                             asmrOneTree.isEmpty(),
                                         asmrOneTree = asmrOneTree,
                                         isLoadingAsmrOne = model.isLoadingAsmrOne,

--- a/app/src/main/java/com/asmr/player/ui/library/AlbumDetailViewModel.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/AlbumDetailViewModel.kt
@@ -19,6 +19,7 @@ import com.asmr.player.data.local.db.entities.TagSource
 import com.asmr.player.data.local.db.entities.TrackTagEntity
 import com.asmr.player.data.remote.api.AsmrOneOtherLanguageEditionInDb
 import com.asmr.player.data.remote.api.AsmrOneTrackNodeResponse
+import com.asmr.player.data.remote.api.AsmrOneAvailabilityApi
 import com.asmr.player.data.remote.crawler.AsmrOneCrawler
 import com.asmr.player.data.remote.dlsite.DlsiteCloudSyncCandidate
 import com.asmr.player.data.remote.dlsite.DlsiteCloudSyncResolveResult
@@ -105,6 +106,7 @@ class AlbumDetailViewModel @Inject constructor(
     private val albumDao: AlbumDao,
     private val trackDao: TrackDao,
     private val asmrOneCrawler: AsmrOneCrawler,
+    private val asmrOneAvailabilityApi: AsmrOneAvailabilityApi,
     private val dlsiteScraper: DLSiteScraper,
     private val dlsiteProductInfoClient: DlsiteProductInfoClient,
     private val dlsitePlayWorkClient: DlsitePlayWorkClient,
@@ -300,6 +302,17 @@ class AlbumDetailViewModel @Inject constructor(
             if (firstKey != null) asmrOneTracksCache.remove(firstKey)
         }
         return tree
+    }
+
+    private suspend fun fetchBackendAsmrOneTracksByRj(rj: String): Pair<String, List<AsmrOneTrackNodeResponse>>? {
+        val normalizedRj = rj.trim().uppercase()
+        if (!RJ_CODE_REGEX.matches(normalizedRj)) return null
+        val result = runCatching { asmrOneAvailabilityApi.getTrackTreeByRj(normalizedRj) }.getOrNull()
+            ?: return null
+        val tree = result.trackTree.orEmpty()
+        if (tree.isEmpty()) return null
+        val workId = result.workId.takeIf { it > 0 }?.toString().orEmpty()
+        return workId to tree
     }
 
     fun getTreeExpanded(stateKey: String): List<String> {
@@ -1104,6 +1117,13 @@ class AlbumDetailViewModel @Inject constructor(
                     val resolvedTarget = resolveInitialDlsiteLoadTarget(loadModel)
                     val latestResolved = (_uiState.value as? AlbumDetailUiState.Success)?.model ?: return@launch
                     if (token != dlsiteLoadToken) return@launch
+                    val targetWorkno = resolvedTarget.workno.trim().uppercase()
+                    val targetChanged = targetWorkno.isNotBlank() &&
+                        !targetWorkno.equals(latestResolved.rjCode.trim().uppercase(), ignoreCase = true)
+                    if (targetChanged) {
+                        asmrOneLoadToken++
+                        asmrOneAttemptedRj.clear()
+                    }
                     loadModel = latestResolved.copy(
                         rjCode = resolvedTarget.workno,
                         displayAlbum = mergeDetailHeaderAlbum(
@@ -1111,14 +1131,19 @@ class AlbumDetailViewModel @Inject constructor(
                             localAlbum = latestResolved.localAlbum,
                             fetchedDlsiteInfo = latestResolved.dlsiteInfo,
                             rjCode = resolvedTarget.workno,
-                            asmrOneWorkId = latestResolved.asmrOneWorkId,
+                            asmrOneWorkId = if (targetChanged) null else latestResolved.asmrOneWorkId,
                             preserveHeaderAlbumMetadata = latestResolved.preserveHeaderAlbumMetadata
                         ),
                         dlsiteWorkno = resolvedTarget.workno,
                         dlsiteEditions = resolvedTarget.editions,
                         dlsiteSelectedLang = resolvedTarget.selectedLang,
                         hasResolvedInitialDlsiteTarget = true,
+                        hasResolvedAsmrOneContent = if (targetChanged) false else latestResolved.hasResolvedAsmrOneContent,
+                        asmrOneWorkId = if (targetChanged) null else latestResolved.asmrOneWorkId,
+                        asmrOneSite = if (targetChanged) null else latestResolved.asmrOneSite,
+                        asmrOneTree = if (targetChanged) emptyList() else latestResolved.asmrOneTree,
                         isLoadingDlsite = true,
+                        isLoadingAsmrOne = if (targetChanged) false else latestResolved.isLoadingAsmrOne,
                         isLoadingDlsiteTrial = false
                     )
                     _uiState.value = AlbumDetailUiState.Success(model = loadModel)
@@ -1352,6 +1377,22 @@ class AlbumDetailViewModel @Inject constructor(
         ensureAsmrOneLoaded()
     }
 
+    private fun finishAsmrOneLoad(keyRj: String, resolved: Boolean, showFailureMessage: Boolean = false) {
+        val updated = (_uiState.value as? AlbumDetailUiState.Success)?.model ?: return
+        val updatedKey = updated.rjCode.trim().uppercase()
+        if (updatedKey.equals(keyRj, ignoreCase = true)) {
+            if (showFailureMessage && updated.asmrOneTree.isEmpty()) {
+                messageManager.showError("在线资源加载失败，请稍后重试")
+            }
+            _uiState.value = AlbumDetailUiState.Success(
+                model = updated.copy(
+                    isLoadingAsmrOne = false,
+                    hasResolvedAsmrOneContent = if (resolved) true else updated.hasResolvedAsmrOneContent
+                )
+            )
+        }
+    }
+
     fun refreshDlsiteTrialSection() {
         val current = _uiState.value as? AlbumDetailUiState.Success ?: return
         val workno = current.model.dlsiteWorkno.trim().uppercase().ifBlank { current.model.rjCode.trim().uppercase() }
@@ -1399,7 +1440,6 @@ class AlbumDetailViewModel @Inject constructor(
         }
         if (
             keyRj.isBlank() ||
-            !current.model.hasResolvedInitialDlsiteTarget ||
             current.model.hasResolvedAsmrOneContent ||
             current.model.isLoadingAsmrOne ||
             asmrOneAttemptedRj.contains(keyRj)
@@ -1411,6 +1451,7 @@ class AlbumDetailViewModel @Inject constructor(
             val latestKey = latestBefore.model.rjCode.trim().uppercase()
             if (!latestKey.equals(keyRj, ignoreCase = true)) {
                 asmrOneAttemptedRj.remove(keyRj)
+                finishAsmrOneLoad(keyRj, resolved = false)
                 return@launch
             }
             _uiState.value = AlbumDetailUiState.Success(
@@ -1429,6 +1470,43 @@ class AlbumDetailViewModel @Inject constructor(
                     ?.uppercase()
                     .orEmpty()
                 val originalRj = jpnWorkno.ifBlank { latestBase.ifBlank { keyRj } }
+                val backendRjs = listOf(keyRj, originalRj, latest.dlsiteWorkno, latestBase)
+                    .map { it.trim().uppercase() }
+                    .filter { RJ_CODE_REGEX.matches(it) }
+                    .distinct()
+                val backendFirst = fetchAsmrOneTracksBackendFirst(
+                    backendRjs = backendRjs,
+                    fetchBackend = { fetchBackendAsmrOneTracksByRj(it) },
+                    fetchFallback = { Triple(null, null, emptyList()) }
+                )
+                if (backendFirst.third.isNotEmpty()) {
+                    val backendWorkId = backendFirst.first.orEmpty()
+                    val updated = (_uiState.value as? AlbumDetailUiState.Success)?.model ?: return@launch
+                    if (token != asmrOneLoadToken) {
+                        asmrOneAttemptedRj.remove(keyRj)
+                        finishAsmrOneLoad(keyRj, resolved = false)
+                        return@launch
+                    }
+                    val displayAlbum = mergeDetailHeaderAlbum(
+                        currentDisplayAlbum = updated.displayAlbum,
+                        localAlbum = updated.localAlbum,
+                        fetchedDlsiteInfo = updated.dlsiteInfo,
+                        rjCode = updated.rjCode,
+                        asmrOneWorkId = backendWorkId.ifBlank { updated.asmrOneWorkId },
+                        preserveHeaderAlbumMetadata = updated.preserveHeaderAlbumMetadata
+                    )
+                    _uiState.value = AlbumDetailUiState.Success(
+                        model = updated.copy(
+                            displayAlbum = displayAlbum,
+                            asmrOneWorkId = backendWorkId.ifBlank { updated.asmrOneWorkId },
+                            asmrOneSite = null,
+                            asmrOneTree = backendFirst.third,
+                            hasResolvedAsmrOneContent = true,
+                            isLoadingAsmrOne = false
+                        )
+                    )
+                    return@launch
+                }
 
                 val collected = isAsmrOneCollected(originalRj, timeoutMs = 1_200L)
                 if (collected == false) {
@@ -1469,32 +1547,19 @@ class AlbumDetailViewModel @Inject constructor(
                         selectDlsiteLanguageInternal(fallbackLang, isUserSelection = false)
                         return@launch
                     }
-                    val updated = (_uiState.value as? AlbumDetailUiState.Success)?.model ?: return@launch
-                    val updatedKey = updated.rjCode.trim().uppercase()
-                    if (updatedKey.equals(keyRj, ignoreCase = true) && updated.isLoadingAsmrOne) {
-                        _uiState.value = AlbumDetailUiState.Success(
-                            model = updated.copy(
-                                isLoadingAsmrOne = false,
-                                hasResolvedAsmrOneContent = true
-                            )
-                        )
-                    }
+                    asmrOneAttemptedRj.remove(keyRj)
+                    finishAsmrOneLoad(keyRj, resolved = true)
                     return@launch
                 }
 
                 val resolvedOriginal = resolveAsmrOneWork(originalRj)
                     ?: resolveAsmrOneWork(keyRj)
                     ?: run {
-                        val updated = (_uiState.value as? AlbumDetailUiState.Success)?.model ?: return@launch
-                        if (token != asmrOneLoadToken) return@launch
                         asmrOneAttemptedRj.remove(keyRj)
-                        if (updated.rjCode.trim().uppercase().equals(keyRj, ignoreCase = true) && updated.isLoadingAsmrOne) {
-                            _uiState.value = AlbumDetailUiState.Success(
-                                model = updated.copy(
-                                    isLoadingAsmrOne = false,
-                                    hasResolvedAsmrOneContent = true
-                                )
-                            )
+                        if (token != asmrOneLoadToken) {
+                            finishAsmrOneLoad(keyRj, resolved = false)
+                        } else {
+                            finishAsmrOneLoad(keyRj, resolved = true)
                         }
                         return@launch
                     }
@@ -1525,23 +1590,12 @@ class AlbumDetailViewModel @Inject constructor(
                 val updated = (_uiState.value as? AlbumDetailUiState.Success)?.model ?: return@launch
                 if (token != asmrOneLoadToken) {
                     asmrOneAttemptedRj.remove(keyRj)
-                    val updatedKey = updated.rjCode.trim().uppercase()
-                    if (updatedKey.equals(keyRj, ignoreCase = true) && updated.isLoadingAsmrOne) {
-                        _uiState.value = AlbumDetailUiState.Success(model = updated.copy(isLoadingAsmrOne = false))
-                    }
+                    finishAsmrOneLoad(keyRj, resolved = false)
                     return@launch
                 }
                 if (workId.isBlank()) {
                     asmrOneAttemptedRj.remove(keyRj)
-                    val updatedKey = updated.rjCode.trim().uppercase()
-                    if (updatedKey.equals(keyRj, ignoreCase = true) && updated.isLoadingAsmrOne) {
-                        _uiState.value = AlbumDetailUiState.Success(
-                            model = updated.copy(
-                                isLoadingAsmrOne = false,
-                                hasResolvedAsmrOneContent = true
-                            )
-                        )
-                    }
+                    finishAsmrOneLoad(keyRj, resolved = true)
                     return@launch
                 }
                 val displayAlbum = mergeDetailHeaderAlbum(
@@ -1564,30 +1618,10 @@ class AlbumDetailViewModel @Inject constructor(
                 )
             } catch (e: kotlinx.coroutines.CancellationException) {
                 asmrOneAttemptedRj.remove(keyRj)
-                val updated = (_uiState.value as? AlbumDetailUiState.Success)?.model ?: return@launch
-                val updatedKey = updated.rjCode.trim().uppercase()
-                if (updatedKey.equals(keyRj, ignoreCase = true) && updated.isLoadingAsmrOne) {
-                    _uiState.value = AlbumDetailUiState.Success(model = updated.copy(isLoadingAsmrOne = false))
-                }
+                finishAsmrOneLoad(keyRj, resolved = false)
             } catch (e: Exception) {
                 asmrOneAttemptedRj.remove(keyRj)
-                val updated = (_uiState.value as? AlbumDetailUiState.Success)?.model ?: return@launch
-                val updatedKey = updated.rjCode.trim().uppercase()
-                if (updatedKey.equals(keyRj, ignoreCase = true)) {
-                    if (updated.asmrOneTree.isEmpty()) {
-                        messageManager.showError("在线资源加载失败，请稍后重试")
-                    }
-                    if (updated.isLoadingAsmrOne) {
-                        _uiState.value = AlbumDetailUiState.Success(
-                            model = updated.copy(
-                                isLoadingAsmrOne = false,
-                                hasResolvedAsmrOneContent = true
-                            )
-                        )
-                    }
-                } else if (updated.isLoadingAsmrOne) {
-                    _uiState.value = AlbumDetailUiState.Success(model = updated.copy(isLoadingAsmrOne = false))
-                }
+                finishAsmrOneLoad(keyRj, resolved = true, showFailureMessage = true)
             }
         }
     }
@@ -2680,6 +2714,7 @@ class AlbumDetailViewModel @Inject constructor(
     }
 
     private companion object {
+        val RJ_CODE_REGEX = Regex("""RJ\d{6,}""")
         const val MAX_RECOMMENDATION_ASMR_ONE_ENRICH = 12
         const val RECOMMENDATION_ASMR_ONE_ENRICH_CONCURRENCY = 4
     }

--- a/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailDlsiteTabs.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailDlsiteTabs.kt
@@ -794,64 +794,6 @@ internal fun AlbumDlsiteInfoBreadcrumbTabV2(
         contentPadding = PaddingValues(top = topContentPadding, bottom = LocalBottomOverlayPadding.current)
     ) {
         item(key = "dlsite-header") { header() }
-        if (isInitialDlsiteLoading) {
-            item(key = "dlsite-gallery-section") {
-                Column(modifier = dlsiteAnimatedSectionModifier(Modifier.fillMaxWidth(), animateIntro)) {
-                    Text(
-                        text = "Gallery",
-                        modifier = Modifier.padding(horizontal = AlbumDetailHorizontalPadding, vertical = 8.dp),
-                        style = MaterialTheme.typography.titleMedium,
-                        fontWeight = FontWeight.Bold
-                    )
-                    DlsiteGalleryLoadingRow()
-                }
-            }
-            item(key = "dlsite-one-header") {
-                Row(
-                    modifier = dlsiteAnimatedSectionModifier(
-                        Modifier
-                            .fillMaxWidth()
-                            .padding(horizontal = AlbumDetailHorizontalPadding, vertical = 8.dp),
-                        animateIntro = animateIntro
-                    ),
-                    verticalAlignment = Alignment.CenterVertically
-                ) {
-                    Text(
-                        text = "ONE",
-                        style = MaterialTheme.typography.titleMedium,
-                        fontWeight = FontWeight.Bold
-                    )
-                }
-            }
-            item(key = "dlsite-one-content") {
-                Box(modifier = dlsiteAnimatedSectionModifier(Modifier.fillMaxWidth(), animateIntro)) {
-                    DlsiteDirectoryLoadingPanel()
-                }
-            }
-            item(key = "dlsite-trial-loading") {
-                Column(modifier = dlsiteAnimatedSectionModifier(Modifier.fillMaxWidth(), animateIntro)) {
-                Row(
-                    modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(horizontal = AlbumDetailHorizontalPadding, vertical = 8.dp),
-                    verticalAlignment = Alignment.CenterVertically
-                ) {
-                    Text(
-                        text = "试听 / 试看",
-                        style = MaterialTheme.typography.titleMedium,
-                        fontWeight = FontWeight.Bold
-                    )
-                }
-                DlsiteTrialLoadingList()
-                }
-            }
-            item(key = "dlsite-recommendations") {
-                Box(modifier = dlsiteAnimatedSectionModifier(Modifier.fillMaxWidth(), animateIntro)) {
-                    DlsiteRecommendationsLoadingBlocks()
-                }
-            }
-            return@LazyColumn
-        }
         item(key = "dlsite-gallery-section") {
             Column(modifier = dlsiteAnimatedSectionModifier(Modifier.fillMaxWidth(), animateIntro)) {
             Text(
@@ -1091,7 +1033,7 @@ internal fun AlbumDlsiteInfoBreadcrumbTabV2(
         }
         if (trialTracks.isEmpty()) {
             item(key = "dlsite-trial-content") {
-                if (isLoadingTrial) {
+                if (isInitialDlsiteLoading || isLoadingTrial) {
                     Box(
                         modifier = dlsiteAnimatedSectionModifier(Modifier.fillMaxWidth(), animateIntro),
                         contentAlignment = Alignment.Center
@@ -1152,10 +1094,14 @@ internal fun AlbumDlsiteInfoBreadcrumbTabV2(
         }
         item(key = "dlsite-recommendations") {
             Box(modifier = dlsiteAnimatedSectionModifier(Modifier.fillMaxWidth(), animateIntro)) {
-                DlsiteRecommendationsBlocks(
-                    recommendations = dlsiteRecommendations,
-                    onOpenAlbumByRj = onOpenAlbumByRj
-                )
+                if (isInitialDlsiteLoading) {
+                    DlsiteRecommendationsLoadingBlocks()
+                } else {
+                    DlsiteRecommendationsBlocks(
+                        recommendations = dlsiteRecommendations,
+                        onOpenAlbumByRj = onOpenAlbumByRj
+                    )
+                }
             }
         }
     }

--- a/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailViewModelSupport.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailViewModelSupport.kt
@@ -370,6 +370,26 @@ internal fun buildDlsiteTrialDownloadTree(trialTracks: List<Track>): List<AsmrOn
     }
 }
 
+internal suspend fun fetchAsmrOneTracksBackendFirst(
+    backendRjs: List<String>,
+    fetchBackend: suspend (String) -> Pair<String, List<AsmrOneTrackNodeResponse>>?,
+    fetchFallback: suspend () -> Triple<String?, Int?, List<AsmrOneTrackNodeResponse>>
+): Triple<String?, Int?, List<AsmrOneTrackNodeResponse>> {
+    backendRjs
+        .asSequence()
+        .map { it.trim().uppercase() }
+        .filter { it.isNotBlank() }
+        .distinct()
+        .forEach { rj ->
+            val backendResult = runCatching { fetchBackend(rj) }.getOrNull()
+            val tree = backendResult?.second.orEmpty()
+            if (backendResult != null && tree.isNotEmpty()) {
+                return Triple(backendResult.first.takeIf { it.isNotBlank() }, null, tree)
+            }
+        }
+    return fetchFallback()
+}
+
 private fun inferDlsiteTrialMediaType(title: String, url: String): TreeFileType? {
     val normalizedUrl = url.trim()
     val normalizedTitle = title.trim()

--- a/app/src/test/java/com/asmr/player/ui/library/AlbumDetailAsmrOneBackendFirstTest.kt
+++ b/app/src/test/java/com/asmr/player/ui/library/AlbumDetailAsmrOneBackendFirstTest.kt
@@ -1,0 +1,51 @@
+package com.asmr.player.ui.library
+
+import com.asmr.player.data.remote.api.AsmrOneTrackNodeResponse
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class AlbumDetailAsmrOneBackendFirstTest {
+    @Test
+    fun fetchAsmrOneTracksBackendFirst_usesBackendTreeImmediately() = runBlocking {
+        var fallbackCalled = false
+        val backendTree = listOf(AsmrOneTrackNodeResponse(title = "backend.wav", mediaDownloadUrl = "https://example.com/backend.wav"))
+
+        val result = fetchAsmrOneTracksBackendFirst(
+            backendRjs = listOf("rj01271410"),
+            fetchBackend = { rj -> "1271410" to backendTree.also { assertEquals("RJ01271410", rj) } },
+            fetchFallback = {
+                fallbackCalled = true
+                Triple("fallback", null, emptyList())
+            }
+        )
+
+        assertEquals("1271410", result.first)
+        assertEquals(backendTree, result.third)
+        assertFalse(fallbackCalled)
+    }
+
+    @Test
+    fun fetchAsmrOneTracksBackendFirst_fallsBackWhenBackendFailsOrHasNoTree() = runBlocking {
+        val requested = mutableListOf<String>()
+        val fallbackTree = listOf(AsmrOneTrackNodeResponse(title = "fallback.wav", mediaDownloadUrl = "https://example.com/fallback.wav"))
+
+        val result = fetchAsmrOneTracksBackendFirst(
+            backendRjs = listOf("RJ01271410", "RJ01271411"),
+            fetchBackend = { rj ->
+                requested += rj
+                if (rj == "RJ01271410") error("backend unavailable")
+                "1271411" to emptyList()
+            },
+            fetchFallback = { Triple("fallback", 1, fallbackTree) }
+        )
+
+        assertEquals(listOf("RJ01271410", "RJ01271411"), requested)
+        assertEquals("fallback", result.first)
+        assertEquals(1, result.second)
+        assertEquals(fallbackTree, result.third)
+        assertTrue(result.third.isNotEmpty())
+    }
+}


### PR DESCRIPTION
## Summary
- decouple ONE directory loading/rendering from DLsite initial detail loading
- fetch ONE track trees from EaraServer /api/asmr-one/tracks?rj= first, then fall back to asmr.one site APIs
- ensure uncollected/not-found ONE works resolve to the empty state instead of staying on skeleton loading

## Tests
- .\gradlew-local.bat :app:testReleaseUnitTest --tests com.asmr.player.ui.library.AlbumDetailAsmrOneBackendFirstTest --tests com.asmr.player.ui.library.AlbumDetailOneStateTest