### PR TITLE
Add newest collected sort to collected search

### DIFF
--- a/app/src/main/java/com/asmr/player/ui/search/SearchSortOption.kt
+++ b/app/src/main/java/com/asmr/player/ui/search/SearchSortOption.kt
@@ -15,6 +15,7 @@ enum class SearchCollectedSortOption(
     val backendSort: String
 ) {
     ReleaseNew("最新发售", "release"),
+    CollectedNew("最新收录", "create_date"),
     RatingHigh("评分最高", "rating");
 
     companion object {

--- a/app/src/test/java/com/asmr/player/ui/search/SearchCollectedSortOptionTest.kt
+++ b/app/src/test/java/com/asmr/player/ui/search/SearchCollectedSortOptionTest.kt
@@ -1,0 +1,14 @@
+package com.asmr.player.ui.search
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class SearchCollectedSortOptionTest {
+    @Test
+    fun newestCollectedSortMapsToBackendCreateDateSort() {
+        assertEquals(SearchCollectedSortOption.ReleaseNew, SearchCollectedSortOption.fromName(null))
+        assertEquals(SearchCollectedSortOption.ReleaseNew, SearchCollectedSortOption.fromName("missing"))
+        assertEquals(SearchCollectedSortOption.CollectedNew, SearchCollectedSortOption.fromName("CollectedNew"))
+        assertEquals("create_date", SearchCollectedSortOption.CollectedNew.backendSort)
+    }
+}

--- a/app/src/test/java/com/asmr/player/ui/search/SearchScreenChromeTest.kt
+++ b/app/src/test/java/com/asmr/player/ui/search/SearchScreenChromeTest.kt
@@ -229,12 +229,13 @@ class SearchScreenChromeTest {
 
         composeRule.onNodeWithTag(SEARCH_COLLECTED_SORT_BUTTON_TAG).performClick()
         composeRule.onNodeWithText("最新发售").assertExists()
+        composeRule.onNodeWithText("最新收录").assertExists()
         composeRule.onNodeWithText("评分最高").assertExists()
         composeRule.onAllNodesWithText("时长最长").assertCountEquals(0)
-        composeRule.onNodeWithText("评分最高").performClick()
+        composeRule.onNodeWithText("最新收录").performClick()
 
         composeRule.runOnIdle {
-            assertEquals(SearchCollectedSortOption.RatingHigh, selectedSort)
+            assertEquals(SearchCollectedSortOption.CollectedNew, selectedSort)
         }
     }
 


### PR DESCRIPTION
## Summary
- add a 最新收录 option for 已收录 search
- send sort=create_date to the backend for newest collected ordering
- cover the backend sort mapping and collected sort menu state in tests

## Verification
- .\\gradlew-local.bat :app:testReleaseUnitTest --tests com.asmr.player.ui.search.SearchCollectedSortOptionTest
- .\\gradlew-local.bat :app:compileReleaseKotlin
- .\\gradlew-local.bat :app:installRelease