### PR TITLE
Fix save/download local library compatibility

### DIFF
--- a/app/src/main/java/com/asmr/player/data/remote/download/DownloadManager.kt
+++ b/app/src/main/java/com/asmr/player/data/remote/download/DownloadManager.kt
@@ -13,6 +13,7 @@ import com.asmr.player.data.local.db.entities.AlbumFtsEntity
 import com.asmr.player.data.local.db.dao.DownloadDao
 import com.asmr.player.data.local.db.entities.DownloadItemEntity
 import com.asmr.player.data.local.db.entities.DownloadTaskEntity
+import com.asmr.player.data.local.db.entities.RemoteSubtitleSourceEntity
 import com.asmr.player.data.local.db.entities.SubtitleEntity
 import com.asmr.player.data.local.db.entities.TrackEntity
 import com.asmr.player.data.local.db.AppDatabaseProvider
@@ -1178,6 +1179,14 @@ private suspend fun upsertDownloadedAlbumToLibrary(
     } catch (_: Exception) {
         null
     } ?: try {
+        albumDao.getAllAlbumsOnce().firstOrNull { album ->
+            listOfNotNull(album.localPath, album.downloadPath)
+                .map { it.trim() }
+                .any { it.equals(dir.absolutePath, ignoreCase = false) }
+        }
+    } catch (_: Exception) {
+        null
+    } ?: try {
         if (rj.isNotBlank()) albumDao.getAlbumByWorkIdOnce(rj) else null
     } catch (_: Exception) {
         null
@@ -1309,44 +1318,84 @@ private suspend fun upsertDownloadedAlbumToLibrary(
         }
     }
 
-    val allAfterInsert = runCatching { trackDao.getTracksForAlbumOnce(albumId) }.getOrDefault(emptyList())
-    val localAfterInsert = allAfterInsert.filter { !it.path.trim().startsWith("http", ignoreCase = true) }
-    val localKeyToId = LinkedHashMap<String, Long>()
-    val localKeyToIdNoGroup = LinkedHashMap<String, Long>()
-    localAfterInsert
-        .sortedWith(compareByDescending<TrackEntity> { it.path.startsWith(prefix) }.thenBy { it.id })
-        .forEach { t ->
-            localKeyToId.putIfAbsent(TrackKeyNormalizer.buildKey(t.title, t.group, null), t.id)
-            localKeyToIdNoGroup.putIfAbsent(TrackKeyNormalizer.buildKey(t.title, "", null), t.id)
+    replaceMatchedOnlineTracksWithLocalTracks(db, albumId, prefix)
+    runCatching { db.localTreeCacheDao().deleteByAlbum(albumId) }
+}
+
+internal suspend fun replaceMatchedOnlineTracksWithLocalTracks(
+    db: com.asmr.player.data.local.db.AppDatabase,
+    albumId: Long,
+    preferredLocalPrefix: String
+) {
+    val trackDao = db.trackDao()
+    val remoteSubtitleSourceDao = db.remoteSubtitleSourceDao()
+    val allTracks = runCatching { trackDao.getTracksForAlbumOnce(albumId) }.getOrDefault(emptyList())
+    val localTracks = allTracks.filter { !it.path.trim().startsWith("http", ignoreCase = true) }
+    val localKeyToTrack = LinkedHashMap<String, TrackEntity>()
+    val localKeyToTrackNoGroup = LinkedHashMap<String, TrackEntity>()
+    localTracks
+        .sortedWith(compareByDescending<TrackEntity> { it.path.startsWith(preferredLocalPrefix) }.thenBy { it.id })
+        .forEach { track ->
+            localKeyToTrack.putIfAbsent(TrackKeyNormalizer.buildKey(track.title, track.group, null), track)
+            localKeyToTrackNoGroup.putIfAbsent(TrackKeyNormalizer.buildKey(track.title, "", null), track)
         }
 
-    allAfterInsert
+    val onlineIdsToDelete = ArrayList<Long>()
+    allTracks
         .filter { it.path.trim().startsWith("http", ignoreCase = true) }
         .forEach { online ->
             val key = TrackKeyNormalizer.buildKey(online.title, online.group, null)
             val keyNoGroup = TrackKeyNormalizer.buildKey(online.title, "", null)
-            val targetId = localKeyToId[key] ?: localKeyToIdNoGroup[keyNoGroup]
-            if (targetId != null) {
-                val sourceSubs = runCatching { trackDao.getSubtitlesForTrack(online.id) }.getOrDefault(emptyList())
-                if (sourceSubs.isNotEmpty()) {
-                    val targetHasSubs = runCatching { trackDao.getSubtitlesForTrack(targetId) }.getOrDefault(emptyList()).isNotEmpty()
-                    if (!targetHasSubs) {
-                        runCatching {
-                            trackDao.insertSubtitles(
-                                sourceSubs.map { s ->
-                                    SubtitleEntity(
-                                        trackId = targetId,
-                                        startMs = s.startMs,
-                                        endMs = s.endMs,
-                                        text = s.text
-                                    )
-                                }
-                            )
-                        }
+            val target = localKeyToTrack[key] ?: localKeyToTrackNoGroup[keyNoGroup] ?: return@forEach
+
+            val sourceSubs = runCatching { trackDao.getSubtitlesForTrack(online.id) }.getOrDefault(emptyList())
+            if (sourceSubs.isNotEmpty()) {
+                val targetHasSubs = runCatching { trackDao.getSubtitlesForTrack(target.id) }.getOrDefault(emptyList()).isNotEmpty()
+                if (!targetHasSubs) {
+                    runCatching {
+                        trackDao.insertSubtitles(
+                            sourceSubs.map { subtitle ->
+                                SubtitleEntity(
+                                    trackId = target.id,
+                                    startMs = subtitle.startMs,
+                                    endMs = subtitle.endMs,
+                                    text = subtitle.text
+                                )
+                            }
+                        )
                     }
                 }
             }
+
+            val remoteSources = runCatching { remoteSubtitleSourceDao.getSourcesForTrackOnce(online.id) }.getOrDefault(emptyList())
+            if (remoteSources.isNotEmpty()) {
+                val targetHasRemoteSources = runCatching {
+                    remoteSubtitleSourceDao.getSourcesForTrackOnce(target.id)
+                }.getOrDefault(emptyList()).isNotEmpty()
+                if (!targetHasRemoteSources) {
+                    runCatching {
+                        remoteSubtitleSourceDao.insertAll(
+                            remoteSources.map { source ->
+                                RemoteSubtitleSourceEntity(
+                                    trackId = target.id,
+                                    url = source.url,
+                                    language = source.language,
+                                    ext = source.ext
+                                )
+                            }
+                        )
+                    }
+                }
+            }
+
+            onlineIdsToDelete += online.id
         }
+
+    if (onlineIdsToDelete.isNotEmpty()) {
+        runCatching { trackDao.deleteSubtitlesForTracks(onlineIdsToDelete) }
+        runCatching { remoteSubtitleSourceDao.deleteByTrackIds(onlineIdsToDelete) }
+        runCatching { trackDao.deleteTracksByIds(onlineIdsToDelete) }
+    }
 }
 
 private fun extractRjCode(text: String): String {

--- a/app/src/main/java/com/asmr/player/ui/library/AlbumDetailScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/AlbumDetailScreen.kt
@@ -1076,7 +1076,7 @@ private fun AlbumDetailHeroBackground(
             contentScale = ContentScale.Crop,
             alignment = Alignment.TopCenter,
             placeholderCornerRadius = 0,
-            peekAnySizeForInitial = true,
+            peekAnySizeForInitial = false,
             loadAtOriginalSize = true,
             modifier = Modifier
                 .fillMaxSize()
@@ -1127,7 +1127,7 @@ private fun AlbumDetailHeroBackground(
             contentScale = ContentScale.Crop,
             alignment = Alignment.TopCenter,
             placeholderCornerRadius = 0,
-            peekAnySizeForInitial = true,
+            peekAnySizeForInitial = false,
             loadAtOriginalSize = true,
             modifier = Modifier
                 .fillMaxSize()
@@ -1344,12 +1344,15 @@ private fun rememberStableAlbumHeroIdentity(album: Album, identitySessionKey: St
 
 @Composable
 private fun rememberStableAlbumHeroCoverSource(album: Album, coverSessionKey: String): String {
-    val current = album.coverPath.trim().ifEmpty { album.coverUrl.trim() }
+    val currentLocal = album.coverPath.trim()
+    val current = currentLocal.ifEmpty { album.coverUrl.trim() }
     var stable by remember(coverSessionKey) { mutableStateOf(current) }
-    LaunchedEffect(current) {
-        if (stable.isBlank() && current.isNotBlank()) {
-            stable = current
-        }
+    LaunchedEffect(currentLocal, current) {
+        stable = resolveStableAlbumHeroCoverSource(
+            stable = stable,
+            currentLocal = currentLocal,
+            current = current
+        )
     }
     return stable
 }

--- a/app/src/main/java/com/asmr/player/ui/library/AlbumDetailViewModel.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/AlbumDetailViewModel.kt
@@ -76,6 +76,7 @@ import kotlinx.coroutines.sync.Semaphore
 import kotlinx.coroutines.sync.withPermit
 import java.io.File
 import java.io.FileOutputStream
+import java.io.IOException
 import java.util.concurrent.atomic.AtomicBoolean
 import javax.inject.Inject
 
@@ -781,18 +782,56 @@ class AlbumDetailViewModel @Inject constructor(
 
         viewModelScope.launch {
             try {
+                var resolvedCoverPath = value
                 withContext(Dispatchers.IO) {
                     val entity = albumDao.getAlbumById(local.id) ?: return@withContext
-                    albumDao.updateAlbum(entity.copy(coverPath = value, coverThumbPath = ""))
+                    resolvedCoverPath = resolveCoverPathForLocalAlbum(entity, value)
+                    albumDao.updateAlbum(entity.copy(coverPath = resolvedCoverPath, coverThumbPath = ""))
+                    runCatching { database.localTreeCacheDao().deleteByAlbum(entity.id) }
                 }
+                updateCurrentCoverState(local.id, resolvedCoverPath, "")
                 enqueueAlbumCoverThumbWork(local.id)
                 messageManager.showSuccess("已设置封面")
-                val rj = current.model.rjCode.ifBlank { local.rjCode.ifBlank { local.workId } }
-                loadAlbum(local.id, rj, force = true)
             } catch (e: Exception) {
                 messageManager.showError("设置封面失败，请检查后重试")
             }
         }
+    }
+
+    private fun resolveCoverPathForLocalAlbum(entity: AlbumEntity, value: String): String {
+        if (!value.startsWith("http", ignoreCase = true)) return value
+        val url = value.trim()
+        val root = listOfNotNull(entity.localPath, entity.downloadPath, entity.path)
+            .map { it.trim() }
+            .firstOrNull { it.isNotBlank() && !it.startsWith("content://") && !it.startsWith("web://") && !it.startsWith("http", ignoreCase = true) }
+            ?.let { File(it) }
+            ?: onlineSaveAlbumDir(entity.toAlbumForCover(), entity.rjCode.ifBlank { entity.workId })
+        val coverPrefix = "cover_${url.hashCode().toString().replace("-", "n")}"
+        return saveOnlineCoverToAlbumDir(url, root, fileNamePrefix = coverPrefix)?.absolutePath ?: value
+    }
+
+    private fun AlbumEntity.toAlbumForCover(): Album {
+        return Album(
+            id = id,
+            title = title,
+            path = path,
+            localPath = localPath,
+            downloadPath = downloadPath,
+            coverUrl = coverUrl,
+            workId = workId,
+            rjCode = rjCode
+        )
+    }
+
+    private fun updateCurrentCoverState(albumId: Long, coverPath: String, coverThumbPath: String) {
+        val cur = _uiState.value as? AlbumDetailUiState.Success ?: return
+        _uiState.value = AlbumDetailUiState.Success(
+            model = cur.model.withUpdatedLocalCover(
+                albumId = albumId,
+                coverPath = coverPath,
+                coverThumbPath = coverThumbPath
+            )
+        )
     }
 
     private fun enqueueAlbumCoverThumbWork(albumId: Long) {
@@ -1982,6 +2021,8 @@ class AlbumDetailViewModel @Inject constructor(
                     return@withContext SaveOnlineToLibraryResult(
                         selectedCount = 0,
                         insertedCount = 0,
+                        resourceEnqueuedCount = 0,
+                        resourceSkippedCount = 0,
                         albumId = 0L,
                         coverUrl = "",
                         coverPath = ""
@@ -1991,6 +2032,13 @@ class AlbumDetailViewModel @Inject constructor(
                 val rj = normalizeRj(displayAlbum.rjCode.ifBlank { displayAlbum.workId }.ifBlank { model.rjCode })
                 val workKey = rj.ifBlank { displayAlbum.workId.trim().ifBlank { displayAlbum.title.trim() } }
                 val onlinePath = "web://rj/${workKey.uppercase()}"
+                val albumDir = onlineSaveAlbumDir(displayAlbum, workKey).apply {
+                    mkdirs()
+                    ensureNoMediaMarkers(this)
+                }
+                val coverFile = saveOnlineCoverToAlbumDir(displayAlbum.coverUrl, albumDir)
+                val playableSelected = selected.filter { isPlayableTreeFileType(it.fileType) }
+                val resourceSelected = selected.filter { !isPlayableTreeFileType(it.fileType) }
 
                 fun canonicalUrl(url: String): String {
                     return url.trim().substringBefore('#').substringBefore('?')
@@ -2003,20 +2051,22 @@ class AlbumDetailViewModel @Inject constructor(
                 database.withTransaction {
                     val existing = if (workKey.isNotBlank()) {
                         runCatching { albumDao.getAlbumByWorkIdOnce(workKey) }.getOrNull()
-                    } else null
+                    } else {
+                        null
+                    }
 
                     val tagsCsv = displayAlbum.tags.joinToString(",")
                     val entity = AlbumEntity(
                         id = existing?.id ?: 0L,
                         title = existing?.title?.takeIf { it.isNotBlank() } ?: displayAlbum.title,
                         path = existing?.path?.takeIf { it.isNotBlank() } ?: onlinePath,
-                        localPath = existing?.localPath,
+                        localPath = existing?.localPath?.takeIf { it.isNotBlank() } ?: albumDir.absolutePath,
                         downloadPath = existing?.downloadPath,
                         circle = existing?.circle?.takeIf { it.isNotBlank() } ?: displayAlbum.circle,
                         cv = existing?.cv?.takeIf { it.isNotBlank() } ?: displayAlbum.cv,
                         tags = existing?.tags?.takeIf { it.isNotBlank() } ?: tagsCsv,
                         coverUrl = existing?.coverUrl?.takeIf { it.isNotBlank() } ?: displayAlbum.coverUrl,
-                        coverPath = existing?.coverPath.orEmpty(),
+                        coverPath = coverFile?.absolutePath ?: existing?.coverPath.orEmpty(),
                         coverThumbPath = existing?.coverThumbPath.orEmpty(),
                         workId = existing?.workId?.takeIf { it.isNotBlank() } ?: displayAlbum.workId.trim().ifBlank { workKey },
                         rjCode = existing?.rjCode?.takeIf { it.isNotBlank() } ?: displayAlbum.rjCode.trim().ifBlank { rj },
@@ -2028,6 +2078,7 @@ class AlbumDetailViewModel @Inject constructor(
                     albumIdResult = albumId
                     coverUrlResult = entity.coverUrl.trim().takeIf { it.isNotBlank() && !it.equals("null", ignoreCase = true) }.orEmpty()
                     coverPathResult = entity.coverPath.trim().takeIf { it.isNotBlank() && !it.equals("null", ignoreCase = true) }.orEmpty()
+                    runCatching { database.localTreeCacheDao().deleteByAlbum(albumId) }
 
                     val fts = AlbumFtsEntity(
                         albumId = albumId,
@@ -2048,7 +2099,7 @@ class AlbumDetailViewModel @Inject constructor(
                         .toSet()
 
                     val seenUrlKeys = linkedSetOf<String>()
-                    val newLeaves = selected.filter { leaf ->
+                    val newLeaves = playableSelected.filter { leaf ->
                         val urlKey = canonicalUrl(leaf.url)
                         val duplicate = urlKey.isBlank() ||
                             existingUrlKeys.contains(urlKey) ||
@@ -2061,14 +2112,14 @@ class AlbumDetailViewModel @Inject constructor(
                         }
                     }
                     val newTracks = newLeaves.map { leaf ->
-                            TrackEntity(
-                                albumId = albumId,
-                                title = leaf.title,
-                                path = leaf.url.trim(),
-                                duration = leaf.duration,
-                                group = leaf.group
-                            )
-                        }
+                        TrackEntity(
+                            albumId = albumId,
+                            title = leaf.title,
+                            path = leaf.url.trim(),
+                            duration = leaf.duration,
+                            group = leaf.group
+                        )
+                    }
                     if (newTracks.isNotEmpty()) {
                         val insertedTrackIds = runCatching { trackDao.insertTracks(newTracks) }.getOrDefault(emptyList())
                         insertedCount = insertedTrackIds.count { it > 0L }
@@ -2087,16 +2138,36 @@ class AlbumDetailViewModel @Inject constructor(
                         if (sources.isNotEmpty()) {
                             runCatching { database.remoteSubtitleSourceDao().insertAll(sources) }
                         }
+                    }
                 }
-            }
 
-            if (albumIdResult > 0L) {
-                refreshAlbumAudioAggregate(albumIdResult)
-            }
+                var resourceEnqueuedCount = 0
+                var resourceSkippedCount = 0
+                val resourceTaskKey = "album:${safeFolderName(workKey.ifBlank { displayAlbum.title })}"
+                resourceSelected.forEach { leaf ->
+                    val enqueued = enqueueOnlineSavedResourceDownload(
+                        album = displayAlbum,
+                        leaf = leaf,
+                        albumDir = albumDir,
+                        taskKey = resourceTaskKey,
+                        taskSubtitle = displayAlbum.title
+                    )
+                    if (enqueued) {
+                        resourceEnqueuedCount += 1
+                    } else {
+                        resourceSkippedCount += 1
+                    }
+                }
 
-            SaveOnlineToLibraryResult(
-                selectedCount = selected.size,
+                if (albumIdResult > 0L) {
+                    refreshAlbumAudioAggregate(albumIdResult)
+                }
+
+                SaveOnlineToLibraryResult(
+                    selectedCount = selected.size,
                     insertedCount = insertedCount,
+                    resourceEnqueuedCount = resourceEnqueuedCount,
+                    resourceSkippedCount = resourceSkippedCount,
                     albumId = albumIdResult,
                     coverUrl = coverUrlResult,
                     coverPath = coverPathResult
@@ -2104,23 +2175,24 @@ class AlbumDetailViewModel @Inject constructor(
             }
 
             val selectedCount = result.selectedCount
-            val insertedCount = result.insertedCount
+            val changedCount = result.insertedCount + result.resourceEnqueuedCount
+            val skippedCount = selectedCount - changedCount
 
             if (result.albumId > 0L) {
                 try {
                     ensureAlbumCoverSaved(result.albumId, result.coverPath, result.coverUrl)
                 } catch (_: Exception) {
                 }
+                enqueueAlbumCoverThumbWork(result.albumId)
             }
             if (selectedCount <= 0) {
-                messageManager.showInfo("没有可保存的音频/视频文件")
-            } else if (insertedCount <= 0) {
+                messageManager.showInfo("没有可保存文件")
+            } else if (changedCount <= 0) {
                 messageManager.showInfo("本地已存在，未重复保存")
-            } else if (insertedCount < selectedCount) {
-                val skipped = selectedCount - insertedCount
-                messageManager.showSuccess("已保存到本地库（${insertedCount}项），跳过已存在（${skipped}项）")
+            } else if (skippedCount > 0) {
+                messageManager.showSuccess("已保存到本地库（${changedCount}项），跳过已存在（${skippedCount}项）")
             } else {
-                messageManager.showSuccess("已保存到本地库（${insertedCount}项）")
+                messageManager.showSuccess("已保存到本地库（${changedCount}项）")
             }
         }
     }
@@ -2128,6 +2200,8 @@ class AlbumDetailViewModel @Inject constructor(
     private data class SaveOnlineToLibraryResult(
         val selectedCount: Int,
         val insertedCount: Int,
+        val resourceEnqueuedCount: Int,
+        val resourceSkippedCount: Int,
         val albumId: Long,
         val coverUrl: String,
         val coverPath: String
@@ -2306,27 +2380,26 @@ class AlbumDetailViewModel @Inject constructor(
         val url: String,
         val duration: Double,
         val group: String,
+        val fileType: TreeFileType,
         val subtitleSources: List<RemoteSubtitleSource>
     )
 
     private fun flattenOnlineSaveLeaves(tree: List<AsmrOneTrackNodeResponse>): List<OnlineSaveLeaf> {
         val out = mutableListOf<OnlineSaveLeaf>()
         fun sanitize(name: String): String = name.trim().ifEmpty { "item" }.replace(Regex("""[\\/:*?"<>|]"""), "_")
-        val audioExts = setOf("mp3", "flac", "wav", "m4a", "ogg", "aac", "opus")
-        val videoExts = setOf("mp4", "mkv", "webm")
         val subtitleExts = setOf("lrc", "srt", "vtt")
 
         data class LeafFile(
             val rawTitle: String,
             val safeTitle: String,
             val url: String,
-            val duration: Double?
+            val duration: Double?,
+            val fileType: TreeFileType
         ) {
             val ext: String = run {
                 val ext0 = rawTitle.substringAfterLast('.', "").lowercase()
                 if (ext0.isNotBlank()) ext0 else url.substringBefore('?').substringAfterLast('.', "").lowercase()
             }
-            val baseName: String = safeTitle.substringBeforeLast('.')
         }
 
         val subtitleCandidates = mutableListOf<Pair<com.asmr.player.util.SubtitleMatchCandidate, LeafFile>>()
@@ -2342,7 +2415,14 @@ class AlbumDetailViewModel @Inject constructor(
                     if (children.isNotEmpty()) collectSubtitleCandidates(children, path)
                     return@forEach
                 }
-                val leaf = LeafFile(rawTitle = rawTitle, safeTitle = safeTitle, url = url, duration = node.duration)
+                val fileType = treeFileTypeForNode(rawTitle, url, node.type)
+                val leaf = LeafFile(
+                    rawTitle = rawTitle,
+                    safeTitle = safeTitle,
+                    url = url,
+                    duration = node.duration,
+                    fileType = fileType
+                )
                 if (subtitleExts.contains(leaf.ext)) {
                     val candidate = SubtitleMatchSupport.inferCandidate(path, leaf.url)
                     if (candidate != null) subtitleCandidates += candidate to leaf
@@ -2357,14 +2437,22 @@ class AlbumDetailViewModel @Inject constructor(
                 val url = node.mediaDownloadUrl ?: node.streamUrl
                 if (children.isNotEmpty() || url.isNullOrBlank()) return@mapNotNull null
                 val safeTitle = sanitize(rawTitle)
-                LeafFile(rawTitle = rawTitle, safeTitle = safeTitle, url = url, duration = node.duration)
+                val fileType = treeFileTypeForNode(rawTitle, url, node.type)
+                if (!isLibraryResourceSavableTreeFileType(fileType)) return@mapNotNull null
+                LeafFile(
+                    rawTitle = rawTitle,
+                    safeTitle = safeTitle,
+                    url = url,
+                    duration = node.duration,
+                    fileType = fileType
+                )
             }
 
-            leafFiles.filter { audioExts.contains(it.ext) || videoExts.contains(it.ext) }.forEach { leaf ->
+            leafFiles.forEach { leaf ->
                 val path = if (parentPath.isBlank()) leaf.safeTitle else "$parentPath/${leaf.safeTitle}"
                 val relDir = path.substringBeforeLast('/', "")
                 val group = relDir
-                val subsRaw = if (audioExts.contains(leaf.ext)) {
+                val subsRaw = if (leaf.fileType == TreeFileType.Audio) {
                     val matched = SubtitleMatchSupport.matchBest(path.substringBeforeLast('.'), subtitleCandidates.map { it.first })
                     if (matched != null) {
                         subtitleCandidates.firstOrNull { it.first.sourceRef == matched.sourceRef }?.second?.let { subtitleLeaf ->
@@ -2374,7 +2462,13 @@ class AlbumDetailViewModel @Inject constructor(
                         emptyList()
                     }
                 } else emptyList()
-                val subs = if (subsRaw.isNotEmpty()) subsRaw else OnlineLyricsStore.get(leaf.url)
+                val subs = if (leaf.fileType == TreeFileType.Audio && subsRaw.isNotEmpty()) {
+                    subsRaw
+                } else if (leaf.fileType == TreeFileType.Audio) {
+                    OnlineLyricsStore.get(leaf.url)
+                } else {
+                    emptyList()
+                }
                 out.add(
                     OnlineSaveLeaf(
                         relativePath = path,
@@ -2382,6 +2476,7 @@ class AlbumDetailViewModel @Inject constructor(
                         url = leaf.url,
                         duration = leaf.duration ?: 0.0,
                         group = group,
+                        fileType = leaf.fileType,
                         subtitleSources = subs
                     )
                 )
@@ -2399,8 +2494,7 @@ class AlbumDetailViewModel @Inject constructor(
         collectSubtitleCandidates(tree, "")
         walk(tree, "")
         return out.map { leaf ->
-            if (!(audioExts.contains(leaf.url.substringBefore('?').substringAfterLast('.', "").lowercase()) ||
-                    videoExts.contains(leaf.url.substringBefore('?').substringAfterLast('.', "").lowercase()))) {
+            if (leaf.fileType != TreeFileType.Audio) {
                 return@map leaf
             }
             val matched = SubtitleMatchSupport.matchBest(leaf.relativePath.substringBeforeLast('.'), subtitleCandidates.map { it.first })
@@ -2413,6 +2507,118 @@ class AlbumDetailViewModel @Inject constructor(
             }
             leaf.copy(subtitleSources = subtitles)
         }
+    }
+
+    private fun onlineSaveAlbumDir(album: Album, workKey: String): File {
+        val baseDir = File(context.getExternalFilesDir(null), "albums")
+        val folderName = safeFolderName(
+            album.rjCode.ifBlank { album.workId }.ifBlank { workKey }.ifBlank { album.title }
+        )
+        return File(baseDir, folderName)
+    }
+
+    private fun ensureNoMediaMarkers(dir: File) {
+        runCatching {
+            if (!dir.exists()) dir.mkdirs()
+            val albumsRoot = File(context.getExternalFilesDir(null), "albums")
+            if (!albumsRoot.exists()) albumsRoot.mkdirs()
+            val rootMarker = File(albumsRoot, ".nomedia")
+            if (!rootMarker.exists()) rootMarker.createNewFile()
+            val marker = File(dir, ".nomedia")
+            if (!marker.exists()) marker.createNewFile()
+        }
+    }
+
+    private fun saveOnlineCoverToAlbumDir(
+        coverUrl: String,
+        albumDir: File,
+        fileNamePrefix: String = "cover"
+    ): File? {
+        val url = coverUrl.trim()
+        if (!url.startsWith("http", ignoreCase = true) || isLikelyPlaceholderCover(url)) return null
+        val ext = url.substringBefore('?').substringAfterLast('.', "").takeIf { it.length in 2..5 } ?: "jpg"
+        val target = File(albumDir, "${safeFileName(fileNamePrefix)}.$ext")
+        if (target.exists() && target.length() > 0L) return target
+        return runCatching {
+            if (!albumDir.exists()) albumDir.mkdirs()
+            val request = Request.Builder()
+                .url(url)
+                .header("Accept", "image/*")
+                .get()
+                .build()
+            imageOkHttpClient.newCall(request).execute().use { response ->
+                if (!response.isSuccessful) throw IOException("HTTP ${response.code}")
+                val body = response.body ?: throw IOException("empty body")
+                FileOutputStream(target).use { output ->
+                    body.byteStream().use { input -> input.copyTo(output) }
+                }
+            }
+            target.takeIf { it.exists() && it.length() > 0L }
+        }.getOrNull()
+    }
+
+    private fun enqueueOnlineSavedResourceDownload(
+        album: Album,
+        leaf: OnlineSaveLeaf,
+        albumDir: File,
+        taskKey: String,
+        taskSubtitle: String
+    ): Boolean {
+        val url = leaf.url.trim()
+        if (!url.startsWith("http", ignoreCase = true)) return false
+        val relPath = leaf.relativePath.replace('\\', '/').trim().trimStart('/')
+        if (relPath.isBlank()) return false
+        val rawName = relPath.substringAfterLast('/', relPath)
+        val fileName = resolveRemoteResourceFileName(rawName, url, leaf.fileType)
+        val relDir = relPath.substringBeforeLast('/', "")
+        val targetDir = if (relDir.isBlank()) albumDir else File(albumDir, relDir)
+        if (!targetDir.exists()) targetDir.mkdirs()
+        ensureNoMediaMarkers(albumDir)
+
+        val outFile = File(targetDir, fileName)
+        if (outFile.exists() && outFile.isFile && outFile.length() > 0L) return false
+        val relativeFilePath = if (relDir.isBlank()) fileName else "$relDir/$fileName"
+
+        downloadManager.enqueueDownload(
+            url = url,
+            fileName = fileName,
+            targetDir = targetDir.absolutePath,
+            taskRootDir = albumDir.absolutePath,
+            relativePath = relativeFilePath,
+            taskSubtitle = taskSubtitle,
+            tags = listOf(taskKey),
+            albumTitle = album.title,
+            albumCircle = album.circle,
+            albumCv = album.cv,
+            albumTagsCsv = album.tags.joinToString(","),
+            albumCoverUrl = album.coverUrl,
+            albumWorkId = album.workId,
+            albumRjCode = album.rjCode
+        )
+        return true
+    }
+
+    private fun resolveRemoteResourceFileName(rawName: String, url: String, fileType: TreeFileType): String {
+        val baseName = safeFileName(rawName)
+        val extFromName = baseName.substringAfterLast('.', "").takeIf { it.isNotBlank() }
+        if (extFromName != null) return baseName
+        val extFromUrl = url.substringBefore('?').substringAfterLast('.', "").takeIf { it.length in 2..6 }
+        val defaultExt = when (fileType) {
+            TreeFileType.Video -> "mp4"
+            TreeFileType.Image -> "jpg"
+            TreeFileType.Pdf -> "pdf"
+            TreeFileType.Archive -> "zip"
+            TreeFileType.Document -> "doc"
+            TreeFileType.Spreadsheet -> "csv"
+            TreeFileType.Presentation -> "ppt"
+            TreeFileType.Code -> "txt"
+            TreeFileType.Ebook -> "epub"
+            TreeFileType.Font -> "ttf"
+            TreeFileType.AppPackage -> "apk"
+            TreeFileType.Text -> "txt"
+            else -> "mp3"
+        }
+        return "$baseName.${extFromUrl ?: defaultExt}"
     }
 
     private fun normalizeRj(raw: String): String {

--- a/app/src/main/java/com/asmr/player/ui/library/LegacyOnlineSavedAlbumSupport.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/LegacyOnlineSavedAlbumSupport.kt
@@ -1,0 +1,53 @@
+package com.asmr.player.ui.library
+
+import com.asmr.player.data.local.db.entities.AlbumEntity
+import com.asmr.player.data.local.db.entities.TrackEntity
+import com.asmr.player.util.isOnlineTrackPath
+import com.asmr.player.util.isVirtualAlbumPath
+import java.io.File
+
+internal fun shouldBackfillLegacyOnlineSavedAlbumRoot(
+    entity: AlbumEntity,
+    tracks: List<TrackEntity>
+): Boolean {
+    val hasNoLocalRoot = entity.localPath?.trim().orEmpty().isBlank() &&
+        entity.downloadPath?.trim().orEmpty().isBlank()
+    if (!hasNoLocalRoot) return false
+
+    val hasOnlineIdentity = isVirtualAlbumPath(entity.path) || tracks.any { isOnlineTrackPath(it.path) }
+    if (!hasOnlineIdentity) return false
+
+    val workKey = legacyOnlineSavedAlbumWorkKey(entity)
+    return workKey.isNotBlank()
+}
+
+internal fun legacyOnlineSavedAlbumFolderName(entity: AlbumEntity): String {
+    return safeLegacyOnlineSavedAlbumFolderName(legacyOnlineSavedAlbumWorkKey(entity))
+}
+
+private fun legacyOnlineSavedAlbumWorkKey(entity: AlbumEntity): String {
+    return extractLegacyRjCode(entity.rjCode)
+        .ifBlank { extractLegacyRjCode(entity.workId) }
+        .ifBlank { extractLegacyRjCode(entity.path) }
+        .ifBlank { extractLegacyRjCode(entity.title) }
+        .ifBlank { entity.workId.trim() }
+        .ifBlank { entity.title.trim() }
+}
+
+private fun extractLegacyRjCode(input: String): String {
+    return Regex("""RJ\d+""", RegexOption.IGNORE_CASE).find(input)?.value?.uppercase().orEmpty()
+}
+
+internal fun safeLegacyOnlineSavedAlbumFolderName(input: String): String {
+    return input.trim().ifEmpty { "album" }.replace(Regex("""[\\/:*?"<>|]"""), "_")
+}
+
+internal fun ensureLibraryAlbumDir(dir: File) {
+    if (!dir.exists()) dir.mkdirs()
+    val albumsRoot = dir.parentFile
+    if (albumsRoot != null && !albumsRoot.exists()) albumsRoot.mkdirs()
+    val rootMarker = albumsRoot?.let { File(it, ".nomedia") }
+    if (rootMarker != null && !rootMarker.exists()) rootMarker.createNewFile()
+    val marker = File(dir, ".nomedia")
+    if (!marker.exists()) marker.createNewFile()
+}

--- a/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailDialogs.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailDialogs.kt
@@ -271,14 +271,14 @@ internal fun AsmrOneDownloadDialog(
     }
 }
 
-private data class OnlineSaveLeafUi(
+internal data class OnlineSaveLeafUi(
     val relativePath: String,
     val title: String,
     val url: String,
     val fileType: TreeFileType
 )
 
-private fun flattenOnlineSaveLeaves(tree: List<AsmrOneTrackNodeResponse>): List<OnlineSaveLeafUi> {
+internal fun flattenOnlineSaveLeaves(tree: List<AsmrOneTrackNodeResponse>): List<OnlineSaveLeafUi> {
     val out = mutableListOf<OnlineSaveLeafUi>()
     fun sanitize(name: String): String = name.trim().ifEmpty { "item" }.replace(Regex("""[\\/:*?"<>|]"""), "_")
 
@@ -292,7 +292,7 @@ private fun flattenOnlineSaveLeaves(tree: List<AsmrOneTrackNodeResponse>): List<
             if (children.isEmpty()) {
                 if (url.isNullOrBlank()) return@forEach
                 val type = treeFileTypeForNode(titleRaw, url, node.type)
-                if (!isLibrarySavableTreeFileType(type)) return@forEach
+                if (!isLibraryResourceSavableTreeFileType(type)) return@forEach
                 out.add(
                     OnlineSaveLeafUi(
                         relativePath = path,
@@ -311,7 +311,7 @@ private fun flattenOnlineSaveLeaves(tree: List<AsmrOneTrackNodeResponse>): List<
     return out
 }
 
-private fun buildMediaLeafPathIndex(tree: List<AsmrOneTrackNodeResponse>): Map<String, List<String>> {
+private fun buildSaveLeafPathIndex(tree: List<AsmrOneTrackNodeResponse>): Map<String, List<String>> {
     val folderToLeaves = linkedMapOf<String, MutableList<String>>()
     fun sanitize(name: String): String = name.trim().ifEmpty { "item" }.replace(Regex("""[\\/:*?"<>|]"""), "_")
     fun walk(nodes: List<AsmrOneTrackNodeResponse>, parentPath: String, folderStack: List<String>) {
@@ -324,7 +324,7 @@ private fun buildMediaLeafPathIndex(tree: List<AsmrOneTrackNodeResponse>): Map<S
             if (children.isEmpty()) {
                 if (url.isNullOrBlank()) return@forEach
                 val type = treeFileTypeForNode(titleRaw, url, node.type)
-                if (!isLibrarySavableTreeFileType(type)) return@forEach
+                if (!isLibraryResourceSavableTreeFileType(type)) return@forEach
                 folderStack.forEach { folder ->
                     folderToLeaves.getOrPut(folder) { mutableListOf() }.add(path)
                 }
@@ -341,7 +341,7 @@ private fun buildMediaLeafPathIndex(tree: List<AsmrOneTrackNodeResponse>): Map<S
     return folderToLeaves
 }
 
-private fun flattenAsmrOneMediaTreeForUi(
+private fun flattenAsmrOneSaveTreeForUi(
     tree: List<AsmrOneTrackNodeResponse>,
     expanded: Set<String>
 ): AsmrTreeUiResult {
@@ -355,7 +355,7 @@ private fun flattenAsmrOneMediaTreeForUi(
         return if (children.isEmpty()) {
             if (url.isNullOrBlank()) return false
             val type = treeFileTypeForNode(titleRaw, url, node.type)
-            isLibrarySavableTreeFileType(type)
+            isLibraryResourceSavableTreeFileType(type)
         } else {
             children.any { nodeHasMedia(it) }
         }
@@ -371,7 +371,7 @@ private fun flattenAsmrOneMediaTreeForUi(
             if (children.isEmpty()) {
                 if (url.isNullOrBlank()) return@forEach
                 val type = treeFileTypeForNode(titleRaw, url, node.type)
-                if (!isLibrarySavableTreeFileType(type)) return@forEach
+                if (!isLibraryResourceSavableTreeFileType(type)) return@forEach
                 out.add(
                     AsmrTreeUiEntry.File(
                         path = path,
@@ -404,7 +404,7 @@ internal fun OnlineSaveDialog(
     onConfirm: (Set<String>) -> Unit
 ) {
     val leaves = remember(trackTree) { flattenOnlineSaveLeaves(trackTree) }
-    val leafPathsByFolder = remember(trackTree) { buildMediaLeafPathIndex(trackTree) }
+    val leafPathsByFolder = remember(trackTree) { buildSaveLeafPathIndex(trackTree) }
     val expanded = remember { mutableStateListOf<String>() }
     val selected = remember(trackTree) { mutableStateListOf<String>().apply { addAll(leaves.map { it.relativePath }) } }
     val listState = rememberLazyListState()
@@ -457,10 +457,10 @@ internal fun OnlineSaveDialog(
                                 .height(180.dp),
                             contentAlignment = Alignment.Center
                         ) {
-                            Text("没有可保存的音频/视频文件")
+                            Text("没有可保存文件")
                         }
                     } else {
-                        val entries = flattenAsmrOneMediaTreeForUi(trackTree, expanded.toSet()).entries
+                        val entries = flattenAsmrOneSaveTreeForUi(trackTree, expanded.toSet()).entries
                         LazyColumn(
                             state = listState,
                             modifier = Modifier.fillMaxSize().thinScrollbar(listState)

--- a/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailDirectorySupport.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailDirectorySupport.kt
@@ -149,6 +149,7 @@ import com.asmr.player.ui.theme.dynamicPageContainerColor
 import com.asmr.player.util.Formatting
 import com.asmr.player.util.MessageManager
 import com.asmr.player.util.RemoteSubtitleSource
+import com.asmr.player.util.isOnlineTrackPath
 
 internal sealed class AsmrTreeUiEntry {
     abstract val path: String
@@ -277,7 +278,11 @@ internal fun isDownloadableTreeFileType(fileType: TreeFileType): Boolean {
     return fileType != TreeFileType.Other && fileType != TreeFileType.Subtitle
 }
 
-internal fun isLibrarySavableTreeFileType(fileType: TreeFileType): Boolean {
+internal fun isLibraryResourceSavableTreeFileType(fileType: TreeFileType): Boolean {
+    return fileType != TreeFileType.Other && fileType != TreeFileType.Subtitle
+}
+
+internal fun isPlayableTreeFileType(fileType: TreeFileType): Boolean {
     return fileType == TreeFileType.Audio || fileType == TreeFileType.Video
 }
 
@@ -422,6 +427,7 @@ internal data class DirectoryFileItem(
     val title: String,
     val fileType: TreeFileType,
     val isPlayable: Boolean,
+    val isOnline: Boolean = false,
     val durationSeconds: Double? = null,
     val sizeSource: FileSizeSource = FileSizeSource.None,
     val absolutePath: String = "",
@@ -436,6 +442,12 @@ internal data class DirectoryFileItem(
     val dlsitePlayImageHeight: Int? = null,
     val dlsitePlayOptimizedName: String? = null
 )
+
+internal fun isOnlineDirectoryAudio(fileType: TreeFileType, absolutePath: String, track: Track?): Boolean {
+    if (fileType != TreeFileType.Audio) return false
+    val path = track?.path?.trim().orEmpty().ifBlank { absolutePath.trim() }
+    return isOnlineTrackPath(path)
+}
 
 internal data class DirectoryBrowserResult(
     val currentPath: String,
@@ -618,6 +630,7 @@ internal fun buildLocalDirectoryBrowser(
                 title = displayTitle,
                 fileType = child.fileType,
                 isPlayable = child.track != null || child.fileType == TreeFileType.Video,
+                isOnline = isOnlineDirectoryAudio(child.fileType, absolutePath, child.track),
                 durationSeconds = child.track?.duration?.takeIf { it > 0.0 },
                 sizeSource = FileSizeSource.Local(path = absolutePath, sizeBytes = child.sizeBytes),
                 absolutePath = absolutePath,
@@ -849,6 +862,7 @@ internal fun buildRemoteDirectoryBrowser(
                 title = child.name.substringBeforeLast('.'),
                 fileType = child.fileType,
                 isPlayable = child.fileType == TreeFileType.Audio || child.fileType == TreeFileType.Video,
+                isOnline = true,
                 durationSeconds = child.durationSeconds,
                 sizeSource = if (child.url.isNotBlank()) FileSizeSource.Remote(child.url) else FileSizeSource.None,
                 absolutePath = child.url,
@@ -1499,6 +1513,14 @@ internal fun fileTypeLabel(fileType: TreeFileType): String = when (fileType) {
     TreeFileType.Font -> "字体"
     TreeFileType.AppPackage -> "安装包"
     TreeFileType.Other -> "文件"
+}
+
+internal fun directoryFileTypeLabel(file: DirectoryFileItem): String {
+    return if (file.fileType == TreeFileType.Audio) {
+        if (file.isOnline) "在线音频" else "本地音频"
+    } else {
+        fileTypeLabel(file.fileType)
+    }
 }
 
 internal fun treeFileTypeIcon(fileType: TreeFileType): ImageVector = when (fileType) {
@@ -2881,9 +2903,9 @@ internal fun DirectoryFileRow(
             is FileSizeSource.Remote -> loadRemoteFileSize(sizeSource.url)?.let(Formatting::formatFileSize)
         }
     }
-    val metaLine = remember(file.fileType, file.durationSeconds, sizeText) {
+    val metaLine = remember(file.fileType, file.isOnline, file.durationSeconds, sizeText) {
         listOf(
-            fileTypeLabel(file.fileType),
+            directoryFileTypeLabel(file),
             Formatting.formatTrackSeconds(file.durationSeconds).takeIf { it.isNotBlank() },
             sizeText
         ).filterNotNull().joinToString(" · ")
@@ -3139,6 +3161,7 @@ internal fun TreeFileRow(
     depth: Int,
     fileType: TreeFileType,
     isPlayable: Boolean,
+    isOnline: Boolean = true,
     showSubtitleStamp: Boolean = false,
     thumbnailModel: Any? = null,
     onPrimary: () -> Unit,
@@ -3164,6 +3187,11 @@ internal fun TreeFileRow(
         val showPrimaryAction = isPlayable
         val showMenu = showPrimaryAction || onDownload != null || onAddToQueue != null || onAddToPlaylist != null || onManageTags != null || onRemoveFromAlbum != null
         val showTrailing = onSetAsCover != null || showMenu
+        val metaLine = if (fileType == TreeFileType.Audio) {
+            if (isOnline) "在线音频" else "本地音频"
+        } else {
+            fileTypeLabel(fileType)
+        }
         ListItem(
             headlineContent = { 
                 Text(
@@ -3173,6 +3201,13 @@ internal fun TreeFileRow(
                     color = colorScheme.textSecondary,
                     style = MaterialTheme.typography.bodyMedium.copy(fontWeight = FontWeight.SemiBold)
                 ) 
+            },
+            supportingContent = {
+                Text(
+                    text = metaLine,
+                    color = colorScheme.textTertiary,
+                    style = MaterialTheme.typography.bodySmall
+                )
             },
             leadingContent = {
                 Row(verticalAlignment = Alignment.CenterVertically) {

--- a/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailViewModelSupport.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailViewModelSupport.kt
@@ -172,6 +172,43 @@ data class AlbumDetailModel(
     val isLoadingDlsitePlay: Boolean
 )
 
+internal fun AlbumDetailModel.withUpdatedLocalCover(
+    albumId: Long,
+    coverPath: String,
+    coverThumbPath: String
+): AlbumDetailModel {
+    val localMatches = localAlbum?.id == albumId
+    val displayMatches = displayAlbum.id == albumId || localMatches
+    if (!localMatches && !displayMatches) return this
+
+    return copy(
+        localAlbum = if (localMatches) {
+            localAlbum?.copy(coverPath = coverPath, coverThumbPath = coverThumbPath)
+        } else {
+            localAlbum
+        },
+        displayAlbum = if (displayMatches) {
+            displayAlbum.copy(coverPath = coverPath, coverThumbPath = coverThumbPath)
+        } else {
+            displayAlbum
+        }
+    )
+}
+
+internal fun resolveStableAlbumHeroCoverSource(
+    stable: String,
+    currentLocal: String,
+    current: String
+): String {
+    return if (currentLocal.isNotBlank() && currentLocal != stable) {
+        currentLocal
+    } else if (stable.isBlank() && current.isNotBlank()) {
+        current
+    } else {
+        stable
+    }
+}
+
 internal fun buildDisplayAlbum(
     rjCode: String,
     localAlbum: Album?,

--- a/app/src/main/java/com/asmr/player/ui/library/libraryviewmodel.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/libraryviewmodel.kt
@@ -230,6 +230,7 @@ class LibraryViewModel @Inject constructor(
         _scanRoots.value = runCatching { scanRootsStore.getRoots() }.getOrDefault(emptySet())
         viewModelScope.launch(Dispatchers.IO) {
             ensureTagTablesInitialized()
+            backfillLegacyOnlineSavedAlbumRoots()
         }
         viewModelScope.launch {
             val shouldAutoScan = withContext(Dispatchers.IO) {
@@ -1681,6 +1682,34 @@ class LibraryViewModel @Inject constructor(
         return "web://rj/${workKey.uppercase()}"
     }
 
+    internal fun legacyOnlineSavedAlbumDir(entity: AlbumEntity): File {
+        val baseDir = File(context.getExternalFilesDir(null), "albums")
+        val folderName = legacyOnlineSavedAlbumFolderName(entity)
+        return File(baseDir, folderName)
+    }
+
+    private suspend fun backfillLegacyOnlineSavedAlbumRoots() {
+        val albums = runCatching { albumDao.getAllAlbumsOnce() }.getOrDefault(emptyList())
+        if (albums.isEmpty()) return
+
+        database.withTransaction {
+            albums.forEach { entity ->
+                if (entity.localPath?.trim().orEmpty().isNotBlank() || entity.downloadPath?.trim().orEmpty().isNotBlank()) {
+                    return@forEach
+                }
+                val tracks = trackDao.getTracksForAlbumOnce(entity.id)
+                if (!shouldBackfillLegacyOnlineSavedAlbumRoot(entity, tracks)) return@forEach
+
+                val albumDir = legacyOnlineSavedAlbumDir(entity)
+                ensureLibraryAlbumDir(albumDir)
+                val updated = entity.copy(localPath = albumDir.absolutePath)
+                albumDao.updateAlbum(updated)
+                runCatching { database.localTreeCacheDao().deleteByAlbum(entity.id) }
+                upsertAlbumFtsIndex(updated.id, updated)
+            }
+        }
+    }
+
     private fun buildTagsToken(tagsCsv: String): String {
         return tagsCsv.split(",")
             .map { TagNormalizer.normalize(it) }
@@ -2391,6 +2420,20 @@ class LibraryViewModel @Inject constructor(
                     val ts = cachedTracks ?: trackDao.getTracksForAlbumOnce(entity.id).also { cachedTracks = it }
                     ts.any { isOnlineTrackPath(it.path) }.also { cachedHasOnlineTracks = it }
                 }
+
+                if (updated.localPath.isNullOrBlank() &&
+                    updated.downloadPath.isNullOrBlank() &&
+                    shouldBackfillLegacyOnlineSavedAlbumRoot(
+                        updated,
+                        cachedTracks ?: trackDao.getTracksForAlbumOnce(entity.id).also { cachedTracks = it }
+                    )
+                ) {
+                    val albumDir = legacyOnlineSavedAlbumDir(updated)
+                    ensureLibraryAlbumDir(albumDir)
+                    updated = updated.copy(localPath = albumDir.absolutePath)
+                    runCatching { database.localTreeCacheDao().deleteByAlbum(updated.id) }
+                }
+
                 if (updated.path.isNotBlank() && !uriOrFileExists(updated.path) && hasOnlineTracks) {
                     val onlinePath = buildOnlineAlbumPath(updated)
                     if (!onlinePath.isNullOrBlank()) {

--- a/app/src/test/java/com/asmr/player/data/remote/download/DownloadLibraryMergeTest.kt
+++ b/app/src/test/java/com/asmr/player/data/remote/download/DownloadLibraryMergeTest.kt
@@ -1,0 +1,100 @@
+package com.asmr.player.data.remote.download
+
+import androidx.room.Room
+import com.asmr.player.data.local.db.AppDatabase
+import com.asmr.player.data.local.db.entities.AlbumEntity
+import com.asmr.player.data.local.db.entities.RemoteSubtitleSourceEntity
+import com.asmr.player.data.local.db.entities.SubtitleEntity
+import com.asmr.player.data.local.db.entities.TrackEntity
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+
+@RunWith(RobolectricTestRunner::class)
+class DownloadLibraryMergeTest {
+    private lateinit var db: AppDatabase
+
+    @Before
+    fun setUp() {
+        db = Room.inMemoryDatabaseBuilder(
+            RuntimeEnvironment.getApplication(),
+            AppDatabase::class.java
+        )
+            .allowMainThreadQueries()
+            .build()
+    }
+
+    @After
+    fun tearDown() {
+        db.close()
+    }
+
+    @Test
+    fun replaceMatchedOnlineTracksWithLocalTracks_migratesSubtitlesAndDeletesOnlineTrack() = runBlocking {
+        val albumId = db.albumDao().insertAlbum(
+            AlbumEntity(
+                title = "Album",
+                path = "web://rj/RJ123456",
+                localPath = "/albums/RJ123456",
+                downloadPath = "/downloads/RJ123456",
+                workId = "RJ123456",
+                rjCode = "RJ123456"
+            )
+        )
+        val onlineId = db.trackDao().insertTrack(
+            TrackEntity(
+                albumId = albumId,
+                title = "Track A",
+                path = "https://example.com/Track%20A.mp3",
+                group = "disc1"
+            )
+        )
+        val localId = db.trackDao().insertTrack(
+            TrackEntity(
+                albumId = albumId,
+                title = "Track A",
+                path = "/downloads/RJ123456/disc1/Track A.mp3",
+                group = "disc1"
+            )
+        )
+        db.trackDao().insertSubtitle(
+            SubtitleEntity(
+                trackId = onlineId,
+                startMs = 100L,
+                endMs = 200L,
+                text = "line"
+            )
+        )
+        db.remoteSubtitleSourceDao().insertAll(
+            listOf(
+                RemoteSubtitleSourceEntity(
+                    trackId = onlineId,
+                    url = "https://example.com/Track%20A.vtt",
+                    language = "ja",
+                    ext = "vtt"
+                )
+            )
+        )
+
+        replaceMatchedOnlineTracksWithLocalTracks(
+            db = db,
+            albumId = albumId,
+            preferredLocalPrefix = "/downloads/RJ123456/"
+        )
+
+        val tracks = db.trackDao().getTracksForAlbumOnce(albumId)
+        assertEquals(listOf(localId), tracks.map { it.id })
+        assertFalse(tracks.any { it.path.startsWith("http") })
+        assertEquals("line", db.trackDao().getSubtitlesForTrack(localId).single().text)
+        assertEquals("https://example.com/Track%20A.vtt", db.remoteSubtitleSourceDao().getSourcesForTrackOnce(localId).single().url)
+        assertTrue(db.trackDao().getSubtitlesForTrack(onlineId).isEmpty())
+        assertTrue(db.remoteSubtitleSourceDao().getSourcesForTrackOnce(onlineId).isEmpty())
+    }
+}

--- a/app/src/test/java/com/asmr/player/ui/library/AlbumDetailDirectorySupportTest.kt
+++ b/app/src/test/java/com/asmr/player/ui/library/AlbumDetailDirectorySupportTest.kt
@@ -158,7 +158,7 @@ class AlbumDetailDirectorySupportTest {
     }
 
     @Test
-    fun filterDownloadableMediaTree_removesSubtitleAndImageLeaves() {
+    fun filterDownloadableMediaTree_keepsImagesAndRemovesSubtitles() {
         val filtered = filterDownloadableMediaTree(
             listOf(
                 AsmrOneTrackNodeResponse(title = "audio.mp3", mediaDownloadUrl = "https://example.com/audio.mp3"),
@@ -169,9 +169,89 @@ class AlbumDetailDirectorySupportTest {
 
         val leafPaths = flattenAsmrOneLeafDownloads(filtered).map { it.relativePath }
 
-        assertEquals(listOf("audio.mp3"), leafPaths)
-        assertFalse(leafPaths.contains("cover.jpg"))
+        assertEquals(listOf("audio.mp3", "cover.jpg"), leafPaths)
+        assertTrue(leafPaths.contains("cover.jpg"))
         assertFalse(leafPaths.contains("sub.srt"))
+    }
+
+    @Test
+    fun flattenOnlineSaveLeaves_includesResourceFilesButSkipsSubtitles() {
+        val leaves = flattenOnlineSaveLeaves(
+            listOf(
+                AsmrOneTrackNodeResponse(title = "audio.mp3", mediaDownloadUrl = "https://example.com/audio.mp3"),
+                AsmrOneTrackNodeResponse(title = "cover.jpg", mediaDownloadUrl = "https://example.com/cover.jpg"),
+                AsmrOneTrackNodeResponse(title = "readme.txt", mediaDownloadUrl = "https://example.com/readme.txt"),
+                AsmrOneTrackNodeResponse(title = "subtitle.vtt", mediaDownloadUrl = "https://example.com/subtitle.vtt")
+            )
+        )
+
+        val paths = leaves.map { it.relativePath }
+
+        assertEquals(listOf("audio.mp3", "cover.jpg", "readme.txt"), paths)
+        assertEquals(TreeFileType.Audio, leaves.first { it.relativePath == "audio.mp3" }.fileType)
+        assertEquals(TreeFileType.Image, leaves.first { it.relativePath == "cover.jpg" }.fileType)
+        assertEquals(TreeFileType.Text, leaves.first { it.relativePath == "readme.txt" }.fileType)
+        assertFalse(paths.contains("subtitle.vtt"))
+    }
+
+    @Test
+    fun directoryFileTypeLabel_distinguishesLocalAndOnlineAudio() {
+        val local = DirectoryFileItem(
+            path = "track.mp3",
+            title = "track",
+            fileType = TreeFileType.Audio,
+            isPlayable = true,
+            isOnline = false
+        )
+        val online = local.copy(isOnline = true)
+
+        assertEquals("本地音频", directoryFileTypeLabel(local))
+        assertEquals("在线音频", directoryFileTypeLabel(online))
+        assertEquals(
+            "图片",
+            directoryFileTypeLabel(
+                local.copy(fileType = TreeFileType.Image, isOnline = true)
+            )
+        )
+    }
+
+    @Test
+    fun buildLocalDirectoryBrowser_marksLogicalSavedAudioAsOnline() {
+        val onlineTrack = Track(
+            albumId = 9L,
+            title = "online",
+            path = "https://example.com/online.mp3"
+        )
+        val localTrack = Track(
+            albumId = 9L,
+            title = "local",
+            path = "/album/local.mp3"
+        )
+        val index = buildLocalTreeIndexFromLeaves(
+            leaves = listOf(
+                LocalTreeLeafCacheEntry(
+                    relativePath = "online.mp3",
+                    absolutePath = "https://example.com/online.mp3",
+                    fileType = TreeFileType.Audio
+                ),
+                LocalTreeLeafCacheEntry(
+                    relativePath = "local.mp3",
+                    absolutePath = "/album/local.mp3",
+                    fileType = TreeFileType.Audio
+                )
+            ),
+            tracks = listOf(onlineTrack, localTrack)
+        )
+
+        val browser = buildLocalDirectoryBrowser(
+            index = index,
+            currentPath = "",
+            album = Album(id = 9L, title = "album", path = "/album"),
+            shouldShowSubtitleStamp = { false }
+        )
+
+        assertEquals("在线音频", directoryFileTypeLabel(browser.files.single { it.title == "online" }))
+        assertEquals("本地音频", directoryFileTypeLabel(browser.files.single { it.title == "local" }))
     }
 
     @Test

--- a/app/src/test/java/com/asmr/player/ui/library/AlbumDetailViewModelSupportTest.kt
+++ b/app/src/test/java/com/asmr/player/ui/library/AlbumDetailViewModelSupportTest.kt
@@ -89,4 +89,72 @@ class AlbumDetailViewModelSupportTest {
         assertEquals("抓取CV", result.cv)
         assertEquals(listOf("抓取标签"), result.tags)
     }
+
+    @Test
+    fun withUpdatedLocalCover_updatesDisplayAlbumWhenLocalAlbumMatches() {
+        val localAlbum = Album(
+            id = 42L,
+            title = "本地作品",
+            path = "/local/RJ123456",
+            coverPath = "/old/cover.jpg",
+            coverThumbPath = "/old/thumb.jpg"
+        )
+        val displayAlbum = Album(
+            id = 0L,
+            title = "展示作品",
+            path = "web://rj/RJ123456",
+            coverPath = "",
+            coverThumbPath = ""
+        )
+        val model = AlbumDetailModel(
+            baseRjCode = "RJ123456",
+            rjCode = "RJ123456",
+            listenTogetherRjListenerCount = null,
+            displayAlbum = displayAlbum,
+            localAlbum = localAlbum,
+            dlsiteInfo = null,
+            dlsiteGalleryUrls = emptyList(),
+            dlsiteTrialTracks = emptyList(),
+            dlsiteRecommendations = com.asmr.player.data.remote.scraper.DlsiteRecommendations(),
+            dlsiteWorkno = "",
+            dlsitePlayWorkno = "",
+            dlsiteEditions = emptyList(),
+            dlsiteSelectedLang = "",
+            hasResolvedInitialDlsiteTarget = false,
+            hasLoadedInitialDlsiteContent = false,
+            hasResolvedAsmrOneContent = false,
+            preserveHeaderAlbumMetadata = false,
+            isDlsiteLanguageUserSelected = false,
+            asmrOneWorkId = null,
+            asmrOneSite = null,
+            asmrOneTree = emptyList(),
+            dlsitePlayTree = emptyList(),
+            isLoadingDlsite = false,
+            isLoadingDlsiteTrial = false,
+            isLoadingAsmrOne = false,
+            isLoadingDlsitePlay = false
+        )
+
+        val result = model.withUpdatedLocalCover(
+            albumId = 42L,
+            coverPath = "/new/cover.jpg",
+            coverThumbPath = ""
+        )
+
+        assertEquals("/new/cover.jpg", result.localAlbum?.coverPath)
+        assertEquals("", result.localAlbum?.coverThumbPath)
+        assertEquals("/new/cover.jpg", result.displayAlbum.coverPath)
+        assertEquals("", result.displayAlbum.coverThumbPath)
+    }
+
+    @Test
+    fun stableAlbumHeroCoverSource_updatesWhenLocalCoverPathChanges() {
+        val current = resolveStableAlbumHeroCoverSource(
+            stable = "https://example.com/old.jpg",
+            currentLocal = "/albums/RJ123456/new-cover.jpg",
+            current = "/albums/RJ123456/new-cover.jpg"
+        )
+
+        assertEquals("/albums/RJ123456/new-cover.jpg", current)
+    }
 }

--- a/app/src/test/java/com/asmr/player/ui/library/LegacyOnlineSavedAlbumSupportTest.kt
+++ b/app/src/test/java/com/asmr/player/ui/library/LegacyOnlineSavedAlbumSupportTest.kt
@@ -1,0 +1,66 @@
+package com.asmr.player.ui.library
+
+import com.asmr.player.data.local.db.entities.AlbumEntity
+import com.asmr.player.data.local.db.entities.TrackEntity
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class LegacyOnlineSavedAlbumSupportTest {
+    @Test
+    fun shouldBackfillLegacyOnlineSavedAlbumRoot_acceptsOldWebAlbumWithoutLocalPath() {
+        val entity = AlbumEntity(
+            id = 1L,
+            title = "旧保存作品",
+            path = "web://rj/RJ123456",
+            workId = "RJ123456",
+            rjCode = "RJ123456"
+        )
+
+        assertTrue(shouldBackfillLegacyOnlineSavedAlbumRoot(entity, emptyList()))
+        assertEquals("RJ123456", legacyOnlineSavedAlbumFolderName(entity))
+    }
+
+    @Test
+    fun shouldBackfillLegacyOnlineSavedAlbumRoot_acceptsOldAlbumWithOnlineTracks() {
+        val entity = AlbumEntity(
+            id = 2L,
+            title = "No RJ Title",
+            path = "web://rj/NO_RJ_TITLE"
+        )
+        val tracks = listOf(
+            TrackEntity(
+                albumId = 2L,
+                title = "track",
+                path = "https://example.com/track.mp3"
+            )
+        )
+
+        assertTrue(shouldBackfillLegacyOnlineSavedAlbumRoot(entity, tracks))
+        assertEquals("No RJ Title", legacyOnlineSavedAlbumFolderName(entity))
+    }
+
+    @Test
+    fun shouldBackfillLegacyOnlineSavedAlbumRoot_skipsAlbumsThatAlreadyHaveLocalRoots() {
+        val entity = AlbumEntity(
+            id = 3L,
+            title = "RJ123456",
+            path = "web://rj/RJ123456",
+            localPath = "/albums/RJ123456"
+        )
+
+        assertFalse(shouldBackfillLegacyOnlineSavedAlbumRoot(entity, emptyList()))
+    }
+
+    @Test
+    fun shouldBackfillLegacyOnlineSavedAlbumRoot_skipsPureLocalAlbums() {
+        val entity = AlbumEntity(
+            id = 4L,
+            title = "Local",
+            path = "/music/Local"
+        )
+
+        assertFalse(shouldBackfillLegacyOnlineSavedAlbumRoot(entity, emptyList()))
+    }
+}


### PR DESCRIPTION
﻿## Summary
- fix online save so non-playable resources and covers create/use an app album directory
- refresh local album hero cover immediately after selecting a directory image
- merge downloaded local tracks with previously saved online tracks and migrate subtitles
- backfill legacy online-saved albums with localPath so local sync is available
- distinguish local vs online audio in directory tree metadata

## Tests
- .\gradlew-local.bat :app:testReleaseUnitTest --tests "com.asmr.player.ui.library.LegacyOnlineSavedAlbumSupportTest" --tests "com.asmr.player.ui.library.AlbumDetailDirectorySupportTest" --tests "com.asmr.player.data.remote.download.DownloadLibraryMergeTest"
- .\gradlew-local.bat :app:installRelease
