### PR TITLE
Optimize list scroll performance

### DIFF
--- a/app/src/main/java/com/asmr/player/cache/CacheConfig.kt
+++ b/app/src/main/java/com/asmr/player/cache/CacheConfig.kt
@@ -6,6 +6,8 @@ data class CacheConfig(
     val diskMaxSizeBytes: Long = 200L * 1024 * 1024,
     val diskTtlMs: Long = 14L * 24 * 60 * 60 * 1000,
     val decodeParallelism: Int = 3,
+    val loadParallelism: Int = 3,
+    val preloadParallelism: Int = 1,
     val logStats: Boolean = false
 )
 

--- a/app/src/main/java/com/asmr/player/cache/CachePolicy.kt
+++ b/app/src/main/java/com/asmr/player/cache/CachePolicy.kt
@@ -8,6 +8,7 @@ data class CachePolicy(
 ) {
     companion object {
         val DEFAULT = CachePolicy(readMemory = true, writeMemory = true, readDisk = true, writeDisk = true)
+        val CACHE_WARMUP = CachePolicy(readMemory = true, writeMemory = true, readDisk = true, writeDisk = false)
         val MEMORY_ONLY = CachePolicy(readMemory = true, writeMemory = true, readDisk = false, writeDisk = false)
         val DISK_ONLY = CachePolicy(readMemory = false, writeMemory = false, readDisk = true, writeDisk = true)
         val NO_CACHE = CachePolicy(readMemory = false, writeMemory = false, readDisk = false, writeDisk = false)

--- a/app/src/main/java/com/asmr/player/cache/ImageCacheManager.kt
+++ b/app/src/main/java/com/asmr/player/cache/ImageCacheManager.kt
@@ -30,6 +30,8 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.async
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Semaphore
+import kotlinx.coroutines.sync.withPermit
 import kotlinx.coroutines.withContext
 import java.io.ByteArrayOutputStream
 import java.util.concurrent.ConcurrentHashMap
@@ -45,6 +47,8 @@ class ImageCacheManager(
 ) {
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
     private val inFlight = ConcurrentHashMap<String, Deferred<Result<ImageBitmap>>>()
+    private val loadSemaphore = Semaphore(config.loadParallelism)
+    private val preloadSemaphore = Semaphore(config.preloadParallelism)
 
     // 数据键(忽略尺寸) -> 最近一次写入内存的完整缓存键。
     // 用于跨尺寸即时复用同一张图片：列表已加载的小图可作为详情大图的瞬时占位。
@@ -112,28 +116,23 @@ class ImageCacheManager(
 
         val created = scope.async {
             runCatching {
-                stats.onNetworkFetch()
-                Trace.beginSection("img.net")
-                val bmp = loaderFacade.loadBitmap(model, size)
-                Trace.endSection()
-                stats.onDecode()
-                if (cachePolicy.writeDisk) {
-                    Trace.beginSection("img.encode")
-                    val bytes = encodeBitmapForDisk(bmp)
-                    Trace.endSection()
-                    diskCache.put(
-                        key,
-                        DiskCache.Entry(
-                            bytes = bytes,
-                            width = bmp.width,
-                            height = bmp.height
-                        )
-                    )
+                loadSemaphore.withPermit {
+                    stats.onNetworkFetch()
+                    Trace.beginSection("img.net")
+                    val bmp = try {
+                        loaderFacade.loadBitmap(model, size)
+                    } finally {
+                        Trace.endSection()
+                    }
+                    stats.onDecode()
+                    if (cachePolicy.writeMemory) {
+                        putMemory(key, dataKey, bmp)
+                    }
+                    if (cachePolicy.writeDisk) {
+                        writeDiskCacheAsync(key, bmp)
+                    }
+                    bmp.asImageBitmap()
                 }
-                if (cachePolicy.writeMemory) {
-                    putMemory(key, dataKey, bmp)
-                }
-                bmp.asImageBitmap()
             }.also {
                 if (config.logStats) {
                     val s = stats.snapshot()
@@ -182,34 +181,30 @@ class ImageCacheManager(
 
     fun preload(models: List<Any>) {
         if (models.isEmpty()) return
-        models.forEach { m ->
-            scope.launch {
-                runCatching { loadImage(model = m, size = null, cachePolicy = CachePolicy.DEFAULT) }
-            }
-        }
+        preload(models, size = null)
     }
 
     fun preload(models: List<Any>, size: IntSize?) {
         if (models.isEmpty()) return
         models.forEach { m ->
             scope.launch {
-                runCatching { loadImage(model = m, size = size, cachePolicy = CachePolicy.DEFAULT) }
+                preloadSemaphore.withPermit {
+                    runCatching { loadImageFromCache(model = m, size = size, cachePolicy = CachePolicy.CACHE_WARMUP) }
+                }
             }
         }
     }
 
     fun preload(scope: CoroutineScope, models: List<Any>): Job {
-        return scope.launch(Dispatchers.IO) {
-            models.forEach { m ->
-                runCatching { loadImage(model = m, size = null, cachePolicy = CachePolicy.DEFAULT) }
-            }
-        }
+        return preload(scope, models, size = null)
     }
 
     fun preload(scope: CoroutineScope, models: List<Any>, size: IntSize?): Job {
         return scope.launch(Dispatchers.IO) {
             models.forEach { m ->
-                runCatching { loadImage(model = m, size = size, cachePolicy = CachePolicy.DEFAULT) }
+                preloadSemaphore.withPermit {
+                    runCatching { loadImageFromCache(model = m, size = size, cachePolicy = CachePolicy.CACHE_WARMUP) }
+                }
             }
         }
     }
@@ -222,14 +217,37 @@ class ImageCacheManager(
     }
 
     private suspend fun encodeBitmapForDisk(bitmap: Bitmap): ByteArray = withContext(decodeDispatcher) {
-        val out = ByteArrayOutputStream()
-        val format = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-            Bitmap.CompressFormat.WEBP_LOSSLESS
-        } else {
-            Bitmap.CompressFormat.PNG
+        Trace.beginSection("img.encode")
+        try {
+            val out = ByteArrayOutputStream()
+            val format = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+                Bitmap.CompressFormat.WEBP_LOSSLESS
+            } else {
+                Bitmap.CompressFormat.PNG
+            }
+            bitmap.compress(format, 100, out)
+            out.toByteArray()
+        } finally {
+            Trace.endSection()
         }
-        bitmap.compress(format, 100, out)
-        out.toByteArray()
+    }
+
+    private fun writeDiskCacheAsync(key: String, bitmap: Bitmap) {
+        val width = bitmap.width
+        val height = bitmap.height
+        scope.launch {
+            runCatching {
+                val bytes = encodeBitmapForDisk(bitmap)
+                diskCache.put(
+                    key,
+                    DiskCache.Entry(
+                        bytes = bytes,
+                        width = width,
+                        height = height
+                    )
+                )
+            }
+        }
     }
 }
 

--- a/app/src/main/java/com/asmr/player/cache/LazyListPreloader.kt
+++ b/app/src/main/java/com/asmr/player/cache/LazyListPreloader.kt
@@ -9,6 +9,9 @@ import androidx.compose.ui.unit.IntSize
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.mapNotNull
+
+private const val MaxRememberedPreloadKeys = 96
 
 @Composable
 fun LazyListPreloader(
@@ -19,8 +22,17 @@ fun LazyListPreloader(
     cacheManagerProvider: () -> ImageCacheManager
 ) {
     val manager = remember { cacheManagerProvider() }
+    val preloadedModels = remember { LinkedHashSet<Any>() }
     LaunchedEffect(state, models, preloadNext, preloadSize) {
-        snapshotFlow { state.layoutInfo.visibleItemsInfo.maxOfOrNull { it.index } ?: -1 }
+        preloadedModels.clear()
+        snapshotFlow {
+            if (state.isScrollInProgress) {
+                null
+            } else {
+                state.layoutInfo.visibleItemsInfo.maxOfOrNull { it.index } ?: -1
+            }
+        }
+            .mapNotNull { it }
             .map { last ->
                 val start = (last + 1).coerceAtLeast(0)
                 val end = (start + preloadNext).coerceAtMost(models.size)
@@ -30,8 +42,11 @@ fun LazyListPreloader(
             .distinctUntilChanged()
             .collect { range ->
                 val r = range ?: return@collect
-                val toPreload = r.map { models[it] }
+                val toPreload = r.mapNotNull { index ->
+                    models[index].takeIf { model -> preloadedModels.add(model) }
+                }
                 manager.preload(toPreload, preloadSize)
+                preloadedModels.trimOldest(maxSize = MaxRememberedPreloadKeys)
             }
     }
 }
@@ -46,8 +61,17 @@ fun LazyListPreloader(
     modelAt: (Int) -> Any?
 ) {
     val manager = remember { cacheManagerProvider() }
+    val preloadedModels = remember { LinkedHashSet<Any>() }
     LaunchedEffect(state, itemCount, preloadNext, preloadSize) {
-        snapshotFlow { state.layoutInfo.visibleItemsInfo.maxOfOrNull { it.index } ?: -1 }
+        preloadedModels.clear()
+        snapshotFlow {
+            if (state.isScrollInProgress) {
+                null
+            } else {
+                state.layoutInfo.visibleItemsInfo.maxOfOrNull { it.index } ?: -1
+            }
+        }
+            .mapNotNull { it }
             .map { last ->
                 val start = (last + 1).coerceAtLeast(0)
                 val end = (start + preloadNext).coerceAtMost(itemCount)
@@ -57,10 +81,22 @@ fun LazyListPreloader(
             .distinctUntilChanged()
             .collect { range ->
                 val r = range ?: return@collect
-                val toPreload = r.mapNotNull(modelAt)
+                val toPreload = r.mapNotNull { index ->
+                    modelAt(index)?.takeIf { model -> preloadedModels.add(model) }
+                }
                 if (toPreload.isNotEmpty()) {
                     manager.preload(toPreload, preloadSize)
+                    preloadedModels.trimOldest(maxSize = MaxRememberedPreloadKeys)
                 }
             }
+    }
+}
+
+private fun <T> LinkedHashSet<T>.trimOldest(maxSize: Int) {
+    while (size > maxSize) {
+        val iterator = iterator()
+        if (!iterator.hasNext()) return
+        iterator.next()
+        iterator.remove()
     }
 }

--- a/app/src/main/java/com/asmr/player/ui/common/ThinScrollbar.kt
+++ b/app/src/main/java/com/asmr/player/ui/common/ThinScrollbar.kt
@@ -157,7 +157,11 @@ private fun LazyListState.thinScrollbarMetrics(): ThinScrollbarMetrics? {
 
     val viewportHeight = (layoutInfo.viewportEndOffset - layoutInfo.viewportStartOffset).toFloat()
         .coerceAtLeast(1f)
-    val averageItemSize = visibleItems.sumOf { it.size }.toFloat() / visibleItems.size
+    var totalVisibleSize = 0
+    for (item in visibleItems) {
+        totalVisibleSize += item.size
+    }
+    val averageItemSize = totalVisibleSize.toFloat() / visibleItems.size
     val estimatedContentHeight =
         averageItemSize * totalItems + layoutInfo.beforeContentPadding + layoutInfo.afterContentPadding
     if (estimatedContentHeight <= viewportHeight) return null
@@ -178,8 +182,25 @@ private fun LazyStaggeredGridState.thinScrollbarMetrics(): ThinScrollbarMetrics?
 
     val viewportHeight = (layoutInfo.viewportEndOffset - layoutInfo.viewportStartOffset).toFloat()
         .coerceAtLeast(1f)
-    val averageItemHeight = visibleItems.sumOf { it.size.height }.toFloat() / visibleItems.size
-    val laneCount = visibleItems.map { it.offset.x }.distinct().size.coerceAtLeast(1)
+    var totalVisibleHeight = 0
+    val laneOffsets = IntArray(visibleItems.size)
+    var laneCount = 0
+    for (item in visibleItems) {
+        totalVisibleHeight += item.size.height
+        var knownLane = false
+        for (index in 0 until laneCount) {
+            if (laneOffsets[index] == item.offset.x) {
+                knownLane = true
+                break
+            }
+        }
+        if (!knownLane) {
+            laneOffsets[laneCount] = item.offset.x
+            laneCount += 1
+        }
+    }
+    val averageItemHeight = totalVisibleHeight.toFloat() / visibleItems.size
+    laneCount = laneCount.coerceAtLeast(1)
     val estimatedRowCount = ceil(totalItems / laneCount.toFloat())
     val estimatedContentHeight =
         averageItemHeight * estimatedRowCount + layoutInfo.beforeContentPadding + layoutInfo.afterContentPadding

--- a/app/src/main/java/com/asmr/player/ui/common/TrackMetaSupport.kt
+++ b/app/src/main/java/com/asmr/player/ui/common/TrackMetaSupport.kt
@@ -12,23 +12,55 @@ import com.asmr.player.util.Formatting
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import java.io.File
+import java.util.concurrent.ConcurrentHashMap
 
 internal data class AudioMetaText(
     val leadingText: String,
     val trailingText: String
 )
 
+private object TrackFileSizeCache {
+    private const val MissingSize = Long.MIN_VALUE
+    private val values = ConcurrentHashMap<String, Long>()
+
+    fun get(path: String): Long? {
+        return when (val cached = getKnown(path)) {
+            null, MissingSize -> null
+            else -> cached
+        }
+    }
+
+    fun getKnown(path: String): Long? = values[path]
+
+    fun resolveKnownSize(cached: Long): Long? {
+        return when (cached) {
+            MissingSize -> null
+            else -> cached
+        }
+    }
+
+    fun put(path: String, size: Long?) {
+        values[path] = size ?: MissingSize
+    }
+}
+
 @Composable
 internal fun rememberAudioMetaText(
     sourcePath: String,
     durationSeconds: Double?,
     prefixSegments: List<String> = emptyList(),
-    suffixSegments: List<String> = emptyList()
+    suffixSegments: List<String> = emptyList(),
+    loadSize: Boolean = true
 ): String {
     val context = LocalContext.current
-    val sizeText by produceState<String?>(initialValue = null, sourcePath) {
+    val sizeText by produceState<String?>(
+        initialValue = cachedTrackFileSize(sourcePath)?.let(Formatting::formatFileSize),
+        sourcePath,
+        loadSize
+    ) {
+        if (!loadSize || value != null) return@produceState
         value = withContext(Dispatchers.IO) {
-            queryTrackFileSize(context, sourcePath)
+            queryCachedTrackFileSize(context, sourcePath)
         }?.let(Formatting::formatFileSize)
     }
     return buildAudioMetaText(
@@ -86,12 +118,18 @@ internal fun rememberAudioMeta(
     sourcePath: String,
     durationSeconds: Double?,
     prefixSegments: List<String> = emptyList(),
-    suffixSegments: List<String> = emptyList()
+    suffixSegments: List<String> = emptyList(),
+    loadSize: Boolean = true
 ): AudioMetaText {
     val context = LocalContext.current
-    val sizeText by produceState<String?>(initialValue = null, sourcePath) {
+    val sizeText by produceState<String?>(
+        initialValue = cachedTrackFileSize(sourcePath)?.let(Formatting::formatFileSize),
+        sourcePath,
+        loadSize
+    ) {
+        if (!loadSize || value != null) return@produceState
         value = withContext(Dispatchers.IO) {
-            queryTrackFileSize(context, sourcePath)
+            queryCachedTrackFileSize(context, sourcePath)
         }?.let(Formatting::formatFileSize)
     }
     return buildAudioMeta(
@@ -118,6 +156,32 @@ internal fun buildTrackMetaLine(
     sizeText: String?
 ): String {
     return buildAudioMetaText(durationSeconds = durationSeconds, sizeText = sizeText)
+}
+
+internal fun cachedTrackFileSize(path: String): Long? {
+    val trimmed = path.trim()
+    if (trimmed.isBlank()) return null
+    return TrackFileSizeCache.get(trimmed)
+}
+
+internal fun cacheTrackFileSize(path: String, size: Long?) {
+    val trimmed = path.trim()
+    if (trimmed.isBlank()) return
+    TrackFileSizeCache.put(trimmed, size)
+}
+
+internal fun queryCachedTrackFileSize(
+    context: Context,
+    path: String
+): Long? {
+    val trimmed = path.trim()
+    if (trimmed.isBlank()) return null
+    TrackFileSizeCache.getKnown(trimmed)?.let { cached ->
+        return TrackFileSizeCache.resolveKnownSize(cached)
+    }
+    val size = queryTrackFileSize(context, trimmed)
+    cacheTrackFileSize(trimmed, size)
+    return size
 }
 
 internal fun queryTrackFileSize(

--- a/app/src/main/java/com/asmr/player/ui/groups/AlbumGroupDetailScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/groups/AlbumGroupDetailScreen.kt
@@ -74,7 +74,7 @@ import com.asmr.player.ui.common.FlatDialogAction
 import com.asmr.player.ui.common.FlatDialogActionTone
 import com.asmr.player.ui.common.LocalBottomOverlayPadding
 import com.asmr.player.ui.common.StableWindowInsets
-import com.asmr.player.ui.common.queryTrackFileSize
+import com.asmr.player.ui.common.queryCachedTrackFileSize
 import com.asmr.player.ui.common.rememberAudioMeta
 import com.asmr.player.ui.common.rememberAudioMetaText
 import com.asmr.player.ui.common.SubtitleStamp
@@ -256,6 +256,7 @@ internal fun AlbumGroupDetailContent(
                                     rjCode = row.rjCode,
                                     coverModel = row.coverModel,
                                     tracks = row.tracks,
+                                    loadFileSizes = !listState.isScrollInProgress,
                                     onToggle = {
                                         expandedAlbumIds.value = if (row.expanded) {
                                             expandedAlbumIds.value - row.albumId
@@ -287,6 +288,7 @@ internal fun AlbumGroupDetailContent(
                                         coverModel = row.coverModel,
                                         showTopDivider = index > 0 && localRows[index - 1] is GroupDetailTrackRow,
                                         isDragging = isDragging,
+                                        loadFileSize = !listState.isScrollInProgress,
                                         modifier = Modifier
                                             .fillMaxWidth()
                                             .testTag("$GROUP_DETAIL_TRACK_TAG_PREFIX:${row.track.mediaId}")
@@ -355,14 +357,16 @@ private fun AlbumSectionHeader(
     rjCode: String,
     coverModel: Any?,
     tracks: List<AlbumGroupTrackRow>,
+    loadFileSizes: Boolean,
     onToggle: () -> Unit,
     onRemoveAlbum: () -> Unit
 ) {
     val colorScheme = AsmrTheme.colorScheme
     val context = LocalContext.current
-    val totalSizeBytes by androidx.compose.runtime.produceState<Long?>(initialValue = null, tracks) {
+    val totalSizeBytes by androidx.compose.runtime.produceState<Long?>(initialValue = null, tracks, loadFileSizes) {
+        if (!loadFileSizes) return@produceState
         value = withContext(Dispatchers.IO) {
-            tracks.sumOf { row -> queryTrackFileSize(context, row.trackPath) ?: 0L }
+            tracks.sumOf { row -> queryCachedTrackFileSize(context, row.trackPath) ?: 0L }
                 .takeIf { it > 0L }
         }
     }
@@ -427,6 +431,7 @@ private fun GroupTrackRow(
     coverModel: Any?,
     showTopDivider: Boolean,
     isDragging: Boolean,
+    loadFileSize: Boolean,
     modifier: Modifier = Modifier,
     onPlay: () -> Unit,
     onMoveToTop: () -> Unit,
@@ -449,7 +454,8 @@ private fun GroupTrackRow(
         val meta = rememberAudioMeta(
             sourcePath = item.trackPath,
             durationSeconds = item.trackDuration,
-            prefixSegments = listOf(item.albumCv.orEmpty())
+            prefixSegments = listOf(item.albumCv.orEmpty()),
+            loadSize = loadFileSize
         )
         AudioItemRow(
             title = item.trackTitle.ifBlank { "未命名" },

--- a/app/src/main/java/com/asmr/player/ui/groups/AlbumGroupDetailScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/groups/AlbumGroupDetailScreen.kt
@@ -42,6 +42,7 @@ import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
@@ -210,6 +211,11 @@ internal fun AlbumGroupDetailContent(
         if (scrollToTopSignal == 0L) return@LaunchedEffect
         listState.smoothScrollToTop()
     }
+    val tracksByAlbumId by remember {
+        derivedStateOf {
+            localRows.tracksByAlbumId()
+        }
+    }
 
     Box(
         modifier = Modifier
@@ -247,7 +253,16 @@ internal fun AlbumGroupDetailContent(
                     item(key = GROUP_DETAIL_REORDER_SENTINEL_KEY) {
                         Spacer(modifier = Modifier.height(1.dp))
                     }
-                    itemsIndexed(localRows, key = { _, row -> row.key }) { index, row ->
+                    itemsIndexed(
+                        items = localRows,
+                        key = { _, row -> row.key },
+                        contentType = { _, row ->
+                            when (row) {
+                                is GroupDetailHeaderRow -> "groupHeader"
+                                is GroupDetailTrackRow -> "groupTrack"
+                            }
+                        }
+                    ) { index, row ->
                         when (row) {
                             is GroupDetailHeaderRow -> {
                                 AlbumSectionHeader(
@@ -280,7 +295,7 @@ internal fun AlbumGroupDetailContent(
                                         .clip(draggedTrackShape)
                                         .background(draggedTrackContainerColor)
                                 ) { isDragging ->
-                                    val albumTracks = localRows.tracksForAlbum(row.albumId)
+                                    val albumTracks = tracksByAlbumId[row.albumId].orEmpty()
                                     val startIndex = albumTracks.indexOfFirst { it.mediaId == row.track.mediaId }
                                         .coerceAtLeast(0)
                                     GroupTrackRow(
@@ -393,6 +408,7 @@ private fun AlbumSectionHeader(
             contentDescription = null,
             contentScale = ContentScale.Crop,
             placeholderCornerRadius = 8,
+            peekAnySizeForInitial = true,
             modifier = Modifier
                 .size(50.dp)
                 .clip(RoundedCornerShape(8.dp))
@@ -451,37 +467,17 @@ private fun GroupTrackRow(
                 color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.2f)
             )
         }
+        val prefixSegments = remember(item.albumCv) {
+            listOf(item.albumCv.orEmpty())
+        }
         val meta = rememberAudioMeta(
             sourcePath = item.trackPath,
             durationSeconds = item.trackDuration,
-            prefixSegments = listOf(item.albumCv.orEmpty()),
+            prefixSegments = prefixSegments,
             loadSize = loadFileSize
         )
-        AudioItemRow(
-            title = item.trackTitle.ifBlank { "未命名" },
-            subtitle = meta.leadingText,
-            fixedTrailingSubtitle = meta.trailingText,
-            showSubtitleStamp = item.hasSubtitles,
-            subtitleStampTestTag = "$GROUP_DETAIL_TRACK_SUBTITLE_STAMP_TAG_PREFIX:${item.mediaId}",
-            menuButtonTestTag = "$GROUP_DETAIL_TRACK_MENU_BUTTON_TAG_PREFIX:${item.mediaId}",
-            onClick = onPlay,
-            showClickIndication = false,
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(horizontal = GroupDetailHorizontalPadding, vertical = 2.dp),
-            leadingContent = {
-                AsmrAsyncImage(
-                    model = coverModel?.toString().orEmpty(),
-                    contentDescription = null,
-                    contentScale = ContentScale.Crop,
-                    placeholderCornerRadius = 6,
-                    modifier = Modifier
-                        .size(48.dp)
-                        .clip(RoundedCornerShape(6.dp))
-                )
-            },
-            titleTextStyle = MaterialTheme.typography.bodyMedium,
-            actions = listOf(
+        val actions = remember(onPlay, onMoveToTop, onMoveToBottom, onRemove) {
+            listOf(
                 AudioItemMenuAction(
                     label = "播放",
                     onClick = onPlay
@@ -502,6 +498,33 @@ private fun GroupTrackRow(
                     showDividerBefore = true
                 )
             )
+        }
+        AudioItemRow(
+            title = item.trackTitle.ifBlank { "未命名" },
+            subtitle = meta.leadingText,
+            fixedTrailingSubtitle = meta.trailingText,
+            showSubtitleStamp = item.hasSubtitles,
+            subtitleStampTestTag = "$GROUP_DETAIL_TRACK_SUBTITLE_STAMP_TAG_PREFIX:${item.mediaId}",
+            menuButtonTestTag = "$GROUP_DETAIL_TRACK_MENU_BUTTON_TAG_PREFIX:${item.mediaId}",
+            onClick = onPlay,
+            showClickIndication = false,
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = GroupDetailHorizontalPadding, vertical = 2.dp),
+            leadingContent = {
+                AsmrAsyncImage(
+                    model = coverModel?.toString().orEmpty(),
+                    contentDescription = null,
+                    contentScale = ContentScale.Crop,
+                    placeholderCornerRadius = 6,
+                    peekAnySizeForInitial = true,
+                    modifier = Modifier
+                        .size(48.dp)
+                        .clip(RoundedCornerShape(6.dp))
+                )
+            },
+            titleTextStyle = MaterialTheme.typography.bodyMedium,
+            actions = actions
         )
     }
 }
@@ -556,6 +579,16 @@ private fun SnapshotStateList<GroupDetailListRow>.tracksForAlbum(albumId: Long):
     return filterIsInstance<GroupDetailTrackRow>()
         .filter { row -> row.albumId == albumId }
         .map { row -> row.track }
+}
+
+private fun List<GroupDetailListRow>.tracksByAlbumId(): Map<Long, List<AlbumGroupTrackRow>> {
+    val result = linkedMapOf<Long, MutableList<AlbumGroupTrackRow>>()
+    for (row in this) {
+        if (row is GroupDetailTrackRow) {
+            result.getOrPut(row.albumId) { mutableListOf() } += row.track
+        }
+    }
+    return result
 }
 
 private fun SnapshotStateList<GroupDetailListRow>.mediaIdsForAlbum(albumId: Long): List<String> {

--- a/app/src/main/java/com/asmr/player/ui/groups/AlbumGroupsScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/groups/AlbumGroupsScreen.kt
@@ -191,6 +191,7 @@ private fun AlbumGroupRow(
                 contentDescription = null,
                 contentScale = ContentScale.Crop,
                 placeholderCornerRadius = 12,
+                peekAnySizeForInitial = true,
                 modifier = Modifier
                     .size(54.dp)
                     .clip(RoundedCornerShape(12.dp))

--- a/app/src/main/java/com/asmr/player/ui/library/AlbumItem.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/AlbumItem.kt
@@ -152,6 +152,7 @@ fun AlbumItem(
                             contentDescription = null,
                             contentScale = ContentScale.Crop,
                             placeholderCornerRadius = 0,
+                            peekAnySizeForInitial = true,
                             modifier = Modifier.fillMaxSize().clip(coverShape),
                             empty = { m -> AsmrShimmerPlaceholder(modifier = m, cornerRadius = 0) },
                         )
@@ -161,6 +162,7 @@ fun AlbumItem(
                             contentDescription = null,
                             contentScale = ContentScale.Crop,
                             placeholderCornerRadius = 0,
+                            peekAnySizeForInitial = true,
                             modifier = Modifier.fillMaxSize().clip(coverShape),
                         )
                     }
@@ -375,6 +377,7 @@ fun AlbumGridItem(
                     contentDescription = null,
                     contentScale = ContentScale.Crop,
                     placeholderCornerRadius = 0,
+                    peekAnySizeForInitial = true,
                     modifier = Modifier.fillMaxSize().clip(coverShape),
                     empty = { m -> AsmrShimmerPlaceholder(modifier = m, cornerRadius = 0) },
                 )
@@ -384,6 +387,7 @@ fun AlbumGridItem(
                     contentDescription = null,
                     contentScale = ContentScale.Crop,
                     placeholderCornerRadius = 0,
+                    peekAnySizeForInitial = true,
                     modifier = Modifier.fillMaxSize().clip(coverShape),
                 )
             }

--- a/app/src/main/java/com/asmr/player/ui/library/LibraryScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/LibraryScreen.kt
@@ -65,6 +65,7 @@ import com.asmr.player.ui.common.StableWindowInsets
 import com.asmr.player.ui.common.rememberAudioMeta
 import com.asmr.player.ui.common.rememberAudioMetaText
 import com.asmr.player.ui.common.rememberTrackMetaLine
+import com.asmr.player.ui.common.queryCachedTrackFileSize
 import com.asmr.player.ui.common.smoothScrollToTop
 import com.asmr.player.ui.common.withAddedBottomPadding
 import androidx.compose.material3.HorizontalDivider
@@ -625,7 +626,10 @@ fun LibraryScreen(
                                                         trackCount = header.trackCount,
                                                         totalDurationSeconds = header.totalDuration,
                                                         totalSizeBytes = header.totalSizeBytes.takeIf { it > 0L }
-                                                            ?: rememberAlbumTrackListTotalSizeBytes(rows),
+                                                            ?: rememberAlbumTrackListTotalSizeBytes(
+                                                                rows = rows,
+                                                                loadFileSizes = !listState.isScrollInProgress
+                                                            ),
                                                         coverModel = albumCoverImageModel(
                                                             coverThumbPath = "",
                                                             coverPath = header.coverPath.takeIf { it != "null" }.orEmpty(),
@@ -679,7 +683,8 @@ fun LibraryScreen(
                                                     val meta = rememberAudioMeta(
                                                         sourcePath = row.trackPath,
                                                         durationSeconds = row.duration,
-                                                        prefixSegments = listOf(row.cv)
+                                                        prefixSegments = listOf(row.cv),
+                                                        loadSize = !listState.isScrollInProgress
                                                     )
 
                                                     Column {
@@ -791,7 +796,7 @@ fun LibraryScreen(
                                     LazyListPreloader(
                                         state = listState,
                                         itemCount = pagedAlbums.itemCount,
-                                        preloadNext = 10,
+                                        preloadNext = 4,
                                         preloadSize = preloadSize,
                                         cacheManagerProvider = { cacheManager },
                                         modelAt = { idx ->
@@ -1273,13 +1278,17 @@ private fun TrackAlbumHeader(
 }
 
 @Composable
-private fun rememberAlbumTrackListTotalSizeBytes(rows: List<com.asmr.player.data.local.db.dao.LibraryTrackRow>): Long? {
+private fun rememberAlbumTrackListTotalSizeBytes(
+    rows: List<com.asmr.player.data.local.db.dao.LibraryTrackRow>,
+    loadFileSizes: Boolean
+): Long? {
     val context = LocalContext.current
     val paths = remember(rows) { rows.map { it.trackPath } }
-    return androidx.compose.runtime.produceState<Long?>(initialValue = null, paths) {
+    return androidx.compose.runtime.produceState<Long?>(initialValue = null, paths, loadFileSizes) {
+        if (!loadFileSizes) return@produceState
         value = withContext(Dispatchers.IO) {
             val total = rows.sumOf { row ->
-                com.asmr.player.ui.common.queryTrackFileSize(context, row.trackPath) ?: 0L
+                queryCachedTrackFileSize(context, row.trackPath) ?: 0L
             }
             total.takeIf { it > 0L }
         }

--- a/app/src/main/java/com/asmr/player/ui/library/LibraryScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/LibraryScreen.kt
@@ -1244,6 +1244,7 @@ private fun TrackAlbumHeader(
             contentDescription = null,
             contentScale = ContentScale.Crop,
             placeholderCornerRadius = 8,
+            peekAnySizeForInitial = true,
             modifier = Modifier
                 .size(50.dp)
                 .clip(RoundedCornerShape(8.dp)),
@@ -1417,6 +1418,7 @@ private fun AlbumGridItem(
                 contentDescription = null,
                 contentScale = ContentScale.Crop,
                 placeholderCornerRadius = 0,
+                peekAnySizeForInitial = true,
                 modifier = Modifier.fillMaxSize().clip(coverShape),
             )
             
@@ -1512,16 +1514,18 @@ private fun AlbumGridItem(
                 leadingVisual = AlbumMetaLeadingVisual.Icon,
             )
 
-            val statsText = buildString {
-                val rv = album.ratingValue
-                if (rv != null && rv > 0.0) {
-                    append("★")
-                    append(String.format("%.1f", rv))
-                    if (album.ratingCount > 0) append("(${album.ratingCount})")
-                }
-                if (album.priceJpy > 0) {
-                    if (isNotEmpty()) append(" · ")
-                    append("¥${album.priceJpy}")
+            val statsText = remember(album.ratingValue, album.ratingCount, album.priceJpy) {
+                buildString {
+                    val rv = album.ratingValue
+                    if (rv != null && rv > 0.0) {
+                        append("★")
+                        append(String.format("%.1f", rv))
+                        if (album.ratingCount > 0) append("(${album.ratingCount})")
+                    }
+                    if (album.priceJpy > 0) {
+                        if (isNotEmpty()) append(" · ")
+                        append("¥${album.priceJpy}")
+                    }
                 }
             }
             if (statsText.isNotBlank()) {
@@ -1607,6 +1611,7 @@ private fun AlbumItem(
                         contentDescription = null,
                         contentScale = ContentScale.Crop,
                         placeholderCornerRadius = 0,
+                        peekAnySizeForInitial = true,
                         modifier = Modifier.fillMaxSize().clip(coverShape),
                     )
                     
@@ -1643,24 +1648,32 @@ private fun AlbumItem(
                 }
             },
             content = {
-                val statsText = buildString {
-                    val rv = album.ratingValue
-                    if (rv != null && rv > 0.0) {
-                        append("★")
-                        append(String.format("%.1f", rv))
-                        if (album.ratingCount > 0) append("(${album.ratingCount})")
-                    }
-                    if (album.dlCount > 0) {
-                        if (isNotEmpty()) append(" · ")
-                        append("DL ${album.dlCount}")
-                    }
-                    if (album.priceJpy > 0) {
-                        if (isNotEmpty()) append(" · ")
-                        append("¥${album.priceJpy}")
-                    }
-                    if (album.releaseDate.isNotBlank()) {
-                        if (isNotEmpty()) append(" · ")
-                        append(album.releaseDate)
+                val statsText = remember(
+                    album.ratingValue,
+                    album.ratingCount,
+                    album.dlCount,
+                    album.priceJpy,
+                    album.releaseDate
+                ) {
+                    buildString {
+                        val rv = album.ratingValue
+                        if (rv != null && rv > 0.0) {
+                            append("★")
+                            append(String.format("%.1f", rv))
+                            if (album.ratingCount > 0) append("(${album.ratingCount})")
+                        }
+                        if (album.dlCount > 0) {
+                            if (isNotEmpty()) append(" · ")
+                            append("DL ${album.dlCount}")
+                        }
+                        if (album.priceJpy > 0) {
+                            if (isNotEmpty()) append(" · ")
+                            append("¥${album.priceJpy}")
+                        }
+                        if (album.releaseDate.isNotBlank()) {
+                            if (isNotEmpty()) append(" · ")
+                            append(album.releaseDate)
+                        }
                     }
                 }
 

--- a/app/src/main/java/com/asmr/player/ui/playlists/PlaylistDetailScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/playlists/PlaylistDetailScreen.kt
@@ -224,6 +224,7 @@ internal fun PlaylistDetailContent(
                                 showSubtitleStamp = item.hasSubtitles,
                                 showTopDivider = index > 0,
                                 isDragging = isDragging,
+                                loadFileSize = !listState.isScrollInProgress,
                                 modifier = Modifier
                                     .fillMaxWidth()
                                     .testTag("$PLAYLIST_DETAIL_ITEM_TAG_PREFIX:${item.mediaId}")
@@ -266,6 +267,7 @@ private fun PlaylistItemRow(
     showSubtitleStamp: Boolean,
     showTopDivider: Boolean,
     isDragging: Boolean,
+    loadFileSize: Boolean,
     modifier: Modifier = Modifier,
     onPlay: () -> Unit,
     onMoveToTop: () -> Unit,
@@ -288,7 +290,8 @@ private fun PlaylistItemRow(
         val meta = rememberAudioMeta(
             sourcePath = item.uri.ifBlank { item.mediaId },
             durationSeconds = item.duration,
-            prefixSegments = listOf(item.artist, item.albumCv)
+            prefixSegments = listOf(item.artist, item.albumCv),
+            loadSize = loadFileSize
         )
         AudioItemRow(
             title = item.title.ifBlank { "未命名" },

--- a/app/src/main/java/com/asmr/player/ui/playlists/PlaylistDetailScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/playlists/PlaylistDetailScreen.kt
@@ -38,6 +38,7 @@ import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
@@ -157,7 +158,11 @@ internal fun PlaylistDetailContent(
         listState.smoothScrollToTop()
     }
 
-    val playItems = localItems.map { item -> item.toPlaybackEntity() }
+    val playItems by remember {
+        derivedStateOf {
+            localItems.map { item -> item.toPlaybackEntity() }
+        }
+    }
     val isCompact = windowSizeClass.widthSizeClass == WindowWidthSizeClass.Compact
     val colorScheme = AsmrTheme.colorScheme
     val draggedItemShape = RoundedCornerShape(18.dp)
@@ -209,7 +214,11 @@ internal fun PlaylistDetailContent(
                     item(key = PLAYLIST_DETAIL_REORDER_SENTINEL_KEY) {
                         Spacer(modifier = Modifier.height(1.dp))
                     }
-                    itemsIndexed(localItems, key = { _, item -> item.mediaId }) { index, item ->
+                    itemsIndexed(
+                        items = localItems,
+                        key = { _, item -> item.mediaId },
+                        contentType = { _, _ -> "playlistDetailItem" }
+                    ) { index, item ->
                         ReorderableItem(
                             reorderableState = reorderState,
                             key = item.mediaId,
@@ -287,36 +296,17 @@ private fun PlaylistItemRow(
                 color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.2f)
             )
         }
+        val prefixSegments = remember(item.artist, item.albumCv) {
+            listOf(item.artist, item.albumCv)
+        }
         val meta = rememberAudioMeta(
             sourcePath = item.uri.ifBlank { item.mediaId },
             durationSeconds = item.duration,
-            prefixSegments = listOf(item.artist, item.albumCv),
+            prefixSegments = prefixSegments,
             loadSize = loadFileSize
         )
-        AudioItemRow(
-            title = item.title.ifBlank { "未命名" },
-            subtitle = meta.leadingText,
-            fixedTrailingSubtitle = meta.trailingText,
-            showSubtitleStamp = showSubtitleStamp,
-            menuButtonTestTag = "$PLAYLIST_DETAIL_ITEM_MENU_BUTTON_TAG_PREFIX:${item.mediaId}",
-            onClick = onPlay,
-            showClickIndication = false,
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(horizontal = PlaylistDetailHorizontalPadding, vertical = 2.dp),
-            leadingContent = {
-                AsmrAsyncImage(
-                    model = item.artworkUri,
-                    contentDescription = null,
-                    contentScale = ContentScale.Crop,
-                    placeholderCornerRadius = 6,
-                    modifier = Modifier
-                        .size(48.dp)
-                        .clip(RoundedCornerShape(6.dp))
-                )
-            },
-            titleTextStyle = MaterialTheme.typography.bodyMedium,
-            actions = listOf(
+        val actions = remember(onPlay, onMoveToTop, onMoveToBottom, onRemove) {
+            listOf(
                 AudioItemMenuAction(
                     label = "播放",
                     onClick = onPlay
@@ -337,6 +327,32 @@ private fun PlaylistItemRow(
                     showDividerBefore = true
                 )
             )
+        }
+        AudioItemRow(
+            title = item.title.ifBlank { "未命名" },
+            subtitle = meta.leadingText,
+            fixedTrailingSubtitle = meta.trailingText,
+            showSubtitleStamp = showSubtitleStamp,
+            menuButtonTestTag = "$PLAYLIST_DETAIL_ITEM_MENU_BUTTON_TAG_PREFIX:${item.mediaId}",
+            onClick = onPlay,
+            showClickIndication = false,
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = PlaylistDetailHorizontalPadding, vertical = 2.dp),
+            leadingContent = {
+                AsmrAsyncImage(
+                    model = item.artworkUri,
+                    contentDescription = null,
+                    contentScale = ContentScale.Crop,
+                    placeholderCornerRadius = 6,
+                    peekAnySizeForInitial = true,
+                    modifier = Modifier
+                        .size(48.dp)
+                        .clip(RoundedCornerShape(6.dp))
+                )
+            },
+            titleTextStyle = MaterialTheme.typography.bodyMedium,
+            actions = actions
         )
     }
 }

--- a/app/src/main/java/com/asmr/player/ui/playlists/PlaylistsScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/playlists/PlaylistsScreen.kt
@@ -190,6 +190,7 @@ private fun PlaylistRow(
                 contentDescription = null,
                 contentScale = ContentScale.Crop,
                 placeholderCornerRadius = 12,
+                peekAnySizeForInitial = true,
                 modifier = Modifier
                     .size(54.dp)
                     .clip(RoundedCornerShape(12.dp)),


### PR DESCRIPTION
## Summary
- Defer and cache file-size metadata work during list scroll.
- Limit image cold-load/preload work and move disk-cache writes off the UI-critical path.
- Reduce lazy-list recomposition/allocation work and reuse in-memory cover placeholders while preserving cover animations and final image quality.

## Verification
- Run gradlew-local.bat :app:installRelease (release compile/package passed; latest install attempt blocked by no connected devices)