### PR TITLE
fix: improve online search swipe gestures

### DIFF
--- a/app/src/main/java/com/asmr/player/main/MainContainer.kt
+++ b/app/src/main/java/com/asmr/player/main/MainContainer.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.PagerState
+import androidx.compose.foundation.pager.PagerDefaults
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
@@ -241,6 +242,7 @@ internal data class BatchPlaylistPickerRequest(
 
 private const val SecondaryPageEnterDurationMs = 440
 private const val SecondaryPageExitDurationMs = 420
+private const val PrimaryPagerSnapThreshold = 0.16f
 private val SecondaryPageSlideEasing = CubicBezierEasing(0.215f, 0.61f, 0.355f, 1f)
 private val AlbumDetailTopBarButtonShape = CircleShape
 
@@ -547,6 +549,10 @@ fun MainContainer(
     val primaryPagerState = rememberPagerState(
         initialPage = initialPrimaryPage,
         pageCount = { primaryPagerRoutes.size }
+    )
+    val primaryPagerFlingBehavior = PagerDefaults.flingBehavior(
+        state = primaryPagerState,
+        snapPositionalThreshold = PrimaryPagerSnapThreshold
     )
     val focusManager = LocalFocusManager.current
     val keyboardController = LocalSoftwareKeyboardController.current
@@ -1635,6 +1641,7 @@ fun MainContainer(
                                         .fillMaxSize()
                                         .padding(top = pagerTopContentPadding),
                                     beyondBoundsPageCount = primaryPagerBeyondBoundsPageCount,
+                                    flingBehavior = primaryPagerFlingBehavior,
                                     userScrollEnabled = !primaryPagerScrollLocked && !hasOverlayRoute,
                                     key = { primaryPagerRoutes[it] }
                                 ) { page ->

--- a/app/src/main/java/com/asmr/player/ui/search/SearchScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/search/SearchScreen.kt
@@ -81,6 +81,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.compositeOver
@@ -150,6 +151,7 @@ private val SearchPageHorizontalPadding = 8.dp
 private const val SearchPullNextPageDragResistance = 0.82f
 private const val SearchPullNextPageFollowRatio = 0.84f
 private const val SearchPullStretchExtraRatio = 0.28f
+private const val SearchPullNextPageVerticalBias = 1.25f
 private val SearchPullNextPageTriggerDistance = 96.dp
 private val SearchPullNextPageMaxDistance = 172.dp
 private val SearchPullNextPageMaxLift = 108.dp
@@ -696,8 +698,11 @@ fun SearchScreen(
                                 awaitEachGesture {
                                     val down = awaitFirstDown(requireUnconsumed = false, pass = PointerEventPass.Initial)
                                     var trackedPointerId = down.id
-                                    var previousY = down.position.y
+                                    var previousPosition = down.position
+                                    var dragFromDown = Offset.Zero
                                     var pullNextGestureActive = false
+                                    var horizontalGestureActive = false
+                                    val touchSlop = viewConfiguration.touchSlop
                                     do {
                                         val event = awaitPointerEvent(PointerEventPass.Initial)
                                         val change =
@@ -705,21 +710,42 @@ fun SearchScreen(
                                                 ?: event.changes.firstOrNull()
                                         if (change != null) {
                                             trackedPointerId = change.id
-                                            val deltaY = change.position.y - previousY
-                                            previousY = change.position.y
+                                            val positionDelta = change.position - previousPosition
+                                            previousPosition = change.position
+                                            if (!pullNextGestureActive && !horizontalGestureActive) {
+                                                dragFromDown += positionDelta
+                                                val isPastTouchSlop = dragFromDown.getDistance() > touchSlop
+                                                if (isPastTouchSlop) {
+                                                    horizontalGestureActive =
+                                                        dragFromDown.x.absoluteValue >=
+                                                            dragFromDown.y.absoluteValue * SearchPullNextPageVerticalBias
+                                                    pullNextGestureActive =
+                                                        !horizontalGestureActive &&
+                                                            dragFromDown.y < 0f &&
+                                                            dragFromDown.y.absoluteValue >=
+                                                            dragFromDown.x.absoluteValue * SearchPullNextPageVerticalBias &&
+                                                            latestIsAtBottom.value &&
+                                                            latestPullNextPageEnabled.value
+                                                    if (pullNextGestureActive) {
+                                                        latestHorizontalPagerScrollLockChanged.value(true)
+                                                    }
+                                                }
+                                            }
+                                            val deltaY = positionDelta.y
                                             when {
+                                                horizontalGestureActive -> Unit
+
                                                 !latestPullNextPageEnabled.value -> {
                                                     if (pullNextPageDragPx != 0f) {
                                                         pullNextPageDragPx = 0f
                                                     }
                                                 }
 
-                                                deltaY < 0f && latestIsAtBottom.value -> {
+                                                deltaY < 0f && latestIsAtBottom.value && pullNextGestureActive -> {
                                                     val delta = (-deltaY) * SearchPullNextPageDragResistance
                                                     pullNextPageDragPx =
                                                         (pullNextPageDragPx + delta)
                                                             .coerceIn(0f, latestPullNextPageMaxDistancePx.value)
-                                                    pullNextGestureActive = true
                                                     latestHorizontalPagerScrollLockChanged.value(true)
                                                     change.consume()
                                                 }


### PR DESCRIPTION
## Summary
- prevent bottom pull-to-next-page from stealing horizontal pager swipes on the online search page
- make primary pager swipes more responsive with a lower snap threshold

## Verification
- .\\gradlew-local.bat :app:installRelease