### PR TITLE
feat: persist library filter and sort preferences

### DIFF
--- a/app/src/androidTest/java/com/asmr/player/ui/library/LibraryChromeAndroidTest.kt
+++ b/app/src/androidTest/java/com/asmr/player/ui/library/LibraryChromeAndroidTest.kt
@@ -1,0 +1,87 @@
+package com.asmr.player.ui.library
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.test.SemanticsMatcher
+import androidx.compose.ui.test.assert
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.asmr.player.ui.theme.AsmrPlayerTheme
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class LibraryChromeAndroidTest {
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    @Test
+    fun libraryChrome_exposesActiveFilterState() {
+        composeRule.setContent {
+            AsmrPlayerTheme {
+                LibraryChrome(
+                    modifier = Modifier,
+                    searchText = "",
+                    onSearchTextChange = {},
+                    onClearSearch = {},
+                    currentSort = LibrarySort.AddedDesc,
+                    sortMenuExpanded = false,
+                    onSortMenuExpandedChange = {},
+                    onSortLastPlayed = {},
+                    onSortAdded = {},
+                    onSortTitle = {},
+                    onOpenFilterScreen = {},
+                    filterActive = true,
+                    rightPanelToggle = null,
+                    dynamicContainerColor = MaterialTheme.colorScheme.surface,
+                    materialColorScheme = MaterialTheme.colorScheme,
+                    chromeOffsetPx = 0f,
+                    collapseFraction = 0f,
+                    onMeasured = {}
+                )
+            }
+        }
+
+        composeRule.onNodeWithTag(LIBRARY_FILTER_BUTTON_TAG).assert(
+            SemanticsMatcher.expectValue(SemanticsProperties.StateDescription, "筛选已启用")
+        )
+    }
+
+    @Test
+    fun libraryChrome_marksCurrentSortMenuItemSelected() {
+        composeRule.setContent {
+            AsmrPlayerTheme {
+                LibraryChrome(
+                    modifier = Modifier,
+                    searchText = "",
+                    onSearchTextChange = {},
+                    onClearSearch = {},
+                    currentSort = LibrarySort.TitleAsc,
+                    sortMenuExpanded = true,
+                    onSortMenuExpandedChange = {},
+                    onSortLastPlayed = {},
+                    onSortAdded = {},
+                    onSortTitle = {},
+                    onOpenFilterScreen = {},
+                    filterActive = false,
+                    rightPanelToggle = null,
+                    dynamicContainerColor = MaterialTheme.colorScheme.surface,
+                    materialColorScheme = MaterialTheme.colorScheme,
+                    chromeOffsetPx = 0f,
+                    collapseFraction = 0f,
+                    onMeasured = {}
+                )
+            }
+        }
+
+        composeRule.onNodeWithTag(LIBRARY_SORT_TITLE_ITEM_TAG).assert(
+            SemanticsMatcher.expectValue(SemanticsProperties.Selected, true)
+        )
+        composeRule.onNodeWithTag(LIBRARY_SORT_ADDED_ITEM_TAG).assert(
+            SemanticsMatcher.expectValue(SemanticsProperties.Selected, false)
+        )
+    }
+}

--- a/app/src/androidTest/java/com/asmr/player/ui/library/LibraryFilterSheetTest.kt
+++ b/app/src/androidTest/java/com/asmr/player/ui/library/LibraryFilterSheetTest.kt
@@ -1,0 +1,68 @@
+package com.asmr.player.ui.library
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.asmr.player.data.local.db.dao.TagWithCount
+import com.asmr.player.ui.theme.AsmrPlayerTheme
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class LibraryFilterSheetTest {
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    @Test
+    fun libraryFilterSheet_keepsDraftUntilApply() {
+        var appliedSpec = LibraryQuerySpec()
+        val tags = listOf(
+            TagWithCount(
+                id = 7L,
+                name = "耳语",
+                nameNormalized = "耳语",
+                albumCount = 3,
+                userAlbumCount = 1
+            )
+        )
+
+        composeRule.setContent {
+            var draftSpec by remember { mutableStateOf(appliedSpec) }
+            AsmrPlayerTheme {
+                LibraryFilterSheet(
+                    modifier = Modifier,
+                    appliedSpec = appliedSpec,
+                    draftSpec = draftSpec,
+                    tags = tags,
+                    circles = listOf("社团A"),
+                    cvs = listOf("CV A"),
+                    presets = emptyList(),
+                    onDraftSpecChange = { draftSpec = it },
+                    onOpenTagManager = {},
+                    onApply = { appliedSpec = draftSpec },
+                    onSavePreset = {},
+                    onDeletePreset = {},
+                    onClose = {}
+                )
+            }
+        }
+
+        composeRule.onNodeWithText("#耳语").performClick()
+        composeRule.runOnIdle {
+            assertEquals(emptySet<Long>(), appliedSpec.includeTagIds)
+        }
+
+        composeRule.onNodeWithText("应用").performClick()
+        composeRule.runOnIdle {
+            assertEquals(setOf(7L), appliedSpec.includeTagIds)
+        }
+    }
+}

--- a/app/src/androidTest/java/com/asmr/player/ui/sidepanel/RecentAlbumsListInitialRenderAndroidTest.kt
+++ b/app/src/androidTest/java/com/asmr/player/ui/sidepanel/RecentAlbumsListInitialRenderAndroidTest.kt
@@ -4,12 +4,12 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.width
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
-import androidx.compose.ui.test.assertExists
 import androidx.compose.ui.unit.dp
 import com.asmr.player.data.local.db.entities.AlbumEntity
-import com.asmr.player.ui.theme.AsmrTheme
+import com.asmr.player.ui.theme.AsmrPlayerTheme
 import org.junit.Rule
 import org.junit.Test
 
@@ -39,10 +39,11 @@ class RecentAlbumsListInitialRenderAndroidTest {
         )
 
         composeRule.setContent {
-            AsmrTheme {
+            AsmrPlayerTheme {
                 Box(modifier = Modifier.width(360.dp).height(600.dp)) {
                     RecentAlbumsList(
                         items = items,
+                        preferredOrderIds = emptyList(),
                         onOpenAlbum = {},
                         onResumePlay = {}
                     )
@@ -50,8 +51,8 @@ class RecentAlbumsListInitialRenderAndroidTest {
             }
         }
 
-        composeRule.onNodeWithText("Album 1").assertExists()
-        composeRule.onNodeWithText("Album 2").assertExists()
+        composeRule.onNodeWithText("Album 1").assertIsDisplayed()
+        composeRule.onNodeWithText("Album 2").assertIsDisplayed()
     }
 }
 

--- a/app/src/main/java/com/asmr/player/data/local/db/dao/TagDao.kt
+++ b/app/src/main/java/com/asmr/player/data/local/db/dao/TagDao.kt
@@ -26,6 +26,9 @@ interface TagDao {
     @Query("SELECT * FROM tags WHERE id = :id LIMIT 1")
     suspend fun getTagById(id: Long): TagEntity?
 
+    @Query("SELECT id FROM tags WHERE id IN (:ids)")
+    suspend fun getExistingTagIds(ids: List<Long>): List<Long>
+
     @Insert(onConflict = OnConflictStrategy.IGNORE)
     suspend fun insertAlbumTags(refs: List<AlbumTagEntity>)
 

--- a/app/src/main/java/com/asmr/player/ui/common/ActiveDropdownMenuItem.kt
+++ b/app/src/main/java/com/asmr/player/ui/common/ActiveDropdownMenuItem.kt
@@ -1,0 +1,94 @@
+package com.asmr.player.ui.common
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.MenuDefaults
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.selected
+import androidx.compose.ui.semantics.stateDescription
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun ActiveDropdownMenuItem(
+    label: String,
+    selected: Boolean,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    testTag: String? = null,
+    activeColor: Color = MaterialTheme.colorScheme.primary,
+    inactiveColor: Color = MaterialTheme.colorScheme.onSurface
+) {
+    DropdownMenuItem(
+        text = {
+            Box(
+                modifier = Modifier.fillMaxWidth(),
+                contentAlignment = Alignment.Center
+            ) {
+                Text(
+                    text = label,
+                    color = if (selected) activeColor else inactiveColor,
+                    fontWeight = if (selected) FontWeight.SemiBold else FontWeight.Normal,
+                    modifier = Modifier
+                        .padding(horizontal = 4.dp, vertical = 3.dp)
+                        .activeWavyUnderline(selected, activeColor)
+                )
+            }
+        },
+        onClick = onClick,
+        colors = MenuDefaults.itemColors(
+            textColor = if (selected) activeColor else inactiveColor
+        ),
+        modifier = modifier
+            .then(if (testTag != null) Modifier.testTag(testTag) else Modifier)
+            .semantics {
+                this.selected = selected
+                stateDescription = if (selected) "当前选项" else "可选项"
+            }
+    )
+}
+
+private fun Modifier.activeWavyUnderline(active: Boolean, color: Color): Modifier {
+    if (!active) return this
+    return drawBehind {
+        val strokeWidth = 2.5.dp.toPx()
+        val amplitude = 1.8.dp.toPx()
+        val wavelength = 7.dp.toPx()
+        val baselineY = size.height - strokeWidth / 2f
+        val path = Path().apply { moveTo(0f, baselineY) }
+        var x = 0f
+        while (x < size.width) {
+            path.relativeQuadraticBezierTo(
+                wavelength / 4f,
+                -amplitude,
+                wavelength / 2f,
+                0f
+            )
+            path.relativeQuadraticBezierTo(
+                wavelength / 4f,
+                amplitude,
+                wavelength / 2f,
+                0f
+            )
+            x += wavelength
+        }
+        drawPath(
+            path = path,
+            color = color,
+            style = Stroke(width = strokeWidth, cap = StrokeCap.Round)
+        )
+    }
+}

--- a/app/src/main/java/com/asmr/player/ui/common/SearchBar.kt
+++ b/app/src/main/java/com/asmr/player/ui/common/SearchBar.kt
@@ -447,7 +447,8 @@ fun CustomSearchBar(
 fun ActionButton(
     icon: ImageVector,
     onClick: () -> Unit,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    active: Boolean = false
 ) {
     val colorScheme = AsmrTheme.colorScheme
     val isDark = colorScheme.isDark
@@ -456,13 +457,18 @@ fun ActionButton(
     } else {
         lerp(colorScheme.surface, colorScheme.primarySoft, 0.08f)
     }
-    val containerColor = containerBaseColor.copy(alpha = if (isDark) 0.93f else 0.95f)
+    val inactiveContainerColor = containerBaseColor.copy(alpha = if (isDark) 0.93f else 0.95f)
         .compositeOver(colorScheme.background)
-    val borderColor = if (isDark) {
+    val activeContainerColor = colorScheme.primary.copy(alpha = if (isDark) 0.18f else 0.12f)
+        .compositeOver(inactiveContainerColor)
+    val containerColor = if (active) activeContainerColor else inactiveContainerColor
+    val inactiveBorderColor = if (isDark) {
         Color.White.copy(alpha = 0.14f)
     } else {
         colorScheme.primaryStrong.copy(alpha = 0.14f)
     }
+    val borderColor = if (active) colorScheme.primary.copy(alpha = 0.46f) else inactiveBorderColor
+    val iconTint = if (active) colorScheme.primary else colorScheme.onSurfaceVariant
     Box(
         modifier = modifier
             .size(50.dp)
@@ -487,7 +493,7 @@ fun ActionButton(
         Icon(
             imageVector = icon,
             contentDescription = null,
-            tint = colorScheme.onSurfaceVariant,
+            tint = iconTint,
             modifier = Modifier.size(24.dp)
         )
     }

--- a/app/src/main/java/com/asmr/player/ui/library/LibraryFilterSheet.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/LibraryFilterSheet.kt
@@ -1,9 +1,10 @@
-﻿package com.asmr.player.ui.library
+package com.asmr.player.ui.library
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.FlowRow
@@ -13,31 +14,30 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
-import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.foundation.verticalScroll
+import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.rounded.ManageSearch
 import androidx.compose.material.icons.rounded.Bookmark
+import androidx.compose.material.icons.rounded.Check
 import androidx.compose.material.icons.rounded.Close
 import androidx.compose.material.icons.rounded.Delete
 import androidx.compose.material.icons.rounded.FilterList
-import androidx.compose.material.icons.rounded.Restore
+import androidx.compose.material.icons.rounded.LocalOffer
 import androidx.compose.material.icons.rounded.Search
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.ElevatedCard
-import androidx.compose.material3.FilterChip
-import androidx.compose.material3.FilterChipDefaults
+import androidx.compose.material3.FilledTonalButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.ListItem
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -51,6 +51,9 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.compositeOver
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.asmr.player.data.local.db.dao.TagWithCount
@@ -71,56 +74,28 @@ fun LibraryFilterScreen(
     val circles by viewModel.availableCircles.collectAsState()
     val cvs by viewModel.availableCvs.collectAsState()
     val presets by viewModel.filterPresets.collectAsState()
-    val colorScheme = AsmrTheme.colorScheme
+    val appliedSpec = remember(querySpec) { querySpec.filterOnly() }
+    var draftSpec by remember(appliedSpec) { mutableStateOf(appliedSpec) }
     var showTagManager by remember { mutableStateOf(false) }
 
-    Column(modifier = Modifier.fillMaxSize()) {
-        Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(horizontal = 12.dp, vertical = 8.dp),
-            horizontalArrangement = Arrangement.End,
-            verticalAlignment = Alignment.CenterVertically
-        ) {
-            IconButton(onClick = { showTagManager = true }) {
-                Icon(
-                    imageVector = Icons.AutoMirrored.Rounded.ManageSearch,
-                    contentDescription = "管理标签",
-                    tint = colorScheme.primary
-                )
-            }
-            IconButton(onClick = { viewModel.clearFilters() }) {
-                Icon(
-                    imageVector = Icons.Rounded.Restore,
-                    contentDescription = "重置筛选",
-                    tint = colorScheme.primary
-                )
-            }
-        }
-
-        LibraryFilterSheet(
-            modifier = Modifier.weight(1f),
-            showHeader = false,
-            querySpec = querySpec,
-            tags = tags,
-            circles = circles,
-            cvs = cvs,
-            presets = presets,
-            onOpenTagManager = { showTagManager = true },
-            onSetSource = { viewModel.setSourceFilter(it) },
-            onToggleTag = { viewModel.toggleTag(it) },
-            onToggleCircle = { viewModel.toggleCircle(it) },
-            onToggleCv = { viewModel.toggleCv(it) },
-            onClear = { viewModel.clearFilters() },
-            onApplyPreset = {
-                viewModel.applyPreset(it)
-                onClose()
-            },
-            onSavePreset = { viewModel.savePreset(it) },
-            onDeletePreset = { viewModel.deletePreset(it) },
-            onClose = onClose
-        )
-    }
+    LibraryFilterSheet(
+        modifier = Modifier.fillMaxSize(),
+        appliedSpec = appliedSpec,
+        draftSpec = draftSpec,
+        tags = tags,
+        circles = circles,
+        cvs = cvs,
+        presets = presets,
+        onDraftSpecChange = { draftSpec = it.filterOnly() },
+        onOpenTagManager = { showTagManager = true },
+        onApply = {
+            viewModel.applyFilters(draftSpec)
+            onClose()
+        },
+        onSavePreset = { name -> viewModel.savePreset(name, draftSpec) },
+        onDeletePreset = { viewModel.deletePreset(it) },
+        onClose = onClose
+    )
 
     if (showTagManager) {
         androidx.compose.ui.window.Dialog(
@@ -142,202 +117,230 @@ fun LibraryFilterScreen(
 @OptIn(ExperimentalLayoutApi::class)
 @Composable
 fun LibraryFilterSheet(
-    querySpec: LibraryQuerySpec,
+    appliedSpec: LibraryQuerySpec,
+    draftSpec: LibraryQuerySpec,
     tags: List<TagWithCount>,
     circles: List<String>,
     cvs: List<String>,
     presets: List<LibraryFilterPreset>,
+    onDraftSpecChange: (LibraryQuerySpec) -> Unit,
     onOpenTagManager: () -> Unit,
-    onSetSource: (LibrarySourceFilter?) -> Unit,
-    onToggleTag: (Long) -> Unit,
-    onToggleCircle: (String) -> Unit,
-    onToggleCv: (String) -> Unit,
-    onClear: () -> Unit,
-    onApplyPreset: (LibraryFilterPreset) -> Unit,
+    onApply: () -> Unit,
     onSavePreset: (String) -> Unit,
     onDeletePreset: (String) -> Unit,
     onClose: () -> Unit,
-    modifier: Modifier = Modifier,
-    showHeader: Boolean = true
+    modifier: Modifier = Modifier
 ) {
-    val colorScheme = AsmrTheme.colorScheme
-    val tagListContainerColor = dynamicPageContainerColor(colorScheme)
+    val listState = rememberLazyListState()
     var tagSearch by rememberSaveable { mutableStateOf("") }
+    var circleSearch by rememberSaveable { mutableStateOf("") }
+    var cvSearch by rememberSaveable { mutableStateOf("") }
     var showSavePreset by remember { mutableStateOf(false) }
     var presetName by rememberSaveable { mutableStateOf("") }
-    val listState = rememberLazyListState()
+    val normalizedAppliedSpec = remember(appliedSpec) { appliedSpec.filterOnly() }
+    val normalizedDraftSpec = remember(draftSpec) { draftSpec.filterOnly() }
+    val isDirty = normalizedDraftSpec != normalizedAppliedSpec
 
     Column(modifier = modifier.fillMaxWidth()) {
-        if (showHeader) {
-            Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = 16.dp, vertical = 12.dp),
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                Row(modifier = Modifier.weight(1f), verticalAlignment = Alignment.CenterVertically) {
-                    Icon(imageVector = Icons.Rounded.FilterList, contentDescription = null, tint = colorScheme.primary)
-                    Spacer(modifier = Modifier.width(8.dp))
-                    Text(text = "筛选", maxLines = 1, overflow = TextOverflow.Ellipsis)
-                }
-                IconButton(onClick = onOpenTagManager) {
-                    Icon(imageVector = Icons.AutoMirrored.Rounded.ManageSearch, contentDescription = null)
-                }
-                IconButton(onClick = onClear) {
-                    Icon(imageVector = Icons.Rounded.Restore, contentDescription = null)
-                }
-                IconButton(onClick = onClose) {
-                    Icon(imageVector = Icons.Rounded.Close, contentDescription = null)
-                }
-            }
-        }
+        LibraryFilterHeader(
+            draftSpec = normalizedDraftSpec,
+            isDirty = isDirty,
+            onOpenTagManager = onOpenTagManager,
+            onClose = onClose
+        )
 
         LazyColumn(
             state = listState,
-            modifier = Modifier.fillMaxWidth().thinScrollbar(listState),
-            contentPadding = PaddingValues(bottom = 16.dp).withAddedBottomPadding(LocalBottomOverlayPadding.current),
-            verticalArrangement = Arrangement.spacedBy(10.dp)
+            modifier = Modifier
+                .weight(1f)
+                .fillMaxWidth()
+                .thinScrollbar(listState),
+            contentPadding = PaddingValues(top = 4.dp, bottom = 96.dp)
+                .withAddedBottomPadding(LocalBottomOverlayPadding.current),
+            verticalArrangement = Arrangement.spacedBy(12.dp)
         ) {
-            item { Spacer(modifier = Modifier.height(2.dp)) }
             item {
-                SectionCard(title = "来源") {
-                    SourceChips(current = querySpec.source, onSetSource = onSetSource)
+                FilterSection(
+                    title = "来源",
+                    subtitle = sourceLabel(normalizedDraftSpec.source)
+                ) {
+                    SourceSelector(
+                        current = normalizedDraftSpec.source,
+                        onSetSource = { source ->
+                            onDraftSpecChange(normalizedDraftSpec.copy(source = source.takeUnless { it == LibrarySourceFilter.Both }))
+                        }
+                    )
                 }
             }
 
             item {
-                SectionCard(
+                FilterSection(
                     title = "标签",
-                    subtitle = if (querySpec.includeTagIds.isNotEmpty()) "已选 ${querySpec.includeTagIds.size}" else null
+                    subtitle = selectedCountText(normalizedDraftSpec.includeTagIds.size)
                 ) {
-                    OutlinedTextField(
+                    FilterSearchField(
                         value = tagSearch,
                         onValueChange = { tagSearch = it },
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .heightIn(min = 30.dp),
-                        singleLine = true,
-                        textStyle = MaterialTheme.typography.bodySmall,
-                        leadingIcon = { Icon(imageVector = Icons.Rounded.Search, contentDescription = null) },
-                        placeholder = { Text("搜索标签", style = MaterialTheme.typography.bodySmall) }
+                        placeholder = "搜索标签"
                     )
-
-                    Spacer(modifier = Modifier.height(10.dp))
-                    val normalizedQuery = remember(tagSearch) { tagSearch.trim().lowercase() }
-                    val filtered = remember(normalizedQuery, tags) {
-                        if (normalizedQuery.isBlank()) {
-                            tags
-                        } else {
-                            tags.filter { it.name.lowercase().contains(normalizedQuery) || it.nameNormalized.contains(normalizedQuery) }
-                        }
-                    }
-                    Surface(
-                        shape = RoundedCornerShape(16.dp),
-                        tonalElevation = 1.dp,
-                        color = tagListContainerColor,
-                        modifier = Modifier.fillMaxWidth()
-                    ) {
-                        val ordered = remember(filtered, querySpec.includeTagIds) {
-                            filtered.sortedWith(
-                                compareByDescending<TagWithCount> { querySpec.includeTagIds.contains(it.id) }
+                    val orderedTags = remember(tags, tagSearch, normalizedDraftSpec.includeTagIds) {
+                        tags.filterByTagQuery(tagSearch)
+                            .sortedWith(
+                                compareByDescending<TagWithCount> { normalizedDraftSpec.includeTagIds.contains(it.id) }
                                     .thenByDescending { it.albumCount }
                                     .thenBy(String.CASE_INSENSITIVE_ORDER) { it.name }
                             )
-                        }.take(400)
-                        val scrollState = rememberScrollState()
-                        Column(
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .height(300.dp)
-                                .verticalScroll(scrollState)
-                                .thinScrollbar(scrollState)
-                                .padding(12.dp)
+                    }
+                    if (orderedTags.isEmpty()) {
+                        EmptyFilterHint(text = "没有匹配的标签")
+                    } else {
+                        FlowRow(
+                            horizontalArrangement = Arrangement.spacedBy(6.dp),
+                            verticalArrangement = Arrangement.spacedBy(6.dp)
                         ) {
-                            FlowRow(
-                                horizontalArrangement = Arrangement.spacedBy(8.dp),
-                                verticalArrangement = Arrangement.spacedBy(8.dp)
-                            ) {
-                                ordered.forEach { tag ->
-                                    val selected = querySpec.includeTagIds.contains(tag.id)
-                                    TagStamp(
-                                        name = tag.name,
-                                        count = tag.albumCount,
-                                        isUserTag = tag.userAlbumCount > 0L,
-                                        selected = selected,
-                                        onClick = { onToggleTag(tag.id) }
-                                    )
+                            orderedTags.forEach { tag ->
+                                FilterTokenPill(
+                                    text = if (tag.name.startsWith("#")) tag.name else "#${tag.name}",
+                                    count = tag.albumCount,
+                                    selected = normalizedDraftSpec.includeTagIds.contains(tag.id),
+                                    tone = FilterTokenTone.Tag,
+                                    onClick = {
+                                        onDraftSpecChange(normalizedDraftSpec.toggleTag(tag.id))
+                                    }
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+
+            item {
+                FilterSection(
+                    title = "社团",
+                    subtitle = selectedCountText(normalizedDraftSpec.circles.size)
+                ) {
+                    FilterSearchField(
+                        value = circleSearch,
+                        onValueChange = { circleSearch = it },
+                        placeholder = "搜索社团"
+                    )
+                    val orderedCircles = remember(circles, circleSearch, normalizedDraftSpec.circles) {
+                        circles.filterByTextQuery(circleSearch)
+                            .sortedWith(
+                                compareByDescending<String> { normalizedDraftSpec.circles.contains(it) }
+                                    .thenBy(String.CASE_INSENSITIVE_ORDER) { it }
+                            )
+                    }
+                    if (orderedCircles.isEmpty()) {
+                        EmptyFilterHint(text = "没有匹配的社团")
+                    } else {
+                        FlowRow(
+                            horizontalArrangement = Arrangement.spacedBy(6.dp),
+                            verticalArrangement = Arrangement.spacedBy(6.dp)
+                        ) {
+                            orderedCircles.forEach { circle ->
+                                FilterTokenPill(
+                                    text = circle,
+                                    selected = normalizedDraftSpec.circles.contains(circle),
+                                    tone = FilterTokenTone.Circle,
+                                    onClick = {
+                                        onDraftSpecChange(normalizedDraftSpec.toggleCircle(circle))
+                                    }
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+
+            item {
+                FilterSection(
+                    title = "CV",
+                    subtitle = selectedCountText(normalizedDraftSpec.cvs.size)
+                ) {
+                    FilterSearchField(
+                        value = cvSearch,
+                        onValueChange = { cvSearch = it },
+                        placeholder = "搜索 CV"
+                    )
+                    val orderedCvs = remember(cvs, cvSearch, normalizedDraftSpec.cvs) {
+                        cvs.filterByTextQuery(cvSearch)
+                            .sortedWith(
+                                compareByDescending<String> { normalizedDraftSpec.cvs.contains(it) }
+                                    .thenBy(String.CASE_INSENSITIVE_ORDER) { it }
+                            )
+                    }
+                    if (orderedCvs.isEmpty()) {
+                        EmptyFilterHint(text = "没有匹配的 CV")
+                    } else {
+                        FlowRow(
+                            horizontalArrangement = Arrangement.spacedBy(6.dp),
+                            verticalArrangement = Arrangement.spacedBy(6.dp)
+                        ) {
+                            orderedCvs.forEach { cv ->
+                                FilterTokenPill(
+                                    text = cv,
+                                    selected = normalizedDraftSpec.cvs.contains(cv),
+                                    tone = FilterTokenTone.Cv,
+                                    onClick = {
+                                        onDraftSpecChange(normalizedDraftSpec.toggleCv(cv))
+                                    }
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+
+            item {
+                PresetSectionHeader(onSavePreset = { showSavePreset = true })
+            }
+            if (presets.isEmpty()) {
+                item {
+                    EmptyFilterHint(
+                        text = "暂无筛选预设",
+                        modifier = Modifier.padding(horizontal = 16.dp)
+                    )
+                }
+            } else {
+                items(presets, key = { it.id }) { preset ->
+                    ElevatedCard(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 16.dp)
+                            .clip(RoundedCornerShape(8.dp))
+                            .clickable {
+                                onDraftSpecChange(preset.spec.filterOnly())
+                            }
+                    ) {
+                        ListItem(
+                            headlineContent = {
+                                Text(preset.name, maxLines = 1, overflow = TextOverflow.Ellipsis)
+                            },
+                            supportingContent = {
+                                Text(
+                                    buildPresetSummary(preset.spec),
+                                    maxLines = 2,
+                                    overflow = TextOverflow.Ellipsis
+                                )
+                            },
+                            trailingContent = {
+                                IconButton(onClick = { onDeletePreset(preset.id) }) {
+                                    Icon(imageVector = Icons.Rounded.Delete, contentDescription = "删除预设")
                                 }
                             }
-                        }
+                        )
                     }
-                }
-            }
-
-            item {
-                SectionCard(
-                    title = "社团",
-                    subtitle = if (querySpec.circles.isNotEmpty()) "已选 ${querySpec.circles.size}" else null
-                ) {
-                    ValueChipGrid(
-                        values = circles.take(30),
-                        selected = querySpec.circles,
-                        onToggle = onToggleCircle
-                    )
-                }
-            }
-
-            item {
-                SectionCard(
-                    title = "CV",
-                    subtitle = if (querySpec.cvs.isNotEmpty()) "已选 ${querySpec.cvs.size}" else null
-                ) {
-                    ValueChipGrid(
-                        values = cvs.take(30),
-                        selected = querySpec.cvs,
-                        onToggle = onToggleCv
-                    )
-                }
-            }
-
-            item {
-                Row(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(horizontal = 16.dp, vertical = 6.dp),
-                    verticalAlignment = Alignment.CenterVertically
-                ) {
-                    Row(modifier = Modifier.weight(1f), verticalAlignment = Alignment.CenterVertically) {
-                        Icon(imageVector = Icons.Rounded.Bookmark, contentDescription = null, tint = colorScheme.primary)
-                        Spacer(modifier = Modifier.width(8.dp))
-                        Text(text = "预设")
-                    }
-                    TextButton(onClick = { showSavePreset = true }) { Text("保存当前") }
-                }
-            }
-            items(presets, key = { it.id }) { preset ->
-                ElevatedCard(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .clickable {
-                            onApplyPreset(preset)
-                            onClose()
-                        }
-                        .padding(horizontal = 16.dp)
-                ) {
-                    ListItem(
-                        headlineContent = { Text(preset.name, maxLines = 1, overflow = TextOverflow.Ellipsis) },
-                        supportingContent = {
-                            Text(buildPresetSummary(preset.spec), maxLines = 2, overflow = TextOverflow.Ellipsis)
-                        },
-                        trailingContent = {
-                            IconButton(onClick = { onDeletePreset(preset.id) }) {
-                                Icon(imageVector = Icons.Rounded.Delete, contentDescription = null)
-                            }
-                        }
-                    )
                 }
             }
         }
+
+        LibraryFilterBottomBar(
+            active = normalizedDraftSpec.hasActiveFilters,
+            isDirty = isDirty,
+            onClose = onClose,
+            onApply = onApply
+        )
     }
 
     if (showSavePreset) {
@@ -360,7 +363,75 @@ fun LibraryFilterSheet(
 }
 
 @Composable
-private fun SectionCard(
+private fun LibraryFilterHeader(
+    draftSpec: LibraryQuerySpec,
+    isDirty: Boolean,
+    onOpenTagManager: () -> Unit,
+    onClose: () -> Unit
+) {
+    val colorScheme = AsmrTheme.colorScheme
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 12.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Surface(
+            shape = RoundedCornerShape(8.dp),
+            color = colorScheme.primary.copy(alpha = if (colorScheme.isDark) 0.16f else 0.10f),
+            contentColor = colorScheme.primary,
+            modifier = Modifier.size(38.dp)
+        ) {
+            Box(contentAlignment = Alignment.Center) {
+                Icon(imageVector = Icons.Rounded.FilterList, contentDescription = null)
+            }
+        }
+        Spacer(modifier = Modifier.width(10.dp))
+        Column(modifier = Modifier.weight(1f)) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Text(
+                    text = "筛选本地库",
+                    color = colorScheme.textPrimary,
+                    style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.SemiBold),
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
+                if (isDirty) {
+                    Spacer(modifier = Modifier.width(6.dp))
+                    Text(
+                        text = "未应用",
+                        color = colorScheme.primary,
+                        style = MaterialTheme.typography.labelSmall
+                    )
+                }
+            }
+            Text(
+                text = buildFilterSummary(draftSpec),
+                color = colorScheme.textSecondary,
+                style = MaterialTheme.typography.bodySmall,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
+            )
+        }
+        IconButton(onClick = onOpenTagManager) {
+            Icon(
+                imageVector = Icons.Rounded.LocalOffer,
+                contentDescription = "管理标签",
+                tint = colorScheme.primary
+            )
+        }
+        IconButton(onClick = onClose) {
+            Icon(
+                imageVector = Icons.Rounded.Close,
+                contentDescription = "关闭筛选",
+                tint = colorScheme.textSecondary
+            )
+        }
+    }
+}
+
+@Composable
+private fun FilterSection(
     title: String,
     subtitle: String? = null,
     content: @Composable () -> Unit
@@ -373,22 +444,31 @@ private fun SectionCard(
             .padding(horizontal = 16.dp)
     ) {
         Row(modifier = Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
-            Text(text = title, color = colorScheme.textPrimary, modifier = Modifier.weight(1f))
+            Text(
+                text = title,
+                color = colorScheme.textPrimary,
+                style = MaterialTheme.typography.titleSmall.copy(fontWeight = FontWeight.SemiBold),
+                modifier = Modifier.weight(1f)
+            )
             if (!subtitle.isNullOrBlank()) {
-                Text(text = subtitle, color = colorScheme.textTertiary)
+                Text(
+                    text = subtitle,
+                    color = colorScheme.textTertiary,
+                    style = MaterialTheme.typography.labelSmall
+                )
             }
         }
         Spacer(modifier = Modifier.height(8.dp))
         Surface(
-            shape = RoundedCornerShape(20.dp),
-            tonalElevation = 1.dp,
+            shape = RoundedCornerShape(8.dp),
+            tonalElevation = 0.dp,
             color = sectionContainerColor,
             modifier = Modifier.fillMaxWidth()
         ) {
             Column(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(14.dp),
+                    .padding(12.dp),
                 verticalArrangement = Arrangement.spacedBy(10.dp)
             ) {
                 content()
@@ -399,173 +479,320 @@ private fun SectionCard(
 
 @OptIn(ExperimentalLayoutApi::class)
 @Composable
-private fun SourceChips(
+private fun SourceSelector(
     current: LibrarySourceFilter?,
     onSetSource: (LibrarySourceFilter?) -> Unit
 ) {
-    val colorScheme = AsmrTheme.colorScheme
-    val normalized = if (current == LibrarySourceFilter.Both) null else current
+    val normalized = current.takeUnless { it == LibrarySourceFilter.Both }
+    val options = listOf(
+        null to "不限",
+        LibrarySourceFilter.LocalOnly to "仅本地",
+        LibrarySourceFilter.DownloadOnly to "仅下载",
+        LibrarySourceFilter.LocalAndDownload to "本地+下载"
+    )
     FlowRow(
-        horizontalArrangement = Arrangement.spacedBy(8.dp),
-        verticalArrangement = Arrangement.spacedBy(8.dp)
+        horizontalArrangement = Arrangement.spacedBy(6.dp),
+        verticalArrangement = Arrangement.spacedBy(6.dp)
     ) {
-        SourceChip(
-            label = "不限",
-            selected = normalized == null,
-            onClick = { onSetSource(null) },
-            colorScheme = colorScheme
-        )
-        SourceChip(
-            label = "仅本地",
-            selected = normalized == LibrarySourceFilter.LocalOnly,
-            onClick = { onSetSource(LibrarySourceFilter.LocalOnly) },
-            colorScheme = colorScheme
-        )
-        SourceChip(
-            label = "仅下载",
-            selected = normalized == LibrarySourceFilter.DownloadOnly,
-            onClick = { onSetSource(LibrarySourceFilter.DownloadOnly) },
-            colorScheme = colorScheme
-        )
-        SourceChip(
-            label = "本地+下载",
-            selected = normalized == LibrarySourceFilter.LocalAndDownload,
-            onClick = { onSetSource(LibrarySourceFilter.LocalAndDownload) },
-            colorScheme = colorScheme
-        )
+        options.forEach { (source, label) ->
+            FilterTokenPill(
+                text = label,
+                selected = normalized == source,
+                tone = FilterTokenTone.Source,
+                onClick = { onSetSource(source) }
+            )
+        }
     }
 }
 
 @Composable
-private fun SourceChip(
-    label: String,
-    selected: Boolean,
-    onClick: () -> Unit,
-    colorScheme: com.asmr.player.ui.theme.AsmrColorScheme
+private fun FilterSearchField(
+    value: String,
+    onValueChange: (String) -> Unit,
+    placeholder: String
 ) {
-    FilterChip(
-        selected = selected,
-        onClick = onClick,
-        label = { Text(label, maxLines = 1, overflow = TextOverflow.Ellipsis) },
-        colors = FilterChipDefaults.filterChipColors(
-            containerColor = colorScheme.surfaceVariant.copy(alpha = 0.42f),
-            labelColor = colorScheme.textPrimary,
-            selectedContainerColor = colorScheme.primary.copy(alpha = 0.18f),
-            selectedLabelColor = colorScheme.primary,
-            selectedLeadingIconColor = colorScheme.primary
-        ),
-        border = FilterChipDefaults.filterChipBorder(
-            enabled = true,
-            selected = selected,
-            borderColor = colorScheme.primary.copy(alpha = 0.25f),
-            selectedBorderColor = colorScheme.primary
+    val colorScheme = AsmrTheme.colorScheme
+    val shape = RoundedCornerShape(8.dp)
+
+    BasicTextField(
+        value = value,
+        onValueChange = onValueChange,
+        modifier = Modifier
+            .fillMaxWidth(),
+        singleLine = true,
+        textStyle = MaterialTheme.typography.bodySmall.copy(color = colorScheme.textPrimary),
+        cursorBrush = SolidColor(colorScheme.primary),
+        decorationBox = { innerTextField ->
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(38.dp)
+                    .clip(shape)
+                    .background(
+                        color = colorScheme.surface.copy(alpha = if (colorScheme.isDark) 0.54f else 0.86f),
+                        shape = shape
+                    )
+                    .border(
+                        width = 1.dp,
+                        color = colorScheme.onSurfaceVariant.copy(alpha = if (colorScheme.isDark) 0.24f else 0.16f),
+                        shape = shape
+                    )
+                    .padding(horizontal = 10.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Icon(
+                    imageVector = Icons.Rounded.Search,
+                    contentDescription = null,
+                    modifier = Modifier.size(16.dp),
+                    tint = colorScheme.textTertiary
+                )
+                Spacer(modifier = Modifier.width(6.dp))
+                Box(
+                    modifier = Modifier.weight(1f),
+                    contentAlignment = Alignment.CenterStart
+                ) {
+                    if (value.isEmpty()) {
+                        Text(
+                            text = placeholder,
+                            color = colorScheme.textTertiary,
+                            style = MaterialTheme.typography.bodySmall,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis
+                        )
+                    }
+                    innerTextField()
+                }
+            }
+        }
+    )
+}
+
+private enum class FilterTokenTone {
+    Source,
+    Tag,
+    Circle,
+    Cv
+}
+
+@Composable
+private fun FilterTokenPill(
+    text: String,
+    selected: Boolean,
+    tone: FilterTokenTone,
+    onClick: () -> Unit,
+    count: Long? = null
+) {
+    val colorScheme = AsmrTheme.colorScheme
+    val shape = when (tone) {
+        FilterTokenTone.Tag -> RoundedCornerShape(7.dp)
+        FilterTokenTone.Source,
+        FilterTokenTone.Circle,
+        FilterTokenTone.Cv -> RoundedCornerShape(999.dp)
+    }
+    val tint = when (tone) {
+        FilterTokenTone.Tag -> colorScheme.textSecondary
+        FilterTokenTone.Source,
+        FilterTokenTone.Circle,
+        FilterTokenTone.Cv -> colorScheme.primary
+    }
+    val container = when {
+        selected -> colorScheme.primary.copy(alpha = if (colorScheme.isDark) 0.20f else 0.14f)
+        tone == FilterTokenTone.Tag -> colorScheme.surfaceVariant.copy(alpha = if (colorScheme.isDark) 0.74f else 0.92f)
+        else -> colorScheme.primary.copy(alpha = if (colorScheme.isDark) 0.10f else 0.06f)
+    }
+    val border = when {
+        selected -> colorScheme.primary.copy(alpha = 0.46f)
+        tone == FilterTokenTone.Tag -> colorScheme.onSurfaceVariant.copy(alpha = if (colorScheme.isDark) 0.30f else 0.18f)
+        else -> colorScheme.primary.copy(alpha = 0.16f)
+    }
+    val content = if (selected) colorScheme.primary else tint
+
+    Row(
+        modifier = Modifier
+            .widthIn(max = 260.dp)
+            .clip(shape)
+            .background(container, shape)
+            .border(0.5.dp, border, shape)
+            .clickable(onClick = onClick)
+            .padding(start = 9.dp, end = if (count != null) 5.dp else 9.dp, top = 5.dp, bottom = 5.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(6.dp)
+    ) {
+        Text(
+            text = text,
+            color = content,
+            style = MaterialTheme.typography.labelSmall,
+            fontWeight = if (selected) FontWeight.SemiBold else null,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis
         )
+        if (count != null && count > 0L) {
+            Surface(
+                color = colorScheme.primary.copy(alpha = if (selected) 0.16f else 0.10f),
+                contentColor = content,
+                shape = RoundedCornerShape(999.dp)
+            ) {
+                Text(
+                    text = count.toString(),
+                    modifier = Modifier.padding(horizontal = 5.dp, vertical = 1.dp),
+                    color = content,
+                    style = MaterialTheme.typography.labelSmall
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun PresetSectionHeader(
+    onSavePreset: () -> Unit
+) {
+    val colorScheme = AsmrTheme.colorScheme
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 2.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Icon(imageVector = Icons.Rounded.Bookmark, contentDescription = null, tint = colorScheme.primary)
+        Spacer(modifier = Modifier.width(8.dp))
+        Text(
+            text = "预设",
+            color = colorScheme.textPrimary,
+            style = MaterialTheme.typography.titleSmall.copy(fontWeight = FontWeight.SemiBold),
+            modifier = Modifier.weight(1f)
+        )
+        TextButton(onClick = onSavePreset) {
+            Text("保存草稿")
+        }
+    }
+}
+
+@Composable
+private fun EmptyFilterHint(
+    text: String,
+    modifier: Modifier = Modifier
+) {
+    val colorScheme = AsmrTheme.colorScheme
+    Text(
+        text = text,
+        color = colorScheme.textTertiary,
+        style = MaterialTheme.typography.bodySmall,
+        modifier = modifier.padding(vertical = 4.dp)
     )
 }
 
 @Composable
-private fun TagStamp(
-    name: String,
-    count: Long,
-    isUserTag: Boolean,
-    selected: Boolean,
-    onClick: () -> Unit
+private fun LibraryFilterBottomBar(
+    active: Boolean,
+    isDirty: Boolean,
+    onClose: () -> Unit,
+    onApply: () -> Unit
 ) {
     val colorScheme = AsmrTheme.colorScheme
-    val tint = if (isUserTag) colorScheme.primary else colorScheme.accent
-    val bg = if (selected) tint.copy(alpha = 0.18f) else colorScheme.surfaceVariant.copy(alpha = 0.45f)
-    val border = if (selected) tint.copy(alpha = 0.45f) else tint.copy(alpha = 0.22f)
-    val nameColor = if (selected) tint else colorScheme.textPrimary
-    val countColor = if (selected) tint else tint.copy(alpha = 0.9f)
-    val countBadgeColor = if (selected) tint.copy(alpha = 0.14f) else tint.copy(alpha = 0.12f)
-    val shape = RoundedCornerShape(999.dp)
-    Row(
-        modifier = Modifier
-            .clip(shape)
-            .background(bg)
-            .border(width = 1.dp, color = border, shape = shape)
-            .clickable { onClick() }
-            .padding(start = 12.dp, end = 8.dp, top = 6.dp, bottom = 6.dp),
-        verticalAlignment = Alignment.CenterVertically
+    val containerColor = colorScheme.surface.copy(alpha = if (colorScheme.isDark) 0.96f else 0.98f)
+        .compositeOver(colorScheme.background)
+    Surface(
+        color = containerColor,
+        tonalElevation = 0.dp,
+        shadowElevation = 6.dp,
+        modifier = Modifier.fillMaxWidth()
     ) {
-        Text(
-            text = name,
-            maxLines = 1,
-            overflow = TextOverflow.Ellipsis,
-            color = nameColor,
-            style = MaterialTheme.typography.labelSmall
-        )
-        Spacer(modifier = Modifier.width(6.dp))
-        Surface(
-            color = countBadgeColor,
-            contentColor = countColor,
-            shape = RoundedCornerShape(999.dp)
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp, vertical = 12.dp)
+                .padding(bottom = LocalBottomOverlayPadding.current),
+            horizontalArrangement = Arrangement.spacedBy(10.dp),
+            verticalAlignment = Alignment.CenterVertically
         ) {
-            Text(
-                text = count.toString(),
-                modifier = Modifier.padding(horizontal = 6.dp, vertical = 2.dp),
-                color = countColor,
-                style = MaterialTheme.typography.labelSmall
-            )
-        }
-    }
-}
-
-@OptIn(ExperimentalLayoutApi::class)
-@Composable
-private fun ValueChipGrid(
-    values: List<String>,
-    selected: Set<String>,
-    onToggle: (String) -> Unit
-) {
-    val colorScheme = AsmrTheme.colorScheme
-    val ordered = remember(values, selected) {
-        values.sortedWith(
-            compareByDescending<String> { selected.contains(it) }
-                .thenBy(String.CASE_INSENSITIVE_ORDER) { it }
-        )
-    }
-    FlowRow(
-        horizontalArrangement = Arrangement.spacedBy(8.dp),
-        verticalArrangement = Arrangement.spacedBy(8.dp)
-    ) {
-        ordered.forEach { value ->
-            val isSelected = selected.contains(value)
-            FilterChip(
-                selected = isSelected,
-                onClick = { onToggle(value) },
-                label = { Text(value, maxLines = 1, overflow = TextOverflow.Ellipsis) },
-                colors = FilterChipDefaults.filterChipColors(
-                    containerColor = colorScheme.surfaceVariant.copy(alpha = 0.42f),
-                    labelColor = colorScheme.textPrimary,
-                    selectedContainerColor = colorScheme.primary.copy(alpha = 0.18f),
-                    selectedLabelColor = colorScheme.primary,
-                    selectedLeadingIconColor = colorScheme.primary
-                ),
-                border = FilterChipDefaults.filterChipBorder(
-                    enabled = true,
-                    selected = isSelected,
-                    borderColor = colorScheme.primary.copy(alpha = 0.25f),
-                    selectedBorderColor = colorScheme.primary
+            TextButton(
+                onClick = onClose,
+                modifier = Modifier.weight(1f)
+            ) {
+                Text("取消")
+            }
+            FilledTonalButton(
+                onClick = onApply,
+                modifier = Modifier.weight(2f),
+                colors = ButtonDefaults.filledTonalButtonColors(
+                    containerColor = if (active || isDirty) colorScheme.primaryContainer else colorScheme.surfaceVariant,
+                    contentColor = if (active || isDirty) colorScheme.onPrimaryContainer else colorScheme.textSecondary
                 )
-            )
+            ) {
+                Icon(
+                    imageVector = Icons.Rounded.Check,
+                    contentDescription = null,
+                    modifier = Modifier.size(18.dp)
+                )
+                Spacer(modifier = Modifier.width(6.dp))
+                Text("应用")
+            }
         }
     }
 }
 
-private fun buildPresetSummary(spec: LibraryQuerySpec): String {
-    val parts = ArrayList<String>(5)
-    val source = when (spec.source) {
+private fun LibraryQuerySpec.toggleTag(tagId: Long): LibraryQuerySpec {
+    val updated = includeTagIds.toMutableSet()
+    if (!updated.add(tagId)) updated.remove(tagId)
+    return copy(includeTagIds = updated)
+}
+
+private fun LibraryQuerySpec.toggleCircle(circle: String): LibraryQuerySpec {
+    val normalized = circle.trim()
+    if (normalized.isBlank()) return this
+    val updated = circles.toMutableSet()
+    if (!updated.add(normalized)) updated.remove(normalized)
+    return copy(circles = updated)
+}
+
+private fun LibraryQuerySpec.toggleCv(cv: String): LibraryQuerySpec {
+    val normalized = cv.trim()
+    if (normalized.isBlank()) return this
+    val updated = cvs.toMutableSet()
+    if (!updated.add(normalized)) updated.remove(normalized)
+    return copy(cvs = updated)
+}
+
+private fun List<TagWithCount>.filterByTagQuery(query: String): List<TagWithCount> {
+    val normalized = query.trim().lowercase()
+    if (normalized.isBlank()) return this
+    return filter { tag ->
+        tag.name.lowercase().contains(normalized) || tag.nameNormalized.contains(normalized)
+    }
+}
+
+private fun List<String>.filterByTextQuery(query: String): List<String> {
+    val normalized = query.trim().lowercase()
+    if (normalized.isBlank()) return this
+    return filter { it.lowercase().contains(normalized) }
+}
+
+private fun selectedCountText(count: Int): String? {
+    return if (count > 0) "已选 $count" else null
+}
+
+private fun sourceLabel(source: LibrarySourceFilter?): String {
+    return when (source) {
         LibrarySourceFilter.LocalOnly -> "仅本地"
         LibrarySourceFilter.DownloadOnly -> "仅下载"
         LibrarySourceFilter.LocalAndDownload -> "本地+下载"
-        LibrarySourceFilter.Both -> "不限来源"
-        null -> "不限来源"
+        LibrarySourceFilter.Both,
+        null -> "不限"
     }
-    parts.add(source)
-    if (!spec.textQuery.isNullOrBlank()) parts.add("搜索")
+}
+
+private fun buildFilterSummary(spec: LibraryQuerySpec): String {
+    if (!spec.hasActiveFilters) return "未选择筛选条件"
+    val parts = ArrayList<String>(4)
+    spec.source?.takeUnless { it == LibrarySourceFilter.Both }?.let { parts.add(sourceLabel(it)) }
     if (spec.includeTagIds.isNotEmpty()) parts.add("标签 ${spec.includeTagIds.size}")
     if (spec.circles.isNotEmpty()) parts.add("社团 ${spec.circles.size}")
     if (spec.cvs.isNotEmpty()) parts.add("CV ${spec.cvs.size}")
+    if (spec.excludeTagIds.isNotEmpty()) parts.add("排除标签 ${spec.excludeTagIds.size}")
     return parts.joinToString(" · ")
+}
+
+private fun buildPresetSummary(spec: LibraryQuerySpec): String {
+    return buildFilterSummary(spec.filterOnly())
 }

--- a/app/src/main/java/com/asmr/player/ui/library/LibraryPresetStore.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/LibraryPresetStore.kt
@@ -1,6 +1,7 @@
 package com.asmr.player.ui.library
 
 import android.content.Context
+import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.stringPreferencesKey
@@ -11,7 +12,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 import java.util.UUID
 
-private val Context.libraryDataStore by preferencesDataStore(name = "library")
+internal val Context.libraryDataStore by preferencesDataStore(name = "library")
 
 data class LibraryFilterPreset(
     val id: String,
@@ -19,14 +20,113 @@ data class LibraryFilterPreset(
     val spec: LibraryQuerySpec
 )
 
-class LibraryPresetStore(
-    private val context: Context,
-    private val gson: Gson = Gson()
+data class PersistedLibraryFilters(
+    val includeTagIds: Set<Long> = emptySet(),
+    val excludeTagIds: Set<Long> = emptySet(),
+    val circles: Set<String> = emptySet(),
+    val cvs: Set<String> = emptySet(),
+    val source: LibrarySourceFilter? = null
 ) {
-    private val key: Preferences.Key<String> = stringPreferencesKey("filter_presets_v1")
+    val hasActiveFilters: Boolean
+        get() = toQuerySpec().hasActiveFilters
 
-    val presets: Flow<List<LibraryFilterPreset>> = context.libraryDataStore.data.map { prefs ->
-        val json = prefs[key].orEmpty()
+    fun toQuerySpec(): LibraryQuerySpec {
+        return LibraryQuerySpec(
+            includeTagIds = includeTagIds,
+            excludeTagIds = excludeTagIds,
+            circles = circles,
+            cvs = cvs,
+            source = source.takeUnless { it == LibrarySourceFilter.Both }
+        )
+    }
+
+    fun applyTo(spec: LibraryQuerySpec): LibraryQuerySpec {
+        return spec.withFiltersFrom(toQuerySpec())
+    }
+
+    fun normalized(validTagIds: Set<Long>? = null): PersistedLibraryFilters {
+        fun cleanTags(ids: Set<Long>): Set<Long> {
+            return ids
+                .asSequence()
+                .filter { it > 0L }
+                .filter { validTagIds == null || validTagIds.contains(it) }
+                .toCollection(linkedSetOf())
+        }
+
+        fun cleanText(values: Set<String>): Set<String> {
+            return values
+                .asSequence()
+                .map { it.trim() }
+                .filter { it.isNotBlank() }
+                .toCollection(linkedSetOf())
+        }
+
+        return PersistedLibraryFilters(
+            includeTagIds = cleanTags(includeTagIds),
+            excludeTagIds = cleanTags(excludeTagIds),
+            circles = cleanText(circles),
+            cvs = cleanText(cvs),
+            source = source.takeUnless { it == LibrarySourceFilter.Both }
+        )
+    }
+
+    companion object {
+        val Empty = PersistedLibraryFilters()
+
+        fun fromSpec(spec: LibraryQuerySpec): PersistedLibraryFilters {
+            return PersistedLibraryFilters(
+                includeTagIds = spec.includeTagIds,
+                excludeTagIds = spec.excludeTagIds,
+                circles = spec.circles,
+                cvs = spec.cvs,
+                source = spec.source
+            ).normalized()
+        }
+    }
+}
+
+private data class PersistedLibraryFiltersWire(
+    val includeTagIds: List<Long>? = null,
+    val excludeTagIds: List<Long>? = null,
+    val circles: List<String>? = null,
+    val cvs: List<String>? = null,
+    val source: String? = null
+) {
+    fun toFilters(): PersistedLibraryFilters {
+        return PersistedLibraryFilters(
+            includeTagIds = includeTagIds.orEmpty().toSet(),
+            excludeTagIds = excludeTagIds.orEmpty().toSet(),
+            circles = circles.orEmpty().toSet(),
+            cvs = cvs.orEmpty().toSet(),
+            source = LibrarySourceFilter.entries.firstOrNull { it.name == source }
+        ).normalized()
+    }
+
+    companion object {
+        fun fromFilters(filters: PersistedLibraryFilters): PersistedLibraryFiltersWire {
+            val normalized = filters.normalized()
+            return PersistedLibraryFiltersWire(
+                includeTagIds = normalized.includeTagIds.toList(),
+                excludeTagIds = normalized.excludeTagIds.toList(),
+                circles = normalized.circles.toList(),
+                cvs = normalized.cvs.toList(),
+                source = normalized.source?.name
+            )
+        }
+    }
+}
+
+class LibraryPreferencesStore(
+    private val context: Context,
+    private val gson: Gson = Gson(),
+    private val dataStore: DataStore<Preferences> = context.libraryDataStore
+) {
+    private val presetsKey: Preferences.Key<String> = stringPreferencesKey("filter_presets_v1")
+    private val sortKey: Preferences.Key<String> = stringPreferencesKey("library_sort_v1")
+    private val filtersKey: Preferences.Key<String> = stringPreferencesKey("library_filters_v1")
+
+    val presets: Flow<List<LibraryFilterPreset>> = dataStore.data.map { prefs ->
+        val json = prefs[presetsKey].orEmpty()
         if (json.isBlank()) return@map emptyList()
         runCatching {
             val t = object : TypeToken<List<LibraryFilterPreset>>() {}.type
@@ -34,33 +134,68 @@ class LibraryPresetStore(
         }.getOrDefault(emptyList())
     }
 
+    val sort: Flow<LibrarySort> = dataStore.data.map { prefs ->
+        LibrarySort.fromStoredName(prefs[sortKey])
+    }
+
+    val filters: Flow<PersistedLibraryFilters> = dataStore.data.map { prefs ->
+        decodeFilters(prefs[filtersKey])
+    }
+
+    suspend fun setSort(sort: LibrarySort) {
+        dataStore.edit { prefs ->
+            prefs[sortKey] = sort.name
+        }
+    }
+
+    suspend fun setFilters(filters: PersistedLibraryFilters) {
+        dataStore.edit { prefs ->
+            val normalized = filters.normalized()
+            if (normalized.hasActiveFilters) {
+                prefs[filtersKey] = gson.toJson(PersistedLibraryFiltersWire.fromFilters(normalized))
+            } else {
+                prefs.remove(filtersKey)
+            }
+        }
+    }
+
     suspend fun savePreset(name: String, spec: LibraryQuerySpec): LibraryFilterPreset {
-        val preset = LibraryFilterPreset(id = UUID.randomUUID().toString(), name = name.trim(), spec = spec)
-        context.libraryDataStore.edit { prefs ->
+        val preset = LibraryFilterPreset(
+            id = UUID.randomUUID().toString(),
+            name = name.trim(),
+            spec = PersistedLibraryFilters.fromSpec(spec).toQuerySpec()
+        )
+        dataStore.edit { prefs ->
             val current = readPresetsFromPrefs(prefs)
             val updated = (current + preset)
                 .distinctBy { it.id }
                 .takeLast(50)
-            prefs[key] = gson.toJson(updated)
+            prefs[presetsKey] = gson.toJson(updated)
         }
         return preset
     }
 
     suspend fun deletePreset(id: String) {
-        context.libraryDataStore.edit { prefs ->
+        dataStore.edit { prefs ->
             val current = readPresetsFromPrefs(prefs)
             val updated = current.filterNot { it.id == id }
-            prefs[key] = gson.toJson(updated)
+            prefs[presetsKey] = gson.toJson(updated)
         }
     }
 
     private fun readPresetsFromPrefs(prefs: Preferences): List<LibraryFilterPreset> {
-        val json = prefs[key].orEmpty()
+        val json = prefs[presetsKey].orEmpty()
         if (json.isBlank()) return emptyList()
         return runCatching {
             val t = object : TypeToken<List<LibraryFilterPreset>>() {}.type
             gson.fromJson<List<LibraryFilterPreset>>(json, t).orEmpty()
         }.getOrDefault(emptyList())
     }
-}
 
+    private fun decodeFilters(json: String?): PersistedLibraryFilters {
+        if (json.isNullOrBlank()) return PersistedLibraryFilters.Empty
+        return runCatching {
+            gson.fromJson(json, PersistedLibraryFiltersWire::class.java)?.toFilters()
+        }.getOrNull() ?: PersistedLibraryFilters.Empty
+    }
+}

--- a/app/src/main/java/com/asmr/player/ui/library/LibraryQuerySpec.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/LibraryQuerySpec.kt
@@ -11,7 +11,28 @@ data class LibraryQuerySpec(
     val circles: Set<String> = emptySet(),
     val source: LibrarySourceFilter? = null,
     val sort: LibrarySort = LibrarySort.AddedDesc
-)
+) {
+    val hasActiveFilters: Boolean
+        get() = includeTagIds.isNotEmpty() ||
+            excludeTagIds.isNotEmpty() ||
+            cvs.isNotEmpty() ||
+            circles.isNotEmpty() ||
+            (source != null && source != LibrarySourceFilter.Both)
+
+    fun filterOnly(): LibraryQuerySpec {
+        return copy(textQuery = null, sort = LibrarySort.AddedDesc)
+    }
+
+    fun withFiltersFrom(spec: LibraryQuerySpec): LibraryQuerySpec {
+        return copy(
+            includeTagIds = spec.includeTagIds,
+            excludeTagIds = spec.excludeTagIds,
+            cvs = spec.cvs,
+            circles = spec.circles,
+            source = spec.source.takeUnless { it == LibrarySourceFilter.Both }
+        )
+    }
+}
 
 enum class LibrarySourceFilter {
     LocalOnly,
@@ -26,7 +47,13 @@ enum class LibrarySort {
     RjAsc,
     CircleAsc,
     CvAsc,
-    LastPlayedDesc
+    LastPlayedDesc;
+
+    companion object {
+        fun fromStoredName(value: String?): LibrarySort {
+            return entries.firstOrNull { it.name == value } ?: AddedDesc
+        }
+    }
 }
 
 object LibraryQueryBuilder {

--- a/app/src/main/java/com/asmr/player/ui/library/LibraryScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/LibraryScreen.kt
@@ -76,7 +76,6 @@ import androidx.compose.material3.FilledTonalButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.DropdownMenu
-import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.TextField
 import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.material3.Surface
@@ -166,6 +165,7 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.stateDescription
 import com.asmr.player.ui.common.CustomSearchBar
+import com.asmr.player.ui.common.ActiveDropdownMenuItem
 import com.asmr.player.ui.common.ActionButton
 import com.asmr.player.ui.common.clearFocusOnTapOutside
 import com.asmr.player.ui.common.collapsibleHeaderUiState
@@ -177,6 +177,9 @@ import com.asmr.player.util.DlsiteAntiHotlink
 internal const val LIBRARY_CHROME_TAG = "library_chrome"
 internal const val LIBRARY_SEARCH_INPUT_TAG = "library_search_input"
 internal const val LIBRARY_SORT_BUTTON_TAG = "library_sort_button"
+internal const val LIBRARY_SORT_LAST_PLAYED_ITEM_TAG = "library_sort_last_played_item"
+internal const val LIBRARY_SORT_ADDED_ITEM_TAG = "library_sort_added_item"
+internal const val LIBRARY_SORT_TITLE_ITEM_TAG = "library_sort_title_item"
 internal const val LIBRARY_FILTER_BUTTON_TAG = "library_filter_button"
 private val LibraryChromeContentGap = 20.dp
 private val LibraryChromeCollapseOvershoot = 12.dp
@@ -280,6 +283,7 @@ fun LibraryScreen(
     val uiState by viewModel.uiState.collectAsState()
     val viewMode by viewModel.libraryViewMode.collectAsState()
     val querySpec by viewModel.querySpec.collectAsState()
+    val hasActiveFilters by viewModel.hasActiveFilters.collectAsState()
     val tags by viewModel.availableTags.collectAsState()
     val userTagsByAlbumId by viewModel.userTagsByAlbumId.collectAsState()
     val userTagsByTrackId by viewModel.userTagsByTrackId.collectAsState()
@@ -857,12 +861,14 @@ fun LibraryScreen(
                                         searchText = ""
                                         viewModel.setSearchQuery("")
                                     },
+                                    currentSort = querySpec.sort,
                                     sortMenuExpanded = sortMenuExpanded,
                                     onSortMenuExpandedChange = { sortMenuExpanded = it },
                                     onSortLastPlayed = { viewModel.setSort(LibrarySort.LastPlayedDesc) },
                                     onSortAdded = { viewModel.setSort(LibrarySort.AddedDesc) },
                                     onSortTitle = { viewModel.setSort(LibrarySort.TitleAsc) },
                                     onOpenFilterScreen = onOpenFilterScreen,
+                                    filterActive = hasActiveFilters,
                                     rightPanelToggle = rightPanelToggle,
                                     dynamicContainerColor = dynamicContainerColor,
                                     materialColorScheme = materialColorScheme,
@@ -1052,12 +1058,14 @@ internal fun LibraryChrome(
     searchText: String,
     onSearchTextChange: (String) -> Unit,
     onClearSearch: () -> Unit,
+    currentSort: LibrarySort,
     sortMenuExpanded: Boolean,
     onSortMenuExpandedChange: (Boolean) -> Unit,
     onSortLastPlayed: () -> Unit,
     onSortAdded: () -> Unit,
     onSortTitle: () -> Unit,
     onOpenFilterScreen: () -> Unit,
+    filterActive: Boolean = false,
     rightPanelToggle: (@Composable (Modifier) -> Unit)?,
     dynamicContainerColor: Color,
     materialColorScheme: androidx.compose.material3.ColorScheme,
@@ -1138,8 +1146,12 @@ internal fun LibraryChrome(
                     onDismissRequest = { onSortMenuExpandedChange(false) },
                     modifier = Modifier.background(chromeActionContainerColor)
                 ) {
-                    DropdownMenuItem(
-                        text = { Text("最近播放") },
+                    ActiveDropdownMenuItem(
+                        label = "最近播放",
+                        selected = currentSort == LibrarySort.LastPlayedDesc,
+                        testTag = LIBRARY_SORT_LAST_PLAYED_ITEM_TAG,
+                        activeColor = materialColorScheme.primary,
+                        inactiveColor = materialColorScheme.onSurface,
                         onClick = {
                             onSortMenuExpandedChange(false)
                             onSortLastPlayed()
@@ -1150,8 +1162,12 @@ internal fun LibraryChrome(
                         thickness = 0.5.dp,
                         color = materialColorScheme.outlineVariant.copy(alpha = 0.3f)
                     )
-                    DropdownMenuItem(
-                        text = { Text("最近加入") },
+                    ActiveDropdownMenuItem(
+                        label = "最近加入",
+                        selected = currentSort == LibrarySort.AddedDesc,
+                        testTag = LIBRARY_SORT_ADDED_ITEM_TAG,
+                        activeColor = materialColorScheme.primary,
+                        inactiveColor = materialColorScheme.onSurface,
                         onClick = {
                             onSortMenuExpandedChange(false)
                             onSortAdded()
@@ -1162,8 +1178,12 @@ internal fun LibraryChrome(
                         thickness = 0.5.dp,
                         color = materialColorScheme.outlineVariant.copy(alpha = 0.3f)
                     )
-                    DropdownMenuItem(
-                        text = { Text("专辑标题") },
+                    ActiveDropdownMenuItem(
+                        label = "专辑标题",
+                        selected = currentSort == LibrarySort.TitleAsc,
+                        testTag = LIBRARY_SORT_TITLE_ITEM_TAG,
+                        activeColor = materialColorScheme.primary,
+                        inactiveColor = materialColorScheme.onSurface,
                         onClick = {
                             onSortMenuExpandedChange(false)
                             onSortTitle()
@@ -1176,7 +1196,10 @@ internal fun LibraryChrome(
         ActionButton(
             icon = Icons.Rounded.FilterList,
             onClick = onOpenFilterScreen,
-            modifier = Modifier.testTag(LIBRARY_FILTER_BUTTON_TAG)
+            modifier = Modifier
+                .testTag(LIBRARY_FILTER_BUTTON_TAG)
+                .semantics { stateDescription = if (filterActive) "筛选已启用" else "筛选未启用" },
+            active = filterActive
         )
         if (rightPanelToggle != null) {
             Spacer(modifier = Modifier.width(8.dp))

--- a/app/src/main/java/com/asmr/player/ui/library/TagManagerSheet.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/TagManagerSheet.kt
@@ -3,18 +3,25 @@
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.rounded.ArrowBack
+import androidx.compose.material.icons.rounded.Search
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.ListItem
@@ -31,6 +38,9 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.asmr.player.data.local.db.dao.TagWithCount
 import com.asmr.player.ui.common.FlatActionDialog
@@ -64,21 +74,38 @@ fun TagManagerSheet(
     }
 
     Column(modifier = Modifier.fillMaxSize()) {
-        Row(modifier = Modifier.fillMaxWidth().padding(horizontal = 6.dp, vertical = 8.dp)) {
-            IconButton(onClick = onClose) {
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 6.dp, vertical = 8.dp),
+            contentAlignment = Alignment.Center
+        ) {
+            IconButton(
+                onClick = onClose,
+                modifier = Modifier.align(Alignment.CenterStart)
+            ) {
                 Icon(imageVector = Icons.AutoMirrored.Rounded.ArrowBack, contentDescription = null)
             }
-            Text(text = "标签管理", modifier = Modifier.weight(1f))
-            TextButton(onClick = onClose) { Text("完成") }
+            Text(
+                text = "标签管理",
+                style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.SemiBold),
+                color = colorScheme.textPrimary
+            )
+            TextButton(
+                onClick = onClose,
+                modifier = Modifier.align(Alignment.CenterEnd)
+            ) {
+                Text("完成")
+            }
         }
 
-        OutlinedTextField(
-            value = filter,
-            onValueChange = { filter = it },
-            modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp),
-            singleLine = true,
-            placeholder = { Text("搜索标签") }
-        )
+        Box(modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp)) {
+            TagManagerSearchField(
+                value = filter,
+                onValueChange = { filter = it },
+                placeholder = "搜索标签"
+            )
+        }
 
         LazyColumn(
             state = listState,
@@ -90,11 +117,18 @@ fun TagManagerSheet(
             items(visibleTags, key = { it.id }) { tag ->
                 ListItem(
                     headlineContent = {
-                        Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                        Row(
+                            modifier = Modifier.fillMaxWidth(),
+                            horizontalArrangement = Arrangement.spacedBy(10.dp),
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
                             Text(
                                 text = tag.name,
                                 style = MaterialTheme.typography.titleSmall,
-                                color = colorScheme.textPrimary
+                                color = colorScheme.textPrimary,
+                                modifier = Modifier.weight(1f),
+                                maxLines = 1,
+                                overflow = TextOverflow.Ellipsis
                             )
                             Row(
                                 horizontalArrangement = Arrangement.spacedBy(8.dp),
@@ -196,6 +230,68 @@ fun TagManagerSheet(
 }
 
 @Composable
+private fun TagManagerSearchField(
+    value: String,
+    onValueChange: (String) -> Unit,
+    placeholder: String
+) {
+    val colorScheme = AsmrTheme.colorScheme
+    val shape = RoundedCornerShape(8.dp)
+
+    BasicTextField(
+        value = value,
+        onValueChange = onValueChange,
+        modifier = Modifier.fillMaxWidth(),
+        singleLine = true,
+        textStyle = MaterialTheme.typography.bodySmall.copy(color = colorScheme.textPrimary),
+        cursorBrush = SolidColor(colorScheme.primary),
+        decorationBox = { innerTextField ->
+            Surface(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(38.dp),
+                shape = shape,
+                color = colorScheme.surface.copy(alpha = if (colorScheme.isDark) 0.54f else 0.86f),
+                border = BorderStroke(
+                    width = 1.dp,
+                    color = colorScheme.onSurfaceVariant.copy(alpha = if (colorScheme.isDark) 0.24f else 0.16f)
+                )
+            ) {
+                Row(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(horizontal = 10.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Icon(
+                        imageVector = Icons.Rounded.Search,
+                        contentDescription = null,
+                        modifier = Modifier.size(16.dp),
+                        tint = colorScheme.textTertiary
+                    )
+                    Spacer(modifier = Modifier.width(6.dp))
+                    Box(
+                        modifier = Modifier.weight(1f),
+                        contentAlignment = Alignment.CenterStart
+                    ) {
+                        if (value.isEmpty()) {
+                            Text(
+                                text = placeholder,
+                                color = colorScheme.textTertiary,
+                                style = MaterialTheme.typography.bodySmall,
+                                maxLines = 1,
+                                overflow = TextOverflow.Ellipsis
+                            )
+                        }
+                        innerTextField()
+                    }
+                }
+            }
+        }
+    )
+}
+
+@Composable
 private fun TagManagerMetricBadge(
     label: String,
     value: String? = null,
@@ -232,8 +328,11 @@ private fun TagManagerMetricBadge(
         ) {
             Text(
                 text = label,
+                modifier = Modifier.widthIn(max = 72.dp),
                 style = MaterialTheme.typography.labelSmall,
-                color = contentColor
+                color = contentColor,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
             )
             if (value != null) {
                 Surface(

--- a/app/src/main/java/com/asmr/player/ui/library/libraryviewmodel.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/libraryviewmodel.kt
@@ -140,7 +140,7 @@ class LibraryViewModel @Inject constructor(
     }
 
     private val scanRootsStore = ScanRootsStore(context)
-    private val presetStore = LibraryPresetStore(context)
+    private val preferencesStore = LibraryPreferencesStore(context)
     private val _scanRoots = MutableStateFlow<Set<String>>(emptySet())
     val scanRoots: StateFlow<List<String>> = _scanRoots
         .map { it.toList().sorted() }
@@ -193,8 +193,13 @@ class LibraryViewModel @Inject constructor(
         }
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyList())
 
-    val filterPresets: StateFlow<List<LibraryFilterPreset>> = presetStore.presets
+    val filterPresets: StateFlow<List<LibraryFilterPreset>> = preferencesStore.presets
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyList())
+
+    val hasActiveFilters: StateFlow<Boolean> = _querySpec
+        .map { it.hasActiveFilters }
+        .distinctUntilChanged()
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), false)
 
     val userTagsByAlbumId: StateFlow<Map<Long, List<String>>> = database.tagDao()
         .getAlbumTagsBySource(TagSource.USER)
@@ -230,6 +235,7 @@ class LibraryViewModel @Inject constructor(
         _scanRoots.value = runCatching { scanRootsStore.getRoots() }.getOrDefault(emptySet())
         viewModelScope.launch(Dispatchers.IO) {
             ensureTagTablesInitialized()
+            restoreLibraryPreferences()
             backfillLegacyOnlineSavedAlbumRoots()
         }
         viewModelScope.launch {
@@ -400,70 +406,110 @@ class LibraryViewModel @Inject constructor(
         _querySpec.update { current ->
             if (current.sort == sort) current else current.copy(sort = sort)
         }
+        viewModelScope.launch(Dispatchers.IO) {
+            preferencesStore.setSort(sort)
+        }
     }
 
     fun setSourceFilter(filter: LibrarySourceFilter?) {
+        updateFilters { current -> current.copy(source = filter.takeUnless { it == LibrarySourceFilter.Both }) }
+    }
+
+    fun applyFilters(spec: LibraryQuerySpec) {
+        applyFilters(PersistedLibraryFilters.fromSpec(spec))
+    }
+
+    private fun applyFilters(filters: PersistedLibraryFilters) {
+        val sanitized = sanitizeFiltersAgainstAvailableTags(filters)
         _querySpec.update { current ->
-            if (current.source == filter) current else current.copy(source = filter)
+            sanitized.applyTo(current)
+        }
+        viewModelScope.launch(Dispatchers.IO) {
+            preferencesStore.setFilters(sanitized)
         }
     }
 
     fun toggleTag(tagId: Long) {
-        _querySpec.update { current ->
+        updateFilters { current ->
             val updated = current.includeTagIds.toMutableSet()
             if (!updated.add(tagId)) updated.remove(tagId)
-            if (updated == current.includeTagIds) current else current.copy(includeTagIds = updated)
+            current.copy(includeTagIds = updated)
         }
     }
 
     fun toggleCircle(circle: String) {
         val normalized = circle.trim()
         if (normalized.isBlank()) return
-        _querySpec.update { current ->
+        updateFilters { current ->
             val updated = current.circles.toMutableSet()
             if (!updated.add(normalized)) updated.remove(normalized)
-            if (updated == current.circles) current else current.copy(circles = updated)
+            current.copy(circles = updated)
         }
     }
 
     fun toggleCv(cv: String) {
         val normalized = cv.trim()
         if (normalized.isBlank()) return
-        _querySpec.update { current ->
+        updateFilters { current ->
             val updated = current.cvs.toMutableSet()
             if (!updated.add(normalized)) updated.remove(normalized)
-            if (updated == current.cvs) current else current.copy(cvs = updated)
+            current.copy(cvs = updated)
         }
     }
 
     fun clearFilters() {
-        _querySpec.update { current ->
-            current.copy(
-                includeTagIds = emptySet(),
-                excludeTagIds = emptySet(),
-                circles = emptySet(),
-                cvs = emptySet(),
-                source = null
-            )
-        }
+        applyFilters(PersistedLibraryFilters.Empty)
     }
 
     fun applyPreset(preset: LibraryFilterPreset) {
-        _querySpec.value = preset.spec
+        applyFilters(preset.spec)
     }
 
-    fun savePreset(name: String) {
+    fun savePreset(name: String, spec: LibraryQuerySpec = _querySpec.value) {
         val trimmed = name.trim()
         if (trimmed.isBlank()) return
         viewModelScope.launch(Dispatchers.IO) {
-            presetStore.savePreset(trimmed, _querySpec.value)
+            preferencesStore.savePreset(trimmed, spec)
         }
     }
 
     fun deletePreset(id: String) {
         viewModelScope.launch(Dispatchers.IO) {
-            presetStore.deletePreset(id)
+            preferencesStore.deletePreset(id)
         }
+    }
+
+    private suspend fun restoreLibraryPreferences() {
+        val storedSort = runCatching { preferencesStore.sort.first() }.getOrDefault(LibrarySort.AddedDesc)
+        val storedFilters = runCatching { preferencesStore.filters.first() }.getOrDefault(PersistedLibraryFilters.Empty)
+        val sanitized = sanitizeFiltersAgainstDatabase(storedFilters)
+        _querySpec.update { current ->
+            sanitized.applyTo(current.copy(sort = storedSort))
+        }
+        if (sanitized != storedFilters.normalized()) {
+            preferencesStore.setFilters(sanitized)
+        }
+    }
+
+    private fun updateFilters(transform: (LibraryQuerySpec) -> LibraryQuerySpec) {
+        val nextFilters = transform(_querySpec.value).filterOnly()
+        applyFilters(nextFilters)
+    }
+
+    private fun sanitizeFiltersAgainstAvailableTags(filters: PersistedLibraryFilters): PersistedLibraryFilters {
+        val validTagIds = availableTags.value.map { it.id }.toSet()
+        if (validTagIds.isEmpty() && (filters.includeTagIds.isNotEmpty() || filters.excludeTagIds.isNotEmpty())) {
+            return filters.normalized()
+        }
+        return filters.normalized(validTagIds)
+    }
+
+    private suspend fun sanitizeFiltersAgainstDatabase(filters: PersistedLibraryFilters): PersistedLibraryFilters {
+        val normalized = filters.normalized()
+        val requestedTagIds = (normalized.includeTagIds + normalized.excludeTagIds).filter { it > 0L }
+        if (requestedTagIds.isEmpty()) return normalized
+        val existing = database.tagDao().getExistingTagIds(requestedTagIds).toSet()
+        return normalized.normalized(existing)
     }
 
     fun setUserTagsForAlbum(albumId: Long, tagsCsv: String) {
@@ -553,6 +599,15 @@ class LibraryViewModel @Inject constructor(
                 tagDao.deleteAlbumTagsByTagId(tagId)
                 database.trackTagDao().deleteTrackTagsByTagId(tagId)
                 tagDao.deleteTag(tagId)
+            }
+            val currentFilters = PersistedLibraryFilters.fromSpec(_querySpec.value)
+            if (currentFilters.includeTagIds.contains(tagId) || currentFilters.excludeTagIds.contains(tagId)) {
+                val updatedFilters = currentFilters.copy(
+                    includeTagIds = currentFilters.includeTagIds - tagId,
+                    excludeTagIds = currentFilters.excludeTagIds - tagId
+                )
+                _querySpec.update { current -> updatedFilters.applyTo(current) }
+                preferencesStore.setFilters(updatedFilters)
             }
             albumIds.forEach { albumId ->
                 val entity = albumDao.getAlbumById(albumId) ?: return@forEach

--- a/app/src/main/java/com/asmr/player/ui/search/SearchScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/search/SearchScreen.kt
@@ -105,6 +105,7 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.asmr.player.domain.model.Album
 import com.asmr.player.ui.common.CustomSearchBar
+import com.asmr.player.ui.common.ActiveDropdownMenuItem
 import com.asmr.player.ui.common.EaraBrandedEmptyState
 import com.asmr.player.ui.common.EaraLogoLoadingIndicator
 import com.asmr.player.ui.common.LocalBottomOverlayPadding
@@ -133,7 +134,9 @@ internal const val SEARCH_INPUT_TAG = "search_input"
 internal const val SEARCH_SCOPE_BUTTON_TAG = "search_scope_button"
 internal const val SEARCH_SCOPE_OPTION_TAG_PREFIX = "search_scope_option"
 internal const val SEARCH_LANGUAGE_BUTTON_TAG = "search_language_button"
+internal const val SEARCH_LANGUAGE_OPTION_TAG_PREFIX = "search_language_option"
 internal const val SEARCH_COLLECTED_SORT_BUTTON_TAG = "search_collected_sort_button"
+internal const val SEARCH_COLLECTED_SORT_OPTION_TAG_PREFIX = "search_collected_sort_option"
 internal const val SEARCH_CLEAR_BUTTON_TAG = "search_clear_button"
 internal const val SEARCH_SUBMIT_BUTTON_TAG = "search_submit_button"
 internal const val SEARCH_SUBMIT_SPINNER_TAG = "search_submit_spinner"
@@ -1417,8 +1420,12 @@ internal fun SearchToolbar(
                                             color = colorScheme.textSecondary.copy(alpha = 0.2f)
                                         )
                                     }
-                                    DropdownMenuItem(
-                                        text = { Text(option.label, color = colorScheme.textPrimary) },
+                                    ActiveDropdownMenuItem(
+                                        label = option.label,
+                                        selected = option == selectedCollectedSort,
+                                        testTag = "${SEARCH_COLLECTED_SORT_OPTION_TAG_PREFIX}_${option.name}",
+                                        activeColor = colorScheme.primary,
+                                        inactiveColor = colorScheme.textPrimary,
                                         onClick = {
                                             secondaryMenuExpanded = false
                                             onCollectedSortSelected(option)
@@ -1438,8 +1445,12 @@ internal fun SearchToolbar(
                                             color = colorScheme.textSecondary.copy(alpha = 0.2f)
                                         )
                                     }
-                                    DropdownMenuItem(
-                                        text = { Text(label, color = colorScheme.textPrimary) },
+                                    ActiveDropdownMenuItem(
+                                        label = label,
+                                        selected = locale == selectedLocale.trim(),
+                                        testTag = "${SEARCH_LANGUAGE_OPTION_TAG_PREFIX}_$locale",
+                                        activeColor = colorScheme.primary,
+                                        inactiveColor = colorScheme.textPrimary,
                                         onClick = {
                                             secondaryMenuExpanded = false
                                             onLocaleSelected(locale)

--- a/app/src/test/java/com/asmr/player/ui/library/LibraryPreferencesStoreTest.kt
+++ b/app/src/test/java/com/asmr/player/ui/library/LibraryPreferencesStoreTest.kt
@@ -1,0 +1,128 @@
+package com.asmr.player.ui.library
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import java.io.File
+
+@RunWith(RobolectricTestRunner::class)
+class LibraryPreferencesStoreTest {
+    private val context = RuntimeEnvironment.getApplication()
+    private val scopes = mutableListOf<CoroutineScope>()
+
+    @After
+    fun tearDown() {
+        scopes.forEach { it.cancel() }
+        scopes.clear()
+    }
+
+    private data class TestStore(
+        val store: LibraryPreferencesStore,
+        val dataStore: DataStore<Preferences>
+    )
+
+    private fun createStore(name: String = "library-${System.nanoTime()}"): TestStore {
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+        scopes += scope
+        val file = File(context.cacheDir, "$name.preferences_pb")
+        runCatching { file.delete() }
+        val dataStore = PreferenceDataStoreFactory.create(
+            scope = scope,
+            produceFile = { file }
+        )
+        return TestStore(
+            store = LibraryPreferencesStore(context = context, dataStore = dataStore),
+            dataStore = dataStore
+        )
+    }
+
+    @Test
+    fun sort_defaultsToAddedDescWhenUnset() = runBlocking {
+        val store = createStore().store
+
+        assertEquals(LibrarySort.AddedDesc, store.sort.first())
+    }
+
+    @Test
+    fun sort_roundTripsStoredValue() = runBlocking {
+        val store = createStore().store
+
+        store.setSort(LibrarySort.LastPlayedDesc)
+
+        assertEquals(LibrarySort.LastPlayedDesc, store.sort.first())
+    }
+
+    @Test
+    fun sort_fallsBackWhenStoredValueIsInvalid() = runBlocking {
+        val testStore = createStore()
+        val store = testStore.store
+
+        testStore.dataStore.edit { prefs ->
+            prefs[stringPreferencesKey("library_sort_v1")] = "MissingSort"
+        }
+
+        assertEquals(LibrarySort.AddedDesc, store.sort.first())
+    }
+
+    @Test
+    fun filters_roundTripOnlyAppliedFilterFields() = runBlocking {
+        val store = createStore().store
+        val filters = PersistedLibraryFilters(
+            includeTagIds = setOf(7L, -1L),
+            excludeTagIds = setOf(9L),
+            circles = setOf(" 社团A ", ""),
+            cvs = setOf("CV A"),
+            source = LibrarySourceFilter.LocalOnly
+        )
+
+        store.setFilters(filters)
+
+        assertEquals(
+            PersistedLibraryFilters(
+                includeTagIds = setOf(7L),
+                excludeTagIds = setOf(9L),
+                circles = setOf("社团A"),
+                cvs = setOf("CV A"),
+                source = LibrarySourceFilter.LocalOnly
+            ),
+            store.filters.first()
+        )
+    }
+
+    @Test
+    fun filters_emptyHasNoActiveFilters() {
+        assertEquals(false, PersistedLibraryFilters.Empty.hasActiveFilters)
+        assertEquals(LibraryQuerySpec(), PersistedLibraryFilters.Empty.toQuerySpec())
+    }
+
+    @Test
+    fun filters_dropDeletedTagIdsWhenValidIdsAreProvided() {
+        val filters = PersistedLibraryFilters(
+            includeTagIds = setOf(1L, 2L),
+            excludeTagIds = setOf(3L),
+            circles = setOf("社团A")
+        )
+
+        assertEquals(
+            PersistedLibraryFilters(
+                includeTagIds = setOf(2L),
+                circles = setOf("社团A")
+            ),
+            filters.normalized(validTagIds = setOf(2L))
+        )
+    }
+}

--- a/app/src/test/java/com/asmr/player/ui/library/LibraryScreenChromeTest.kt
+++ b/app/src/test/java/com/asmr/player/ui/library/LibraryScreenChromeTest.kt
@@ -34,6 +34,7 @@ class LibraryScreenChromeTest {
                     searchText = "voice",
                     onSearchTextChange = {},
                     onClearSearch = {},
+                    currentSort = LibrarySort.AddedDesc,
                     sortMenuExpanded = false,
                     onSortMenuExpandedChange = {},
                     onSortLastPlayed = {},

--- a/app/src/test/java/com/asmr/player/ui/search/SearchScreenChromeTest.kt
+++ b/app/src/test/java/com/asmr/player/ui/search/SearchScreenChromeTest.kt
@@ -231,12 +231,46 @@ class SearchScreenChromeTest {
         composeRule.onNodeWithText("最新发售").assertExists()
         composeRule.onNodeWithText("最新收录").assertExists()
         composeRule.onNodeWithText("评分最高").assertExists()
+        composeRule.onNodeWithTag("${SEARCH_COLLECTED_SORT_OPTION_TAG_PREFIX}_${SearchCollectedSortOption.ReleaseNew.name}").assert(
+            SemanticsMatcher.expectValue(SemanticsProperties.Selected, true)
+        )
+        composeRule.onNodeWithTag("${SEARCH_COLLECTED_SORT_OPTION_TAG_PREFIX}_${SearchCollectedSortOption.CollectedNew.name}").assert(
+            SemanticsMatcher.expectValue(SemanticsProperties.Selected, false)
+        )
         composeRule.onAllNodesWithText("时长最长").assertCountEquals(0)
         composeRule.onNodeWithText("最新收录").performClick()
 
         composeRule.runOnIdle {
             assertEquals(SearchCollectedSortOption.CollectedNew, selectedSort)
         }
+    }
+
+    @Test
+    fun languageMenu_marksCurrentLocaleSelected() {
+        composeRule.setContent {
+            AsmrPlayerTheme {
+                SearchToolbar(
+                    keyword = "",
+                    onKeywordChange = {},
+                    selectedFilter = SearchFilterOption.Trend,
+                    selectedLocale = "zh_CN",
+                    filterControlsLocked = false,
+                    searchSubmitLocked = false,
+                    showSearchSpinner = false,
+                    onSearchSubmit = {},
+                    onFilterSelected = {},
+                    onLocaleSelected = {}
+                )
+            }
+        }
+
+        composeRule.onNodeWithTag(SEARCH_LANGUAGE_BUTTON_TAG).performClick()
+        composeRule.onNodeWithTag("${SEARCH_LANGUAGE_OPTION_TAG_PREFIX}_zh_CN").assert(
+            SemanticsMatcher.expectValue(SemanticsProperties.Selected, true)
+        )
+        composeRule.onNodeWithTag("${SEARCH_LANGUAGE_OPTION_TAG_PREFIX}_ja_JP").assert(
+            SemanticsMatcher.expectValue(SemanticsProperties.Selected, false)
+        )
     }
 
     @Test


### PR DESCRIPTION
## Summary
- 持久化本地库排序方式与已应用筛选条件，启动时恢复并过滤已删除标签 ID。
- 重构本地库筛选页为草稿选择 + 应用确认流程，并在筛选生效时高亮主界面筛选按钮。
- 优化筛选页与标签管理页 UI：统一 tag 样式、紧凑搜索框、标签管理入口图标与标签状态布局。
- 增加通用激活态下拉菜单项，并为本地库偏好、筛选页、Chrome 状态和搜索菜单选中态补充测试。

## Test Plan
- `.\gradlew-local.bat :app:testReleaseUnitTest --tests com.asmr.player.ui.library.LibraryPreferencesStoreTest`
- `.\gradlew-local.bat :app:compileDebugAndroidTestKotlin`
- `.\gradlew-local.bat :app:installRelease`