### PR TITLE
Fix album detail online loading states

### DIFF
--- a/app/src/main/java/com/asmr/player/ui/library/AlbumDetailScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/AlbumDetailScreen.kt
@@ -244,6 +244,26 @@ internal fun shouldExpandAlbumHeaderMetaReveal(
     return deferMetaRevealExpected || !presentInitially
 }
 
+internal data class AlbumDetailOnlineLoadPlan(
+    val loadDlsite: Boolean = false,
+    val loadAsmrOne: Boolean = false,
+    val loadDlsitePlay: Boolean = false
+)
+
+internal fun albumDetailOnlineLoadPlan(
+    selectedTab: Int,
+    hasResolvedInitialDlsiteTarget: Boolean
+): AlbumDetailOnlineLoadPlan {
+    return when (selectedTab) {
+        1 -> AlbumDetailOnlineLoadPlan(loadDlsite = true, loadAsmrOne = true)
+        2 -> AlbumDetailOnlineLoadPlan(
+            loadDlsite = true,
+            loadDlsitePlay = hasResolvedInitialDlsiteTarget
+        )
+        else -> AlbumDetailOnlineLoadPlan()
+    }
+}
+
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalFoundationApi::class)
 @Composable
 fun AlbumDetailScreen(
@@ -658,19 +678,18 @@ fun AlbumDetailScreen(
                                 model.dlsiteWorkno,
                                 model.hasResolvedInitialDlsiteTarget
                             ) {
-                                when (selectedTab) {
-                                    1 -> {
-                                        viewModel.ensureDlsiteLoaded()
-                                        if (model.hasResolvedInitialDlsiteTarget) {
-                                            viewModel.ensureAsmrOneLoaded()
-                                        }
-                                    }
-                                    2 -> {
-                                        viewModel.ensureDlsiteLoaded()
-                                        if (model.hasResolvedInitialDlsiteTarget) {
-                                            viewModel.ensureDlsitePlayLoaded()
-                                        }
-                                    }
+                                val loadPlan = albumDetailOnlineLoadPlan(
+                                    selectedTab = selectedTab,
+                                    hasResolvedInitialDlsiteTarget = model.hasResolvedInitialDlsiteTarget
+                                )
+                                if (loadPlan.loadDlsite) {
+                                    viewModel.ensureDlsiteLoaded()
+                                }
+                                if (loadPlan.loadAsmrOne) {
+                                    viewModel.ensureAsmrOneLoaded()
+                                }
+                                if (loadPlan.loadDlsitePlay) {
+                                    viewModel.ensureDlsitePlayLoaded()
                                 }
                             }
 
@@ -827,6 +846,8 @@ fun AlbumDetailScreen(
                                         tree = model.dlsitePlayTree,
                                         isLoading = model.isLoadingDlsitePlay,
                                         shouldAutoLoad = selectedTab == 2 && model.hasResolvedInitialDlsiteTarget,
+                                        isAwaitingInitialTarget = selectedTab == 2 && !model.hasResolvedInitialDlsiteTarget,
+                                        hasResolvedDlsitePlayContent = model.hasResolvedDlsitePlayContent,
                                         onOpenLogin = onOpenDlsiteLogin,
                                         onEnsureLoaded = { viewModel.ensureDlsitePlayLoaded() },
                                         onPlayMediaItems = onPlayMediaItems,

--- a/app/src/main/java/com/asmr/player/ui/library/AlbumDetailViewModel.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/AlbumDetailViewModel.kt
@@ -1348,6 +1348,7 @@ class AlbumDetailViewModel @Inject constructor(
                 hasResolvedInitialDlsiteTarget = true,
                 hasLoadedInitialDlsiteContent = false,
                 hasResolvedAsmrOneContent = false,
+                hasResolvedDlsitePlayContent = false,
                 isDlsiteLanguageUserSelected = current.model.isDlsiteLanguageUserSelected || isUserSelection,
                 asmrOneWorkId = null,
                 asmrOneSite = null,
@@ -1687,7 +1688,12 @@ class AlbumDetailViewModel @Inject constructor(
         ) return
         dlsitePlayAttemptedRj.add(attemptKey)
         viewModelScope.launch {
-            _uiState.value = AlbumDetailUiState.Success(model = current.model.copy(isLoadingDlsitePlay = true))
+            _uiState.value = AlbumDetailUiState.Success(
+                model = current.model.copy(
+                    isLoadingDlsitePlay = true,
+                    hasResolvedDlsitePlayContent = false
+                )
+            )
             try {
                 val editions = runCatching {
                     if (current.model.dlsiteEditions.size > 1) {
@@ -1745,13 +1751,19 @@ class AlbumDetailViewModel @Inject constructor(
                     model = updated.copy(
                         dlsitePlayTree = result.tree,
                         dlsitePlayWorkno = pickedWorkno?.trim().orEmpty(),
+                        hasResolvedDlsitePlayContent = true,
                         isLoadingDlsitePlay = false
                     )
                 )
             } catch (e: Exception) {
                 dlsitePlayAttemptedRj.remove(attemptKey)
                 val updated = (_uiState.value as? AlbumDetailUiState.Success)?.model ?: return@launch
-                _uiState.value = AlbumDetailUiState.Success(model = updated.copy(isLoadingDlsitePlay = false))
+                _uiState.value = AlbumDetailUiState.Success(
+                    model = updated.copy(
+                        hasResolvedDlsitePlayContent = true,
+                        isLoadingDlsitePlay = false
+                    )
+                )
             }
         }
     }
@@ -1810,6 +1822,7 @@ class AlbumDetailViewModel @Inject constructor(
             hasResolvedInitialDlsiteTarget = false,
             hasLoadedInitialDlsiteContent = false,
             hasResolvedAsmrOneContent = false,
+            hasResolvedDlsitePlayContent = false,
             preserveHeaderAlbumMetadata = preserveHeaderAlbumMetadata,
             isDlsiteLanguageUserSelected = false,
             asmrOneWorkId = null,

--- a/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailDlsiteTabs.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailDlsiteTabs.kt
@@ -699,6 +699,19 @@ internal fun shouldShowAsmrOneDirectoryLoading(
         (hasAsmrOneTree && !hasDirectoryBrowser)
 }
 
+internal fun shouldShowDlsitePlayDirectoryLoading(
+    isAwaitingInitialTarget: Boolean,
+    hasResolvedDlsitePlayContent: Boolean,
+    isLoadingDlsitePlay: Boolean,
+    hasDlsitePlayTree: Boolean,
+    hasDirectoryBrowser: Boolean
+): Boolean {
+    return isAwaitingInitialTarget ||
+        !hasResolvedDlsitePlayContent ||
+        isLoadingDlsitePlay ||
+        (hasDlsitePlayTree && !hasDirectoryBrowser)
+}
+
 @Composable
 internal fun AlbumDlsiteInfoBreadcrumbTabV2(
     album: Album,
@@ -1121,6 +1134,8 @@ internal fun AlbumDlsitePlayBreadcrumbTabV2(
     tree: List<AsmrOneTrackNodeResponse>,
     isLoading: Boolean,
     shouldAutoLoad: Boolean,
+    isAwaitingInitialTarget: Boolean,
+    hasResolvedDlsitePlayContent: Boolean,
     onOpenLogin: () -> Unit,
     onEnsureLoaded: () -> Unit,
     onPlayMediaItems: (List<MediaItem>, Int) -> Unit,
@@ -1169,8 +1184,12 @@ internal fun AlbumDlsitePlayBreadcrumbTabV2(
         return
     }
 
+    var autoLoadDispatched by remember(treeStateKey) { mutableStateOf(false) }
     LaunchedEffect(loggedIn, rjCode, shouldAutoLoad) {
-        if (loggedIn && shouldAutoLoad) onEnsureLoaded()
+        if (loggedIn && shouldAutoLoad && !autoLoadDispatched) {
+            autoLoadDispatched = true
+            onEnsureLoaded()
+        }
     }
 
     val headerItemCount = 2
@@ -1218,6 +1237,13 @@ internal fun AlbumDlsitePlayBreadcrumbTabV2(
             withContext(Dispatchers.Default) { buildRemoteDirectoryBrowser(index, currentPath) }
         }
     }
+    val isDirectoryPending = shouldShowDlsitePlayDirectoryLoading(
+        isAwaitingInitialTarget = isAwaitingInitialTarget,
+        hasResolvedDlsitePlayContent = hasResolvedDlsitePlayContent,
+        isLoadingDlsitePlay = isLoading,
+        hasDlsitePlayTree = tree.isNotEmpty(),
+        hasDirectoryBrowser = browser != null
+    )
     LaunchedEffect(currentPath, treeStateKey) {
         onPersistCurrentPath(currentPath)
     }
@@ -1259,7 +1285,7 @@ internal fun AlbumDlsitePlayBreadcrumbTabV2(
         if (tree.isEmpty()) {
             item {
                 Box(modifier = Modifier.fillMaxWidth().height(220.dp), contentAlignment = Alignment.Center) {
-                    if (isLoading) {
+                    if (isDirectoryPending) {
                         EaraLogoLoadingIndicator(tint = AsmrTheme.colorScheme.primary)
                     } else {
                         Text("暂无可播放资源")
@@ -1269,7 +1295,7 @@ internal fun AlbumDlsitePlayBreadcrumbTabV2(
             return@LazyColumn
         }
 
-        if (browser == null) {
+        if (isDirectoryPending || browser == null) {
             item {
                 Box(modifier = Modifier.fillMaxWidth().height(220.dp), contentAlignment = Alignment.Center) {
                     EaraLogoLoadingIndicator(tint = AsmrTheme.colorScheme.primary)

--- a/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailViewModelSupport.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailViewModelSupport.kt
@@ -160,6 +160,7 @@ data class AlbumDetailModel(
     val hasResolvedInitialDlsiteTarget: Boolean,
     val hasLoadedInitialDlsiteContent: Boolean,
     val hasResolvedAsmrOneContent: Boolean,
+    val hasResolvedDlsitePlayContent: Boolean,
     val preserveHeaderAlbumMetadata: Boolean,
     val isDlsiteLanguageUserSelected: Boolean,
     val asmrOneWorkId: String?,

--- a/app/src/test/java/com/asmr/player/ui/library/AlbumDetailOneStateTest.kt
+++ b/app/src/test/java/com/asmr/player/ui/library/AlbumDetailOneStateTest.kt
@@ -1,5 +1,6 @@
 package com.asmr.player.ui.library
 
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -28,6 +29,74 @@ class AlbumDetailOneStateTest {
                 isAwaitingAsmrOneLoad = false,
                 isLoadingAsmrOne = false,
                 hasAsmrOneTree = false,
+                hasDirectoryBrowser = false
+            )
+        )
+    }
+
+    @Test
+    fun albumDetailOnlineLoadPlan_loadsOneWithoutWaitingForDlsiteTarget() {
+        assertEquals(
+            AlbumDetailOnlineLoadPlan(loadDlsite = true, loadAsmrOne = true),
+            albumDetailOnlineLoadPlan(
+                selectedTab = 1,
+                hasResolvedInitialDlsiteTarget = false
+            )
+        )
+    }
+
+    @Test
+    fun albumDetailOnlineLoadPlan_keepsDlsitePlayBehindResolvedTarget() {
+        assertEquals(
+            AlbumDetailOnlineLoadPlan(loadDlsite = true, loadDlsitePlay = false),
+            albumDetailOnlineLoadPlan(
+                selectedTab = 2,
+                hasResolvedInitialDlsiteTarget = false
+            )
+        )
+        assertEquals(
+            AlbumDetailOnlineLoadPlan(loadDlsite = true, loadDlsitePlay = true),
+            albumDetailOnlineLoadPlan(
+                selectedTab = 2,
+                hasResolvedInitialDlsiteTarget = true
+            )
+        )
+    }
+
+    @Test
+    fun shouldShowDlsitePlayDirectoryLoading_waitsForInitialTargetBeforeEmptyState() {
+        assertTrue(
+            shouldShowDlsitePlayDirectoryLoading(
+                isAwaitingInitialTarget = true,
+                hasResolvedDlsitePlayContent = false,
+                isLoadingDlsitePlay = false,
+                hasDlsitePlayTree = false,
+                hasDirectoryBrowser = false
+            )
+        )
+    }
+
+    @Test
+    fun shouldShowDlsitePlayDirectoryLoading_stopsAfterEmptyLoadCompletes() {
+        assertFalse(
+            shouldShowDlsitePlayDirectoryLoading(
+                isAwaitingInitialTarget = false,
+                hasResolvedDlsitePlayContent = true,
+                isLoadingDlsitePlay = false,
+                hasDlsitePlayTree = false,
+                hasDirectoryBrowser = false
+            )
+        )
+    }
+
+    @Test
+    fun shouldShowDlsitePlayDirectoryLoading_waitsForDirectoryIndex() {
+        assertTrue(
+            shouldShowDlsitePlayDirectoryLoading(
+                isAwaitingInitialTarget = false,
+                hasResolvedDlsitePlayContent = true,
+                isLoadingDlsitePlay = false,
+                hasDlsitePlayTree = true,
                 hasDirectoryBrowser = false
             )
         )

--- a/app/src/test/java/com/asmr/player/ui/library/AlbumDetailViewModelSupportTest.kt
+++ b/app/src/test/java/com/asmr/player/ui/library/AlbumDetailViewModelSupportTest.kt
@@ -123,6 +123,7 @@ class AlbumDetailViewModelSupportTest {
             hasResolvedInitialDlsiteTarget = false,
             hasLoadedInitialDlsiteContent = false,
             hasResolvedAsmrOneContent = false,
+            hasResolvedDlsitePlayContent = false,
             preserveHeaderAlbumMetadata = false,
             isDlsiteLanguageUserSelected = false,
             asmrOneWorkId = null,


### PR DESCRIPTION
## Summary
- start ONE directory loading in parallel with DLsite detail scraping for online album detail pages
- keep DLsite Play purchased detail in a loading state until initial target and playable tree loading have actually completed
- add focused tests for online load planning and directory loading state decisions

## Verification
- .\\gradlew-local.bat :app:testNonMinifiedReleaseUnitTest --tests com.asmr.player.ui.library.AlbumDetailOneStateTest --tests com.asmr.player.ui.library.AlbumDetailViewModelSupportTest
- .\\gradlew-local.bat :app:installRelease