### PR TITLE
Fix cover crossfade jank and bump version to 1.1.5

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -70,8 +70,8 @@ android {
         applicationId = "com.asmr.player"
         minSdk = 24
         targetSdk = 34
-        versionCode = 10105
-        versionName = "1.1.4"
+        versionCode = 10106
+        versionName = "1.1.5"
         buildConfigField("String", "UPDATE_REPO_OWNER", "\"eValDoll\"")
         buildConfigField("String", "UPDATE_REPO_NAME", "\"EaraAsmrPlayer\"")
         buildConfigField("String", "LISTEN_TOGETHER_BASE_URL", "\"$listenTogetherBaseUrl\"")

--- a/app/src/main/java/com/asmr/player/ui/common/AsmrAsyncImage.kt
+++ b/app/src/main/java/com/asmr/player/ui/common/AsmrAsyncImage.kt
@@ -113,29 +113,6 @@ fun AsmrAsyncImage(
             val hasExistingPainter = painter.value != null
             val shouldRetainPainter = (retainPainterDuringReload || loadAtOriginalSize || seededPlaceholder.value) && hasExistingPainter
             val requestSize = if (loadAtOriginalSize) null else sz
-            val cachedImage = manager.loadImageFromCache(
-                model = normalizedModel,
-                size = requestSize,
-                cachePolicy = CachePolicy.MEMORY_ONLY
-            )
-            if (cachedImage != null) {
-                painter.value = BitmapPainter(cachedImage)
-                loadedSize.value = sz
-                seededPlaceholder.value = false
-                state.value = AsmrAsyncImageState.Success
-                if (fadeIn && !shouldRetainPainter) {
-                    crossfade.snapTo(0f)
-                    crossfadeRunning.value = true
-                    try {
-                        crossfade.animateTo(1f, tween(durationMillis = fadeInMillis))
-                    } finally {
-                        crossfadeRunning.value = false
-                    }
-                } else {
-                    crossfade.snapTo(1f)
-                }
-                return@LaunchedEffect
-            }
             if (!shouldRetainPainter) {
                 state.value = AsmrAsyncImageState.Loading
                 painter.value = null
@@ -219,6 +196,8 @@ fun AsmrAsyncImage(
         }
     }
 }
+
+internal val NoImageLoadingIndicator: @Composable (Modifier) -> Unit = {}
 
 private enum class AsmrAsyncImageState {
     Loading,

--- a/app/src/main/java/com/asmr/player/ui/library/AlbumItem.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/AlbumItem.kt
@@ -59,6 +59,7 @@ import com.asmr.player.domain.model.Album
 import com.asmr.player.cache.CacheImageModel
 import com.asmr.player.ui.common.AsmrAsyncImage
 import com.asmr.player.ui.common.CoverContentRow
+import com.asmr.player.ui.common.NoImageLoadingIndicator
 import com.asmr.player.ui.common.AsmrShimmerPlaceholder
 import com.asmr.player.ui.library.AlbumMetaLeadingVisual.Icon
 import com.asmr.player.util.DlsiteAntiHotlink
@@ -159,6 +160,7 @@ fun AlbumItem(
                         reloadKey = coverReloadKey,
                         retainPainterDuringReload = coverRetainPainterDuringReload,
                         peekAnySizeForInitial = true,
+                        loading = NoImageLoadingIndicator,
                         modifier = Modifier.fillMaxSize().clip(coverShape),
                     )
                     if (coverBadge?.bottomScrim == true) {
@@ -396,6 +398,7 @@ fun AlbumGridItem(
                 reloadKey = coverReloadKey,
                 retainPainterDuringReload = coverRetainPainterDuringReload,
                 peekAnySizeForInitial = true,
+                loading = NoImageLoadingIndicator,
                 modifier = Modifier.fillMaxSize().clip(coverShape),
             )
             if (coverBadge?.bottomScrim == true) {

--- a/app/src/main/java/com/asmr/player/ui/library/LibraryScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/LibraryScreen.kt
@@ -60,6 +60,7 @@ import com.asmr.player.ui.common.AudioItemMenuAction
 import com.asmr.player.ui.common.AudioItemRow
 import com.asmr.player.ui.common.EaraBrandedEmptyState
 import com.asmr.player.ui.common.EaraLogoLoadingIndicator
+import com.asmr.player.ui.common.NoImageLoadingIndicator
 import com.asmr.player.ui.common.FlatActionDialog
 import com.asmr.player.ui.common.FlatDialogAction
 import com.asmr.player.ui.common.FlatDialogActionTone
@@ -1288,6 +1289,7 @@ private fun TrackAlbumHeader(
             contentScale = ContentScale.Crop,
             placeholderCornerRadius = 8,
             peekAnySizeForInitial = true,
+            loading = NoImageLoadingIndicator,
             modifier = Modifier
                 .size(50.dp)
                 .clip(RoundedCornerShape(8.dp)),
@@ -1462,6 +1464,7 @@ private fun AlbumGridItem(
                 contentScale = ContentScale.Crop,
                 placeholderCornerRadius = 0,
                 peekAnySizeForInitial = true,
+                loading = NoImageLoadingIndicator,
                 modifier = Modifier.fillMaxSize().clip(coverShape),
             )
             
@@ -1655,6 +1658,7 @@ private fun AlbumItem(
                         contentScale = ContentScale.Crop,
                         placeholderCornerRadius = 0,
                         peekAnySizeForInitial = true,
+                        loading = NoImageLoadingIndicator,
                         modifier = Modifier.fillMaxSize().clip(coverShape),
                     )
                     

--- a/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailDlsiteTabs.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailDlsiteTabs.kt
@@ -133,6 +133,7 @@ import com.asmr.player.ui.common.SubtitleStamp
 import com.asmr.player.ui.common.AudioItemMenuButtonSize
 import com.asmr.player.ui.common.DiscPlaceholder
 import com.asmr.player.ui.common.AsmrAsyncImage
+import com.asmr.player.ui.common.NoImageLoadingIndicator
 import com.asmr.player.ui.common.AsmrShimmerPlaceholder
 import com.asmr.player.ui.common.CvChipsFlow
 import com.asmr.player.ui.common.EaraLogoLoadingIndicator
@@ -969,6 +970,7 @@ internal fun AlbumDlsiteInfoBreadcrumbTabV2(
                                 contentDescription = null,
                                 contentScale = ContentScale.Crop,
                                 placeholderCornerRadius = DlsiteGalleryThumbCornerRadius,
+                                loading = NoImageLoadingIndicator,
                                 modifier = Modifier.fillMaxSize()
                             )
                         }

--- a/app/src/main/java/com/asmr/player/ui/search/SearchAssistScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/search/SearchAssistScreen.kt
@@ -67,6 +67,7 @@ import com.asmr.player.cache.CacheImageModel
 import com.asmr.player.hotlistening.SearchSuggestionTerm
 import com.asmr.player.ui.common.AsmrAsyncImage
 import com.asmr.player.ui.common.AsmrShimmerPlaceholder
+import com.asmr.player.ui.common.NoImageLoadingIndicator
 import com.asmr.player.ui.common.FlatActionDialog
 import com.asmr.player.ui.common.FlatDialogAction
 import com.asmr.player.ui.common.FlatDialogActionTone
@@ -833,6 +834,7 @@ private fun SearchAssistWorkChip(
             contentDescription = null,
             contentScale = ContentScale.Crop,
             placeholderCornerRadius = 0,
+            loading = NoImageLoadingIndicator,
             modifier = Modifier
                 .aspectRatio(1f)
                 .height(if (compact) 76.dp else 84.dp)


### PR DESCRIPTION
## Summary
- Drop the synchronous memory-cache read in `AsmrAsyncImage` that bypassed the crossfade animation path and caused first-frame jank while scrolling lists/grids.
- Suppress the loading indicator on library, album-detail gallery, and search covers via a shared `NoImageLoadingIndicator` so covers fade in cleanly instead of flashing a spinner.
- Bump `versionCode` 10105 → 10106 and `versionName` 1.1.4 → 1.1.5.

## Changes
- `AsmrAsyncImage.kt` — remove cache short-circuit; add `NoImageLoadingIndicator`.
- `AlbumItem.kt`, `LibraryScreen.kt`, `AlbumDetailDlsiteTabs.kt`, `SearchAssistScreen.kt` — pass `loading = NoImageLoadingIndicator` to cover images.
- `app/build.gradle.kts` — version bump.
