### PR TITLE
Refine image loading states and playback artwork behavior

### DIFF
--- a/app/src/main/java/com/asmr/player/ui/common/AsmrAsyncImage.kt
+++ b/app/src/main/java/com/asmr/player/ui/common/AsmrAsyncImage.kt
@@ -44,7 +44,9 @@ fun AsmrAsyncImage(
         DiscPlaceholder(modifier = m, cornerRadius = placeholderCornerRadius)
     },
     empty: @Composable (Modifier) -> Unit = placeholder,
-    loading: @Composable (Modifier) -> Unit = {},
+    loading: @Composable (Modifier) -> Unit = { m ->
+        AsmrImageLoadingPlaceholder(modifier = m, cornerRadius = placeholderCornerRadius)
+    },
     retainPainterDuringReload: Boolean = false,
     reloadKey: Any? = null,
     loadWhenSizeStableForMillis: Long = 0L,
@@ -114,7 +116,7 @@ fun AsmrAsyncImage(
             val cachedImage = manager.loadImageFromCache(
                 model = normalizedModel,
                 size = requestSize,
-                cachePolicy = CachePolicy.DEFAULT
+                cachePolicy = CachePolicy.MEMORY_ONLY
             )
             if (cachedImage != null) {
                 painter.value = BitmapPainter(cachedImage)

--- a/app/src/main/java/com/asmr/player/ui/common/AsmrAsyncImage.kt
+++ b/app/src/main/java/com/asmr/player/ui/common/AsmrAsyncImage.kt
@@ -44,9 +44,7 @@ fun AsmrAsyncImage(
         DiscPlaceholder(modifier = m, cornerRadius = placeholderCornerRadius)
     },
     empty: @Composable (Modifier) -> Unit = placeholder,
-    loading: @Composable (Modifier) -> Unit = { m ->
-        AsmrImageLoadingPlaceholder(modifier = m, cornerRadius = placeholderCornerRadius)
-    },
+    loading: @Composable (Modifier) -> Unit = {},
     retainPainterDuringReload: Boolean = false,
     reloadKey: Any? = null,
     loadWhenSizeStableForMillis: Long = 0L,
@@ -112,6 +110,30 @@ fun AsmrAsyncImage(
             crossfadeRunning.value = false
             val hasExistingPainter = painter.value != null
             val shouldRetainPainter = (retainPainterDuringReload || loadAtOriginalSize || seededPlaceholder.value) && hasExistingPainter
+            val requestSize = if (loadAtOriginalSize) null else sz
+            val cachedImage = manager.loadImageFromCache(
+                model = normalizedModel,
+                size = requestSize,
+                cachePolicy = CachePolicy.DEFAULT
+            )
+            if (cachedImage != null) {
+                painter.value = BitmapPainter(cachedImage)
+                loadedSize.value = sz
+                seededPlaceholder.value = false
+                state.value = AsmrAsyncImageState.Success
+                if (fadeIn && !shouldRetainPainter) {
+                    crossfade.snapTo(0f)
+                    crossfadeRunning.value = true
+                    try {
+                        crossfade.animateTo(1f, tween(durationMillis = fadeInMillis))
+                    } finally {
+                        crossfadeRunning.value = false
+                    }
+                } else {
+                    crossfade.snapTo(1f)
+                }
+                return@LaunchedEffect
+            }
             if (!shouldRetainPainter) {
                 state.value = AsmrAsyncImageState.Loading
                 painter.value = null
@@ -123,7 +145,7 @@ fun AsmrAsyncImage(
             val img = withTimeoutOrNull(15_000) {
                 manager.loadImage(
                     model = normalizedModel,
-                    size = if (loadAtOriginalSize) null else sz,
+                    size = requestSize,
                     cachePolicy = CachePolicy.DEFAULT
                 )
             } ?: throw IllegalStateException("Image load timeout")

--- a/app/src/main/java/com/asmr/player/ui/player/NowPlayingScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/player/NowPlayingScreen.kt
@@ -1582,6 +1582,8 @@ internal fun NowPlayingScreen(
                         playbackPositionMs = progress.positionMs,
                         lyrics = lyricsState.lyrics,
                         lyricColors = lyricColors,
+                        accentColor = accentColor,
+                        onAccentColor = onAccentColor,
                         lyricsPageSettings = lyricsPageSettings,
                         onSeekTo = { viewModel.seekTo(it) },
                         onTimelinePlay = { targetMs ->

--- a/app/src/main/java/com/asmr/player/ui/player/nowplaying/NowPlayingSurfaceComponents.kt
+++ b/app/src/main/java/com/asmr/player/ui/player/nowplaying/NowPlayingSurfaceComponents.kt
@@ -84,12 +84,12 @@ import com.asmr.player.ui.common.DismissOutsideBoundsOverlay
 import com.asmr.player.ui.common.AppVolumeHearingWarningDialog
 import com.asmr.player.ui.common.AppVolumeSlider
 import com.asmr.player.ui.common.AppVolumeWarningSessionState
+import com.asmr.player.ui.common.AsmrImageLoadingPlaceholder
 import com.asmr.player.ui.common.StableWindowInsets
 import com.asmr.player.playback.AppVolume
 import com.asmr.player.playback.PlaybackSnapshot
 import com.asmr.player.ui.common.EqualizerPanel
 import com.asmr.player.ui.common.rememberProtectedAppVolumeChangeState
-import com.asmr.player.ui.common.DiscPlaceholder
 import com.asmr.player.ui.common.smoothScrollToIndex
 import com.asmr.player.ui.library.TagAssignDialog
 import com.asmr.player.service.AudioOutputRouteKind
@@ -343,8 +343,15 @@ internal fun ArtworkBox(
                     alignment = artworkAlignment,
                     placeholderCornerRadius = 28,
                     placeholder = {},
-                    loading = {},
+                    loading = { modifier ->
+                        AsmrImageLoadingPlaceholder(
+                            modifier = modifier,
+                            cornerRadius = 28,
+                            indicatorSize = 36.dp
+                        )
+                    },
                     empty = {},
+                    peekAnySizeForInitial = true,
                     retainPainterDuringReload = true,
                     loadWhenSizeStableForMillis = 120L,
                     modifier = Modifier

--- a/app/src/main/java/com/asmr/player/ui/player/nowplaying/NowPlayingSurfaceComponents.kt
+++ b/app/src/main/java/com/asmr/player/ui/player/nowplaying/NowPlayingSurfaceComponents.kt
@@ -197,6 +197,8 @@ internal fun NowPlayingLyricsSurface(
     playbackPositionMs: Long,
     lyrics: List<SubtitleEntry>,
     lyricColors: LyricReadableColors,
+    accentColor: Color,
+    onAccentColor: Color,
     lyricsPageSettings: LyricsPageSettings,
     onSeekTo: (Long) -> Unit,
     onTimelinePlay: ((Long) -> Unit)? = null,
@@ -219,7 +221,13 @@ internal fun NowPlayingLyricsSurface(
                 )
                 if (onAddLyrics != null) {
                     Spacer(modifier = Modifier.height(14.dp))
-                    Button(onClick = onAddLyrics) {
+                    Button(
+                        onClick = onAddLyrics,
+                        colors = ButtonDefaults.buttonColors(
+                            containerColor = accentColor,
+                            contentColor = onAccentColor
+                        )
+                    ) {
                         Text("添加歌词")
                     }
                 }


### PR DESCRIPTION
## Summary
- refine async image loading behavior so placeholders only show for empty or error states while preserving cache-hit fast paths
- style the now playing lyrics empty-state action with the active accent colors
- fix regressions where playback cover/theme updates felt delayed and gallery thumbnails could sit on a gray surface too long

## Testing
- .\\gradlew-local.bat :app:installRelease