### PR TITLE
Optimize album group picker overlay

### DIFF
--- a/app/src/main/java/com/asmr/player/main/MainContainer.kt
+++ b/app/src/main/java/com/asmr/player/main/MainContainer.kt
@@ -2014,9 +2014,6 @@ fun MainContainer(
                         onOpenPlaylistPicker = { item ->
                             albumBatchPlaylistPickerRequest = BatchPlaylistPickerRequest(listOf(item))
                         },
-                        onOpenGroupPicker = { targetAlbumId ->
-                            navController.navigateSingleTop("group_picker?albumId=$targetAlbumId")
-                        },
                         onOpenDlsiteLogin = { navController.navigateSingleTop("dlsite_login") },
                         onOpenAlbumByRj = { navigator.openAlbumDetailByRjStacked(it) }
                     )
@@ -2062,9 +2059,6 @@ fun MainContainer(
                         onOpenPlaylistPicker = { item ->
                             albumBatchPlaylistPickerRequest = BatchPlaylistPickerRequest(listOf(item))
                         },
-                        onOpenGroupPicker = { targetAlbumId ->
-                            navController.navigateSingleTop("group_picker?albumId=$targetAlbumId")
-                        },
                         onOpenDlsiteLogin = { navController.navigateSingleTop("dlsite_login") },
                         onOpenAlbumByRj = { navigator.openAlbumDetailByRjStacked(it) }
                     )
@@ -2096,9 +2090,6 @@ fun MainContainer(
                         },
                         onOpenPlaylistPicker = { item ->
                             albumBatchPlaylistPickerRequest = BatchPlaylistPickerRequest(listOf(item))
-                        },
-                        onOpenGroupPicker = { albumId ->
-                            navController.navigateSingleTop("group_picker?albumId=$albumId")
                         },
                         onOpenDlsiteLogin = { navController.navigateSingleTop("dlsite_login") },
                         onOpenAlbumByRj = { navigator.openAlbumDetailByRjStacked(it) }

--- a/app/src/main/java/com/asmr/player/ui/groups/AlbumGroupPickerScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/groups/AlbumGroupPickerScreen.kt
@@ -12,13 +12,18 @@ import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.rounded.ArrowBack
 import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
@@ -49,6 +54,7 @@ fun AlbumGroupPickerScreen(
     windowSizeClass: WindowSizeClass,
     albumId: Long,
     onBack: () -> Unit,
+    embeddedInDialog: Boolean = false,
     viewModel: AlbumGroupsViewModel = hiltViewModel()
 ) {
     val groups by viewModel.groups.collectAsState()
@@ -86,14 +92,44 @@ fun AlbumGroupPickerScreen(
             Column(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(horizontal = 16.dp, vertical = 12.dp),
+                    .padding(
+                        horizontal = if (embeddedInDialog) 6.dp else 16.dp,
+                        vertical = if (embeddedInDialog) 8.dp else 12.dp
+                    ),
                 verticalArrangement = Arrangement.spacedBy(10.dp)
             ) {
-                Text(
-                    text = "选择分组",
-                    style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.Bold),
-                    color = colorScheme.textPrimary
-                )
+                if (embeddedInDialog) {
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        IconButton(
+                            onClick = onBack,
+                            enabled = !isAdding
+                        ) {
+                            Icon(
+                                imageVector = Icons.AutoMirrored.Rounded.ArrowBack,
+                                contentDescription = "返回",
+                                tint = colorScheme.textPrimary
+                            )
+                        }
+                        Text(
+                            text = "选择分组",
+                            modifier = Modifier.weight(1f),
+                            style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.Bold),
+                            color = colorScheme.textPrimary,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis
+                        )
+                        Spacer(modifier = Modifier.size(48.dp))
+                    }
+                } else {
+                    Text(
+                        text = "选择分组",
+                        style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.Bold),
+                        color = colorScheme.textPrimary
+                    )
+                }
 
                 Row(verticalAlignment = Alignment.CenterVertically) {
                     OutlinedTextField(

--- a/app/src/main/java/com/asmr/player/ui/library/AlbumDetailScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/AlbumDetailScreen.kt
@@ -142,6 +142,7 @@ import com.asmr.player.ui.common.ImagePreviewRequest
 import com.asmr.player.ui.common.collapsibleHeaderUiState
 import com.asmr.player.ui.common.consumeTapThrough
 import com.asmr.player.ui.common.rememberCollapsibleHeaderState
+import com.asmr.player.ui.groups.AlbumGroupPickerScreen
 import com.asmr.player.ui.playlists.PlaylistPickerScreen
 import com.asmr.player.ui.theme.AsmrTheme
 import com.asmr.player.ui.common.LocalBottomOverlayPadding
@@ -298,7 +299,6 @@ fun AlbumDetailScreen(
     onAddMediaItemsToQueue: (List<MediaItem>) -> Unit = {},
     onAddMediaItemsToFavorites: (List<MediaItem>) -> Unit = {},
     onOpenPlaylistPicker: (MediaItem) -> Unit = {},
-    onOpenGroupPicker: (albumId: Long) -> Unit = { _ -> },
     onOpenDlsiteLogin: () -> Unit = {},
     onOpenAlbumByRj: (String) -> Unit = {},
     initialTab: Int? = null,
@@ -323,6 +323,7 @@ fun AlbumDetailScreen(
     var showOnlineSaveDialog by remember { mutableStateOf(false) }
     var pendingOnlineSaveSelection by remember { mutableStateOf<Set<String>?>(null) }
     var batchPlaylistItems by remember { mutableStateOf<List<MediaItem>?>(null) }
+    var groupPickerAlbumId by remember { mutableStateOf<Long?>(null) }
     var downloadSource by remember { mutableStateOf(OnlineDownloadSource.AsmrOne) }
 
     LaunchedEffect(albumId, rjCode) {
@@ -658,7 +659,7 @@ fun AlbumDetailScreen(
                                 losslessDownloadEnabled = tab == 2 && resolvedInitialTarget && model.dlsitePlayTree.isNotEmpty(),
                                 saveEnabled = canUseAsmrOneTreeActions,
                                 showGroupButton = isLocalTab && model.localAlbum != null,
-                                onOpenGroupPicker = onOpenGroupPicker,
+                                onOpenGroupPicker = { id -> groupPickerAlbumId = id },
                                 introSessionKey = introSessionKey,
                                 animateIntro = shouldAnimateHeaderIntro,
                                 deferMetaRevealExpected = !isLocalTab,
@@ -943,6 +944,25 @@ fun AlbumDetailScreen(
                             showOnlineSaveDialog = false
                         }
                     )
+                }
+
+                groupPickerAlbumId?.let { targetAlbumId ->
+                    Dialog(
+                        onDismissRequest = { groupPickerAlbumId = null },
+                        properties = androidx.compose.ui.window.DialogProperties(usePlatformDefaultWidth = false)
+                    ) {
+                        AlbumDetailPickerSheetSurface(
+                            color = MaterialTheme.colorScheme.background,
+                            contentColor = colorScheme.textPrimary
+                        ) {
+                            AlbumGroupPickerScreen(
+                                windowSizeClass = windowSizeClass,
+                                albumId = targetAlbumId,
+                                onBack = { groupPickerAlbumId = null },
+                                embeddedInDialog = true
+                            )
+                        }
+                    }
                 }
 
                 batchPlaylistItems?.let { items ->

--- a/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailDialogs.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailDialogs.kt
@@ -51,7 +51,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
-import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.foundation.gestures.detectTransformGestures
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.pointer.pointerInput
@@ -137,6 +136,36 @@ import com.asmr.player.util.Formatting
 import com.asmr.player.util.MessageManager
 import com.asmr.player.util.RemoteSubtitleSource
 
+private val AlbumDetailPickerSheetTopRadius = 28.dp
+private val AlbumDetailPickerSheetTopGap = 10.dp
+
+@Composable
+internal fun AlbumDetailPickerSheetSurface(
+    color: Color = MaterialTheme.colorScheme.background,
+    contentColor: Color = MaterialTheme.colorScheme.onBackground,
+    content: @Composable () -> Unit
+) {
+    Box(
+        modifier = Modifier.fillMaxSize(),
+        contentAlignment = Alignment.BottomCenter
+    ) {
+        Surface(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(top = AlbumDetailPickerSheetTopGap),
+            shape = RoundedCornerShape(
+                topStart = AlbumDetailPickerSheetTopRadius,
+                topEnd = AlbumDetailPickerSheetTopRadius
+            ),
+            color = color,
+            contentColor = contentColor,
+            shadowElevation = 12.dp
+        ) {
+            content()
+        }
+    }
+}
+
 @Composable
 internal fun AsmrOneDownloadDialog(
     albumTitle: String,
@@ -155,7 +184,7 @@ internal fun AsmrOneDownloadDialog(
         onDismissRequest = onDismiss,
         properties = androidx.compose.ui.window.DialogProperties(usePlatformDefaultWidth = false)
     ) {
-        Surface(modifier = Modifier.fillMaxSize(), color = MaterialTheme.colorScheme.background) {
+        AlbumDetailPickerSheetSurface {
             Column(modifier = Modifier.fillMaxSize()) {
                 Row(
                     modifier = Modifier
@@ -413,7 +442,7 @@ internal fun OnlineSaveDialog(
         onDismissRequest = onDismiss,
         properties = androidx.compose.ui.window.DialogProperties(usePlatformDefaultWidth = false)
     ) {
-        Surface(modifier = Modifier.fillMaxSize(), color = MaterialTheme.colorScheme.background) {
+        AlbumDetailPickerSheetSurface {
             Column(modifier = Modifier.fillMaxSize()) {
                 Row(
                     modifier = Modifier


### PR DESCRIPTION
## Summary
- keep the library album detail page expanded while opening the group picker as an in-detail overlay
- reuse a sheet-style picker surface with rounded top corners for group, download, and save selection dialogs
- remove obsolete album-detail group-picker navigation callbacks

## Verification
- .\\gradlew-local.bat :app:assembleRelease
- .\\gradlew-local.bat :app:installRelease