### PR TITLE
Polish playback artwork, floating lyrics, and hot listening UI

### DIFF
--- a/app/src/main/java/com/asmr/player/data/settings/FloatingLyricsSettings.kt
+++ b/app/src/main/java/com/asmr/player/data/settings/FloatingLyricsSettings.kt
@@ -4,6 +4,7 @@ data class FloatingLyricsSettings(
     val color: Int = 0xFFFFFFFF.toInt(),
     val size: Float = 16f,
     val opacity: Float = 0.7f,
+    val xOffset: Int = 0,
     val yOffset: Int = 120,
     val align: Int = 1, // 0:Left, 1:Center, 2:Right
     val touchable: Boolean = true

--- a/app/src/main/java/com/asmr/player/data/settings/SettingsDataStore.kt
+++ b/app/src/main/java/com/asmr/player/data/settings/SettingsDataStore.kt
@@ -30,6 +30,7 @@ object SettingsKeys {
     val FLOATING_LYRICS_COLOR = intPreferencesKey("floating_lyrics_color")
     val FLOATING_LYRICS_SIZE = floatPreferencesKey("floating_lyrics_size")
     val FLOATING_LYRICS_OPACITY = floatPreferencesKey("floating_lyrics_opacity")
+    val FLOATING_LYRICS_X = intPreferencesKey("floating_lyrics_x")
     val FLOATING_LYRICS_Y = intPreferencesKey("floating_lyrics_y")
     val FLOATING_LYRICS_ALIGN = intPreferencesKey("floating_lyrics_align")
     val FLOATING_LYRICS_TOUCHABLE = booleanPreferencesKey("floating_lyrics_touchable")

--- a/app/src/main/java/com/asmr/player/data/settings/SettingsRepository.kt
+++ b/app/src/main/java/com/asmr/player/data/settings/SettingsRepository.kt
@@ -72,6 +72,7 @@ class SettingsRepository @Inject constructor(
             color = prefs[SettingsKeys.FLOATING_LYRICS_COLOR] ?: 0xFFFFFFFF.toInt(),
             size = prefs[SettingsKeys.FLOATING_LYRICS_SIZE] ?: 16f,
             opacity = prefs[SettingsKeys.FLOATING_LYRICS_OPACITY] ?: 0.7f,
+            xOffset = prefs[SettingsKeys.FLOATING_LYRICS_X] ?: 0,
             yOffset = prefs[SettingsKeys.FLOATING_LYRICS_Y] ?: 120,
             align = prefs[SettingsKeys.FLOATING_LYRICS_ALIGN] ?: 1, // 0:Left, 1:Center, 2:Right
             touchable = prefs[SettingsKeys.FLOATING_LYRICS_TOUCHABLE] ?: true
@@ -270,6 +271,7 @@ class SettingsRepository @Inject constructor(
                 it[SettingsKeys.FLOATING_LYRICS_COLOR] = settings.color
                 it[SettingsKeys.FLOATING_LYRICS_SIZE] = settings.size
                 it[SettingsKeys.FLOATING_LYRICS_OPACITY] = settings.opacity
+                it[SettingsKeys.FLOATING_LYRICS_X] = settings.xOffset
                 it[SettingsKeys.FLOATING_LYRICS_Y] = settings.yOffset
                 it[SettingsKeys.FLOATING_LYRICS_ALIGN] = settings.align
                 it[SettingsKeys.FLOATING_LYRICS_TOUCHABLE] = settings.touchable

--- a/app/src/main/java/com/asmr/player/service/FloatingLyricsOverlay.kt
+++ b/app/src/main/java/com/asmr/player/service/FloatingLyricsOverlay.kt
@@ -2,6 +2,8 @@ package com.asmr.player.service
 
 import android.content.Context
 import android.graphics.PixelFormat
+import android.graphics.Color as AndroidColor
+import android.graphics.Paint
 import android.graphics.Typeface
 import android.graphics.drawable.GradientDrawable
 import android.os.Build
@@ -14,9 +16,11 @@ import android.view.WindowManager
 import android.widget.LinearLayout
 import android.widget.TextView
 import com.asmr.player.data.settings.FloatingLyricsSettings
+import kotlin.math.roundToInt
 
 class FloatingLyricsOverlay(
-    private val context: Context
+    private val context: Context,
+    private val onSettingsChanged: (FloatingLyricsSettings) -> Unit = {}
 ) {
     private val windowManager = context.getSystemService(Context.WINDOW_SERVICE) as WindowManager
     private var container: View? = null
@@ -41,7 +45,18 @@ class FloatingLyricsOverlay(
         val line1 = layout.getChildAt(0) as? TextView ?: return
         
         line1.textSize = settings.size
-        line1.setTextColor(settings.color)
+        line1.setTextColor(adjustTextColorForReadability(settings.color))
+        line1.setShadowLayer(
+            dp(4).toFloat(),
+            0f,
+            dp(1).toFloat(),
+            AndroidColor.argb(
+                if (isLightColor(settings.color)) 176 else 208,
+                0,
+                0,
+                0
+            )
+        )
         
         val align = when (settings.align) {
             0 -> Gravity.START
@@ -56,7 +71,8 @@ class FloatingLyricsOverlay(
             setColor(0xFF000000.toInt())
         }
         
-        // 更新位置
+        // 始终应用 settings 中的位置，确保设置页滑条和已持久化拖拽位置都能立即生效。
+        p.x = settings.xOffset
         p.y = settings.yOffset
         
         // 更新点击穿透
@@ -87,9 +103,10 @@ class FloatingLyricsOverlay(
 
         val line1 = TextView(context).apply {
             id = View.generateViewId()
-            setTextColor(currentSettings.color)
+            setTextColor(adjustTextColorForReadability(currentSettings.color))
             textSize = currentSettings.size
             setTypeface(typeface, Typeface.BOLD)
+            paintFlags = paintFlags or Paint.SUBPIXEL_TEXT_FLAG or Paint.ANTI_ALIAS_FLAG
             isSingleLine = true
             ellipsize = TextUtils.TruncateAt.MARQUEE
             marqueeRepeatLimit = -1
@@ -119,7 +136,7 @@ class FloatingLyricsOverlay(
             PixelFormat.TRANSLUCENT
         ).apply {
             gravity = Gravity.TOP or Gravity.START
-            x = 0
+            x = currentSettings.xOffset
             y = currentSettings.yOffset
         }
 
@@ -138,9 +155,15 @@ class FloatingLyricsOverlay(
                     val dy = (event.rawY - downRawY).toInt()
                     p.x = lastX + dx
                     p.y = lastY + dy
-                    currentSettings = currentSettings.copy(yOffset = p.y)
+                    currentSettings = currentSettings.copy(xOffset = p.x, yOffset = p.y)
                     runCatching { windowManager.updateViewLayout(layout, p) }
                     true
+                }
+                MotionEvent.ACTION_UP,
+                MotionEvent.ACTION_CANCEL -> {
+                    currentSettings = currentSettings.copy(xOffset = p.x, yOffset = p.y)
+                    onSettingsChanged(currentSettings)
+                    false
                 }
                 else -> false
             }
@@ -168,5 +191,35 @@ class FloatingLyricsOverlay(
     private fun dp(value: Int): Int {
         val density = context.resources.displayMetrics.density
         return (value * density).toInt()
+    }
+
+    private fun adjustTextColorForReadability(color: Int): Int {
+        val hsv = FloatArray(3)
+        AndroidColor.colorToHSV(color, hsv)
+        hsv[1] = if (isLightThemeApprox()) {
+            hsv[1].coerceIn(0.48f, 0.88f)
+        } else {
+            hsv[1].coerceIn(0.42f, 0.90f)
+        }
+        hsv[2] = if (isLightThemeApprox()) {
+            hsv[2].coerceIn(0.98f, 1.0f)
+        } else {
+            hsv[2].coerceIn(0.94f, 1.0f)
+        }
+        return AndroidColor.HSVToColor(255, hsv)
+    }
+
+    private fun isLightColor(color: Int): Boolean {
+        val luminance = (
+            0.2126f * AndroidColor.red(color) +
+                0.7152f * AndroidColor.green(color) +
+                0.0722f * AndroidColor.blue(color)
+            ) / 255f
+        return luminance > 0.72f
+    }
+
+    private fun isLightThemeApprox(): Boolean {
+        val nightMask = context.resources.configuration.uiMode and android.content.res.Configuration.UI_MODE_NIGHT_MASK
+        return nightMask != android.content.res.Configuration.UI_MODE_NIGHT_YES
     }
 }

--- a/app/src/main/java/com/asmr/player/service/PlaybackService.kt
+++ b/app/src/main/java/com/asmr/player/service/PlaybackService.kt
@@ -340,7 +340,11 @@ class PlaybackService : MediaSessionService() {
             initialHideSystemControls = sfwHideSystemControlsEnabled
         )
         setMediaNotificationProvider(notificationProvider!!)
-        overlay = FloatingLyricsOverlay(this)
+        overlay = FloatingLyricsOverlay(this) { settings ->
+            serviceScope.launch {
+                settingsRepository.updateFloatingLyricsSettings(settings)
+            }
+        }
         
         exoPlayer.addListener(object : androidx.media3.common.Player.Listener {
             override fun onIsPlayingChanged(isPlaying: Boolean) {

--- a/app/src/main/java/com/asmr/player/ui/hotlistening/HotListeningScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/hotlistening/HotListeningScreen.kt
@@ -451,7 +451,13 @@ private fun HotListeningEntry.toCoverBadge(): AlbumCoverBadge {
         HotListeningSortMode.PlayCount -> Icons.Rounded.PlayArrow
         HotListeningSortMode.ListenDuration -> Icons.Rounded.AccessTime
     }
-    return AlbumCoverBadge(icon = icon, text = metricLabel)
+    return AlbumCoverBadge(
+        icon = icon,
+        text = metricLabel,
+        showContainer = false,
+        bottomScrim = true,
+        compactOffset = true
+    )
 }
 
 private val HotListeningSortMode.toggleLabel: String

--- a/app/src/main/java/com/asmr/player/ui/library/AlbumDetailViewModel.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/AlbumDetailViewModel.kt
@@ -1,10 +1,18 @@
 package com.asmr.player.ui.library
 
 import android.content.Context
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import android.os.SystemClock
 import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.room.withTransaction
+import androidx.work.ExistingWorkPolicy
+import androidx.work.OneTimeWorkRequestBuilder
+import androidx.work.WorkManager
+import androidx.work.workDataOf
+import com.asmr.player.BuildConfig
 import com.asmr.player.data.local.db.AppDatabase
 import com.asmr.player.data.local.db.dao.AlbumDao
 import com.asmr.player.data.local.db.dao.TagWithCount
@@ -13,36 +21,37 @@ import com.asmr.player.data.local.db.entities.AlbumEntity
 import com.asmr.player.data.local.db.entities.AlbumFtsEntity
 import com.asmr.player.data.local.db.entities.AlbumTagEntity
 import com.asmr.player.data.local.db.entities.RemoteSubtitleSourceEntity
-import com.asmr.player.data.local.db.entities.TrackEntity
 import com.asmr.player.data.local.db.entities.TagEntity
 import com.asmr.player.data.local.db.entities.TagSource
+import com.asmr.player.data.local.db.entities.TrackEntity
 import com.asmr.player.data.local.db.entities.TrackTagEntity
+import com.asmr.player.data.lyrics.LyricsLoader
+import com.asmr.player.data.lyrics.deriveLyricsRelativePathNoExt
+import com.asmr.player.data.remote.NetworkHeaders
+import com.asmr.player.data.remote.api.AsmrOneAvailabilityApi
 import com.asmr.player.data.remote.api.AsmrOneOtherLanguageEditionInDb
 import com.asmr.player.data.remote.api.AsmrOneTrackNodeResponse
-import com.asmr.player.data.remote.api.AsmrOneAvailabilityApi
+import com.asmr.player.data.remote.auth.DlsiteAuthStore
+import com.asmr.player.data.remote.auth.buildDlsiteCookieHeader
 import com.asmr.player.data.remote.crawler.AsmrOneCrawler
+import com.asmr.player.data.remote.crawler.asmrOneWorkMatchesRj
+import com.asmr.player.data.remote.dlsite.DLSITE_PLAY_PREVIEW_CACHE_VERSION
 import com.asmr.player.data.remote.dlsite.DlsiteCloudSyncCandidate
 import com.asmr.player.data.remote.dlsite.DlsiteCloudSyncResolveResult
-import com.asmr.player.data.remote.dlsite.DLSITE_PLAY_PREVIEW_CACHE_VERSION
-import com.asmr.player.data.remote.dlsite.DlsitePlayLoadStatus
-import com.asmr.player.data.remote.dlsite.DlsitePlayWorkClient
-import com.asmr.player.data.remote.dlsite.DlsitePlayTreeResult
 import com.asmr.player.data.remote.dlsite.DlsiteLanguageEdition
+import com.asmr.player.data.remote.dlsite.DlsitePlayLoadStatus
+import com.asmr.player.data.remote.dlsite.DlsitePlayTreeResult
+import com.asmr.player.data.remote.dlsite.DlsitePlayWorkClient
 import com.asmr.player.data.remote.dlsite.DlsiteProductInfoClient
 import com.asmr.player.data.remote.dlsite.descrambleDlsitePlayBitmap
 import com.asmr.player.data.remote.dlsite.parseDlsitePlayImageSeed
 import com.asmr.player.data.remote.dlsite.resolveCloudSyncWorkId
 import com.asmr.player.data.remote.dlsite.resolveDlsiteCloudSync
 import com.asmr.player.data.remote.dlsite.resolveSelectedDlsiteCloudSync
-import com.asmr.player.data.remote.auth.DlsiteAuthStore
-import com.asmr.player.data.remote.auth.buildDlsiteCookieHeader
 import com.asmr.player.data.remote.download.DownloadManager
 import com.asmr.player.data.remote.scraper.DLSiteScraper
 import com.asmr.player.data.remote.scraper.DlsiteRecommendedWork
 import com.asmr.player.data.remote.scraper.DlsiteRecommendations
-import com.asmr.player.data.remote.NetworkHeaders
-import com.asmr.player.data.lyrics.LyricsLoader
-import com.asmr.player.data.lyrics.deriveLyricsRelativePathNoExt
 import com.asmr.player.domain.model.Album
 import com.asmr.player.domain.model.Track
 import com.asmr.player.listentogether.ListenTogetherRepository
@@ -50,56 +59,48 @@ import com.asmr.player.ui.common.queryTrackFileSize
 import com.asmr.player.ui.nav.AlbumCoverHint
 import com.asmr.player.ui.nav.AlbumCoverHintStore
 import com.asmr.player.ui.nav.albumFromCoverHint
+import com.asmr.player.util.DlsiteWorkNo
+import com.asmr.player.util.MessageManager
 import com.asmr.player.util.OnlineLyricsStore
 import com.asmr.player.util.RemoteSubtitleSource
 import com.asmr.player.util.SubtitleMatchSupport
 import com.asmr.player.util.SyncCoordinator
+import com.asmr.player.util.TagNormalizer
 import com.asmr.player.util.TrackKeyNormalizer
-import com.asmr.player.util.DlsiteWorkNo
-import com.asmr.player.data.remote.crawler.asmrOneWorkMatchesRj
+import com.asmr.player.work.AlbumCoverThumbWorker
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
-import kotlinx.coroutines.CompletableDeferred
-import kotlinx.coroutines.Job
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.async
-import kotlinx.coroutines.coroutineScope
-import kotlinx.coroutines.delay
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.distinctUntilChanged
-import kotlinx.coroutines.flow.flowOn
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
-import kotlinx.coroutines.withTimeoutOrNull
-import kotlinx.coroutines.sync.Semaphore
-import kotlinx.coroutines.sync.withPermit
 import java.io.File
 import java.io.FileOutputStream
 import java.io.IOException
 import java.util.concurrent.atomic.AtomicBoolean
 import javax.inject.Inject
-
-import com.asmr.player.util.MessageManager
-import com.asmr.player.util.TagNormalizer
+import javax.inject.Named
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
-import android.graphics.Bitmap
-import android.graphics.BitmapFactory
-import android.os.SystemClock
-import androidx.work.ExistingWorkPolicy
-import androidx.work.OneTimeWorkRequestBuilder
-import androidx.work.WorkManager
-import androidx.work.workDataOf
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Semaphore
+import kotlinx.coroutines.sync.withPermit
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeoutOrNull
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.Response
-import javax.inject.Named
-import com.asmr.player.BuildConfig
-import com.asmr.player.work.AlbumCoverThumbWorker
+
+private const val LISTEN_TOGETHER_RJ_SUMMARY_POLL_INTERVAL_MS = 60_000L
 
 @HiltViewModel
 class AlbumDetailViewModel @Inject constructor(
@@ -213,7 +214,7 @@ class AlbumDetailViewModel @Inject constructor(
                         viewModelScope.launch {
                             while (true) {
                                 refreshListenTogetherRjSummary(rj)
-                                delay(15_000L)
+                                delay(LISTEN_TOGETHER_RJ_SUMMARY_POLL_INTERVAL_MS)
                             }
                         }
                     }

--- a/app/src/main/java/com/asmr/player/ui/library/AlbumItem.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/AlbumItem.kt
@@ -10,6 +10,7 @@ import androidx.compose.animation.slideInVertically
 import androidx.compose.animation.slideOutVertically
 import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.background
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -19,14 +20,15 @@ import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.foundation.background
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Brush
 import androidx.compose.material3.Icon as MaterialIcon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -52,6 +54,7 @@ import androidx.compose.ui.unit.Constraints
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import com.asmr.player.domain.model.Album
 import com.asmr.player.cache.CacheImageModel
 import com.asmr.player.ui.common.AsmrAsyncImage
@@ -158,12 +161,33 @@ fun AlbumItem(
                         peekAnySizeForInitial = true,
                         modifier = Modifier.fillMaxSize().clip(coverShape),
                     )
+                    if (coverBadge?.bottomScrim == true) {
+                        Box(
+                            modifier = Modifier
+                                .align(Alignment.BottomCenter)
+                                .fillMaxWidth()
+                                .fillMaxHeight(0.34f)
+                                .background(
+                                    Brush.verticalGradient(
+                                        colors = listOf(
+                                            Color.Transparent,
+                                            Color.Black.copy(alpha = 0.18f),
+                                            Color.Black.copy(alpha = 0.42f),
+                                            Color.Black.copy(alpha = 0.68f)
+                                        )
+                                    )
+                                )
+                        )
+                    }
                     coverBadge?.let { badge ->
                         AlbumCoverMetricBadge(
                             badge = badge,
                             modifier = Modifier
                                 .align(Alignment.BottomEnd)
-                                .padding(6.dp)
+                                .padding(
+                                    end = if (badge.compactOffset) 4.dp else 6.dp,
+                                    bottom = if (badge.compactOffset) 4.dp else 6.dp
+                                )
                         )
                     }
                 }
@@ -374,6 +398,24 @@ fun AlbumGridItem(
                 peekAnySizeForInitial = true,
                 modifier = Modifier.fillMaxSize().clip(coverShape),
             )
+            if (coverBadge?.bottomScrim == true) {
+                Box(
+                    modifier = Modifier
+                        .align(Alignment.BottomCenter)
+                        .fillMaxWidth()
+                        .fillMaxHeight(0.36f)
+                        .background(
+                            Brush.verticalGradient(
+                                colors = listOf(
+                                    Color.Transparent,
+                                    Color.Black.copy(alpha = 0.18f),
+                                    Color.Black.copy(alpha = 0.44f),
+                                    Color.Black.copy(alpha = 0.70f)
+                                )
+                            )
+                        )
+                )
+            }
             
             val rj = album.rjCode.ifBlank { album.workId }
             if (rj.isNotBlank()) {
@@ -418,7 +460,10 @@ fun AlbumGridItem(
                     badge = badge,
                     modifier = Modifier
                         .align(Alignment.BottomEnd)
-                        .padding(8.dp)
+                        .padding(
+                            end = if (badge.compactOffset) 5.dp else 8.dp,
+                            bottom = if (badge.compactOffset) 5.dp else 8.dp
+                        )
                 )
             }
 
@@ -645,7 +690,10 @@ private fun AlbumDetailSkeletonLine(
 @Immutable
 data class AlbumCoverBadge(
     val icon: ImageVector,
-    val text: String
+    val text: String,
+    val showContainer: Boolean = true,
+    val bottomScrim: Boolean = false,
+    val compactOffset: Boolean = false
 )
 
 @Composable
@@ -654,26 +702,42 @@ private fun AlbumCoverMetricBadge(
     modifier: Modifier = Modifier
 ) {
     if (badge.text.isBlank()) return
-    Row(
-        modifier = modifier
-            .background(Color.Black.copy(alpha = 0.58f), RoundedCornerShape(4.dp))
-            .padding(horizontal = 5.dp, vertical = 3.dp),
-        horizontalArrangement = Arrangement.spacedBy(3.dp),
-        verticalAlignment = Alignment.CenterVertically
-    ) {
-        MaterialIcon(
-            imageVector = badge.icon,
-            contentDescription = null,
-            tint = Color.White,
-            modifier = Modifier.size(12.dp)
-        )
-        Text(
-            text = badge.text,
-            style = MaterialTheme.typography.labelSmall,
-            color = Color.White,
-            maxLines = 1,
-            overflow = TextOverflow.Ellipsis
-        )
+    Box(modifier = modifier) {
+        Row(
+            modifier = Modifier
+                .align(Alignment.BottomEnd)
+                .then(
+                    if (badge.showContainer) {
+                        Modifier.background(Color.Black.copy(alpha = 0.58f), RoundedCornerShape(4.dp))
+                    } else {
+                        Modifier
+                    }
+                )
+                .padding(
+                    horizontal = if (badge.showContainer) 5.dp else 0.dp,
+                    vertical = if (badge.showContainer) 3.dp else 0.dp
+                ),
+            horizontalArrangement = Arrangement.spacedBy(if (badge.showContainer) 3.dp else 2.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            MaterialIcon(
+                imageVector = badge.icon,
+                contentDescription = null,
+                tint = Color.White,
+                modifier = Modifier.size(if (badge.showContainer) 12.dp else 10.dp)
+            )
+            Text(
+                text = badge.text,
+                style = if (badge.showContainer) {
+                    MaterialTheme.typography.labelSmall
+                } else {
+                    MaterialTheme.typography.labelSmall.copy(fontSize = 10.sp)
+                },
+                color = Color.White,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
+            )
+        }
     }
 }
 

--- a/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailDialogs.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailDialogs.kt
@@ -660,6 +660,8 @@ private fun AsmrTreeFolderCheckboxRow(
     ) {
         Row(
             modifier = Modifier
+                .clip(RoundedCornerShape(8.dp))
+                .clickable(onClick = onToggleExpand)
                 .padding(start = (depth * 12).dp, end = 4.dp, top = 2.dp, bottom = 2.dp),
             verticalAlignment = Alignment.CenterVertically
         ) {
@@ -670,14 +672,13 @@ private fun AsmrTreeFolderCheckboxRow(
                     modifier = Modifier.size(30.dp)
                 )
             }
-            IconButton(onClick = onToggleExpand, modifier = Modifier.size(28.dp)) {
-                Icon(
-                    imageVector = if (expanded) Icons.Rounded.KeyboardArrowDown else Icons.AutoMirrored.Rounded.KeyboardArrowRight,
-                    contentDescription = null,
-                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                    modifier = Modifier.size(20.dp)
-                )
-            }
+            Icon(
+                imageVector = if (expanded) Icons.Rounded.KeyboardArrowDown else Icons.AutoMirrored.Rounded.KeyboardArrowRight,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.size(20.dp)
+            )
+            Spacer(modifier = Modifier.width(8.dp))
             Text(
                 text = title,
                 maxLines = 1,

--- a/app/src/main/java/com/asmr/player/ui/player/nowplaying/NowPlayingSurfaceComponents.kt
+++ b/app/src/main/java/com/asmr/player/ui/player/nowplaying/NowPlayingSurfaceComponents.kt
@@ -255,7 +255,6 @@ internal fun ArtworkBox(
     modifier: Modifier = Modifier
 ) {
     val shape = RoundedCornerShape(28.dp)
-    val hasArtwork = metadata?.artworkUri != null
     val videoSurfaceHandle = remember(viewModel) {
         VideoSurfaceVisibilityHandle { visible -> viewModel.setVideoSurfaceVisible(visible) }
     }
@@ -269,10 +268,8 @@ internal fun ArtworkBox(
                 enabled = dragPreviewEnabled && dragPreviewState != null,
                 state = dragPreviewState ?: CoverDragPreviewState(),
                 minPointers = 2
-            )
-            .clip(shape)
-            .background(if (isVideo) videoBackdropColor else Color.Transparent)
-            .then(if (hasArtwork && !edgeBlendEnabled) Modifier.shadow(12.dp, shape) else Modifier)
+            ),
+        contentAlignment = Alignment.Center
     ) {
         if (isVideo) {
             var fullscreen by rememberSaveable { mutableStateOf(false) }
@@ -286,7 +283,11 @@ internal fun ArtworkBox(
                     onToggleFullscreen = { fullscreen = true },
                     viewKey = "inline",
                     backdropColor = videoBackdropColor,
-                    modifier = Modifier.fillMaxSize().clipToBounds()
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .clip(shape)
+                        .background(videoBackdropColor)
+                        .clipToBounds()
                 )
             } else {
                 Box(modifier = Modifier.fillMaxSize().background(videoBackdropColor))
@@ -310,35 +311,39 @@ internal fun ArtworkBox(
                 }
             }
         } else {
-            Box(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .clickable { onOpenLyrics() }
-            ) {
-                if (edgeBlendEnabled) {
-                    val artwork = metadata?.artworkUri
-                    if (artwork != null) {
+            if (edgeBlendEnabled) {
+                val artwork = metadata?.artworkUri
+                if (artwork != null) {
+                    Box(
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .clickable { onOpenLyrics() }
+                    ) {
                         CoverArtworkEdgeBlend(
                             artworkModel = artwork,
                             blendColor = edgeBlendColor,
                             modifier = Modifier.fillMaxSize(),
                             artworkAlignment = artworkAlignment
                         )
-                    } else {
-                        DiscPlaceholder(modifier = Modifier.fillMaxSize(), cornerRadius = 28)
                     }
-                } else {
-                    AsmrAsyncImage(
-                        model = metadata?.artworkUri,
-                        contentDescription = null,
-                        contentScale = ContentScale.Crop,
-                        alignment = artworkAlignment,
-                        placeholderCornerRadius = 28,
-                        retainPainterDuringReload = true,
-                        loadWhenSizeStableForMillis = 120L,
-                        modifier = Modifier.fillMaxSize(),
-                    )
                 }
+            } else {
+                AsmrAsyncImage(
+                    model = metadata?.artworkUri,
+                    contentDescription = null,
+                    contentScale = ContentScale.Crop,
+                    alignment = artworkAlignment,
+                    placeholderCornerRadius = 28,
+                    placeholder = {},
+                    loading = {},
+                    empty = {},
+                    retainPainterDuringReload = true,
+                    loadWhenSizeStableForMillis = 120L,
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .clip(shape)
+                        .clickable { onOpenLyrics() },
+                )
             }
         }
     }

--- a/app/src/main/java/com/asmr/player/ui/player/playerviewmodel.kt
+++ b/app/src/main/java/com/asmr/player/ui/player/playerviewmodel.kt
@@ -71,6 +71,7 @@ import java.util.Date
 import java.util.Locale
 
 private const val ONLINE_MANUAL_LYRICS_MESSAGE = "在线音频如需替换歌词，请先下载音频到本地"
+private const val LISTEN_TOGETHER_POLL_INTERVAL_MS = 60_000L
 
 @HiltViewModel
 @OptIn(FlowPreview::class)
@@ -936,7 +937,7 @@ class PlayerViewModel @Inject constructor(
                         backendConfigured = true,
                         status = ListenTogetherStatus.Ready
                     )
-                    delay(response?.heartbeatIntervalMs?.coerceIn(5_000L, 60_000L) ?: 15_000L)
+                    delay(response?.heartbeatIntervalMs?.coerceAtLeast(LISTEN_TOGETHER_POLL_INTERVAL_MS) ?: LISTEN_TOGETHER_POLL_INTERVAL_MS)
                 }.onFailure {
                     _listenTogetherUiState.value = _listenTogetherUiState.value.copy(
                         available = true,
@@ -945,7 +946,7 @@ class PlayerViewModel @Inject constructor(
                         backendConfigured = true,
                         status = ListenTogetherStatus.Error
                     )
-                    delay(15_000L)
+                    delay(LISTEN_TOGETHER_POLL_INTERVAL_MS)
                 }
             }
         }

--- a/app/src/main/java/com/asmr/player/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/settings/SettingsScreen.kt
@@ -684,10 +684,10 @@ fun SettingsScreen(
                             val presetColors = remember {
                                 listOf(
                                     0xFFFFFFFF.toInt(),
-                                    0xFFFFEB3B.toInt(),
-                                    0xFF00E5FF.toInt(),
-                                    0xFF69F0AE.toInt(),
-                                    0xFFFF4081.toInt()
+                                    0xFFFFE14D.toInt(),
+                                    0xFF39D5FF.toInt(),
+                                    0xFF5CFF95.toInt(),
+                                    0xFFFF5FA2.toInt()
                                 )
                             }
                             Column(modifier = Modifier.fillMaxWidth(), verticalArrangement = Arrangement.spacedBy(10.dp)) {


### PR DESCRIPTION
## Summary
- polish hot listening badges, bottom scrims, and folder-row toggle behavior in download/save sheets
- increase listen-together polling intervals and refine now playing artwork loading containers
- persist floating lyrics overlay position and improve floating lyrics color/readability behavior

## Testing
- .\\gradlew-local.bat :app:installRelease