### PR TITLE
Fix bottom chrome compact layout stability

### DIFF
--- a/app/src/main/java/com/asmr/player/main/MainContainer.kt
+++ b/app/src/main/java/com/asmr/player/main/MainContainer.kt
@@ -1290,7 +1290,12 @@ fun MainContainer(
             )
         }
         val useLargeBottomChrome = windowSizeClass.widthSizeClass != WindowWidthSizeClass.Compact && !isPhone
-        val bottomOverlayPadding = bottomChromeOverlayHeight(useLargeBottomChrome)
+        val navigationBarBottomPadding = StableWindowInsets.navigationBars
+            .only(WindowInsetsSides.Bottom)
+            .asPaddingValues()
+            .calculateBottomPadding()
+        val bottomChromeBottomPadding = 24.dp + navigationBarBottomPadding
+        val bottomOverlayPadding = bottomChromeOverlayHeight(useLargeBottomChrome) + navigationBarBottomPadding
         CompositionLocalProvider(
             LocalBottomOverlayPadding provides bottomOverlayPadding,
             LocalRightPanelExpandedState provides rightPanelExpandedState
@@ -2288,7 +2293,7 @@ fun MainContainer(
                     modifier = Modifier
                         .align(Alignment.BottomStart)
                         .graphicsLayer { clip = false }
-                        .padding(start = bottomChromeHorizontalPadding, bottom = 24.dp)
+                        .padding(start = bottomChromeHorizontalPadding, bottom = bottomChromeBottomPadding)
                         .width(chromeWidth)
                 ) {
                     PrimaryBottomChrome(

--- a/app/src/main/java/com/asmr/player/ui/nav/BottomChrome.kt
+++ b/app/src/main/java/com/asmr/player/ui/nav/BottomChrome.kt
@@ -14,11 +14,9 @@ import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -139,6 +137,7 @@ private val BottomNavGlowExpandedSizeLarge = 50.dp
 private val BottomNavGlowCollapsedSize = 46.dp
 private val BottomNavGlowCollapsedSizeLarge = 52.dp
 private const val BottomNavPageToggleGroupSize = BottomNavExpandedSlotCount - 1
+private const val BottomChromeMinCompactScale = 0.72f
 private const val QuarterArcKappa = 0.55228475f
 private const val BottomNavOverflowOutlineCollapseTailFraction = 0.18f
 
@@ -188,6 +187,35 @@ private data class BottomChromeMetrics(
         get() = (expandedHorizontalPadding * 2) +
             (itemSlotWidth * BottomNavExpandedSlotCount) +
             (expandedItemSpacing * (BottomNavExpandedSlotCount - 1))
+
+    fun scaled(scale: Float): BottomChromeMetrics {
+        val resolvedScale = scale.coerceIn(BottomChromeMinCompactScale, 1f)
+        if (resolvedScale >= 0.999f) return this
+        return copy(
+            overlayHeight = overlayHeight * resolvedScale,
+            barHeight = barHeight * resolvedScale,
+            barCornerRadius = barCornerRadius * resolvedScale,
+            collapsedWidth = collapsedWidth * resolvedScale,
+            chipSize = chipSize * resolvedScale,
+            itemSlotWidth = itemSlotWidth * resolvedScale,
+            expandedItemSpacing = expandedItemSpacing * resolvedScale,
+            expandedHorizontalPadding = expandedHorizontalPadding * resolvedScale,
+            overflowPanelWidth = overflowPanelWidth * resolvedScale,
+            overflowTopCapHeight = overflowTopCapHeight * resolvedScale,
+            overflowShoulderLift = overflowShoulderLift * resolvedScale,
+            overflowNeckBottomOffset = overflowNeckBottomOffset * resolvedScale,
+            overflowLeftShoulderReach = overflowLeftShoulderReach * resolvedScale,
+            overflowRightShoulderReach = overflowRightShoulderReach * resolvedScale,
+            overflowHorizontalBias = overflowHorizontalBias * resolvedScale,
+            overflowTopContentPadding = overflowTopContentPadding * resolvedScale,
+            overflowBottomPadding = overflowBottomPadding * resolvedScale,
+            overflowItemSize = overflowItemSize * resolvedScale,
+            overflowItemSpacing = overflowItemSpacing * resolvedScale,
+            iconSize = iconSize * resolvedScale,
+            glowExpandedSize = glowExpandedSize * resolvedScale,
+            glowCollapsedSize = glowCollapsedSize * resolvedScale
+        )
+    }
 }
 
 fun bottomChromeOverlayHeight(largeLayout: Boolean): Dp =
@@ -325,80 +353,6 @@ private fun resolveBottomNavGroupIndex(
     return routeIndex / groupSize.coerceAtLeast(1)
 }
 
-private fun computeVisibleNavItems(
-    allItems: List<BottomChromeNavItem>,
-    activeRoute: String,
-    availableWidth: Dp,
-    metrics: BottomChromeMetrics = bottomChromeMetrics(largeLayout = false),
-    preferredPinnedRoute: String? = null,
-    maxVisibleItems: Int? = null
-): BottomChromeNavLayout {
-    if (allItems.isEmpty()) {
-        return BottomChromeNavLayout(emptyList(), emptyList(), showsOverflow = false)
-    }
-
-    val slotWidth = metrics.itemSlotWidth.value
-    val slotSpacing = metrics.expandedItemSpacing.value
-    val horizontalPadding = (metrics.expandedHorizontalPadding * 2).value
-    val width = availableWidth.value.coerceAtLeast(slotWidth + horizontalPadding)
-    fun requiredWidth(slotCount: Int): Float {
-        if (slotCount <= 0) return horizontalPadding
-        return horizontalPadding +
-            (slotWidth * slotCount) +
-            (slotSpacing * (slotCount - 1))
-    }
-
-    val maxWithoutOverflow = (1..allItems.size)
-        .lastOrNull { requiredWidth(it) <= width }
-        ?.coerceAtLeast(1)
-        ?: 1
-    if (allItems.size <= maxWithoutOverflow) {
-        return BottomChromeNavLayout(
-            visibleItems = allItems,
-            overflowItems = emptyList(),
-            showsOverflow = false
-        )
-    }
-
-    val maxVisible = ((1..allItems.size)
-        .lastOrNull { requiredWidth(it) <= width }
-        ?: 1) - 1
-    
-    val resolvedMaxVisible = maxVisible
-        .coerceAtLeast(1)
-        .coerceAtMost(allItems.size - 1)
-        .let { computed -> maxVisibleItems?.let { computed.coerceAtMost(it) } ?: computed }
-    val activeItem = allItems.firstOrNull { it.route == activeRoute } ?: allItems.first()
-    val fixedVisibleCount = (resolvedMaxVisible - 1).coerceAtLeast(0)
-    val fixedVisibleItems = allItems.take(fixedVisibleCount)
-    val defaultPinnedItem = allItems.getOrNull(fixedVisibleCount) ?: activeItem
-    val preferredPinnedItem = allItems.firstOrNull { it.route == preferredPinnedRoute }
-        ?.takeIf { it !in fixedVisibleItems }
-    val slotItem = preferredPinnedItem
-        ?: activeItem.takeIf { it !in fixedVisibleItems }
-        ?: defaultPinnedItem
-    val visible = fixedVisibleItems
-        .plus(slotItem)
-        .take(resolvedMaxVisible)
-        .distinct()
-        .toMutableList()
-    if (visible.size < resolvedMaxVisible) {
-        allItems.forEach { item ->
-            if (visible.size >= resolvedMaxVisible) return@forEach
-            if (item !in visible) {
-                visible += item
-            }
-        }
-    }
-    val overflow = allItems.filterNot { it in visible }
-
-    return BottomChromeNavLayout(
-        visibleItems = visible,
-        overflowItems = overflow,
-        showsOverflow = overflow.isNotEmpty()
-    )
-}
-
 private fun computeOverflowHeadroom(
     itemCount: Int,
     metrics: BottomChromeMetrics
@@ -515,7 +469,7 @@ private fun computeBottomNavRailShift(
     entries: List<BottomNavRailEntry>,
     offsets: List<Dp>,
     activeRoute: String,
-    currentWidth: Dp,
+    collapseProgress: Float,
     metrics: BottomChromeMetrics
 ): Dp {
     val activeIndex = entries.indexOfFirst { !it.isOverflow && it.item.route == activeRoute }
@@ -523,18 +477,11 @@ private fun computeBottomNavRailShift(
         ?: return 0.dp
     val activeLeft = offsets.getOrNull(activeIndex) ?: return 0.dp
     val activeWidth = entries[activeIndex].width
-    val activeRight = activeLeft + activeWidth
     val collapsedActiveLeft = ((metrics.collapsedWidth - activeWidth) / 2f).coerceAtLeast(0.dp)
     val collapsedShift = activeLeft - collapsedActiveLeft
     if (collapsedShift == 0.dp) return 0.dp
 
-    val moveStartWidth = maxOf(
-        (activeRight + metrics.expandedHorizontalPadding).value,
-        metrics.collapsedWidth.value + abs((collapsedActiveLeft - activeLeft).value)
-    )
-    val moveRange = (moveStartWidth - metrics.collapsedWidth.value).coerceAtLeast(1f)
-    val progress = ((moveStartWidth - currentWidth.value) / moveRange).coerceIn(0f, 1f)
-    return collapsedShift * progress
+    return collapsedShift * collapseProgress.coerceIn(0f, 1f)
 }
 
 private fun computeBottomNavEntryVisibility(
@@ -573,88 +520,145 @@ fun BottomChrome(
     miniPlayerContent: (@Composable (Modifier) -> Unit)? = null
 ) {
     BoxWithConstraints(modifier = modifier) {
-        val metrics = remember(largeLayout) { bottomChromeMetrics(largeLayout) }
+        val baseMetrics = remember(largeLayout) { bottomChromeMetrics(largeLayout) }
         val navExpanded = !miniPlayerVisible || miniPlayerDisplayMode == MiniPlayerDisplayMode.CoverOnly
-        val miniCollapsedWidth = if (largeLayout) 84.dp else 72.dp
-        val chromeSpacing = if (largeLayout) 8.dp else 6.dp
+        val baseMiniCollapsedWidth = if (largeLayout) 84.dp else 72.dp
+        val baseChromeSpacing = if (largeLayout) 8.dp else 6.dp
+        val compactScaleTarget = remember(
+            maxWidth,
+            miniPlayerVisible,
+            baseMetrics,
+            baseMiniCollapsedWidth,
+            baseChromeSpacing
+        ) {
+            val requiredWidth = baseMetrics.preferredExpandedWidth +
+                if (miniPlayerVisible) baseMiniCollapsedWidth + baseChromeSpacing else 0.dp
+            (maxWidth.value / requiredWidth.value)
+                .coerceIn(BottomChromeMinCompactScale, 1f)
+        }
+        val compactScale by animateFloatAsState(
+            targetValue = compactScaleTarget,
+            animationSpec = spring(
+                dampingRatio = Spring.DampingRatioNoBouncy,
+                stiffness = Spring.StiffnessMediumLow
+            ),
+            label = "bottomChromeCompactScale"
+        )
+        val metrics = remember(baseMetrics, compactScale) { baseMetrics.scaled(compactScale) }
+        val miniCollapsedWidth = baseMiniCollapsedWidth * compactScale
+        val miniExpandedMinWidth = (if (largeLayout) 244.dp else 204.dp) * compactScale
+        val chromeSpacing = baseChromeSpacing * compactScale
         val expandedNavWidthLimit = maxWidth.coerceAtMost(metrics.preferredExpandedWidth)
-        val miniWidthTarget = when {
-            !miniPlayerVisible -> 0.dp
-            miniPlayerDisplayMode == MiniPlayerDisplayMode.Expanded ->
-                (maxWidth - metrics.collapsedWidth - chromeSpacing).coerceAtLeast(if (largeLayout) 244.dp else 204.dp)
-            else -> miniCollapsedWidth
-        }
-        val navWidthTarget = when {
-            !miniPlayerVisible -> expandedNavWidthLimit
-            navExpanded -> (maxWidth - miniWidthTarget - chromeSpacing)
-                .coerceAtLeast(if (largeLayout) 108.dp else 92.dp)
+        val miniExpandedWidth = (maxWidth - metrics.collapsedWidth - chromeSpacing)
+            .coerceAtLeast(miniExpandedMinWidth)
+        val expandedNavWidth = if (!miniPlayerVisible) {
+            expandedNavWidthLimit
+        } else {
+            (maxWidth - miniCollapsedWidth - chromeSpacing)
+                .coerceAtLeast(metrics.preferredExpandedWidth)
                 .coerceAtMost(expandedNavWidthLimit)
-            else -> metrics.collapsedWidth
         }
-        val miniWidth by animateDpAsState(
-            targetValue = miniWidthTarget,
+        val expansionProgress by animateFloatAsState(
+            targetValue = if (miniPlayerVisible && miniPlayerDisplayMode == MiniPlayerDisplayMode.Expanded) 1f else 0f,
             animationSpec = spring(
                 dampingRatio = Spring.DampingRatioNoBouncy,
                 stiffness = Spring.StiffnessMediumLow
             ),
-            label = "bottomChromeMiniWidth"
+            label = "bottomChromeExpansionProgress"
         )
-        val navWidth by animateDpAsState(
-            targetValue = navWidthTarget,
-            animationSpec = spring(
-                dampingRatio = Spring.DampingRatioNoBouncy,
-                stiffness = Spring.StiffnessMediumLow
-            ),
-            label = "bottomChromeNavWidth"
-        )
-        val maxVisibleItems = when {
-            !navExpanded -> 1
-            else -> BottomNavExpandedSlotCount - 1
+        val miniWidth = if (!miniPlayerVisible) {
+            0.dp
+        } else {
+            miniCollapsedWidth + (miniExpandedWidth - miniCollapsedWidth) * expansionProgress
         }
-        val chromeArrangement = Arrangement.spacedBy(
-            space = chromeSpacing,
-            alignment = Alignment.CenterHorizontally
-        )
-        Row(
+        val navWidthTarget = if (miniPlayerVisible && miniPlayerDisplayMode == MiniPlayerDisplayMode.Expanded) {
+            metrics.collapsedWidth
+        } else {
+            expandedNavWidth
+        }
+        val navWidth = if (!miniPlayerVisible) {
+            expandedNavWidth
+        } else {
+            expandedNavWidth + (metrics.collapsedWidth - expandedNavWidth) * expansionProgress
+        }
+        val navCollapseProgress = if (miniPlayerVisible) expansionProgress else 0f
+        val coverOnlyGroupWidth = if (miniPlayerVisible) {
+            expandedNavWidth + chromeSpacing + miniCollapsedWidth
+        } else {
+            expandedNavWidth
+        }
+        val expandedGroupWidth = if (miniPlayerVisible) {
+            metrics.collapsedWidth + chromeSpacing + miniExpandedWidth
+        } else {
+            expandedNavWidth
+        }
+        val trackWidth = if (miniPlayerVisible) {
+            maxOf(coverOnlyGroupWidth, expandedGroupWidth).coerceAtMost(maxWidth)
+        } else {
+            expandedNavWidth
+        }
+        val currentGroupWidth = if (miniPlayerVisible) {
+            navWidth + chromeSpacing + miniWidth
+        } else {
+            navWidth
+        }
+        val groupOffset = ((trackWidth - currentGroupWidth).coerceAtLeast(0.dp) / 2f)
+
+        Box(
             modifier = Modifier
                 .fillMaxWidth()
-                .graphicsLayer { clip = false },
-            horizontalArrangement = chromeArrangement,
-            verticalAlignment = Alignment.Bottom
+                .height(metrics.barHeight)
+                .align(Alignment.BottomCenter)
+                .graphicsLayer { clip = false }
         ) {
-            BottomNavigationPill(
-                navItems = navItems,
-                activeRoute = activeRoute,
-                selectionProgresses = selectionProgresses,
-                preferredPinnedRoute = preferredPinnedRoute,
-                expanded = navExpanded,
-                availableWidth = navWidthTarget,
-                currentWidth = navWidth,
-                metrics = metrics,
-                maxVisibleItems = maxVisibleItems,
-                overflowExpanded = overflowExpanded,
-                onOverflowExpandedChange = onOverflowExpandedChange,
-                onExpandRequest = { onMiniPlayerDisplayModeChange(MiniPlayerDisplayMode.CoverOnly) },
-                onNavigate = onNavigate,
-                onOverflowProtectedBoundsChange = onOverflowProtectedBoundsChange,
-                modifier = Modifier.width(navWidth)
-            )
+            Box(
+                modifier = Modifier
+                    .align(Alignment.BottomCenter)
+                    .width(trackWidth)
+                    .height(metrics.barHeight)
+                    .graphicsLayer { clip = false }
+            ) {
+                BottomNavigationPill(
+                    navItems = navItems,
+                    activeRoute = activeRoute,
+                    selectionProgresses = selectionProgresses,
+                    preferredPinnedRoute = preferredPinnedRoute,
+                    expanded = navExpanded,
+                    availableWidth = expandedNavWidth,
+                    targetWidth = navWidthTarget,
+                    currentWidth = navWidth,
+                    collapseProgress = navCollapseProgress,
+                    metrics = metrics,
+                    overflowExpanded = overflowExpanded,
+                    onOverflowExpandedChange = onOverflowExpandedChange,
+                    onExpandRequest = { onMiniPlayerDisplayModeChange(MiniPlayerDisplayMode.CoverOnly) },
+                    onNavigate = onNavigate,
+                    onOverflowProtectedBoundsChange = onOverflowProtectedBoundsChange,
+                    modifier = Modifier
+                        .align(Alignment.BottomStart)
+                        .offset(x = groupOffset)
+                        .width(navWidth)
+                )
 
-            if (miniPlayerVisible) {
-                val miniPlayerModifier = Modifier
-                    .width(miniWidth.coerceAtLeast(miniCollapsedWidth))
-                    .testTag(BottomChromeMiniPlayerTag)
-                if (miniPlayerContent != null) {
-                    miniPlayerContent(miniPlayerModifier)
-                } else {
-                    MiniPlayer(
-                        displayMode = miniPlayerDisplayMode,
-                        onDisplayModeChange = onMiniPlayerDisplayModeChange,
-                        onOpenNowPlaying = onOpenNowPlaying,
-                        onOpenQueue = onOpenQueue,
-                        largeLayout = largeLayout,
-                        modifier = miniPlayerModifier
-                    )
+                if (miniPlayerVisible) {
+                    val miniPlayerModifier = Modifier
+                        .align(Alignment.BottomStart)
+                        .offset(x = groupOffset + navWidth + chromeSpacing)
+                        .width(miniWidth.coerceAtLeast(miniCollapsedWidth))
+                        .testTag(BottomChromeMiniPlayerTag)
+                    if (miniPlayerContent != null) {
+                        miniPlayerContent(miniPlayerModifier)
+                    } else {
+                        MiniPlayer(
+                            displayMode = miniPlayerDisplayMode,
+                            onDisplayModeChange = onMiniPlayerDisplayModeChange,
+                            onOpenNowPlaying = onOpenNowPlaying,
+                            onOpenQueue = onOpenQueue,
+                            largeLayout = largeLayout,
+                            compactScale = compactScale,
+                            modifier = miniPlayerModifier
+                        )
+                    }
                 }
             }
         }
@@ -669,9 +673,10 @@ private fun BottomNavigationPill(
     preferredPinnedRoute: String? = null,
     expanded: Boolean,
     availableWidth: Dp,
+    targetWidth: Dp = availableWidth,
     currentWidth: Dp = availableWidth,
+    collapseProgress: Float = 0f,
     metrics: BottomChromeMetrics = bottomChromeMetrics(largeLayout = false),
-    maxVisibleItems: Int? = null,
     overflowExpanded: Boolean = false,
     onOverflowExpandedChange: (Boolean) -> Unit = {},
     onExpandRequest: () -> Unit = {},
@@ -692,9 +697,10 @@ private fun BottomNavigationPill(
         preferredPinnedRoute = preferredPinnedRoute,
         expanded = expanded,
         availableWidth = availableWidth,
+        targetWidth = targetWidth,
         currentWidth = currentWidth,
+        collapseProgress = collapseProgress,
         metrics = metrics,
-        maxVisibleItems = maxVisibleItems,
         overflowExpanded = overflowExpanded,
         onOverflowExpandedChange = onOverflowExpandedChange,
         onExpandRequest = onExpandRequest,
@@ -713,9 +719,10 @@ private fun BottomNavigationPillSurface(
     preferredPinnedRoute: String?,
     expanded: Boolean,
     availableWidth: Dp,
+    targetWidth: Dp,
     currentWidth: Dp,
+    collapseProgress: Float,
     metrics: BottomChromeMetrics,
-    maxVisibleItems: Int? = null,
     overflowExpanded: Boolean = false,
     onOverflowExpandedChange: (Boolean) -> Unit = {},
     onExpandRequest: () -> Unit,
@@ -794,15 +801,12 @@ private fun BottomNavigationPillSurface(
             displayedGroupIndex = resolvedGroupIndex
         }
     }
-    val visibleGroupItems = if (expanded) {
-        navGroups.getOrNull(resolvedGroupIndex).orEmpty()
-    } else {
-        listOfNotNull(activeItem)
-    }
-    val showsGroupToggle = expanded && navGroups.size > 1
+    val visibleGroupItems = navGroups.getOrNull(resolvedGroupIndex).orEmpty()
+        .ifEmpty { listOfNotNull(activeItem) }
+    val showsGroupToggle = navGroups.size > 1
     val motionLayout = remember(visibleGroupItems, activeItem, showsGroupToggle) {
         BottomChromeNavLayout(
-            visibleItems = visibleGroupItems.ifEmpty { listOfNotNull(activeItem) },
+            visibleItems = visibleGroupItems,
             overflowItems = emptyList(),
             showsOverflow = showsGroupToggle
         )
@@ -811,14 +815,14 @@ private fun BottomNavigationPillSurface(
     val motionEntries = buildBottomNavRailEntries(motionLayout, metrics)
     val motionOffsets = computeBottomNavRailOffsets(
         entries = motionEntries,
-        currentWidth = currentWidth,
+        currentWidth = availableWidth,
         metrics = metrics
     )
     val railShift = computeBottomNavRailShift(
         entries = motionEntries,
         offsets = motionOffsets,
         activeRoute = layoutFocusRoute,
-        currentWidth = currentWidth,
+        collapseProgress = collapseProgress,
         metrics = metrics
     )
     val canShowOverflow = false
@@ -892,7 +896,7 @@ private fun BottomNavigationPillSurface(
         overflowRevealProgress = overflowRevealProgress
     )
     val interactionBlocked =
-        abs(currentWidth.value - availableWidth.value) > 0.5f ||
+        abs(currentWidth.value - targetWidth.value) > 0.5f ||
             (overflowRevealProgress > 0.01f && overflowRevealProgress < 0.99f)
 
     SideEffect {
@@ -1013,7 +1017,7 @@ private fun BottomNavigationPillSurface(
                     BottomNavItemChip(
                         item = entry.item,
                         selectedProgress = selectedProgress,
-                        collapsed = !expanded,
+                        collapseProgress = collapseProgress,
                         metrics = metrics,
                         enabled = if (entry.isOverflow) {
                             navGroups.size > 1 && isFullyVisible
@@ -1278,7 +1282,7 @@ private fun buildBottomNavContainerPath(
 private fun BottomNavItemChip(
     item: BottomChromeNavItem,
     selectedProgress: Float,
-    collapsed: Boolean,
+    collapseProgress: Float,
     metrics: BottomChromeMetrics,
     enabled: Boolean = true,
     onClick: () -> Unit,
@@ -1294,14 +1298,8 @@ private fun BottomNavItemChip(
     )
     val iconScale = 1f + (0.16f * resolvedSelectedProgress)
     val glowAlpha = resolvedSelectedProgress
-    val glowSize by animateDpAsState(
-        targetValue = if (collapsed) metrics.glowCollapsedSize else metrics.glowExpandedSize,
-        animationSpec = spring(
-            dampingRatio = Spring.DampingRatioMediumBouncy,
-            stiffness = Spring.StiffnessLow
-        ),
-        label = "bottomNavItemGlowSize"
-    )
+    val glowSize = metrics.glowExpandedSize +
+        (metrics.glowCollapsedSize - metrics.glowExpandedSize) * collapseProgress.coerceIn(0f, 1f)
     val glowColor = colorScheme.primaryStrong.copy(alpha = if (colorScheme.isDark) 0.22f else 0.18f)
     val interactionSource = remember { MutableInteractionSource() }
 

--- a/app/src/main/java/com/asmr/player/ui/player/MiniPlayer.kt
+++ b/app/src/main/java/com/asmr/player/ui/player/MiniPlayer.kt
@@ -70,6 +70,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
+import kotlin.math.roundToInt
 
 enum class MiniPlayerDisplayMode {
     CoverOnly,
@@ -106,6 +107,7 @@ fun MiniPlayer(
     onOpenNowPlaying: () -> Unit,
     onOpenQueue: () -> Unit,
     largeLayout: Boolean = false,
+    compactScale: Float = 1f,
     modifier: Modifier = Modifier,
     viewModel: PlayerViewModel = hiltViewModel()
 ) {
@@ -133,9 +135,11 @@ fun MiniPlayer(
     val metadata = item.mediaMetadata
     val colorScheme = AsmrTheme.colorScheme
     val currentMediaId = item.mediaId
-    val barHeight = if (largeLayout) 64.dp else 56.dp
-    val coverSize = if (largeLayout) 60.dp else 52.dp
-    val coverInset = 2.dp
+    val resolvedCompactScale = compactScale.coerceIn(0.72f, 1f)
+    val barHeight = (if (largeLayout) 64.dp else 56.dp) * resolvedCompactScale
+    val coverSize = (if (largeLayout) 60.dp else 52.dp) * resolvedCompactScale
+    val coverInset = 2.dp * resolvedCompactScale
+    val expandedEndCornerRadius = (if (largeLayout) 26.dp else 22.dp) * resolvedCompactScale
     val miniPlayerBorderColor = if (colorScheme.isDark) {
         Color.White.copy(alpha = 0.14f)
     } else {
@@ -186,18 +190,23 @@ fun MiniPlayer(
                     artworkModel = metadata.artworkUri,
                     isPlaying = isPlayingEffective,
                     onExpand = { onDisplayModeChange(MiniPlayerDisplayMode.Expanded) },
-                    largeLayout = largeLayout
+                    largeLayout = largeLayout,
+                    compactScale = resolvedCompactScale
                 )
             }
 
             MiniPlayerDisplayMode.Expanded -> {
                 BoxWithConstraints {
                     val widthProgress = ((maxWidth.value - 220f) / 280f).coerceIn(0f, 1f)
-                    val controlsSpacing = ((if (largeLayout) 4f else 2f) + (if (largeLayout) 6f else 5f) * widthProgress).dp
-                    val controlsButtonSize = ((if (largeLayout) 32f else 28f) + (if (largeLayout) 8f else 6f) * widthProgress).dp
-                    val favoriteIconSize = if (largeLayout) 19.dp else 17.dp
-                    val playbackIconSize = if (largeLayout) 22.dp else 20.dp
-                    val queueIconSize = if (largeLayout) 20.dp else 18.dp
+                    val controlsSpacing =
+                        ((if (largeLayout) 4f else 2f) + (if (largeLayout) 6f else 5f) * widthProgress).dp *
+                            resolvedCompactScale
+                    val controlsButtonSize =
+                        ((if (largeLayout) 32f else 28f) + (if (largeLayout) 8f else 6f) * widthProgress).dp *
+                            resolvedCompactScale
+                    val favoriteIconSize = (if (largeLayout) 19.dp else 17.dp) * resolvedCompactScale
+                    val playbackIconSize = (if (largeLayout) 22.dp else 20.dp) * resolvedCompactScale
+                    val queueIconSize = (if (largeLayout) 20.dp else 18.dp) * resolvedCompactScale
 
                     ElevatedCard(
                         modifier = Modifier
@@ -206,8 +215,8 @@ fun MiniPlayer(
                         shape = RoundedCornerShape(
                             topStart = coverSize / 2,
                             bottomStart = coverSize / 2,
-                            topEnd = if (largeLayout) 26.dp else 22.dp,
-                            bottomEnd = if (largeLayout) 26.dp else 22.dp
+                            topEnd = expandedEndCornerRadius,
+                            bottomEnd = expandedEndCornerRadius
                         ),
                         colors = CardDefaults.elevatedCardColors(
                             containerColor = lerp(
@@ -240,7 +249,7 @@ fun MiniPlayer(
                                         model = metadata.artworkUri,
                                         contentDescription = null,
                                         contentScale = ContentScale.Crop,
-                                        placeholderCornerRadius = 52,
+                                        placeholderCornerRadius = (52 * resolvedCompactScale).roundToInt(),
                                         modifier = Modifier.fillMaxSize()
                                     )
                                 }
@@ -248,7 +257,10 @@ fun MiniPlayer(
                                 Column(
                                     modifier = Modifier
                                         .weight(1f)
-                                        .padding(start = if (largeLayout) 12.dp else 10.dp, end = 8.dp)
+                                        .padding(
+                                            start = (if (largeLayout) 12.dp else 10.dp) * resolvedCompactScale,
+                                            end = 8.dp * resolvedCompactScale
+                                        )
                                         .clickable(onClick = onOpenNowPlaying),
                                     verticalArrangement = Arrangement.Center
                                 ) {
@@ -271,7 +283,7 @@ fun MiniPlayer(
                                 Row(
                                     modifier = Modifier
                                         .fillMaxHeight()
-                                        .padding(end = 8.dp),
+                                        .padding(end = 8.dp * resolvedCompactScale),
                                     verticalAlignment = Alignment.CenterVertically,
                                     horizontalArrangement = Arrangement.spacedBy(controlsSpacing)
                                 ) {
@@ -318,7 +330,7 @@ fun MiniPlayer(
                                 progress = { progress },
                                 modifier = Modifier
                                     .fillMaxWidth()
-                                    .height(if (largeLayout) 3.dp else 2.dp),
+                                    .height((if (largeLayout) 3.dp else 2.dp) * resolvedCompactScale),
                                 color = colorScheme.primary,
                                 trackColor = colorScheme.primary.copy(alpha = 0.1f)
                             )
@@ -333,8 +345,8 @@ fun MiniPlayer(
                                 shape = RoundedCornerShape(
                                     topStart = coverSize / 2,
                                     bottomStart = coverSize / 2,
-                                    topEnd = if (largeLayout) 26.dp else 22.dp,
-                                    bottomEnd = if (largeLayout) 26.dp else 22.dp
+                                    topEnd = expandedEndCornerRadius,
+                                    bottomEnd = expandedEndCornerRadius
                                 )
                             )
                     )
@@ -350,12 +362,16 @@ private fun MiniPlayerCoverOnly(
     isPlaying: Boolean,
     onExpand: () -> Unit,
     largeLayout: Boolean,
+    compactScale: Float,
     modifier: Modifier = Modifier
 ) {
     val colorScheme = AsmrTheme.colorScheme
-    val compactMinWidth = if (largeLayout) 76.dp else 64.dp
-    val barHeight = if (largeLayout) 64.dp else 56.dp
-    val coverSize = if (largeLayout) 60.dp else 52.dp
+    val compactMinWidth = (if (largeLayout) 76.dp else 64.dp) * compactScale
+    val barHeight = (if (largeLayout) 64.dp else 56.dp) * compactScale
+    val coverSize = (if (largeLayout) 60.dp else 52.dp) * compactScale
+    val placeholderCornerRadius = ((if (largeLayout) 60 else 52) * compactScale)
+        .roundToInt()
+        .coerceAtLeast(1)
     val miniPlayerBorderColor = if (colorScheme.isDark) {
         Color.White.copy(alpha = 0.14f)
     } else {
@@ -380,13 +396,14 @@ private fun MiniPlayerCoverOnly(
                 model = artworkModel,
                 contentDescription = null,
                 contentScale = ContentScale.Crop,
-                placeholderCornerRadius = if (largeLayout) 60 else 52,
+                placeholderCornerRadius = placeholderCornerRadius,
                 modifier = Modifier.fillMaxSize()
             )
             MiniPlayerActivityBars(
                 isPlaying = isPlaying,
                 modifier = Modifier.align(Alignment.Center),
-                tint = Color.White
+                tint = Color.White,
+                compactScale = compactScale
             )
         }
     }
@@ -396,6 +413,7 @@ private fun MiniPlayerCoverOnly(
 private fun MiniPlayerActivityBars(
     isPlaying: Boolean,
     tint: Color,
+    compactScale: Float,
     modifier: Modifier = Modifier
 ) {
     val transition = rememberInfiniteTransition(label = "miniPlayerBars")
@@ -417,16 +435,17 @@ private fun MiniPlayerActivityBars(
 
     Row(
         modifier = modifier,
-        horizontalArrangement = Arrangement.spacedBy(1.8.dp),
+        horizontalArrangement = Arrangement.spacedBy(1.8.dp * compactScale),
         verticalAlignment = Alignment.CenterVertically
     ) {
         heights.forEachIndexed { index, height ->
-            val maxHeight = 8.2f + (index % 3) * 1.8f + index * 0.35f
+            val maxHeight = (8.2f + (index % 3) * 1.8f + index * 0.35f) * compactScale
+            val minHeight = 4f * compactScale
             Box(
                 modifier = Modifier
                     .size(
-                        width = 2.6.dp,
-                        height = (if (isPlaying) 4f + height.value * maxHeight else 4f).dp
+                        width = 2.6.dp * compactScale,
+                        height = (if (isPlaying) minHeight + height.value * maxHeight else minHeight).dp
                     )
                     .clip(RoundedCornerShape(99.dp))
                     .background(tint)

--- a/app/src/test/java/com/asmr/player/ui/nav/BottomChromeTest.kt
+++ b/app/src/test/java/com/asmr/player/ui/nav/BottomChromeTest.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.size
 import androidx.compose.material3.Text
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -15,6 +16,7 @@ import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performTouchInput
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.junit.Assert.assertEquals
@@ -99,6 +101,180 @@ class BottomChromeTest {
     }
 
     @Test
+    fun compactWidthWithMiniPlayer_scalesChromeWithoutChangingVisibleNavCount_336dp() {
+        compactWidthWithMiniPlayer_scalesChromeWithoutChangingVisibleNavCount(336.dp)
+    }
+
+    @Test
+    fun compactWidthWithMiniPlayer_scalesChromeWithoutChangingVisibleNavCount_360dp() {
+        compactWidthWithMiniPlayer_scalesChromeWithoutChangingVisibleNavCount(360.dp)
+    }
+
+    @Test
+    fun compactWidthWithMiniPlayer_keepsNavHeightStableBetweenModes() {
+        val displayMode = mutableStateOf(MiniPlayerDisplayMode.CoverOnly)
+
+        composeRule.setContent {
+            AsmrPlayerTheme {
+                BottomChrome(
+                    activeRoute = Routes.Library,
+                    miniPlayerVisible = true,
+                    miniPlayerDisplayMode = displayMode.value,
+                    onMiniPlayerDisplayModeChange = {},
+                    onOpenNowPlaying = {},
+                    onOpenQueue = {},
+                    onNavigate = {},
+                    modifier = Modifier.size(width = 336.dp, height = 120.dp),
+                    miniPlayerContent = { miniModifier ->
+                        Box(
+                            modifier = miniModifier.height(56.dp),
+                            contentAlignment = Alignment.Center
+                        ) {
+                            Text("Mini")
+                        }
+                    }
+                )
+            }
+        }
+
+        val coverOnlyBounds = composeRule.onNodeWithTag(BottomNavBarTag).getUnclippedBoundsInRoot()
+        val coverOnlyHeight = coverOnlyBounds.bottom - coverOnlyBounds.top
+
+        composeRule.runOnIdle {
+            displayMode.value = MiniPlayerDisplayMode.Expanded
+        }
+        composeRule.waitForIdle()
+
+        val expandedBounds = composeRule.onNodeWithTag(BottomNavBarTag).getUnclippedBoundsInRoot()
+        val expandedHeight = expandedBounds.bottom - expandedBounds.top
+
+        assertTrue(
+            "Expected compact nav bar height to stay stable while mini player expands",
+            abs((coverOnlyHeight - expandedHeight).value) <= 0.5f
+        )
+    }
+
+    @Test
+    fun compactWidthWithMiniPlayer_doesNotJumpActiveItemWhenExpanding() {
+        val displayMode = mutableStateOf(MiniPlayerDisplayMode.CoverOnly)
+        composeRule.mainClock.autoAdvance = false
+        try {
+            composeRule.setContent {
+                AsmrPlayerTheme {
+                    BottomChrome(
+                        activeRoute = "settings",
+                        miniPlayerVisible = true,
+                        miniPlayerDisplayMode = displayMode.value,
+                        onMiniPlayerDisplayModeChange = {},
+                        onOpenNowPlaying = {},
+                        onOpenQueue = {},
+                        onNavigate = {},
+                        modifier = Modifier.size(width = 336.dp, height = 120.dp),
+                        miniPlayerContent = { miniModifier ->
+                            Box(
+                                modifier = miniModifier.height(56.dp),
+                                contentAlignment = Alignment.Center
+                            ) {
+                                Text("Mini")
+                            }
+                        }
+                    )
+                }
+            }
+
+            composeRule.waitForIdle()
+            val beforeLeft = composeRule.onNodeWithTag("bottomNavItem:settings")
+                .getUnclippedBoundsInRoot()
+                .left
+
+            composeRule.runOnIdle {
+                displayMode.value = MiniPlayerDisplayMode.Expanded
+            }
+            composeRule.waitForIdle()
+
+            val afterLeft = composeRule.onNodeWithTag("bottomNavItem:settings")
+                .getUnclippedBoundsInRoot()
+                .left
+
+            assertTrue(
+                "Expected active nav item not to jump horizontally on the first expand frame",
+                abs((afterLeft - beforeLeft).value) <= 0.5f
+            )
+        } finally {
+            composeRule.mainClock.autoAdvance = true
+        }
+    }
+
+    @Test
+    fun compactWidthWithMiniPlayer_activeItemFollowsCollapseWithoutHorizontalBacktrack() {
+        val displayMode = mutableStateOf(MiniPlayerDisplayMode.CoverOnly)
+        composeRule.mainClock.autoAdvance = false
+        try {
+            composeRule.setContent {
+                AsmrPlayerTheme {
+                    BottomChrome(
+                        activeRoute = "settings",
+                        miniPlayerVisible = true,
+                        miniPlayerDisplayMode = displayMode.value,
+                        onMiniPlayerDisplayModeChange = {},
+                        onOpenNowPlaying = {},
+                        onOpenQueue = {},
+                        onNavigate = {},
+                        modifier = Modifier.size(width = 336.dp, height = 120.dp),
+                        miniPlayerContent = { miniModifier ->
+                            Box(
+                                modifier = miniModifier.height(56.dp),
+                                contentAlignment = Alignment.Center
+                            ) {
+                                Text("Mini")
+                            }
+                        }
+                    )
+                }
+            }
+
+            composeRule.waitForIdle()
+            val collapseCenters = mutableListOf(activeItemCenterX("settings"))
+            composeRule.runOnIdle {
+                displayMode.value = MiniPlayerDisplayMode.Expanded
+            }
+            repeat(30) {
+                composeRule.mainClock.advanceTimeByFrame()
+                composeRule.waitForIdle()
+                collapseCenters += activeItemCenterX("settings")
+            }
+
+            assertNoHorizontalBacktrack(
+                label = "collapsing nav active item",
+                positions = collapseCenters
+            )
+            val totalCollapseMove = abs(collapseCenters.last() - collapseCenters.first())
+            val earlyCollapseMove = abs(collapseCenters[4] - collapseCenters.first())
+            assertTrue(
+                "Expected the active item to start moving with the collapse animation instead of snapping late",
+                earlyCollapseMove >= totalCollapseMove * 0.08f
+            )
+
+            val expandCenters = mutableListOf(activeItemCenterX("settings"))
+            composeRule.runOnIdle {
+                displayMode.value = MiniPlayerDisplayMode.CoverOnly
+            }
+            repeat(30) {
+                composeRule.mainClock.advanceTimeByFrame()
+                composeRule.waitForIdle()
+                expandCenters += activeItemCenterX("settings")
+            }
+
+            assertNoHorizontalBacktrack(
+                label = "expanding nav active item",
+                positions = expandCenters
+            )
+        } finally {
+            composeRule.mainClock.autoAdvance = true
+        }
+    }
+
+    @Test
     fun navBar_withoutMiniPlayer_staysCentered() {
         composeRule.setContent {
             AsmrPlayerTheme {
@@ -155,8 +331,7 @@ class BottomChromeTest {
                         miniPlayerContent = { miniModifier ->
                             Box(
                                 modifier = miniModifier
-                                    .height(56.dp)
-                                    .testTag("testMiniPlayer"),
+                                    .height(56.dp),
                                 contentAlignment = Alignment.Center
                             ) {
                                 Text("Mini")
@@ -169,7 +344,7 @@ class BottomChromeTest {
 
         val rootBounds = composeRule.onNodeWithTag(BOTTOM_CHROME_ROOT_TAG).getUnclippedBoundsInRoot()
         val navBounds = composeRule.onNodeWithTag(BottomNavBarTag).getUnclippedBoundsInRoot()
-        val miniBounds = composeRule.onNodeWithTag("testMiniPlayer").getUnclippedBoundsInRoot()
+        val miniBounds = composeRule.onNodeWithTag(BottomChromeMiniPlayerTag).getUnclippedBoundsInRoot()
         val rootCenterX = (rootBounds.left + rootBounds.right) / 2f
         val groupCenterX = (navBounds.left + miniBounds.right) / 2f
 
@@ -209,5 +384,67 @@ class BottomChromeTest {
         assertEquals(activeContainer.green, partial.green, 0.0001f)
         assertEquals(activeContainer.blue, partial.blue, 0.0001f)
         assertTrue(abs(partial.alpha - (activeContainer.alpha * 0.5f)) <= 0.0001f)
+    }
+
+    private fun compactWidthWithMiniPlayer_scalesChromeWithoutChangingVisibleNavCount(width: Dp) {
+        composeRule.setContent {
+            AsmrPlayerTheme {
+                BottomChrome(
+                    activeRoute = Routes.Library,
+                    miniPlayerVisible = true,
+                    miniPlayerDisplayMode = MiniPlayerDisplayMode.CoverOnly,
+                    onMiniPlayerDisplayModeChange = {},
+                    onOpenNowPlaying = {},
+                    onOpenQueue = {},
+                    onNavigate = {},
+                    modifier = Modifier.size(width = width, height = 120.dp),
+                    miniPlayerContent = { miniModifier ->
+                        Box(
+                            modifier = miniModifier
+                                .height(56.dp),
+                            contentAlignment = Alignment.Center
+                        ) {
+                            Text("Mini")
+                        }
+                    }
+                )
+            }
+        }
+
+        val navBounds = composeRule.onNodeWithTag(BottomNavBarTag).getUnclippedBoundsInRoot()
+        val overflowBounds = composeRule.onNodeWithTag(BottomNavOverflowTag).getUnclippedBoundsInRoot()
+        val miniBounds = composeRule.onNodeWithTag(BottomChromeMiniPlayerTag).getUnclippedBoundsInRoot()
+        composeRule.onNodeWithTag("bottomNavItem:playlist_system/favorites").getUnclippedBoundsInRoot()
+
+        assertTrue(
+            "Expected compact overflow toggle to stay inside the nav bar",
+            overflowBounds.right.value <= navBounds.right.value + 0.5f
+        )
+        assertTrue(
+            "Expected compact nav bar and mini player not to overlap",
+            navBounds.right.value <= miniBounds.left.value + 0.5f
+        )
+
+        composeRule.onNodeWithTag(BottomNavOverflowTag).performClick()
+        composeRule.onNodeWithTag("bottomNavItem:playlists").getUnclippedBoundsInRoot()
+    }
+
+    private fun activeItemCenterX(route: String): Float {
+        val bounds = composeRule.onNodeWithTag("bottomNavItem:$route")
+            .getUnclippedBoundsInRoot()
+        return ((bounds.left + bounds.right) / 2f).value
+    }
+
+    private fun assertNoHorizontalBacktrack(label: String, positions: List<Float>) {
+        val meaningfulDeltas = positions
+            .zipWithNext { previous, next -> next - previous }
+            .filter { abs(it) > 0.25f }
+        if (meaningfulDeltas.isEmpty()) return
+
+        val direction = meaningfulDeltas.first()
+        assertTrue(
+            "Expected $label to move in one horizontal direction without backtracking: $positions",
+            meaningfulDeltas.all { it * direction >= -0.01f }
+        )
     }
 }


### PR DESCRIPTION
## Summary
- 修复紧凑宽度设备上底部导航与迷你播放栏并排时的溢出、不可点击问题
- 保持底部导航固定 4 个导航项 + 1 个切换按钮，不再按宽度动态改变按钮数量
- 为紧凑宽度等比例缩放底部导航和迷你播放栏尺寸、间距
- 将展开/折叠改为固定轨道 + 单一进度驱动，减少左右抖动和尺寸抖动
- 使用标准 Android navigation bar insets 抬高底部 Chrome 和 overlay padding

## Tests
- .\gradlew-local.bat :app:testDebugUnitTest --tests com.asmr.player.ui.nav.BottomChromeTest
- .\gradlew-local.bat :app:installRelease
  - Installed on Small_Phone_API_36(AVD) - 16