### PR TITLE
Polish album detail reveal animations

### DIFF
--- a/app/src/main/java/com/asmr/player/ui/library/AlbumDetailScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/AlbumDetailScreen.kt
@@ -216,9 +216,9 @@ private val AlbumHeaderExpandTweenSpec = tween<IntSize>(
     easing = FastOutLinearInEasing
 )
 
-private val AlbumHeaderActionMorphSpec = spring<Float>(
-    dampingRatio = Spring.DampingRatioNoBouncy,
-    stiffness = Spring.StiffnessMediumLow
+private val AlbumHeaderActionMorphSpec = tween<Float>(
+    durationMillis = 280,
+    easing = FastOutSlowInEasing
 )
 
 private val DlsiteSectionResizeTweenSpec = tween<IntSize>(
@@ -1443,7 +1443,7 @@ private fun AlbumHeader(
     }
 
     // 记录“首帧时各信息块是否已存在”：本地库专辑进入时 cv/tags 已就绪，应直接淡入不撑开（消除下沉抖动）；
-    // 在线专辑即使从列表 hint 拿到了 cv，也仍按延迟元信息处理，保留平移撑开的进入节奏。
+    // 在线专辑即使从列表 hint 拿到了 cv，也仍按延迟元信息处理，保留延迟淡入/展开的进入节奏。
     val cvPresentInitially = remember(headerAnimationScopeKey) { album.cv.isNotBlank() }
     val tagsPresentInitially = remember(headerAnimationScopeKey) { album.tags.isNotEmpty() }
     val cvExpandLayout = shouldExpandAlbumHeaderMetaReveal(deferMetaRevealExpected, cvPresentInitially)
@@ -1989,20 +1989,12 @@ private fun AlbumHeaderInfoReveal(
         animationSpec = AlbumHeaderEnterTweenSpec,
         label = "albumHeaderInfoAlpha"
     )
-    val offsetYProgress by animateFloatAsState(
-        targetValue = if (visible) 0f else 1f,
-        animationSpec = AlbumHeaderEnterTweenSpec,
-        label = "albumHeaderInfoOffsetY"
-    )
-    val density = LocalDensity.current
-    val offsetYPx = with(density) { 14.dp.toPx() } * offsetYProgress
     if (!expandLayout) {
-        // 进入时就已存在的内容（本地库 cv/tags、按钮行）：只做淡入 + 轻微上移，
-        // 不改变布局高度，避免从 0 高度展开把下方列表先推下再回弹（“下沉”抖动）。
+        // 进入时就已存在的内容（RJ、cv/tags、按钮行）：只做淡入，不做纵向平移，
+        // 避免先超过最终位置再回到目标位置。
         Box(
             modifier = Modifier.graphicsLayer {
                 this.alpha = alpha
-                translationY = offsetYPx
             }
         ) {
             content()
@@ -2025,7 +2017,6 @@ private fun AlbumHeaderInfoReveal(
         Box(
             modifier = Modifier.graphicsLayer {
                 this.alpha = alpha
-                translationY = offsetYPx
             }
         ) {
             content()

--- a/app/src/main/java/com/asmr/player/ui/library/AlbumDetailScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/AlbumDetailScreen.kt
@@ -566,7 +566,8 @@ fun AlbumDetailScreen(
 
                         val headerContent: @Composable (Int) -> Unit = { tab ->
                             val isLocalTab = tab == 0
-                            val canSaveOnlineForTab = tab == 1 && asmrOneTree.isNotEmpty()
+                            val resolvedInitialTarget = model.hasResolvedInitialDlsiteTarget
+                            val canSaveOnlineForTab = tab == 1 && resolvedInitialTarget && asmrOneTree.isNotEmpty()
                             val headerAlbum = headerAlbumForTab(tab)
                             val headerDlsiteEditions = if (isLocalTab) {
                                 emptyList()
@@ -598,7 +599,7 @@ fun AlbumDetailScreen(
                                     }
                                     showAsmrDownloadDialog = true
                                 },
-                                showDlsitePlayLossless = tab == 2,
+                                showDlsitePlayLossless = tab == 2 && resolvedInitialTarget,
                                 onLosslessDownloadClick = {
                                     viewModel.downloadDlsitePlayLosslessArchive()
                                 },
@@ -606,11 +607,11 @@ fun AlbumDetailScreen(
                                     showOnlineSaveDialog = true
                                 },
                                 downloadEnabled = when (tab) {
-                                    1 -> asmrOneTree.isNotEmpty()
-                                    2 -> model.dlsitePlayTree.isNotEmpty()
+                                    1 -> resolvedInitialTarget && asmrOneTree.isNotEmpty()
+                                    2 -> resolvedInitialTarget && model.dlsitePlayTree.isNotEmpty()
                                     else -> false
                                 },
-                                losslessDownloadEnabled = tab == 2 && model.dlsitePlayTree.isNotEmpty(),
+                                losslessDownloadEnabled = tab == 2 && resolvedInitialTarget && model.dlsitePlayTree.isNotEmpty(),
                                 saveEnabled = canSaveOnlineForTab,
                                 showGroupButton = isLocalTab && model.localAlbum != null,
                                 onOpenGroupPicker = onOpenGroupPicker,
@@ -654,15 +655,21 @@ fun AlbumDetailScreen(
                             LaunchedEffect(
                                 selectedTab,
                                 model.rjCode,
-                                model.dlsiteWorkno
+                                model.dlsiteWorkno,
+                                model.hasResolvedInitialDlsiteTarget
                             ) {
                                 when (selectedTab) {
                                     1 -> {
                                         viewModel.ensureDlsiteLoaded()
-                                        viewModel.ensureAsmrOneLoaded()
+                                        if (model.hasResolvedInitialDlsiteTarget) {
+                                            viewModel.ensureAsmrOneLoaded()
+                                        }
                                     }
                                     2 -> {
                                         viewModel.ensureDlsiteLoaded()
+                                        if (model.hasResolvedInitialDlsiteTarget) {
+                                            viewModel.ensureDlsitePlayLoaded()
+                                        }
                                     }
                                 }
                             }
@@ -819,7 +826,7 @@ fun AlbumDetailScreen(
                                         rjCode = model.rjCode,
                                         tree = model.dlsitePlayTree,
                                         isLoading = model.isLoadingDlsitePlay,
-                                        shouldAutoLoad = selectedTab == 2,
+                                        shouldAutoLoad = selectedTab == 2 && model.hasResolvedInitialDlsiteTarget,
                                         onOpenLogin = onOpenDlsiteLogin,
                                         onEnsureLoaded = { viewModel.ensureDlsitePlayLoaded() },
                                         onPlayMediaItems = onPlayMediaItems,
@@ -855,7 +862,7 @@ fun AlbumDetailScreen(
                     }
                 }
 
-                val canSaveOnline = selectedTab == 1 && asmrOneTree.isNotEmpty()
+                val canSaveOnline = selectedTab == 1 && model.hasResolvedInitialDlsiteTarget && asmrOneTree.isNotEmpty()
                 if (showAsmrDownloadDialog) {
                     val downloadTree = when (downloadSource) {
                         OnlineDownloadSource.AsmrOne -> asmrOneTree

--- a/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailDlsiteTabs.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailDlsiteTabs.kt
@@ -146,20 +146,25 @@ import com.asmr.player.util.Formatting
 import com.asmr.player.util.MessageManager
 import com.asmr.player.util.RemoteSubtitleSource
 
+private val DlsiteGalleryThumbWidth = 140.dp
+private val DlsiteGalleryThumbHeight = 100.dp
+private val DlsiteGalleryThumbGap = 10.dp
+private const val DlsiteGalleryThumbCornerRadius = 12
+
 @Composable
 private fun DlsiteGalleryLoadingRow() {
     val placeholders = remember { listOf(0, 1, 2, 3) }
     LazyRow(
         modifier = Modifier
             .fillMaxWidth()
-            .padding(horizontal = 12.dp),
-        horizontalArrangement = Arrangement.spacedBy(10.dp),
+            .padding(horizontal = AlbumDetailHorizontalPadding),
+        horizontalArrangement = Arrangement.spacedBy(DlsiteGalleryThumbGap),
         contentPadding = PaddingValues(vertical = 10.dp)
     ) {
         items(placeholders, key = { it }, contentType = { "galleryLoadingThumb" }) {
             AsmrShimmerPlaceholder(
-                modifier = Modifier.size(width = 140.dp, height = 100.dp),
-                cornerRadius = 12
+                modifier = Modifier.size(width = DlsiteGalleryThumbWidth, height = DlsiteGalleryThumbHeight),
+                cornerRadius = DlsiteGalleryThumbCornerRadius
             )
         }
     }
@@ -813,7 +818,7 @@ internal fun AlbumDlsiteInfoBreadcrumbTabV2(
             } else {
                 LazyRow(
                     modifier = Modifier.fillMaxWidth().padding(horizontal = AlbumDetailHorizontalPadding),
-                    horizontalArrangement = Arrangement.spacedBy(10.dp),
+                    horizontalArrangement = Arrangement.spacedBy(DlsiteGalleryThumbGap),
                     contentPadding = PaddingValues(vertical = 10.dp)
                 ) {
                     items(items = galleryUrls, key = { it }, contentType = { "galleryThumb" }) { url ->
@@ -822,7 +827,7 @@ internal fun AlbumDlsiteInfoBreadcrumbTabV2(
                             if (headers.isEmpty()) url else CacheImageModel(data = url, headers = headers, keyTag = "dlsite")
                         }
                         Card(
-                            modifier = Modifier.size(width = 140.dp, height = 100.dp).clickable {
+                            modifier = Modifier.size(width = DlsiteGalleryThumbWidth, height = DlsiteGalleryThumbHeight).clickable {
                                 buildGalleryImagePreviewRequest(
                                     galleryUrls = galleryUrls,
                                     clickedUrl = url,
@@ -848,7 +853,7 @@ internal fun AlbumDlsiteInfoBreadcrumbTabV2(
                                 model = model,
                                 contentDescription = null,
                                 contentScale = ContentScale.Crop,
-                                placeholderCornerRadius = 12,
+                                placeholderCornerRadius = DlsiteGalleryThumbCornerRadius,
                                 modifier = Modifier.fillMaxSize()
                             )
                         }


### PR DESCRIPTION
## Summary
- remove vertical offset from album header reveal rows so RJ/CV/tags/actions settle without rebound
- gate album detail download/save/lossless actions until the initial DLsite target is resolved to avoid action state flicker
- align DLsite Gallery loading skeleton sizing and padding with final thumbnails to avoid horizontal jitter

## Verification
- .\\gradlew-local.bat :app:installRelease