### PR TITLE
Fix album detail loading states

### DIFF
--- a/app/src/main/java/com/asmr/player/main/MainContainer.kt
+++ b/app/src/main/java/com/asmr/player/main/MainContainer.kt
@@ -2020,7 +2020,16 @@ fun MainContainer(
                             albumBatchPlaylistPickerRequest = BatchPlaylistPickerRequest(listOf(item))
                         },
                         onOpenDlsiteLogin = { navController.navigateSingleTop("dlsite_login") },
-                        onOpenAlbumByRj = { navigator.openAlbumDetailByRjStacked(it) }
+                        onOpenAlbumByRj = { targetRj, work ->
+                            AlbumCoverHintStore.record(
+                                albumId = null,
+                                rjCode = targetRj,
+                                title = work?.title,
+                                circle = null,
+                                coverUrl = work?.coverUrl
+                            )
+                            navigator.openAlbumDetailByRjStacked(targetRj)
+                        }
                     )
                 }
                 composable(
@@ -2065,7 +2074,16 @@ fun MainContainer(
                             albumBatchPlaylistPickerRequest = BatchPlaylistPickerRequest(listOf(item))
                         },
                         onOpenDlsiteLogin = { navController.navigateSingleTop("dlsite_login") },
-                        onOpenAlbumByRj = { navigator.openAlbumDetailByRjStacked(it) }
+                        onOpenAlbumByRj = { targetRj, work ->
+                            AlbumCoverHintStore.record(
+                                albumId = null,
+                                rjCode = targetRj,
+                                title = work?.title,
+                                circle = null,
+                                coverUrl = work?.coverUrl
+                            )
+                            navigator.openAlbumDetailByRjStacked(targetRj)
+                        }
                     )
                 }
                 composable(
@@ -2097,7 +2115,16 @@ fun MainContainer(
                             albumBatchPlaylistPickerRequest = BatchPlaylistPickerRequest(listOf(item))
                         },
                         onOpenDlsiteLogin = { navController.navigateSingleTop("dlsite_login") },
-                        onOpenAlbumByRj = { navigator.openAlbumDetailByRjStacked(it) }
+                        onOpenAlbumByRj = { targetRj, work ->
+                            AlbumCoverHintStore.record(
+                                albumId = null,
+                                rjCode = targetRj,
+                                title = work?.title,
+                                circle = null,
+                                coverUrl = work?.coverUrl
+                            )
+                            navigator.openAlbumDetailByRjStacked(targetRj)
+                        }
                     )
                 }
                 composable(

--- a/app/src/main/java/com/asmr/player/ui/common/AsmrAsyncImage.kt
+++ b/app/src/main/java/com/asmr/player/ui/common/AsmrAsyncImage.kt
@@ -147,13 +147,14 @@ fun AsmrAsyncImage(
     val p = painter.value
     val currentState = state.value
     val progress = crossfade.value.coerceIn(0f, 1f)
+    val hasSeededPainter = p != null && seededPlaceholder.value
     Box(modifier = containerModifier) {
         when {
             currentState == AsmrAsyncImageState.Error -> {
                 placeholder(contentModifier)
             }
             else -> {
-                if (currentState == AsmrAsyncImageState.Loading || (fadeIn && progress < 1f)) {
+                if (!hasSeededPainter && (currentState == AsmrAsyncImageState.Loading || (fadeIn && progress < 1f))) {
                     val loadingAlpha = if (currentState == AsmrAsyncImageState.Loading) 1f else (1f - progress)
                     val loadingModifier = if (loadingAlpha >= 0.999f) {
                         contentModifier

--- a/app/src/main/java/com/asmr/player/ui/library/AlbumDetailScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/AlbumDetailScreen.kt
@@ -300,7 +300,7 @@ fun AlbumDetailScreen(
     onAddMediaItemsToFavorites: (List<MediaItem>) -> Unit = {},
     onOpenPlaylistPicker: (MediaItem) -> Unit = {},
     onOpenDlsiteLogin: () -> Unit = {},
-    onOpenAlbumByRj: (String) -> Unit = {},
+    onOpenAlbumByRj: (String, DlsiteRecommendedWork?) -> Unit = { _, _ -> },
     initialTab: Int? = null,
     viewModel: AlbumDetailViewModel = hiltViewModel()
 ) {
@@ -821,6 +821,7 @@ fun AlbumDetailScreen(
                                         isAwaitingInitialLoad = !model.hasLoadedInitialDlsiteContent,
                                         isAwaitingAsmrOneLoad = !model.hasResolvedAsmrOneContent &&
                                             asmrOneTree.isEmpty(),
+                                        hasResolvedAsmrOneContent = model.hasResolvedAsmrOneContent,
                                         asmrOneTree = asmrOneTree,
                                         isLoadingAsmrOne = model.isLoadingAsmrOne,
                                         isLoadingTrial = model.isLoadingDlsiteTrial,
@@ -1147,7 +1148,7 @@ private fun AlbumDetailHeroBackground(
             contentScale = ContentScale.Crop,
             alignment = Alignment.TopCenter,
             placeholderCornerRadius = 0,
-            peekAnySizeForInitial = false,
+            peekAnySizeForInitial = true,
             loadAtOriginalSize = true,
             modifier = Modifier
                 .fillMaxSize()
@@ -1198,7 +1199,7 @@ private fun AlbumDetailHeroBackground(
             contentScale = ContentScale.Crop,
             alignment = Alignment.TopCenter,
             placeholderCornerRadius = 0,
-            peekAnySizeForInitial = false,
+            peekAnySizeForInitial = true,
             loadAtOriginalSize = true,
             modifier = Modifier
                 .fillMaxSize()

--- a/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailDlsiteTabs.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailDlsiteTabs.kt
@@ -9,6 +9,7 @@ import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.SizeTransform
 import androidx.compose.animation.animateContentSize
+import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.FastOutSlowInEasing
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.animateDpAsState
@@ -58,6 +59,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.graphics.RectangleShape
+import androidx.compose.ui.graphics.CompositingStrategy
 import androidx.compose.foundation.gestures.detectTransformGestures
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.pointer.pointerInput
@@ -189,11 +191,21 @@ private fun DlsiteSectionPlaceholderLine(
 }
 
 @Composable
-private fun DlsiteDirectoryLoadingPanel() {
+private fun rememberDlsiteDirectoryListHeight(): Dp {
     val screenHeight = androidx.compose.ui.platform.LocalConfiguration.current.screenHeightDp.dp
-    val fixedHeight = remember(screenHeight) {
+    return remember(screenHeight) {
         (screenHeight * 0.48f).coerceIn(240.dp, 460.dp)
     }
+}
+
+@Composable
+private fun rememberStableOneDirectoryContainerHeight(): Dp {
+    return rememberDlsiteDirectoryListHeight() + 152.dp
+}
+
+@Composable
+private fun DlsiteDirectoryLoadingPanel() {
+    val fixedHeight = rememberDlsiteDirectoryListHeight()
     Surface(
         shape = RoundedCornerShape(12.dp),
         tonalElevation = 1.dp,
@@ -699,6 +711,47 @@ private fun LazyItemScope.dlsiteAnimatedSectionModifier(
 }
 
 @Composable
+private fun StableOneDirectoryTreeContent(
+    targetState: DirectoryTreePanelState,
+    modifier: Modifier = Modifier,
+    content: @Composable (DirectoryTreePanelState) -> Unit
+) {
+    val contentAlpha = remember { Animatable(if (targetState == DirectoryTreePanelState.Content) 0f else 1f) }
+    LaunchedEffect(targetState) {
+        if (targetState == DirectoryTreePanelState.Content) {
+            contentAlpha.snapTo(0f)
+            contentAlpha.animateTo(1f, animationSpec = tween(durationMillis = 220, easing = FastOutSlowInEasing))
+        } else {
+            contentAlpha.snapTo(1f)
+        }
+    }
+    AnimatedContent(
+        targetState = targetState,
+        modifier = modifier
+            .height(rememberStableOneDirectoryContainerHeight())
+            .clipToBounds(),
+        transitionSpec = {
+            fadeIn(animationSpec = tween(durationMillis = 140))
+                .togetherWith(fadeOut(animationSpec = tween(durationMillis = 90)))
+        },
+        label = "stableAsmrOneDirectoryTree",
+        content = { state ->
+            val stateModifier = if (state == DirectoryTreePanelState.Content) {
+                Modifier.graphicsLayer {
+                    alpha = contentAlpha.value
+                    compositingStrategy = CompositingStrategy.ModulateAlpha
+                }
+            } else {
+                Modifier
+            }
+            Box(modifier = stateModifier.fillMaxSize()) {
+                content(state)
+            }
+        }
+    )
+}
+
+@Composable
 private fun DirectoryTreeAnimatedContent(
     targetState: DirectoryTreePanelState,
     label: String,
@@ -732,15 +785,16 @@ private fun DirectoryTreeAnimatedContent(
 
 internal fun shouldShowAsmrOneDirectoryLoading(
     isAwaitingAsmrOneLoad: Boolean,
+    hasResolvedAsmrOneContent: Boolean,
     isLoadingAsmrOne: Boolean,
     hasAsmrOneTree: Boolean,
     hasDirectoryBrowser: Boolean
 ): Boolean {
-    return !hasDirectoryBrowser && (
-        isAwaitingAsmrOneLoad ||
-            isLoadingAsmrOne ||
-            hasAsmrOneTree
-        )
+    if (hasDirectoryBrowser && hasAsmrOneTree) return false
+    return isAwaitingAsmrOneLoad ||
+        !hasResolvedAsmrOneContent ||
+        isLoadingAsmrOne ||
+        hasAsmrOneTree
 }
 
 internal fun shouldShowDlsitePlayDirectoryLoading(
@@ -768,6 +822,7 @@ internal fun AlbumDlsiteInfoBreadcrumbTabV2(
     isLoading: Boolean,
     isAwaitingInitialLoad: Boolean,
     isAwaitingAsmrOneLoad: Boolean,
+    hasResolvedAsmrOneContent: Boolean,
     asmrOneTree: List<AsmrOneTrackNodeResponse>,
     isLoadingAsmrOne: Boolean,
     isLoadingTrial: Boolean,
@@ -794,7 +849,7 @@ internal fun AlbumDlsiteInfoBreadcrumbTabV2(
     initialScroll: Pair<Int, Int>,
     onPersistScroll: (Int, Int) -> Unit,
     dlsiteRecommendations: DlsiteRecommendations,
-    onOpenAlbumByRj: (String) -> Unit,
+    onOpenAlbumByRj: (String, DlsiteRecommendedWork?) -> Unit,
     loadRemoteFileSize: suspend (String) -> Long?
 ) {
     val scope = rememberCoroutineScope()
@@ -844,6 +899,7 @@ internal fun AlbumDlsiteInfoBreadcrumbTabV2(
     val isInitialDlsiteLoading = isLoading || isAwaitingInitialLoad
     val isAsmrOnePending = shouldShowAsmrOneDirectoryLoading(
         isAwaitingAsmrOneLoad = isAwaitingAsmrOneLoad,
+        hasResolvedAsmrOneContent = hasResolvedAsmrOneContent,
         isLoadingAsmrOne = isLoadingAsmrOne,
         hasAsmrOneTree = asmrOneTree.isNotEmpty(),
         hasDirectoryBrowser = browser != null
@@ -947,9 +1003,8 @@ internal fun AlbumDlsiteInfoBreadcrumbTabV2(
         }
         item(key = "dlsite-one-content") {
             Box(modifier = dlsiteAnimatedSectionModifier(Modifier.fillMaxWidth(), animateIntro)) {
-                DirectoryTreeAnimatedContent(
+                StableOneDirectoryTreeContent(
                     targetState = asmrOnePanelState,
-                    label = "asmrOneDirectoryTree",
                     modifier = Modifier.fillMaxWidth()
                 ) { panelState ->
                     when (panelState) {
@@ -969,7 +1024,7 @@ internal fun AlbumDlsiteInfoBreadcrumbTabV2(
                                     onAddToFavorites = onAddMediaItemsToFavorites,
                                     onOpenBatchPlaylistPicker = onOpenBatchPlaylistPicker,
                                     onAddMediaItemsToQueue = onAddMediaItemsToQueue,
-                                    animateIntro = animateIntro,
+                                    animateIntro = false,
                                     parentChromeState = chromeState,
                                     folderKeyPrefix = "asmr-folder",
                                     fileKeyPrefix = "asmr-file",

--- a/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailSharedSections.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailSharedSections.kt
@@ -237,7 +237,7 @@ internal fun AlbumDescription(album: Album) {
 @Composable
 internal fun DlsiteRecommendationsBlocks(
     recommendations: DlsiteRecommendations,
-    onOpenAlbumByRj: (String) -> Unit
+    onOpenAlbumByRj: (String, DlsiteRecommendedWork?) -> Unit
 ) {
     if (recommendations.circleWorks.isEmpty() && 
         recommendations.sameVoiceWorks.isEmpty() && 
@@ -271,7 +271,7 @@ internal fun DlsiteRecommendationsBlocks(
 private fun DlsiteRecommendationsBlock(
     title: String,
     items: List<DlsiteRecommendedWork>,
-    onOpenAlbumByRj: (String) -> Unit
+    onOpenAlbumByRj: (String, DlsiteRecommendedWork?) -> Unit
 ) {
     if (items.isEmpty()) return
     val colorScheme = AsmrTheme.colorScheme
@@ -290,7 +290,7 @@ private fun DlsiteRecommendationsBlock(
                 }
             ) { _, w ->
                 val rj = sanitizeRj(w.rjCode).ifBlank { w.rjCode }
-                DlsiteRecommendedWorkCard(work = w, displayRj = rj, onClick = { onOpenAlbumByRj(rj) })
+                DlsiteRecommendedWorkCard(work = w, displayRj = rj, onClick = { onOpenAlbumByRj(rj, w) })
             }
         }
     }

--- a/app/src/test/java/com/asmr/player/ui/library/AlbumDetailOneStateTest.kt
+++ b/app/src/test/java/com/asmr/player/ui/library/AlbumDetailOneStateTest.kt
@@ -11,6 +11,7 @@ class AlbumDetailOneStateTest {
         assertTrue(
             shouldShowAsmrOneDirectoryLoading(
                 isAwaitingAsmrOneLoad = true,
+                hasResolvedAsmrOneContent = false,
                 isLoadingAsmrOne = false,
                 hasAsmrOneTree = false,
                 hasDirectoryBrowser = false
@@ -19,6 +20,7 @@ class AlbumDetailOneStateTest {
         assertTrue(
             shouldShowAsmrOneDirectoryLoading(
                 isAwaitingAsmrOneLoad = false,
+                hasResolvedAsmrOneContent = true,
                 isLoadingAsmrOne = false,
                 hasAsmrOneTree = true,
                 hasDirectoryBrowser = false
@@ -27,6 +29,7 @@ class AlbumDetailOneStateTest {
         assertFalse(
             shouldShowAsmrOneDirectoryLoading(
                 isAwaitingAsmrOneLoad = false,
+                hasResolvedAsmrOneContent = true,
                 isLoadingAsmrOne = true,
                 hasAsmrOneTree = true,
                 hasDirectoryBrowser = true
@@ -35,9 +38,36 @@ class AlbumDetailOneStateTest {
         assertFalse(
             shouldShowAsmrOneDirectoryLoading(
                 isAwaitingAsmrOneLoad = false,
+                hasResolvedAsmrOneContent = true,
                 isLoadingAsmrOne = false,
                 hasAsmrOneTree = false,
                 hasDirectoryBrowser = false
+            )
+        )
+    }
+
+    @Test
+    fun shouldShowAsmrOneDirectoryLoading_waitsUntilFallbackCompletes() {
+        assertTrue(
+            shouldShowAsmrOneDirectoryLoading(
+                isAwaitingAsmrOneLoad = false,
+                hasResolvedAsmrOneContent = false,
+                isLoadingAsmrOne = false,
+                hasAsmrOneTree = false,
+                hasDirectoryBrowser = false
+            )
+        )
+    }
+
+    @Test
+    fun shouldShowAsmrOneDirectoryLoading_ignoresEmptyDirectoryBrowserBeforeResolved() {
+        assertTrue(
+            shouldShowAsmrOneDirectoryLoading(
+                isAwaitingAsmrOneLoad = false,
+                hasResolvedAsmrOneContent = false,
+                isLoadingAsmrOne = false,
+                hasAsmrOneTree = false,
+                hasDirectoryBrowser = true
             )
         )
     }


### PR DESCRIPTION
﻿## Summary
- reuse cached album covers in the detail hero without showing skeleton over cached images
- keep ONE directory loading visible through backend-to-asmr.one fallback and stabilize its layout while fading content in
- seed recommended work title and cover before opening its album detail page

## Verification
- .\gradlew-local.bat :app:testReleaseUnitTest --tests "com.asmr.player.ui.library.AlbumDetailOneStateTest"
- .\gradlew-local.bat :app:installRelease
