### PR TITLE
Fix album detail online tree flicker

### DIFF
--- a/app/src/main/java/com/asmr/player/ui/library/AlbumDetailScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/AlbumDetailScreen.kt
@@ -718,6 +718,10 @@ fun AlbumDetailScreen(
                                 }
                             }
 
+                            val asmrOneTreeStableRj = model.baseRjCode.ifBlank { model.rjCode }.trim().uppercase()
+                            val asmrOneTreeStateKey = "tree:asmrOne:$asmrOneTreeStableRj"
+                            val asmrOneScrollStateKey = "scroll:$asmrOneTreeStateKey"
+
                             Box(
                                 modifier = Modifier
                                     .align(Alignment.TopCenter)
@@ -847,18 +851,17 @@ fun AlbumDetailScreen(
                                         },
                                         onPreviewImages = { request -> imagePreviewRequest = request },
                                         onPreviewFile = { onlinePreviewFile = it },
-                                        treeStateKey = "tree:asmrOne:${model.rjCode.trim().uppercase()}",
-                                        initialCurrentPath = viewModel.getTreeCurrentPath("tree:asmrOne:${model.rjCode.trim().uppercase()}"),
+                                        treeStateKey = asmrOneTreeStateKey,
+                                        initialCurrentPath = viewModel.getTreeCurrentPath(asmrOneTreeStateKey),
                                         topContentPadding = 0.dp,
                                         chromeState = tabChromeState,
                                         animateIntro = shouldPlayInitialAnimations,
                                         onPersistCurrentPath = { path ->
-                                            val rj = model.rjCode.trim().uppercase()
-                                            viewModel.persistTreeCurrentPath("tree:asmrOne:$rj", path)
+                                            viewModel.persistTreeCurrentPath(asmrOneTreeStateKey, path)
                                         },
-                                        initialScroll = viewModel.getListScrollPosition("scroll:tree:asmrOne:${model.rjCode.trim().uppercase()}"),
+                                        initialScroll = viewModel.getListScrollPosition(asmrOneScrollStateKey),
                                         onPersistScroll = { index, offset ->
-                                            viewModel.persistListScrollPosition("scroll:tree:asmrOne:${model.rjCode.trim().uppercase()}", index, offset)
+                                            viewModel.persistListScrollPosition(asmrOneScrollStateKey, index, offset)
                                         },
                                         dlsiteRecommendations = model.dlsiteRecommendations,
                                         onOpenAlbumByRj = onOpenAlbumByRj,

--- a/app/src/main/java/com/asmr/player/ui/library/AlbumDetailViewModel.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/AlbumDetailViewModel.kt
@@ -1159,6 +1159,8 @@ class AlbumDetailViewModel @Inject constructor(
                     val targetWorkno = resolvedTarget.workno.trim().uppercase()
                     val targetChanged = targetWorkno.isNotBlank() &&
                         !targetWorkno.equals(latestResolved.rjCode.trim().uppercase(), ignoreCase = true)
+                    val keepAsmrOneContentDuringTargetSwitch = targetChanged &&
+                        latestResolved.asmrOneTree.isNotEmpty()
                     if (targetChanged) {
                         asmrOneLoadToken++
                         asmrOneAttemptedRj.clear()
@@ -1178,9 +1180,21 @@ class AlbumDetailViewModel @Inject constructor(
                         dlsiteSelectedLang = resolvedTarget.selectedLang,
                         hasResolvedInitialDlsiteTarget = true,
                         hasResolvedAsmrOneContent = if (targetChanged) false else latestResolved.hasResolvedAsmrOneContent,
-                        asmrOneWorkId = if (targetChanged) null else latestResolved.asmrOneWorkId,
-                        asmrOneSite = if (targetChanged) null else latestResolved.asmrOneSite,
-                        asmrOneTree = if (targetChanged) emptyList() else latestResolved.asmrOneTree,
+                        asmrOneWorkId = if (targetChanged && !keepAsmrOneContentDuringTargetSwitch) {
+                            null
+                        } else {
+                            latestResolved.asmrOneWorkId
+                        },
+                        asmrOneSite = if (targetChanged && !keepAsmrOneContentDuringTargetSwitch) {
+                            null
+                        } else {
+                            latestResolved.asmrOneSite
+                        },
+                        asmrOneTree = if (targetChanged && !keepAsmrOneContentDuringTargetSwitch) {
+                            emptyList()
+                        } else {
+                            latestResolved.asmrOneTree
+                        },
                         isLoadingDlsite = true,
                         isLoadingAsmrOne = if (targetChanged) false else latestResolved.isLoadingAsmrOne,
                         isLoadingDlsiteTrial = false
@@ -1470,12 +1484,7 @@ class AlbumDetailViewModel @Inject constructor(
     fun ensureAsmrOneLoaded() {
         val current = _uiState.value as? AlbumDetailUiState.Success ?: return
         val keyRj = current.model.rjCode.trim().uppercase()
-        if (current.model.asmrOneTree.isNotEmpty()) {
-            if (!current.model.hasResolvedAsmrOneContent) {
-                _uiState.value = AlbumDetailUiState.Success(
-                    model = current.model.copy(hasResolvedAsmrOneContent = true)
-                )
-            }
+        if (current.model.asmrOneTree.isNotEmpty() && current.model.hasResolvedAsmrOneContent) {
             return
         }
         if (

--- a/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailDlsiteTabs.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailDlsiteTabs.kt
@@ -7,6 +7,7 @@ import androidx.activity.compose.BackHandler
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.SizeTransform
 import androidx.compose.animation.animateContentSize
 import androidx.compose.animation.core.FastOutSlowInEasing
 import androidx.compose.animation.core.animateFloatAsState
@@ -15,7 +16,9 @@ import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.slideInHorizontally
+import androidx.compose.animation.slideInVertically
 import androidx.compose.animation.slideOutHorizontally
+import androidx.compose.animation.slideOutVertically
 import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
@@ -676,6 +679,13 @@ private val DlsiteSectionPlacementTweenSpec = tween<IntOffset>(
     easing = FastOutSlowInEasing
 )
 
+private enum class DirectoryTreePanelState {
+    Loading,
+    Content,
+    Empty,
+    MissingRj
+}
+
 @OptIn(ExperimentalFoundationApi::class)
 private fun LazyItemScope.dlsiteAnimatedSectionModifier(
     modifier: Modifier = Modifier,
@@ -688,15 +698,49 @@ private fun LazyItemScope.dlsiteAnimatedSectionModifier(
     )
 }
 
+@Composable
+private fun DirectoryTreeAnimatedContent(
+    targetState: DirectoryTreePanelState,
+    label: String,
+    modifier: Modifier = Modifier,
+    content: @Composable (DirectoryTreePanelState) -> Unit
+) {
+    AnimatedContent(
+        targetState = targetState,
+        modifier = modifier.animateContentSize(
+            animationSpec = tween(durationMillis = 260, easing = FastOutSlowInEasing)
+        ),
+        transitionSpec = {
+            (
+                fadeIn(animationSpec = tween(durationMillis = 180, delayMillis = 60)) +
+                    slideInVertically(
+                        animationSpec = tween(durationMillis = 260, easing = FastOutSlowInEasing),
+                        initialOffsetY = { height -> (height * 0.06f).toInt() }
+                    )
+                ).togetherWith(
+                fadeOut(animationSpec = tween(durationMillis = 120)) +
+                    slideOutVertically(
+                        animationSpec = tween(durationMillis = 160, easing = FastOutSlowInEasing),
+                        targetOffsetY = { height -> -(height * 0.03f).toInt() }
+                    )
+            ).using(SizeTransform(clip = false))
+        },
+        label = label,
+        content = { state -> content(state) }
+    )
+}
+
 internal fun shouldShowAsmrOneDirectoryLoading(
     isAwaitingAsmrOneLoad: Boolean,
     isLoadingAsmrOne: Boolean,
     hasAsmrOneTree: Boolean,
     hasDirectoryBrowser: Boolean
 ): Boolean {
-    return isAwaitingAsmrOneLoad ||
-        isLoadingAsmrOne ||
-        (hasAsmrOneTree && !hasDirectoryBrowser)
+    return !hasDirectoryBrowser && (
+        isAwaitingAsmrOneLoad ||
+            isLoadingAsmrOne ||
+            hasAsmrOneTree
+        )
 }
 
 internal fun shouldShowDlsitePlayDirectoryLoading(
@@ -706,10 +750,12 @@ internal fun shouldShowDlsitePlayDirectoryLoading(
     hasDlsitePlayTree: Boolean,
     hasDirectoryBrowser: Boolean
 ): Boolean {
-    return isAwaitingInitialTarget ||
-        !hasResolvedDlsitePlayContent ||
-        isLoadingDlsitePlay ||
-        (hasDlsitePlayTree && !hasDirectoryBrowser)
+    return !hasDirectoryBrowser && (
+        isAwaitingInitialTarget ||
+            !hasResolvedDlsitePlayContent ||
+            isLoadingDlsitePlay ||
+            hasDlsitePlayTree
+        )
 }
 
 @Composable
@@ -894,137 +940,147 @@ internal fun AlbumDlsiteInfoBreadcrumbTabV2(
                 }
             }
         }
-        if (asmrOneTree.isNotEmpty() && browser != null) {
-            item(key = "dlsite-one-content") {
-                Box(modifier = dlsiteAnimatedSectionModifier(Modifier.fillMaxWidth(), animateIntro)) {
-                    val browserValue = browser ?: return@Box
-                    DirectoryBrowserPanelV4(
-                    panelKey = treeStateKey,
-                    currentPath = currentPath,
-                    breadcrumbs = browserValue.breadcrumbs,
-                    batchTargets = browserValue.batchTargets,
-                    folders = browserValue.folders,
-                    files = browserValue.files,
-                    onNavigate = { path -> currentPath = path },
-                    onAddToFavorites = onAddMediaItemsToFavorites,
-                        onOpenBatchPlaylistPicker = onOpenBatchPlaylistPicker,
-                        onAddMediaItemsToQueue = onAddMediaItemsToQueue,
-                        animateIntro = animateIntro,
-                        parentChromeState = chromeState,
-                        folderKeyPrefix = "asmr-folder",
-                        fileKeyPrefix = "asmr-file",
-                    fileContent = { file, selectionMode, selected, enterSelectionMode, onSelectedChange ->
-                        val leaf = asmrLeafByRelPath[file.path]
-                        DirectoryFileRow(
-                            file = file.copy(showSubtitleStamp = file.subtitleSources.isNotEmpty()),
-                            loadRemoteFileSize = loadRemoteFileSize,
-                            onPrimary = {
-                                when (file.fileType) {
-                                    TreeFileType.Audio -> {
-                                        scope.launch {
-                                            val prepared = withContext(Dispatchers.Default) {
-                                                val start = asmrLeafByRelPath[file.path] ?: return@withContext null
-                                                val folderPath = file.path.substringBeforeLast('/', "")
-                                                val siblingLeaves = asmrLeafTracks.filter {
-                                                    it.relativePath.substringBeforeLast('/', "") == folderPath
-                                                }
-                                                val queueLeaves = siblingLeaves.ifEmpty { listOf(start) }
-                                                PreparedTrackPlayback(
-                                                    tracks = queueLeaves.sortedBy { SmartSortKey.of(it.title) }.map { it.toTrack() },
-                                                    startTrack = start.toTrack(),
-                                                    onlineLyrics = queueLeaves.associate { it.url to it.subtitles }
-                                                )
-                                            } ?: return@launch
-                                            com.asmr.player.util.OnlineLyricsStore.replaceAll(prepared.onlineLyrics)
-                                            onPlayTracks(album, prepared.tracks, prepared.startTrack)
-                                        }
-                                    }
-                                    TreeFileType.Video -> {
-                                        val item = file.playlistTarget?.toMediaItem()
-                                        if (item != null) {
-                                            onPlayMediaItems(listOf(item), 0)
-                                        } else {
-                                            onPreviewFile(
-                                                AsmrTreeUiEntry.File(
-                                                    path = file.path,
-                                                    title = file.title,
-                                                    depth = 0,
-                                                    fileType = file.fileType,
-                                                    isPlayable = false,
-                                                    url = file.url
-                                                )
-                                            )
-                                        }
-                                    }
-                                    TreeFileType.Image -> {
-                                        buildDirectoryImagePreviewRequest(
-                                            files = browserValue.files,
-                                            clickedPath = file.path,
-                                            toPreviewItem = { imageFile ->
-                                                val imageUrl = imageFile.url.takeIf { it.isNotBlank() } ?: return@buildDirectoryImagePreviewRequest null
-                                                ImagePreviewItem(
-                                                    key = imageFile.path,
-                                                    title = imageFile.title,
-                                                    openPathOrUrl = imageUrl,
-                                                    prepareImage = {
-                                                        ImagePreviewPreparedItem(
-                                                            imageModel = imageUrl,
-                                                            openPathOrUrl = imageUrl
+        val asmrOnePanelState = when {
+            asmrOneTree.isNotEmpty() && browser != null -> DirectoryTreePanelState.Content
+            isAsmrOnePending -> DirectoryTreePanelState.Loading
+            else -> DirectoryTreePanelState.Empty
+        }
+        item(key = "dlsite-one-content") {
+            Box(modifier = dlsiteAnimatedSectionModifier(Modifier.fillMaxWidth(), animateIntro)) {
+                DirectoryTreeAnimatedContent(
+                    targetState = asmrOnePanelState,
+                    label = "asmrOneDirectoryTree",
+                    modifier = Modifier.fillMaxWidth()
+                ) { panelState ->
+                    when (panelState) {
+                        DirectoryTreePanelState.Content -> {
+                            val browserValue = browser
+                            if (browserValue == null) {
+                                DlsiteDirectoryLoadingPanel()
+                            } else {
+                                DirectoryBrowserPanelV4(
+                                    panelKey = treeStateKey,
+                                    currentPath = currentPath,
+                                    breadcrumbs = browserValue.breadcrumbs,
+                                    batchTargets = browserValue.batchTargets,
+                                    folders = browserValue.folders,
+                                    files = browserValue.files,
+                                    onNavigate = { path -> currentPath = path },
+                                    onAddToFavorites = onAddMediaItemsToFavorites,
+                                    onOpenBatchPlaylistPicker = onOpenBatchPlaylistPicker,
+                                    onAddMediaItemsToQueue = onAddMediaItemsToQueue,
+                                    animateIntro = animateIntro,
+                                    parentChromeState = chromeState,
+                                    folderKeyPrefix = "asmr-folder",
+                                    fileKeyPrefix = "asmr-file",
+                                    fileContent = { file, selectionMode, selected, enterSelectionMode, onSelectedChange ->
+                                        val leaf = asmrLeafByRelPath[file.path]
+                                        DirectoryFileRow(
+                                            file = file.copy(showSubtitleStamp = file.subtitleSources.isNotEmpty()),
+                                            loadRemoteFileSize = loadRemoteFileSize,
+                                            onPrimary = {
+                                                when (file.fileType) {
+                                                    TreeFileType.Audio -> {
+                                                        scope.launch {
+                                                            val prepared = withContext(Dispatchers.Default) {
+                                                                val start = asmrLeafByRelPath[file.path] ?: return@withContext null
+                                                                val folderPath = file.path.substringBeforeLast('/', "")
+                                                                val siblingLeaves = asmrLeafTracks.filter {
+                                                                    it.relativePath.substringBeforeLast('/', "") == folderPath
+                                                                }
+                                                                val queueLeaves = siblingLeaves.ifEmpty { listOf(start) }
+                                                                PreparedTrackPlayback(
+                                                                    tracks = queueLeaves.sortedBy { SmartSortKey.of(it.title) }.map { it.toTrack() },
+                                                                    startTrack = start.toTrack(),
+                                                                    onlineLyrics = queueLeaves.associate { it.url to it.subtitles }
+                                                                )
+                                                            } ?: return@launch
+                                                            com.asmr.player.util.OnlineLyricsStore.replaceAll(prepared.onlineLyrics)
+                                                            onPlayTracks(album, prepared.tracks, prepared.startTrack)
+                                                        }
+                                                    }
+                                                    TreeFileType.Video -> {
+                                                        val item = file.playlistTarget?.toMediaItem()
+                                                        if (item != null) {
+                                                            onPlayMediaItems(listOf(item), 0)
+                                                        } else {
+                                                            onPreviewFile(
+                                                                AsmrTreeUiEntry.File(
+                                                                    path = file.path,
+                                                                    title = file.title,
+                                                                    depth = 0,
+                                                                    fileType = file.fileType,
+                                                                    isPlayable = false,
+                                                                    url = file.url
+                                                                )
+                                                            )
+                                                        }
+                                                    }
+                                                    TreeFileType.Image -> {
+                                                        buildDirectoryImagePreviewRequest(
+                                                            files = browserValue.files,
+                                                            clickedPath = file.path,
+                                                            toPreviewItem = { imageFile ->
+                                                                val imageUrl = imageFile.url.takeIf { it.isNotBlank() } ?: return@buildDirectoryImagePreviewRequest null
+                                                                ImagePreviewItem(
+                                                                    key = imageFile.path,
+                                                                    title = imageFile.title,
+                                                                    openPathOrUrl = imageUrl,
+                                                                    prepareImage = {
+                                                                        ImagePreviewPreparedItem(
+                                                                            imageModel = imageUrl,
+                                                                            openPathOrUrl = imageUrl
+                                                                        )
+                                                                    }
+                                                                )
+                                                            }
+                                                        )?.let(onPreviewImages) ?: onPreviewFile(
+                                                            AsmrTreeUiEntry.File(
+                                                                path = file.path,
+                                                                title = file.title,
+                                                                depth = 0,
+                                                                fileType = file.fileType,
+                                                                isPlayable = false,
+                                                                url = file.url
+                                                            )
                                                         )
                                                     }
-                                                )
-                                            }
-                                        )?.let(onPreviewImages) ?: onPreviewFile(
-                                            AsmrTreeUiEntry.File(
-                                                path = file.path,
-                                                title = file.title,
-                                                depth = 0,
-                                                fileType = file.fileType,
-                                                isPlayable = false,
-                                                url = file.url
-                                            )
+                                                    else -> onPreviewFile(
+                                                        AsmrTreeUiEntry.File(
+                                                            path = file.path,
+                                                            title = file.title,
+                                                            depth = 0,
+                                                            fileType = file.fileType,
+                                                            isPlayable = false,
+                                                            url = file.url
+                                                        )
+                                                    )
+                                                }
+                                            },
+                                            selectionMode = selectionMode,
+                                            selected = selected,
+                                            onEnterSelectionMode = enterSelectionMode,
+                                            onSelectedChange = onSelectedChange,
+                                            onDownload = if (isDownloadableTreeFileType(file.fileType)) ({ onDownloadOne(file.path) }) else null,
+                                            onAddToQueue = if (leaf != null) ({
+                                                com.asmr.player.util.OnlineLyricsStore.set(leaf.url, leaf.subtitles)
+                                                onAddToQueue(leaf.toTrack())
+                                            }) else null,
+                                            onAddToPlaylist = if (file.fileType == TreeFileType.Audio) ({ onAddToPlaylistOne(file.path) }) else null
                                         )
                                     }
-                                    else -> onPreviewFile(
-                                        AsmrTreeUiEntry.File(
-                                            path = file.path,
-                                            title = file.title,
-                                            depth = 0,
-                                            fileType = file.fileType,
-                                            isPlayable = false,
-                                            url = file.url
-                                        )
-                                    )
-                                }
-                            },
-                            selectionMode = selectionMode,
-                            selected = selected,
-                            onEnterSelectionMode = enterSelectionMode,
-                            onSelectedChange = onSelectedChange,
-                            onDownload = if (isDownloadableTreeFileType(file.fileType)) ({ onDownloadOne(file.path) }) else null,
-                            onAddToQueue = if (leaf != null) ({
-                                com.asmr.player.util.OnlineLyricsStore.set(leaf.url, leaf.subtitles)
-                                onAddToQueue(leaf.toTrack())
-                            }) else null,
-                            onAddToPlaylist = if (file.fileType == TreeFileType.Audio) ({ onAddToPlaylistOne(file.path) }) else null
+                                )
+                            }
+                        }
+                        DirectoryTreePanelState.Loading -> DlsiteDirectoryLoadingPanel()
+                        DirectoryTreePanelState.Empty -> DlsiteSectionEmptyState(
+                            text = "ONE 暂未收录",
+                            artworkKind = DlsiteEmptyArtworkKind.One,
+                            modifier = Modifier
                         )
+                        DirectoryTreePanelState.MissingRj -> Unit
                     }
-                    )
                 }
-            }
-        } else if (isAsmrOnePending) {
-            item(key = "dlsite-one-content") {
-                Box(modifier = dlsiteAnimatedSectionModifier(Modifier.fillMaxWidth(), animateIntro)) {
-                    DlsiteDirectoryLoadingPanel()
-                }
-            }
-        } else {
-            item(key = "dlsite-one-content") {
-                DlsiteSectionEmptyState(
-                    text = "ONE 暂未收录",
-                    artworkKind = DlsiteEmptyArtworkKind.One,
-                    modifier = dlsiteAnimatedSectionModifier(Modifier, animateIntro)
-                )
             }
         }
         item(key = "dlsite-trial-header") {
@@ -1273,164 +1329,177 @@ internal fun AlbumDlsitePlayBreadcrumbTabV2(
             }
         }
 
-        if (rj.isBlank()) {
-            item {
-                Box(modifier = Modifier.fillMaxWidth().height(220.dp), contentAlignment = Alignment.Center) {
-                    Text("缺少 RJ 编号，无法加载")
-                }
-            }
-            return@LazyColumn
+        val dlsitePlayPanelState = when {
+            rj.isBlank() -> DirectoryTreePanelState.MissingRj
+            tree.isEmpty() && isDirectoryPending -> DirectoryTreePanelState.Loading
+            tree.isEmpty() -> DirectoryTreePanelState.Empty
+            isDirectoryPending || browser == null -> DirectoryTreePanelState.Loading
+            else -> DirectoryTreePanelState.Content
         }
-
-        if (tree.isEmpty()) {
-            item {
-                Box(modifier = Modifier.fillMaxWidth().height(220.dp), contentAlignment = Alignment.Center) {
-                    if (isDirectoryPending) {
-                        EaraLogoLoadingIndicator(tint = AsmrTheme.colorScheme.primary)
-                    } else {
+        item(key = "dlplay-content:$treeStateKey") {
+            DirectoryTreeAnimatedContent(
+                targetState = dlsitePlayPanelState,
+                label = "dlsitePlayDirectoryTree",
+                modifier = Modifier.fillMaxWidth()
+            ) { panelState ->
+                when (panelState) {
+                    DirectoryTreePanelState.MissingRj -> Box(
+                        modifier = Modifier.fillMaxWidth().height(220.dp),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        Text("缺少 RJ 编号，无法加载")
+                    }
+                    DirectoryTreePanelState.Empty -> Box(
+                        modifier = Modifier.fillMaxWidth().height(220.dp),
+                        contentAlignment = Alignment.Center
+                    ) {
                         Text("暂无可播放资源")
+                    }
+                    DirectoryTreePanelState.Loading -> Box(
+                        modifier = Modifier.fillMaxWidth().height(220.dp),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        EaraLogoLoadingIndicator(tint = AsmrTheme.colorScheme.primary)
+                    }
+                    DirectoryTreePanelState.Content -> {
+                        val browserValue = browser
+                        if (browserValue == null) {
+                            Box(
+                                modifier = Modifier.fillMaxWidth().height(220.dp),
+                                contentAlignment = Alignment.Center
+                            ) {
+                                EaraLogoLoadingIndicator(tint = AsmrTheme.colorScheme.primary)
+                            }
+                        } else {
+                            DirectoryBrowserPanelV4(
+                                panelKey = treeStateKey,
+                                currentPath = currentPath,
+                                breadcrumbs = browserValue.breadcrumbs,
+                                batchTargets = browserValue.batchTargets,
+                                folders = browserValue.folders,
+                                files = browserValue.files,
+                                onNavigate = { path -> currentPath = path },
+                                onAddToFavorites = onAddMediaItemsToFavorites,
+                                onOpenBatchPlaylistPicker = onOpenBatchPlaylistPicker,
+                                onAddMediaItemsToQueue = onAddMediaItemsToQueue,
+                                animateIntro = animateIntro,
+                                parentChromeState = chromeState,
+                                folderKeyPrefix = "dlplay-folder",
+                                fileKeyPrefix = "dlplay-file",
+                                fileContent = { file, selectionMode, selected, enterSelectionMode, onSelectedChange ->
+                                    val leaf = leafByRelPath[file.path]
+                                    DirectoryFileRow(
+                                        file = file.copy(showSubtitleStamp = file.subtitleSources.isNotEmpty()),
+                                        loadRemoteFileSize = loadRemoteFileSize,
+                                        onPrimary = {
+                                            when (file.fileType) {
+                                                TreeFileType.Audio, TreeFileType.Video -> {
+                                                    scope.launch {
+                                                        val prepared = withContext(Dispatchers.Default) {
+                                                            val folderPath = file.path.substringBeforeLast('/', "")
+                                                            val siblings = browserValue.files
+                                                                .filter { sibling ->
+                                                                    sibling.path.substringBeforeLast('/', "") == folderPath &&
+                                                                        (sibling.fileType == TreeFileType.Audio || sibling.fileType == TreeFileType.Video) &&
+                                                                        sibling.playlistTarget != null
+                                                                }
+                                                                .sortedBy { SmartSortKey.of(it.title) }
+                                                            val items = siblings.mapNotNull { it.playlistTarget?.toMediaItem() }
+                                                            if (items.isEmpty()) return@withContext null
+                                                            val clickedId = file.playlistTarget?.mediaId.orEmpty()
+                                                            val startIndex = items.indexOfFirst { it.mediaId == clickedId }
+                                                                .takeIf { it >= 0 } ?: 0
+                                                            PreparedMediaPlayback(items, startIndex)
+                                                        }
+                                                        if (prepared != null) {
+                                                            if (leaf != null) {
+                                                                com.asmr.player.util.OnlineLyricsStore.set(leaf.url, leaf.subtitles)
+                                                            }
+                                                            onPlayMediaItems(prepared.items, prepared.startIndex)
+                                                        } else {
+                                                            onPreviewFile(
+                                                                AsmrTreeUiEntry.File(
+                                                                    path = file.path,
+                                                                    title = file.title,
+                                                                    depth = 0,
+                                                                    fileType = file.fileType,
+                                                                    isPlayable = false,
+                                                                    url = file.url
+                                                                )
+                                                            )
+                                                        }
+                                                    }
+                                                }
+                                                TreeFileType.Image -> {
+                                                    val request = buildDirectoryImagePreviewRequest(
+                                                        files = browserValue.files,
+                                                        clickedPath = file.path,
+                                                        toPreviewItem = { imageFile ->
+                                                            val imageUrl = imageFile.url.takeIf { it.isNotBlank() } ?: return@buildDirectoryImagePreviewRequest null
+                                                            ImagePreviewItem(
+                                                                key = imageFile.path,
+                                                                title = imageFile.title,
+                                                                openPathOrUrl = imageUrl,
+                                                                prepareImage = {
+                                                                    val prepared = prepareImagePreview(
+                                                                        imageUrl,
+                                                                        imageFile.dlsitePlayOptimizedName,
+                                                                        imageFile.dlsitePlayImageCrypt,
+                                                                        imageFile.dlsitePlayImageWidth,
+                                                                        imageFile.dlsitePlayImageHeight
+                                                                    ) ?: imageUrl
+                                                                    ImagePreviewPreparedItem(
+                                                                        imageModel = prepared,
+                                                                        openPathOrUrl = prepared
+                                                                    )
+                                                                }
+                                                            )
+                                                        }
+                                                    )
+                                                    if (request != null) {
+                                                        onPreviewImages(request)
+                                                    } else {
+                                                        onPreviewFile(
+                                                            AsmrTreeUiEntry.File(
+                                                                path = file.path,
+                                                                title = file.title,
+                                                                depth = 0,
+                                                                fileType = file.fileType,
+                                                                isPlayable = false,
+                                                                url = file.url
+                                                            )
+                                                        )
+                                                    }
+                                                }
+                                                else -> onPreviewFile(
+                                                    AsmrTreeUiEntry.File(
+                                                        path = file.path,
+                                                        title = file.title,
+                                                        depth = 0,
+                                                        fileType = file.fileType,
+                                                        isPlayable = false,
+                                                        url = file.url
+                                                    )
+                                                )
+                                            }
+                                        },
+                                        selectionMode = selectionMode,
+                                        selected = selected,
+                                        onEnterSelectionMode = enterSelectionMode,
+                                        onSelectedChange = onSelectedChange,
+                                        onDownload = if (isDownloadableTreeFileType(file.fileType)) ({ onDownloadOne(file.path) }) else null,
+                                        onAddToQueue = if (leaf != null) ({
+                                            com.asmr.player.util.OnlineLyricsStore.set(leaf.url, leaf.subtitles)
+                                            onAddToQueue(leaf.toTrack())
+                                        }) else null,
+                                        onAddToPlaylist = null
+                                    )
+                                }
+                            )
+                        }
                     }
                 }
             }
-            return@LazyColumn
-        }
-
-        if (isDirectoryPending || browser == null) {
-            item {
-                Box(modifier = Modifier.fillMaxWidth().height(220.dp), contentAlignment = Alignment.Center) {
-                    EaraLogoLoadingIndicator(tint = AsmrTheme.colorScheme.primary)
-                }
-            }
-            return@LazyColumn
-        }
-
-        item {
-            val browserValue = browser ?: return@item
-            DirectoryBrowserPanelV4(
-                panelKey = treeStateKey,
-                currentPath = currentPath,
-                breadcrumbs = browserValue.breadcrumbs,
-                batchTargets = browserValue.batchTargets,
-                folders = browserValue.folders,
-                files = browserValue.files,
-                onNavigate = { path -> currentPath = path },
-                onAddToFavorites = onAddMediaItemsToFavorites,
-                onOpenBatchPlaylistPicker = onOpenBatchPlaylistPicker,
-                onAddMediaItemsToQueue = onAddMediaItemsToQueue,
-                animateIntro = animateIntro,
-                parentChromeState = chromeState,
-                folderKeyPrefix = "dlplay-folder",
-                fileKeyPrefix = "dlplay-file",
-                fileContent = { file, selectionMode, selected, enterSelectionMode, onSelectedChange ->
-                    val leaf = leafByRelPath[file.path]
-                    DirectoryFileRow(
-                        file = file.copy(showSubtitleStamp = file.subtitleSources.isNotEmpty()),
-                        loadRemoteFileSize = loadRemoteFileSize,
-                        onPrimary = {
-                            when (file.fileType) {
-                                TreeFileType.Audio, TreeFileType.Video -> {
-                                    scope.launch {
-                                        val prepared = withContext(Dispatchers.Default) {
-                                            val folderPath = file.path.substringBeforeLast('/', "")
-                                            val siblings = browserValue.files
-                                                .filter { sibling ->
-                                                    sibling.path.substringBeforeLast('/', "") == folderPath &&
-                                                        (sibling.fileType == TreeFileType.Audio || sibling.fileType == TreeFileType.Video) &&
-                                                        sibling.playlistTarget != null
-                                                }
-                                                .sortedBy { SmartSortKey.of(it.title) }
-                                            val items = siblings.mapNotNull { it.playlistTarget?.toMediaItem() }
-                                            if (items.isEmpty()) return@withContext null
-                                            val clickedId = file.playlistTarget?.mediaId.orEmpty()
-                                            val startIndex = items.indexOfFirst { it.mediaId == clickedId }
-                                                .takeIf { it >= 0 } ?: 0
-                                            PreparedMediaPlayback(items, startIndex)
-                                        }
-                                        if (prepared != null) {
-                                            if (leaf != null) {
-                                                com.asmr.player.util.OnlineLyricsStore.set(leaf.url, leaf.subtitles)
-                                            }
-                                            onPlayMediaItems(prepared.items, prepared.startIndex)
-                                        } else {
-                                            onPreviewFile(
-                                                AsmrTreeUiEntry.File(
-                                                    path = file.path,
-                                                    title = file.title,
-                                                    depth = 0,
-                                                    fileType = file.fileType,
-                                                    isPlayable = false,
-                                                    url = file.url
-                                                )
-                                            )
-                                        }
-                                    }
-                                }
-                                TreeFileType.Image -> {
-                                    val request = buildDirectoryImagePreviewRequest(
-                                        files = browserValue.files,
-                                        clickedPath = file.path,
-                                        toPreviewItem = { imageFile ->
-                                            val imageUrl = imageFile.url.takeIf { it.isNotBlank() } ?: return@buildDirectoryImagePreviewRequest null
-                                            ImagePreviewItem(
-                                                key = imageFile.path,
-                                                title = imageFile.title,
-                                                openPathOrUrl = imageUrl,
-                                                prepareImage = {
-                                                    val prepared = prepareImagePreview(
-                                                        imageUrl,
-                                                        imageFile.dlsitePlayOptimizedName,
-                                                        imageFile.dlsitePlayImageCrypt,
-                                                        imageFile.dlsitePlayImageWidth,
-                                                        imageFile.dlsitePlayImageHeight
-                                                    ) ?: imageUrl
-                                                    ImagePreviewPreparedItem(
-                                                        imageModel = prepared,
-                                                        openPathOrUrl = prepared
-                                                    )
-                                                }
-                                            )
-                                        }
-                                    )
-                                    if (request != null) {
-                                        onPreviewImages(request)
-                                    } else {
-                                        onPreviewFile(
-                                            AsmrTreeUiEntry.File(
-                                                path = file.path,
-                                                title = file.title,
-                                                depth = 0,
-                                                fileType = file.fileType,
-                                                isPlayable = false,
-                                                url = file.url
-                                            )
-                                        )
-                                    }
-                                }
-                                else -> onPreviewFile(
-                                    AsmrTreeUiEntry.File(
-                                        path = file.path,
-                                        title = file.title,
-                                        depth = 0,
-                                        fileType = file.fileType,
-                                        isPlayable = false,
-                                        url = file.url
-                                    )
-                                )
-                            }
-                        },
-                        selectionMode = selectionMode,
-                        selected = selected,
-                        onEnterSelectionMode = enterSelectionMode,
-                        onSelectedChange = onSelectedChange,
-                        onDownload = if (isDownloadableTreeFileType(file.fileType)) ({ onDownloadOne(file.path) }) else null,
-                        onAddToQueue = if (leaf != null) ({
-                            com.asmr.player.util.OnlineLyricsStore.set(leaf.url, leaf.subtitles)
-                            onAddToQueue(leaf.toTrack())
-                        }) else null,
-                        onAddToPlaylist = null
-                    )
-                }
-            )
         }
     }
 }

--- a/app/src/test/java/com/asmr/player/ui/library/AlbumDetailOneStateTest.kt
+++ b/app/src/test/java/com/asmr/player/ui/library/AlbumDetailOneStateTest.kt
@@ -27,6 +27,14 @@ class AlbumDetailOneStateTest {
         assertFalse(
             shouldShowAsmrOneDirectoryLoading(
                 isAwaitingAsmrOneLoad = false,
+                isLoadingAsmrOne = true,
+                hasAsmrOneTree = true,
+                hasDirectoryBrowser = true
+            )
+        )
+        assertFalse(
+            shouldShowAsmrOneDirectoryLoading(
+                isAwaitingAsmrOneLoad = false,
                 isLoadingAsmrOne = false,
                 hasAsmrOneTree = false,
                 hasDirectoryBrowser = false
@@ -152,6 +160,19 @@ class AlbumDetailOneStateTest {
                 isLoadingDlsitePlay = false,
                 hasDlsitePlayTree = true,
                 hasDirectoryBrowser = false
+            )
+        )
+    }
+
+    @Test
+    fun shouldShowDlsitePlayDirectoryLoading_keepsVisibleTreeDuringBackgroundLoad() {
+        assertFalse(
+            shouldShowDlsitePlayDirectoryLoading(
+                isAwaitingInitialTarget = false,
+                hasResolvedDlsitePlayContent = true,
+                isLoadingDlsitePlay = true,
+                hasDlsitePlayTree = true,
+                hasDirectoryBrowser = true
             )
         )
     }


### PR DESCRIPTION
## Summary
- keep ASMR.ONE directory content stable while DLsite target resolution refreshes in the background
- avoid showing directory loading again when a tree is already visible
- add a subtle animated transition when online directory trees appear

## Verification
- .\gradlew-local.bat :app:testReleaseUnitTest --tests com.asmr.player.ui.library.AlbumDetailOneStateTest
- .\gradlew-local.bat :app:installRelease