### PR TITLE
Fix page bounce after inertial list scroll

### DIFF
--- a/app/src/main/java/com/asmr/player/main/MainContainer.kt
+++ b/app/src/main/java/com/asmr/player/main/MainContainer.kt
@@ -6,10 +6,12 @@ import android.view.WindowManager
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.BackHandler
 import androidx.activity.compose.setContent
+import androidx.compose.foundation.MutatePriority
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.gestures.stopScroll
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.PagerState
 import androidx.compose.foundation.pager.PagerDefaults
@@ -775,6 +777,7 @@ fun MainContainer(
             primaryNavigationJob = scope.launch {
                 var completed = false
                 try {
+                    primaryPagerState.stopScroll(MutatePriority.PreventUserInput)
                     val currentPage = primaryPagerState.currentPage
                     resolvePrimaryPagerApproachPage(
                         currentPage = currentPage,
@@ -917,27 +920,57 @@ fun MainContainer(
         val route = currentPrimaryRoute ?: return@LaunchedEffect
         val pendingRoute = pendingPrimaryNavigationRoute
         if (pendingRoute != null) {
-            if (route == pendingRoute && primaryNavigationJob == null) {
+            val pendingPage = primaryPagerRoutes.indexOf(pendingRoute)
+            if (
+                shouldClearPendingPrimaryNavigationRoute(
+                    currentRoute = route,
+                    pendingRoute = pendingRoute,
+                    navigationInProgress = primaryNavigationJob != null,
+                    pendingPage = pendingPage,
+                    settledPage = primaryPagerState.settledPage
+                )
+            ) {
                 pendingPrimaryNavigationRoute = null
+            } else if (
+                route == pendingRoute &&
+                primaryNavigationJob == null &&
+                shouldSyncPrimaryPagerToRoute(
+                    targetPage = pendingPage,
+                    settledPage = primaryPagerState.settledPage
+                )
+            ) {
+                primaryPagerState.stopScroll(MutatePriority.PreventUserInput)
+                primaryPagerState.scrollToPage(pendingPage)
             }
             return@LaunchedEffect
         }
         val targetPage = primaryPagerRoutes.indexOf(route)
-        if (targetPage >= 0 && primaryPagerState.currentPage != targetPage) {
+        if (
+            shouldSyncPrimaryPagerToRoute(
+                targetPage = targetPage,
+                settledPage = primaryPagerState.settledPage
+            )
+        ) {
+            primaryPagerState.stopScroll(MutatePriority.PreventUserInput)
             primaryPagerState.scrollToPage(targetPage)
         }
     }
 
-    LaunchedEffect(primaryPagerState, primaryPagerRoutes) {
+    LaunchedEffect(primaryPagerState) {
         snapshotFlow { primaryPagerState.isScrollInProgress }
-            .collect { inProgress ->
-                if (inProgress) {
-                    focusManager.clearFocus(force = true)
-                    keyboardController?.hide()
-                    return@collect
-                }
+            .distinctUntilChanged()
+            .filter { it }
+            .collect {
+                focusManager.clearFocus(force = true)
+                keyboardController?.hide()
+            }
+    }
+
+    LaunchedEffect(primaryPagerState, primaryPagerRoutes) {
+        snapshotFlow { primaryPagerState.settledPage }
+            .distinctUntilChanged()
+            .collect { page ->
                 if (pendingPrimaryNavigationRouteState.value != null) return@collect
-                val page = primaryPagerState.currentPage
                 val currentPrimary = currentPrimaryRouteState.value ?: return@collect
                 val targetRoute = primaryPagerRoutes.getOrNull(page) ?: return@collect
                 if (targetRoute != currentPrimary) {
@@ -1656,6 +1689,7 @@ fun MainContainer(
                                         Routes.Library -> {
                                             LibraryScreen(
                                                 windowSizeClass = windowSizeClass,
+                                                isActive = visualPrimaryRoute == route,
                                                 scrollToTopSignal = libraryScrollToTopSignal,
                                                 onAlbumClick = { album ->
                                                     AlbumCoverHintStore.record(
@@ -1692,6 +1726,7 @@ fun MainContainer(
                                         Routes.Search -> {
                                             SearchScreen(
                                                 windowSizeClass = windowSizeClass,
+                                                isActive = visualPrimaryRoute == route,
                                                 scrollToTopSignal = searchScrollToTopSignal,
                                                 submittedSearchKeyword = submittedSearchKeyword,
                                                 submittedSearchOrderName = submittedSearchOrderName,
@@ -1740,6 +1775,7 @@ fun MainContainer(
                                         Routes.HotListening -> {
                                             HotListeningScreen(
                                                 windowSizeClass = windowSizeClass,
+                                                isActive = visualPrimaryRoute == route,
                                                 scrollToTopSignal = hotListeningScrollToTopSignal,
                                                 onAlbumClick = { album ->
                                                     AlbumCoverHintStore.record(
@@ -1768,6 +1804,7 @@ fun MainContainer(
                                         "playlist_system/favorites" -> {
                                             SystemPlaylistScreen(
                                                 windowSizeClass = windowSizeClass,
+                                                isActive = visualPrimaryRoute == route,
                                                 scrollToTopSignal = favoritesScrollToTopSignal,
                                                 onPlayAll = { items, startItem ->
                                                     playerViewModel.playPlaylistItems(items, startItem)
@@ -1780,6 +1817,7 @@ fun MainContainer(
                                         "playlists" -> {
                                             PlaylistsScreen(
                                                 windowSizeClass = windowSizeClass,
+                                                isActive = visualPrimaryRoute == route,
                                                 scrollToTopSignal = playlistsScrollToTopSignal,
                                                 onPlaylistClick = { playlist ->
                                                     val encoded = URLEncoder.encode(playlist.name, "UTF-8")
@@ -1792,6 +1830,7 @@ fun MainContainer(
                                         "groups" -> {
                                             com.asmr.player.ui.groups.AlbumGroupsScreen(
                                                 windowSizeClass = windowSizeClass,
+                                                isActive = visualPrimaryRoute == route,
                                                 scrollToTopSignal = groupsScrollToTopSignal,
                                                 onGroupClick = { group ->
                                                     val encoded = encodeRouteArg(group.name)
@@ -1804,6 +1843,7 @@ fun MainContainer(
                                         "settings" -> {
                                             SettingsScreen(
                                                 windowSizeClass = windowSizeClass,
+                                                isActive = visualPrimaryRoute == route,
                                                 viewModel = settingsViewModel,
                                                 libraryViewModel = libraryViewModel,
                                                 scrollToTopSignal = settingsScrollToTopSignal,

--- a/app/src/main/java/com/asmr/player/main/MainNavigationSupport.kt
+++ b/app/src/main/java/com/asmr/player/main/MainNavigationSupport.kt
@@ -259,6 +259,23 @@ internal fun resolvePrimaryPagerApproachPage(
     return targetPage + if (targetPage > currentPage) -1 else 1
 }
 
+internal fun shouldSyncPrimaryPagerToRoute(
+    targetPage: Int,
+    settledPage: Int
+): Boolean = targetPage >= 0 && settledPage != targetPage
+
+internal fun shouldClearPendingPrimaryNavigationRoute(
+    currentRoute: String?,
+    pendingRoute: String?,
+    navigationInProgress: Boolean,
+    pendingPage: Int,
+    settledPage: Int
+): Boolean {
+    if (pendingRoute.isNullOrBlank()) return false
+    if (currentRoute != pendingRoute || navigationInProgress) return false
+    return pendingPage >= 0 && settledPage == pendingPage
+}
+
 internal fun resolvePrimaryPagerBeyondBoundsPageCount(pageCount: Int): Int {
     return (pageCount - 1).coerceAtLeast(0)
 }

--- a/app/src/main/java/com/asmr/player/ui/downloads/DownloadsScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/downloads/DownloadsScreen.kt
@@ -2,8 +2,10 @@
 
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.tween
+import androidx.compose.foundation.MutatePriority
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.stopScroll
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -84,6 +86,7 @@ private val DownloadsPageHorizontalPadding = 8.dp
 @Composable
 fun DownloadsScreen(
     windowSizeClass: WindowSizeClass,
+    isActive: Boolean = true,
     scrollToTopSignal: Long = 0L,
     viewModel: DownloadsViewModel = hiltViewModel()
 ) {
@@ -100,6 +103,10 @@ fun DownloadsScreen(
     LaunchedEffect(scrollToTopSignal) {
         if (scrollToTopSignal == 0L) return@LaunchedEffect
         listState.smoothScrollToTop()
+    }
+    LaunchedEffect(isActive) {
+        if (isActive) return@LaunchedEffect
+        listState.stopScroll(MutatePriority.PreventUserInput)
     }
 
     val isCompact = windowSizeClass.widthSizeClass == WindowWidthSizeClass.Compact

--- a/app/src/main/java/com/asmr/player/ui/groups/AlbumGroupsScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/groups/AlbumGroupsScreen.kt
@@ -1,7 +1,9 @@
 package com.asmr.player.ui.groups
 
+import androidx.compose.foundation.MutatePriority
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.stopScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -72,6 +74,7 @@ private val AlbumGroupRowActionIconSize = 18.dp
 @Composable
 fun AlbumGroupsScreen(
     windowSizeClass: WindowSizeClass,
+    isActive: Boolean = true,
     onGroupClick: (AlbumGroupEntity) -> Unit,
     scrollToTopSignal: Long = 0L,
     viewModel: AlbumGroupsViewModel = hiltViewModel()
@@ -87,6 +90,10 @@ fun AlbumGroupsScreen(
         containerColor = Color.Transparent,
         contentColor = colorScheme.onBackground
     ) { padding ->
+        LaunchedEffect(isActive) {
+            if (isActive) return@LaunchedEffect
+            listState.stopScroll(MutatePriority.PreventUserInput)
+        }
         LaunchedEffect(scrollToTopSignal) {
             if (scrollToTopSignal == 0L) return@LaunchedEffect
             listState.smoothScrollToTop()

--- a/app/src/main/java/com/asmr/player/ui/hotlistening/HotListeningScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/hotlistening/HotListeningScreen.kt
@@ -1,5 +1,6 @@
 package com.asmr.player.ui.hotlistening
 
+import androidx.compose.foundation.MutatePriority
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -12,6 +13,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.itemsIndexed as lazyItemsIndexed
+import androidx.compose.foundation.gestures.stopScroll
 import androidx.compose.foundation.lazy.staggeredgrid.LazyStaggeredGridState
 import androidx.compose.foundation.lazy.staggeredgrid.LazyVerticalStaggeredGrid
 import androidx.compose.foundation.lazy.staggeredgrid.StaggeredGridCells
@@ -84,6 +86,7 @@ private fun hotListeningItemKey(section: String, index: Int, album: Album): Stri
 @Composable
 fun HotListeningScreen(
     windowSizeClass: WindowSizeClass,
+    isActive: Boolean = true,
     onAlbumClick: (Album) -> Unit,
     scrollToTopSignal: Long = 0L,
     viewModel: HotListeningViewModel = hiltViewModel()
@@ -161,6 +164,13 @@ fun HotListeningScreen(
         when (viewMode) {
             0 -> listState.smoothScrollToTop()
             else -> gridState.smoothScrollToTop()
+        }
+    }
+    LaunchedEffect(isActive, viewMode) {
+        if (isActive) return@LaunchedEffect
+        when (viewMode) {
+            0 -> listState.stopScroll(MutatePriority.PreventUserInput)
+            else -> gridState.stopScroll(MutatePriority.PreventUserInput)
         }
     }
 

--- a/app/src/main/java/com/asmr/player/ui/library/LibraryScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/LibraryScreen.kt
@@ -7,6 +7,8 @@ import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.MutatePriority
+import androidx.compose.foundation.gestures.stopScroll
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -269,6 +271,7 @@ private fun LibraryActionItem(
 @Composable
 fun LibraryScreen(
     windowSizeClass: WindowSizeClass,
+    isActive: Boolean = true,
     onAlbumClick: (Album) -> Unit,
     onPlayTracks: (Album, List<Track>, Track) -> Unit,
     onOpenPlaylistPicker: (MediaItem) -> Unit = {},
@@ -377,6 +380,13 @@ fun LibraryScreen(
             else -> listState.smoothScrollToTop()
         }
         chromeState.expand()
+    }
+    LaunchedEffect(isActive, mode) {
+        if (isActive) return@LaunchedEffect
+        when (mode) {
+            1 -> gridState.stopScroll(MutatePriority.PreventUserInput)
+            else -> listState.stopScroll(MutatePriority.PreventUserInput)
+        }
     }
 
     Scaffold(

--- a/app/src/main/java/com/asmr/player/ui/playlists/PlaylistDetailScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/playlists/PlaylistDetailScreen.kt
@@ -1,8 +1,10 @@
 package com.asmr.player.ui.playlists
 
 import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.MutatePriority
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.stopScroll
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -94,6 +96,7 @@ private const val PLAYLIST_DETAIL_REORDER_SENTINEL_KEY = "__playlist_detail_reor
 @Composable
 fun PlaylistDetailScreen(
     windowSizeClass: WindowSizeClass,
+    isActive: Boolean = true,
     playlistId: Long,
     title: String,
     onPlayAll: (List<PlaylistItemEntity>, PlaylistItemEntity) -> Unit,
@@ -106,6 +109,7 @@ fun PlaylistDetailScreen(
     val items by viewModel.items.collectAsState()
     PlaylistDetailContent(
         windowSizeClass = windowSizeClass,
+        isActive = isActive,
         title = title,
         items = items,
         onPlayAll = onPlayAll,
@@ -120,6 +124,7 @@ fun PlaylistDetailScreen(
 @Composable
 internal fun PlaylistDetailContent(
     windowSizeClass: WindowSizeClass,
+    isActive: Boolean = true,
     title: String,
     items: List<PlaylistItemWithSubtitles>,
     onPlayAll: (List<PlaylistItemEntity>, PlaylistItemEntity) -> Unit,
@@ -156,6 +161,10 @@ internal fun PlaylistDetailContent(
     LaunchedEffect(scrollToTopSignal) {
         if (scrollToTopSignal == 0L) return@LaunchedEffect
         listState.smoothScrollToTop()
+    }
+    LaunchedEffect(isActive) {
+        if (isActive) return@LaunchedEffect
+        listState.stopScroll(MutatePriority.PreventUserInput)
     }
 
     val playItems by remember {

--- a/app/src/main/java/com/asmr/player/ui/playlists/PlaylistsScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/playlists/PlaylistsScreen.kt
@@ -1,5 +1,7 @@
 ﻿package com.asmr.player.ui.playlists
 
+import androidx.compose.foundation.MutatePriority
+import androidx.compose.foundation.gestures.stopScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -68,6 +70,7 @@ private val PlaylistRowActionIconSize = 18.dp
 @Composable
 fun PlaylistsScreen(
     windowSizeClass: WindowSizeClass,
+    isActive: Boolean = true,
     onPlaylistClick: (PlaylistEntity) -> Unit,
     scrollToTopSignal: Long = 0L,
     viewModel: PlaylistsViewModel = hiltViewModel()
@@ -86,6 +89,10 @@ fun PlaylistsScreen(
         containerColor = Color.Transparent,
         contentColor = colorScheme.onBackground
     ) { padding ->
+        LaunchedEffect(isActive) {
+            if (isActive) return@LaunchedEffect
+            listState.stopScroll(MutatePriority.PreventUserInput)
+        }
         LaunchedEffect(scrollToTopSignal) {
             if (scrollToTopSignal == 0L) return@LaunchedEffect
             listState.smoothScrollToTop()

--- a/app/src/main/java/com/asmr/player/ui/playlists/SystemPlaylistScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/playlists/SystemPlaylistScreen.kt
@@ -17,6 +17,7 @@ import com.asmr.player.ui.theme.AsmrTheme
 @Composable
 fun SystemPlaylistScreen(
     windowSizeClass: WindowSizeClass,
+    isActive: Boolean = true,
     onPlayAll: (List<PlaylistItemEntity>, PlaylistItemEntity) -> Unit,
     scrollToTopSignal: Long = 0L,
     viewModel: PlaylistsViewModel = hiltViewModel()
@@ -34,6 +35,7 @@ fun SystemPlaylistScreen(
 
     PlaylistDetailScreen(
         windowSizeClass = windowSizeClass,
+        isActive = isActive,
         playlistId = playlist.id,
         title = playlist.name,
         onPlayAll = onPlayAll,

--- a/app/src/main/java/com/asmr/player/ui/search/SearchScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/search/SearchScreen.kt
@@ -7,11 +7,13 @@ import androidx.compose.animation.core.snap
 import androidx.compose.animation.core.spring
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.MutatePriority
 import androidx.compose.foundation.gestures.awaitFirstDown
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.awaitEachGesture
+import androidx.compose.foundation.gestures.stopScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -239,6 +241,7 @@ private fun SearchFilterIconView(
 @Composable
 fun SearchScreen(
     windowSizeClass: WindowSizeClass,
+    isActive: Boolean = true,
     onAlbumClick: (Album, Boolean, Boolean) -> Unit,
     onOpenSearchAssist: (SearchAssistSearchRequest) -> Unit = {},
     submittedSearchKeyword: String = "",
@@ -639,6 +642,15 @@ fun SearchScreen(
             else -> gridState.smoothScrollToTop()
         }
         chromeState.expand()
+    }
+    LaunchedEffect(isActive, viewMode) {
+        if (isActive) return@LaunchedEffect
+        when (viewMode) {
+            0 -> listState.stopScroll(MutatePriority.PreventUserInput)
+            else -> gridState.stopScroll(MutatePriority.PreventUserInput)
+        }
+        pullNextPageDragPx = 0f
+        latestHorizontalPagerScrollLockChanged.value(false)
     }
 
     Scaffold(

--- a/app/src/main/java/com/asmr/player/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/settings/SettingsScreen.kt
@@ -8,12 +8,14 @@ import android.provider.DocumentsContract
 import android.provider.Settings
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.MutatePriority
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.collectIsDraggedAsState
 import androidx.compose.foundation.interaction.collectIsPressedAsState
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.stopScroll
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.rememberLazyListState
@@ -89,6 +91,7 @@ private const val MONOCHROME_THEME_SENTINEL = 0x01000000
 @Composable
 fun SettingsScreen(
     windowSizeClass: WindowSizeClass,
+    isActive: Boolean = true,
     viewModel: SettingsViewModel = hiltViewModel(),
     libraryViewModel: LibraryViewModel = hiltViewModel(),
     scrollToTopSignal: Long = 0L,
@@ -163,6 +166,10 @@ fun SettingsScreen(
         containerColor = Color.Transparent,
         contentColor = colorScheme.onBackground
     ) { padding ->
+        LaunchedEffect(isActive) {
+            if (isActive) return@LaunchedEffect
+            listState.stopScroll(MutatePriority.PreventUserInput)
+        }
         LaunchedEffect(scrollToTopSignal) {
             if (scrollToTopSignal == 0L) return@LaunchedEffect
             listState.smoothScrollToTop()

--- a/app/src/test/java/com/asmr/player/MainNavigationSupportTest.kt
+++ b/app/src/test/java/com/asmr/player/MainNavigationSupportTest.kt
@@ -64,6 +64,47 @@ class MainNavigationSupportTest {
     }
 
     @Test
+    fun shouldSyncPrimaryPagerToRoute_onlyWhenSettledPageDiffersFromTarget() {
+        assertEquals(false, shouldSyncPrimaryPagerToRoute(targetPage = -1, settledPage = 0))
+        assertEquals(false, shouldSyncPrimaryPagerToRoute(targetPage = 2, settledPage = 2))
+        assertEquals(true, shouldSyncPrimaryPagerToRoute(targetPage = 2, settledPage = 1))
+    }
+
+    @Test
+    fun shouldClearPendingPrimaryNavigationRoute_waitsUntilPagerSettlesOnPendingPage() {
+        assertEquals(
+            false,
+            shouldClearPendingPrimaryNavigationRoute(
+                currentRoute = "search",
+                pendingRoute = "search",
+                navigationInProgress = false,
+                pendingPage = 1,
+                settledPage = 0
+            )
+        )
+        assertEquals(
+            false,
+            shouldClearPendingPrimaryNavigationRoute(
+                currentRoute = "search",
+                pendingRoute = "search",
+                navigationInProgress = true,
+                pendingPage = 1,
+                settledPage = 1
+            )
+        )
+        assertEquals(
+            true,
+            shouldClearPendingPrimaryNavigationRoute(
+                currentRoute = "search",
+                pendingRoute = "search",
+                navigationInProgress = false,
+                pendingPage = 1,
+                settledPage = 1
+            )
+        )
+    }
+
+    @Test
     fun resolvePrimaryPagerBeyondBoundsPageCount_keepsAllPrimaryPagesComposed() {
         assertEquals(0, resolvePrimaryPagerBeyondBoundsPageCount(0))
         assertEquals(0, resolvePrimaryPagerBeyondBoundsPageCount(1))


### PR DESCRIPTION
## Summary
- stop primary pager momentum before programmatic bottom-nav page switches
- stop inactive primary page lists/grids immediately when switching tabs to prevent old inertial scroll callbacks from restoring the previous page
- add navigation sync tests for pending route and settled page handling

## Verification
- .\\gradlew-local.bat :app:compileReleaseKotlin
- .\\gradlew-local.bat :app:installRelease