### PR TITLE
Add lyric playback timeline

### DIFF
--- a/app/src/main/java/com/asmr/player/ui/player/AppleLyricsView.kt
+++ b/app/src/main/java/com/asmr/player/ui/player/AppleLyricsView.kt
@@ -1,30 +1,45 @@
 package com.asmr.player.ui.player
 
 import android.os.SystemClock
+import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.animateColorAsState
 import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.AnimationVector1D
 import androidx.compose.animation.core.FastOutSlowInEasing
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.scrollBy
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.PlayArrow
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableLongStateOf
@@ -37,7 +52,9 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.PathEffect
 import androidx.compose.ui.graphics.Shadow
+import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.luminance
 import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
@@ -55,6 +72,7 @@ import androidx.compose.ui.unit.sp
 import com.asmr.player.data.settings.LyricsPageSettings
 import com.asmr.player.ui.common.thinScrollbar
 import com.asmr.player.ui.theme.AsmrTheme
+import com.asmr.player.util.Formatting
 import com.asmr.player.util.SubtitleEntry
 import com.asmr.player.util.SubtitleIndexFinder
 import androidx.compose.runtime.withFrameNanos
@@ -70,6 +88,8 @@ internal fun AppleLyricsView(
     currentPosition: Long,
     onSeekTo: (Long) -> Unit,
     onOpenLyrics: () -> Unit = {},
+    onTimelinePlay: ((Long) -> Unit)? = null,
+    showPlaybackTimeline: Boolean = false,
     colors: LyricReadableColors,
     modifier: Modifier = Modifier,
     isLandscape: Boolean = false,
@@ -204,7 +224,26 @@ internal fun AppleLyricsView(
         val centeredActiveTopPx = ((viewportLayout.viewportWindowHeightPx - activeItemHeightPx) / 2f).coerceAtLeast(0f)
         val centeredActiveBottomDp = viewportWindowHeightDp / 2f
         val viewportCenterY = viewportLayout.viewportWindowHeightPx / 2f
+        val timelineCenterInViewportPx = (viewportHeightPx / 2f - viewportLayout.viewportTopOffsetPx)
+            .coerceIn(0f, viewportLayout.viewportWindowHeightPx)
         val maxWaveOffsetPx = viewportLayout.viewportWindowHeightPx * 0.22f
+        val timelineTargetIndex by remember(lyrics.size, timelineCenterInViewportPx, listState) {
+            derivedStateOf {
+                centeredLyricIndexForTimeline(
+                    visibleItems = listState.layoutInfo.visibleItemsInfo.map { item ->
+                        LyricVisibleItemFrame(
+                            index = item.index,
+                            offsetPx = item.offset,
+                            sizePx = item.size
+                        )
+                    },
+                    viewportCenterPx = timelineCenterInViewportPx,
+                    totalCount = lyrics.size
+                )
+            }
+        }
+        val timelineTargetPositionMs = lyrics.getOrNull(timelineTargetIndex)?.startMs
+        val timelineVisible = showPlaybackTimeline && lyrics.isNotEmpty() && autoFocusSuspended
         LaunchedEffect(lastUserScrollAt, autoFocusSuspended) {
             if (autoFocusSuspended) {
                 val scheduledAt = lastUserScrollAt
@@ -424,6 +463,33 @@ internal fun AppleLyricsView(
                 }
             }
         }
+
+        AnimatedVisibility(
+            visible = timelineVisible,
+            enter = fadeIn(animationSpec = tween(durationMillis = 140)),
+            exit = fadeOut(animationSpec = tween(durationMillis = 180)),
+            modifier = Modifier
+                .align(Alignment.Center)
+                .fillMaxWidth()
+                .padding(
+                    start = if (isLandscape) 12.dp else 18.dp,
+                    end = if (isLandscape) 8.dp else 14.dp
+                )
+        ) {
+            LyricsPlaybackTimeline(
+                targetPositionMs = timelineTargetPositionMs,
+                colors = colors,
+                isLandscape = isLandscape,
+                onPlayClick = { targetMs ->
+                    if (timelineTargetIndex in lyrics.indices) {
+                        pendingSmoothFocusIndex = timelineTargetIndex
+                    }
+                    autoFocusSuspended = false
+                    pendingAnimatedRefocus = false
+                    (onTimelinePlay ?: onSeekTo)(targetMs)
+                }
+            )
+        }
     }
 }
 
@@ -551,6 +617,94 @@ private fun focusScrollDurationMillis(
 }
 
 private fun Float?.orElseZero(): Float = this ?: 0f
+
+@Composable
+private fun LyricsPlaybackTimeline(
+    targetPositionMs: Long?,
+    colors: LyricReadableColors,
+    isLandscape: Boolean,
+    onPlayClick: (Long) -> Unit
+) {
+    val enabled = targetPositionMs != null
+    val buttonSize = if (isLandscape) 34.dp else 40.dp
+    val iconSize = if (isLandscape) 19.dp else 22.dp
+    val timelineColor = colors.accentEmphasis.copy(alpha = if (enabled) 0.82f else 0.36f)
+    val containerColor = colors.activeContainer.copy(alpha = if (enabled) 0.96f else 0.54f)
+    val contentColor = colors.activeText.copy(alpha = if (enabled) 0.94f else 0.46f)
+    val targetText = targetPositionMs?.let { Formatting.formatTrackTime(it) } ?: "--:--"
+    val description = targetPositionMs?.let { "跳转到 ${Formatting.formatTrackTime(it)} 播放" } ?: "跳转播放"
+    val density = LocalDensity.current
+
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(if (isLandscape) 36.dp else 44.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Canvas(
+            modifier = Modifier
+                .weight(1f)
+                .height(if (isLandscape) 18.dp else 20.dp)
+        ) {
+            val strokeWidth = with(density) { 1.dp.toPx() }
+            val dash = with(density) { 6.dp.toPx() }
+            val gap = with(density) { 5.dp.toPx() }
+            drawLine(
+                color = timelineColor,
+                start = Offset(0f, size.height / 2f),
+                end = Offset(size.width, size.height / 2f),
+                strokeWidth = strokeWidth,
+                cap = StrokeCap.Round,
+                pathEffect = PathEffect.dashPathEffect(
+                    intervals = floatArrayOf(dash, gap),
+                    phase = 0f
+                )
+            )
+        }
+        Spacer(modifier = Modifier.width(if (isLandscape) 6.dp else 8.dp))
+        Surface(
+            shape = RoundedCornerShape(999.dp),
+            color = containerColor,
+            contentColor = contentColor,
+            tonalElevation = 0.dp,
+            shadowElevation = if (enabled) 2.dp else 0.dp
+        ) {
+            Text(
+                text = targetText,
+                modifier = Modifier.padding(
+                    horizontal = if (isLandscape) 8.dp else 10.dp,
+                    vertical = if (isLandscape) 4.dp else 5.dp
+                ),
+                style = MaterialTheme.typography.labelMedium.copy(fontWeight = FontWeight.Bold),
+                color = contentColor
+            )
+        }
+        Spacer(modifier = Modifier.width(if (isLandscape) 6.dp else 8.dp))
+        Surface(
+            modifier = Modifier.size(buttonSize),
+            shape = CircleShape,
+            color = containerColor,
+            contentColor = contentColor,
+            tonalElevation = 0.dp,
+            shadowElevation = if (enabled) 3.dp else 0.dp
+        ) {
+            IconButton(
+                onClick = {
+                    targetPositionMs?.let(onPlayClick)
+                },
+                enabled = enabled,
+                modifier = Modifier.fillMaxSize()
+            ) {
+                Icon(
+                    imageVector = Icons.Rounded.PlayArrow,
+                    contentDescription = description,
+                    modifier = Modifier.size(iconSize),
+                    tint = contentColor
+                )
+            }
+        }
+    }
+}
 
 private suspend fun resetLyricWaveOffsets(
     itemOffsets: Map<Int, Animatable<Float, AnimationVector1D>>,

--- a/app/src/main/java/com/asmr/player/ui/player/LyricsPage.kt
+++ b/app/src/main/java/com/asmr/player/ui/player/LyricsPage.kt
@@ -145,6 +145,11 @@ internal fun LyricsPage(
                     lyrics = uiState.lyrics,
                     currentPosition = position,
                     onSeekTo = onSeekTo,
+                    onTimelinePlay = { targetMs ->
+                        onSeekTo(targetMs)
+                        playerViewModel.play()
+                    },
+                    showPlaybackTimeline = true,
                     colors = lyricColors,
                     modifier = Modifier.fillMaxSize(),
                     isLandscape = isLandscape,

--- a/app/src/main/java/com/asmr/player/ui/player/LyricsPageLayout.kt
+++ b/app/src/main/java/com/asmr/player/ui/player/LyricsPageLayout.kt
@@ -2,6 +2,7 @@ package com.asmr.player.ui.player
 
 import androidx.compose.ui.text.style.TextAlign
 import com.asmr.player.data.settings.LyricsPageSettings
+import kotlin.math.abs
 import kotlin.math.floor
 import kotlin.math.max
 
@@ -9,6 +10,12 @@ internal data class LyricsViewportLayout(
     val nominalItemHeightPx: Float,
     val viewportWindowHeightPx: Float,
     val viewportTopOffsetPx: Float
+)
+
+internal data class LyricVisibleItemFrame(
+    val index: Int,
+    val offsetPx: Int,
+    val sizePx: Int
 )
 
 internal fun buildLyricsViewportLayout(
@@ -22,7 +29,13 @@ internal fun buildLyricsViewportLayout(
         1, 2, 3 -> quarterHeightPx
         else -> viewportHeightPx
     }
-    val viewportWindowHeightPx = maxOf(requestedWindowHeightPx, measuredWindowHeightPx.coerceAtMost(requestedWindowHeightPx))
+    val canUseMeasuredWindow = settings.displayAreaMode in 1..3
+    val resolvedWindowHeightPx = if (canUseMeasuredWindow && measuredWindowHeightPx > 0f) {
+        measuredWindowHeightPx.coerceAtMost(requestedWindowHeightPx)
+    } else {
+        requestedWindowHeightPx
+    }
+    val viewportWindowHeightPx = resolvedWindowHeightPx
         .coerceAtMost(viewportHeightPx)
         .coerceAtLeast(nominalItemHeightPx)
     val viewportTopOffsetPx = when (settings.displayAreaMode) {
@@ -50,4 +63,22 @@ internal fun lyricTextAlign(align: Int): TextAlign = when (align) {
     0 -> TextAlign.Start
     2 -> TextAlign.End
     else -> TextAlign.Center
+}
+
+internal fun centeredLyricIndexForTimeline(
+    visibleItems: List<LyricVisibleItemFrame>,
+    viewportCenterPx: Float,
+    totalCount: Int
+): Int {
+    if (totalCount <= 0 || !viewportCenterPx.isFinite()) return -1
+    return visibleItems
+        .asSequence()
+        .filter { item -> item.index in 0 until totalCount && item.sizePx > 0 }
+        .minWithOrNull(
+            compareBy<LyricVisibleItemFrame> { item ->
+                abs(item.offsetPx + item.sizePx / 2f - viewportCenterPx)
+            }.thenBy { item -> item.index }
+        )
+        ?.index
+        ?: -1
 }

--- a/app/src/main/java/com/asmr/player/ui/player/NowPlayingScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/player/NowPlayingScreen.kt
@@ -1584,6 +1584,10 @@ internal fun NowPlayingScreen(
                         lyricColors = lyricColors,
                         lyricsPageSettings = lyricsPageSettings,
                         onSeekTo = { viewModel.seekTo(it) },
+                        onTimelinePlay = { targetMs ->
+                            viewModel.seekTo(targetMs)
+                            viewModel.play()
+                        },
                         onAddLyrics = openManualLyricsAction,
                         modifier = Modifier
                             .fillMaxSize()

--- a/app/src/main/java/com/asmr/player/ui/player/nowplaying/NowPlayingSurfaceComponents.kt
+++ b/app/src/main/java/com/asmr/player/ui/player/nowplaying/NowPlayingSurfaceComponents.kt
@@ -199,6 +199,7 @@ internal fun NowPlayingLyricsSurface(
     lyricColors: LyricReadableColors,
     lyricsPageSettings: LyricsPageSettings,
     onSeekTo: (Long) -> Unit,
+    onTimelinePlay: ((Long) -> Unit)? = null,
     onAddLyrics: (() -> Unit)? = null,
     modifier: Modifier = Modifier
 ) {
@@ -228,6 +229,8 @@ internal fun NowPlayingLyricsSurface(
                 lyrics = lyrics,
                 currentPosition = playbackPositionMs,
                 onSeekTo = onSeekTo,
+                onTimelinePlay = onTimelinePlay,
+                showPlaybackTimeline = true,
                 colors = lyricColors,
                 modifier = Modifier.fillMaxSize(),
                 isLandscape = isLandscape,

--- a/app/src/test/java/com/asmr/player/ui/player/LyricsPageLayoutTest.kt
+++ b/app/src/test/java/com/asmr/player/ui/player/LyricsPageLayoutTest.kt
@@ -42,10 +42,52 @@ class LyricsPageLayoutTest {
     }
 
     @Test
+    fun viewportLayout_ignoresMeasuredWindowForFullDisplayArea() {
+        val layout = buildLyricsViewportLayout(
+            settings = LyricsPageSettings(displayAreaMode = 0),
+            viewportHeightPx = 640f,
+            nominalItemHeightPx = 100f,
+            measuredWindowHeightPx = 140f
+        )
+
+        assertEquals(640f, layout.viewportWindowHeightPx, 0.001f)
+        assertEquals(0f, layout.viewportTopOffsetPx, 0.001f)
+    }
+
+    @Test
     fun lyricTextAlign_mapsStoredValues() {
         assertEquals(TextAlign.Start, lyricTextAlign(0))
         assertEquals(TextAlign.Center, lyricTextAlign(1))
         assertEquals(TextAlign.End, lyricTextAlign(2))
         assertEquals(TextAlign.Center, lyricTextAlign(999))
+    }
+
+    @Test
+    fun centeredLyricIndexForTimeline_picksNearestVisibleItemCenter() {
+        val frames = listOf(
+            LyricVisibleItemFrame(index = 0, offsetPx = -20, sizePx = 60),
+            LyricVisibleItemFrame(index = 1, offsetPx = 40, sizePx = 80),
+            LyricVisibleItemFrame(index = 2, offsetPx = 120, sizePx = 60)
+        )
+
+        assertEquals(1, centeredLyricIndexForTimeline(frames, viewportCenterPx = 100f, totalCount = 3))
+    }
+
+    @Test
+    fun centeredLyricIndexForTimeline_ignoresInvalidFrames() {
+        val frames = listOf(
+            LyricVisibleItemFrame(index = -1, offsetPx = 0, sizePx = 100),
+            LyricVisibleItemFrame(index = 4, offsetPx = 10, sizePx = 100),
+            LyricVisibleItemFrame(index = 1, offsetPx = 80, sizePx = 0),
+            LyricVisibleItemFrame(index = 2, offsetPx = 80, sizePx = 40)
+        )
+
+        assertEquals(2, centeredLyricIndexForTimeline(frames, viewportCenterPx = 100f, totalCount = 3))
+    }
+
+    @Test
+    fun centeredLyricIndexForTimeline_returnsMinusOneWhenUnavailable() {
+        assertEquals(-1, centeredLyricIndexForTimeline(emptyList(), viewportCenterPx = 100f, totalCount = 3))
+        assertEquals(-1, centeredLyricIndexForTimeline(emptyList(), viewportCenterPx = 100f, totalCount = 0))
     }
 }


### PR DESCRIPTION
## Summary
- Add a dashed playback timeline overlay while users manually scroll lyrics
- Add a right-side play action to seek to the centered lyric timestamp and start playback
- Wire the timeline into both lyrics page entry points and cover layout helper tests

## Verification
- `.\gradlew-local.bat :app:testReleaseUnitTest --tests "com.asmr.player.ui.player.LyricsPageLayoutTest"`
- `.\gradlew-local.bat :app:installRelease`
