### PR TITLE
Tune scroll fling feel

### DIFF
--- a/app/src/main/java/com/asmr/player/MainActivity.kt
+++ b/app/src/main/java/com/asmr/player/MainActivity.kt
@@ -184,6 +184,7 @@ import com.asmr.player.ui.common.rememberAppVolumeWarningSessionState
 import com.asmr.player.ui.common.rememberCurrentAudioOutputRouteKind
 import com.asmr.player.ui.common.rememberProtectedAppVolumeChangeState
 import com.asmr.player.ui.common.AudioOutputRouteIcon
+import com.asmr.player.ui.common.calmVerticalFling
 import com.asmr.player.ui.common.DismissOutsideBoundsOverlay
 import com.asmr.player.service.AudioOutputRouteKind
 import javax.inject.Inject
@@ -552,7 +553,11 @@ class MainActivity : ComponentActivity() {
             AsmrPlayerTheme(mode = mode, hue = globalHue) {
                 var showSplash by rememberSaveable { mutableStateOf(true) }
                 var contentReady by remember { mutableStateOf(false) }
-                Box(modifier = Modifier.fillMaxSize()) {
+                Box(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .calmVerticalFling()
+                ) {
                     val visibleMessagesSnapshot = visibleMessages.toList()
                     MainContainer(
                         windowSizeClass = windowSizeClass,

--- a/app/src/main/java/com/asmr/player/main/MainContainer.kt
+++ b/app/src/main/java/com/asmr/player/main/MainContainer.kt
@@ -138,6 +138,7 @@ import com.asmr.player.ui.nav.bottomChromeOverlayHeight
 import com.asmr.player.ui.nav.isPrimaryRoute
 import com.asmr.player.ui.nav.resolvePrimaryRoute
 import com.asmr.player.ui.common.LocalBottomOverlayPadding
+import com.asmr.player.ui.common.rememberCalmScrollableFlingBehavior
 import com.asmr.player.ui.splash.EaraSplashOverlay
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
@@ -1234,6 +1235,7 @@ fun MainContainer(
                         Box(modifier = Modifier.weight(1f).fillMaxWidth()) {
                             LazyColumn(
                                 modifier = Modifier.fillMaxSize(),
+                                flingBehavior = rememberCalmScrollableFlingBehavior(),
                                 contentPadding = PaddingValues(top = 10.dp, bottom = 32.dp)
                             ) {
                                 items(navItems, key = { it.third }) { (icon, label, route) ->

--- a/app/src/main/java/com/asmr/player/ui/common/AppScrollFlingTuning.kt
+++ b/app/src/main/java/com/asmr/player/ui/common/AppScrollFlingTuning.kt
@@ -1,0 +1,160 @@
+package com.asmr.player.ui.common
+
+import androidx.compose.foundation.gestures.FlingBehavior
+import androidx.compose.foundation.gestures.ScrollScope
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.withFrameNanos
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
+import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.Velocity
+import androidx.compose.ui.unit.dp
+import kotlin.math.abs
+import kotlin.math.exp
+import kotlin.math.min
+import kotlinx.coroutines.CancellationException
+
+private const val VerticalFlingDampingStartDpPerSecond = 850f
+private const val MaxVerticalFlingVelocityDpPerSecond = 3200f
+private const val VerticalFlingVelocityScale = 0.6f
+private const val FastFlingVelocityDpPerSecond = 1800f
+private const val LowMidFlingVelocityDpPerSecond = 360f
+private const val FastFlingDecayRatePerSecond = 2.6f
+private const val MidFlingDecayRatePerSecond = 0.95f
+private const val LowFlingDecayRatePerSecond = 1.25f
+private const val CalmFlingStopVelocityDpPerSecond = 10f
+private const val MaxFlingFrameSeconds = 1f / 30f
+
+@Composable
+fun Modifier.calmVerticalFling(): Modifier {
+    val density = LocalDensity.current
+    val nestedScrollConnection = remember(density) {
+        val dampingStartPxPerSecond = with(density) {
+            VerticalFlingDampingStartDpPerSecond.dp.toPx()
+        }
+        val maxVelocityPxPerSecond = with(density) {
+            MaxVerticalFlingVelocityDpPerSecond.dp.toPx()
+        }
+        object : NestedScrollConnection {
+            override suspend fun onPreFling(available: Velocity): Velocity {
+                val adjustedY = calmVerticalFlingVelocity(
+                    velocity = available.y,
+                    dampingStartPxPerSecond = dampingStartPxPerSecond,
+                    maxVelocityPxPerSecond = maxVelocityPxPerSecond,
+                    velocityScale = VerticalFlingVelocityScale
+                )
+                if (adjustedY == available.y) return Velocity.Zero
+                return Velocity(x = 0f, y = available.y - adjustedY)
+            }
+        }
+    }
+    return nestedScroll(nestedScrollConnection)
+}
+
+@Composable
+fun rememberCalmScrollableFlingBehavior(): FlingBehavior {
+    val density = LocalDensity.current
+    return remember(density) {
+        CalmScrollableFlingBehavior(
+            stopVelocityPxPerSecond = with(density) {
+                CalmFlingStopVelocityDpPerSecond.dp.toPx()
+            },
+            fastVelocityPxPerSecond = with(density) {
+                FastFlingVelocityDpPerSecond.dp.toPx()
+            },
+            lowMidVelocityPxPerSecond = with(density) {
+                LowMidFlingVelocityDpPerSecond.dp.toPx()
+            }
+        )
+    }
+}
+
+internal fun calmVerticalFlingVelocity(
+    velocity: Float,
+    dampingStartPxPerSecond: Float,
+    maxVelocityPxPerSecond: Float,
+    velocityScale: Float
+): Float {
+    if (!velocity.isFinite()) return velocity
+
+    val maxVelocity = maxVelocityPxPerSecond.coerceAtLeast(0f)
+    val dampingStart = dampingStartPxPerSecond.coerceIn(0f, maxVelocity)
+    val scale = velocityScale.coerceIn(0f, 1f)
+    val magnitude = abs(velocity)
+    val adjustedMagnitude = if (magnitude <= dampingStart) {
+        magnitude
+    } else {
+        dampingStart + (magnitude - dampingStart) * scale
+    }
+    val cappedMagnitude = min(adjustedMagnitude, maxVelocity)
+    return if (velocity < 0f) -cappedMagnitude else cappedMagnitude
+}
+
+internal fun decayedCalmFlingVelocity(
+    velocity: Float,
+    frameSeconds: Float,
+    decayRatePerSecond: Float
+): Float {
+    if (!velocity.isFinite()) return velocity
+    val seconds = frameSeconds.coerceIn(0f, MaxFlingFrameSeconds)
+    val rate = decayRatePerSecond.coerceAtLeast(0f)
+    return velocity * exp((-rate * seconds).toDouble()).toFloat()
+}
+
+internal fun calmFlingDecayRateForVelocity(
+    velocity: Float,
+    fastVelocityPxPerSecond: Float,
+    lowMidVelocityPxPerSecond: Float
+): Float {
+    val magnitude = abs(velocity)
+    val fastVelocity = fastVelocityPxPerSecond.coerceAtLeast(0f)
+    val lowMidVelocity = lowMidVelocityPxPerSecond.coerceIn(0f, fastVelocity)
+    return when {
+        magnitude > fastVelocity -> FastFlingDecayRatePerSecond
+        magnitude > lowMidVelocity -> MidFlingDecayRatePerSecond
+        else -> LowFlingDecayRatePerSecond
+    }
+}
+
+private class CalmScrollableFlingBehavior(
+    private val stopVelocityPxPerSecond: Float,
+    private val fastVelocityPxPerSecond: Float,
+    private val lowMidVelocityPxPerSecond: Float
+) : FlingBehavior {
+    override suspend fun ScrollScope.performFling(initialVelocity: Float): Float {
+        if (!initialVelocity.isFinite()) return initialVelocity
+        var velocity = initialVelocity
+        val stopVelocity = stopVelocityPxPerSecond.coerceAtLeast(0f)
+        if (abs(velocity) <= stopVelocity) return velocity
+
+        try {
+            var previousFrameTime = withFrameNanos { it }
+            while (abs(velocity) > stopVelocity) {
+                val frameTime = withFrameNanos { it }
+                val frameSeconds = ((frameTime - previousFrameTime) / 1_000_000_000f)
+                    .coerceIn(0f, MaxFlingFrameSeconds)
+                previousFrameTime = frameTime
+                if (frameSeconds == 0f) continue
+
+                val delta = velocity * frameSeconds
+                val consumed = scrollBy(delta)
+                if (abs(delta - consumed) > 0.5f) return velocity
+
+                velocity = decayedCalmFlingVelocity(
+                    velocity = velocity,
+                    frameSeconds = frameSeconds,
+                    decayRatePerSecond = calmFlingDecayRateForVelocity(
+                        velocity = velocity,
+                        fastVelocityPxPerSecond = fastVelocityPxPerSecond,
+                        lowMidVelocityPxPerSecond = lowMidVelocityPxPerSecond
+                    )
+                )
+            }
+        } catch (cancelled: CancellationException) {
+            throw cancelled
+        }
+        return 0f
+    }
+}

--- a/app/src/main/java/com/asmr/player/ui/common/ManualReorderDialog.kt
+++ b/app/src/main/java/com/asmr/player/ui/common/ManualReorderDialog.kt
@@ -170,6 +170,7 @@ internal fun ManualReorderDialog(
                         .reorderable(reorderState)
                         .detectReorderAfterLongPress(reorderState)
                         .thinScrollbar(listState),
+                    flingBehavior = rememberCalmScrollableFlingBehavior(),
                     contentPadding = PaddingValues(
                         start = 16.dp,
                         top = 12.dp,

--- a/app/src/main/java/com/asmr/player/ui/downloads/DownloadsScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/downloads/DownloadsScreen.kt
@@ -74,6 +74,7 @@ import com.asmr.player.ui.common.FlatActionDialog
 import com.asmr.player.ui.common.FlatDialogAction
 import com.asmr.player.ui.common.FlatDialogActionTone
 import com.asmr.player.ui.common.LocalBottomOverlayPadding
+import com.asmr.player.ui.common.rememberCalmScrollableFlingBehavior
 import com.asmr.player.ui.common.smoothScrollToTop
 import com.asmr.player.ui.common.thinScrollbar
 import com.asmr.player.ui.theme.AsmrTheme
@@ -173,6 +174,7 @@ fun DownloadsScreen(
                 LazyColumn(
                     state = listState,
                     modifier = Modifier.thinScrollbar(listState),
+                    flingBehavior = rememberCalmScrollableFlingBehavior(),
                     verticalArrangement = Arrangement.spacedBy(6.dp),
                     contentPadding = PaddingValues(
                         top = 4.dp,

--- a/app/src/main/java/com/asmr/player/ui/groups/AlbumGroupDetailScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/groups/AlbumGroupDetailScreen.kt
@@ -78,6 +78,7 @@ import com.asmr.player.ui.common.StableWindowInsets
 import com.asmr.player.ui.common.queryCachedTrackFileSize
 import com.asmr.player.ui.common.rememberAudioMeta
 import com.asmr.player.ui.common.rememberAudioMetaText
+import com.asmr.player.ui.common.rememberCalmScrollableFlingBehavior
 import com.asmr.player.ui.common.SubtitleStamp
 import com.asmr.player.ui.common.smoothScrollToTop
 import com.asmr.player.ui.common.thinScrollbar
@@ -248,6 +249,7 @@ internal fun AlbumGroupDetailContent(
                         .fillMaxSize()
                         .reorderable(reorderState)
                         .thinScrollbar(listState),
+                    flingBehavior = rememberCalmScrollableFlingBehavior(),
                     contentPadding = PaddingValues(bottom = LocalBottomOverlayPadding.current)
                 ) {
                     item(key = GROUP_DETAIL_REORDER_SENTINEL_KEY) {

--- a/app/src/main/java/com/asmr/player/ui/groups/AlbumGroupPickerScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/groups/AlbumGroupPickerScreen.kt
@@ -46,6 +46,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import com.asmr.player.ui.common.rememberCalmScrollableFlingBehavior
 import com.asmr.player.ui.common.thinScrollbar
 import com.asmr.player.ui.theme.AsmrTheme
 
@@ -168,6 +169,7 @@ fun AlbumGroupPickerScreen(
                 LazyColumn(
                     state = listState,
                     modifier = Modifier.fillMaxSize().thinScrollbar(listState),
+                    flingBehavior = rememberCalmScrollableFlingBehavior(),
                     contentPadding = androidx.compose.foundation.layout.PaddingValues(horizontal = 16.dp, vertical = 8.dp),
                     verticalArrangement = Arrangement.spacedBy(10.dp)
                 ) {

--- a/app/src/main/java/com/asmr/player/ui/groups/AlbumGroupsScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/groups/AlbumGroupsScreen.kt
@@ -61,6 +61,7 @@ import com.asmr.player.ui.common.FlatDialogAction
 import com.asmr.player.ui.common.FlatDialogActionTone
 import com.asmr.player.ui.common.FlatTextFieldDialog
 import com.asmr.player.ui.common.LocalBottomOverlayPadding
+import com.asmr.player.ui.common.rememberCalmScrollableFlingBehavior
 import com.asmr.player.ui.common.StableWindowInsets
 import com.asmr.player.ui.common.smoothScrollToTop
 import com.asmr.player.ui.common.thinScrollbar
@@ -125,6 +126,7 @@ fun AlbumGroupsScreen(
                     LazyColumn(
                         state = listState,
                         modifier = Modifier.fillMaxSize().thinScrollbar(listState),
+                        flingBehavior = rememberCalmScrollableFlingBehavior(),
                         contentPadding = PaddingValues(horizontal = AlbumGroupsPageHorizontalPadding, vertical = 8.dp)
                             .withAddedBottomPadding(LocalBottomOverlayPadding.current + 72.dp),
                         verticalArrangement = Arrangement.spacedBy(12.dp)

--- a/app/src/main/java/com/asmr/player/ui/hotlistening/HotListeningScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/hotlistening/HotListeningScreen.kt
@@ -56,6 +56,7 @@ import com.asmr.player.hotlistening.HotListeningSortMode
 import com.asmr.player.ui.common.EaraBrandedEmptyState
 import com.asmr.player.ui.common.EaraLogoLoadingIndicator
 import com.asmr.player.ui.common.LocalBottomOverlayPadding
+import com.asmr.player.ui.common.rememberCalmScrollableFlingBehavior
 import com.asmr.player.ui.common.smoothScrollToTop
 import com.asmr.player.ui.common.thinScrollbar
 import com.asmr.player.ui.common.withAddedBottomPadding
@@ -273,6 +274,7 @@ fun HotListeningScreen(
                         modifier = Modifier
                             .fillMaxSize()
                             .thinScrollbar(listState),
+                        flingBehavior = rememberCalmScrollableFlingBehavior(),
                         contentPadding = PaddingValues(bottom = 8.dp)
                             .withAddedBottomPadding(LocalBottomOverlayPadding.current)
                     ) {
@@ -321,6 +323,7 @@ fun HotListeningScreen(
                         modifier = Modifier
                             .fillMaxSize()
                             .thinScrollbar(gridState),
+                        flingBehavior = rememberCalmScrollableFlingBehavior(),
                         contentPadding = PaddingValues(
                             start = 8.dp,
                             end = 8.dp,

--- a/app/src/main/java/com/asmr/player/ui/library/CloudSyncSelectionDialog.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/CloudSyncSelectionDialog.kt
@@ -61,6 +61,7 @@ import com.asmr.player.data.remote.dlsite.DlsiteCloudSyncCandidate
 import com.asmr.player.ui.common.AsmrShimmerPlaceholder
 import com.asmr.player.ui.common.CvChipsSingleLine
 import com.asmr.player.ui.common.DiscPlaceholder
+import com.asmr.player.ui.common.rememberCalmScrollableFlingBehavior
 import com.asmr.player.ui.common.thinScrollbar
 import com.asmr.player.ui.theme.AsmrTheme
 import com.asmr.player.util.DlsiteAntiHotlink
@@ -188,6 +189,7 @@ internal fun CloudSyncSelectionDialog(
                         .height(CLOUD_SYNC_SELECTION_LIST_HEIGHT)
                         .testTag(CLOUD_SYNC_SELECTION_LIST_TAG)
                         .thinScrollbar(listState),
+                    flingBehavior = rememberCalmScrollableFlingBehavior(),
                     verticalArrangement = Arrangement.spacedBy(CLOUD_SYNC_SELECTION_ROW_SPACING)
                 ) {
                     itemsIndexed(

--- a/app/src/main/java/com/asmr/player/ui/library/LibraryFilterSheet.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/LibraryFilterSheet.kt
@@ -59,6 +59,7 @@ import androidx.compose.ui.unit.dp
 import com.asmr.player.data.local.db.dao.TagWithCount
 import com.asmr.player.ui.common.FlatTextFieldDialog
 import com.asmr.player.ui.common.LocalBottomOverlayPadding
+import com.asmr.player.ui.common.rememberCalmScrollableFlingBehavior
 import com.asmr.player.ui.common.thinScrollbar
 import com.asmr.player.ui.common.withAddedBottomPadding
 import com.asmr.player.ui.theme.AsmrTheme
@@ -155,6 +156,7 @@ fun LibraryFilterSheet(
                 .weight(1f)
                 .fillMaxWidth()
                 .thinScrollbar(listState),
+            flingBehavior = rememberCalmScrollableFlingBehavior(),
             contentPadding = PaddingValues(top = 4.dp, bottom = 96.dp)
                 .withAddedBottomPadding(LocalBottomOverlayPadding.current),
             verticalArrangement = Arrangement.spacedBy(12.dp)

--- a/app/src/main/java/com/asmr/player/ui/library/LibraryScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/LibraryScreen.kt
@@ -67,6 +67,7 @@ import com.asmr.player.ui.common.FlatDialogActionTone
 import com.asmr.player.ui.common.StableWindowInsets
 import com.asmr.player.ui.common.rememberAudioMeta
 import com.asmr.player.ui.common.rememberAudioMetaText
+import com.asmr.player.ui.common.rememberCalmScrollableFlingBehavior
 import com.asmr.player.ui.common.rememberTrackMetaLine
 import com.asmr.player.ui.common.queryCachedTrackFileSize
 import com.asmr.player.ui.common.smoothScrollToTop
@@ -594,6 +595,7 @@ fun LibraryScreen(
                                             .clearFocusOnTapOutside()
                                             .nestedScroll(chromeState.nestedScrollConnection)
                                             .thinScrollbar(listState),
+                                        flingBehavior = rememberCalmScrollableFlingBehavior(),
                                         contentPadding = PaddingValues(top = topPadding, bottom = 8.dp)
                                             .withAddedBottomPadding(LocalBottomOverlayPadding.current)
                                     ) {
@@ -780,6 +782,7 @@ fun LibraryScreen(
                                             .clearFocusOnTapOutside()
                                             .nestedScroll(chromeState.nestedScrollConnection)
                                             .thinScrollbar(gridState),
+                                        flingBehavior = rememberCalmScrollableFlingBehavior(),
                                         contentPadding = PaddingValues(top = topPadding, start = LibraryPageHorizontalPadding, end = LibraryPageHorizontalPadding, bottom = 16.dp)
                                             .withAddedBottomPadding(LocalBottomOverlayPadding.current),
                                         verticalItemSpacing = AlbumGridItemSpacing,
@@ -844,6 +847,7 @@ fun LibraryScreen(
                                             .clearFocusOnTapOutside()
                                             .nestedScroll(chromeState.nestedScrollConnection)
                                             .thinScrollbar(listState),
+                                        flingBehavior = rememberCalmScrollableFlingBehavior(),
                                         contentPadding = PaddingValues(top = topPadding, bottom = 8.dp)
                                             .withAddedBottomPadding(LocalBottomOverlayPadding.current)
                                     ) {

--- a/app/src/main/java/com/asmr/player/ui/library/TagAssignDialog.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/TagAssignDialog.kt
@@ -38,8 +38,9 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import com.asmr.player.data.local.db.dao.TagWithCount
-import com.asmr.player.ui.theme.AsmrTheme
 import com.asmr.player.ui.common.LocalBottomOverlayPadding
+import com.asmr.player.ui.common.rememberCalmScrollableFlingBehavior
+import com.asmr.player.ui.theme.AsmrTheme
 import com.asmr.player.util.TagNormalizer
 
 @OptIn(ExperimentalLayoutApi::class)
@@ -105,7 +106,10 @@ fun TagAssignDialog(
                     modifier = Modifier
                         .fillMaxSize()
                         .padding(horizontal = 16.dp)
-                        .verticalScroll(rememberScrollState())
+                        .verticalScroll(
+                            state = rememberScrollState(),
+                            flingBehavior = rememberCalmScrollableFlingBehavior()
+                        )
                         .padding(bottom = LocalBottomOverlayPadding.current),
                     verticalArrangement = Arrangement.spacedBy(12.dp)
                 ) {

--- a/app/src/main/java/com/asmr/player/ui/library/TagManagerSheet.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/TagManagerSheet.kt
@@ -46,6 +46,7 @@ import com.asmr.player.data.local.db.dao.TagWithCount
 import com.asmr.player.ui.common.FlatActionDialog
 import com.asmr.player.ui.common.FlatDialogAction
 import com.asmr.player.ui.common.FlatDialogActionTone
+import com.asmr.player.ui.common.rememberCalmScrollableFlingBehavior
 import com.asmr.player.ui.common.thinScrollbar
 import com.asmr.player.ui.theme.AsmrTheme
 
@@ -112,7 +113,8 @@ fun TagManagerSheet(
             modifier = Modifier
                 .fillMaxWidth()
                 .weight(1f, fill = true)
-                .thinScrollbar(listState)
+                .thinScrollbar(listState),
+            flingBehavior = rememberCalmScrollableFlingBehavior()
         ) {
             items(visibleTags, key = { it.id }) { tag ->
                 ListItem(

--- a/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailDialogs.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailDialogs.kt
@@ -126,6 +126,7 @@ import com.asmr.player.ui.common.CvChipsFlow
 import com.asmr.player.ui.common.EaraLogoLoadingIndicator
 import com.asmr.player.ui.common.collapsibleHeaderUiState
 import com.asmr.player.ui.common.rememberCollapsibleHeaderState
+import com.asmr.player.ui.common.rememberCalmScrollableFlingBehavior
 import com.asmr.player.ui.playlists.PlaylistPickerScreen
 import com.asmr.player.ui.theme.AsmrTheme
 import com.asmr.player.ui.common.LocalBottomOverlayPadding
@@ -225,6 +226,7 @@ internal fun AsmrOneDownloadDialog(
                         LazyColumn(
                             state = listState,
                             modifier = Modifier.fillMaxSize().thinScrollbar(listState),
+                            flingBehavior = rememberCalmScrollableFlingBehavior(),
                             contentPadding = PaddingValues(vertical = 2.dp)
                         ) {
                             itemsIndexed(items = entries, key = { _, it -> it.path }) { index, entry ->
@@ -474,6 +476,7 @@ internal fun OnlineSaveDialog(
                         LazyColumn(
                             state = listState,
                             modifier = Modifier.fillMaxSize().thinScrollbar(listState),
+                            flingBehavior = rememberCalmScrollableFlingBehavior(),
                             contentPadding = PaddingValues(vertical = 2.dp)
                         ) {
                             itemsIndexed(items = entries, key = { _, it -> it.path }) { index, entry ->
@@ -1037,7 +1040,14 @@ internal fun FilePreviewDialog(
                                     }.getOrNull() ?: "读取失败"
                                 }
                             }
-                            Column(modifier = Modifier.fillMaxSize().verticalScroll(rememberScrollState())) {
+                            Column(
+                                modifier = Modifier
+                                    .fillMaxSize()
+                                    .verticalScroll(
+                                        state = rememberScrollState(),
+                                        flingBehavior = rememberCalmScrollableFlingBehavior()
+                                    )
+                            ) {
                                 Text(
                                     text = textContent ?: "",
                                     style = MaterialTheme.typography.bodySmall,

--- a/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailDirectorySupport.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailDirectorySupport.kt
@@ -140,6 +140,7 @@ import com.asmr.player.ui.common.ImagePreviewRequest
 import com.asmr.player.ui.common.CollapsibleHeaderState
 import com.asmr.player.ui.common.collapsibleHeaderUiState
 import com.asmr.player.ui.common.rememberCollapsibleHeaderState
+import com.asmr.player.ui.common.rememberCalmScrollableFlingBehavior
 import com.asmr.player.ui.playlists.PlaylistPickerScreen
 import com.asmr.player.ui.theme.AsmrColorScheme
 import com.asmr.player.ui.theme.AsmrTheme
@@ -1878,6 +1879,7 @@ internal fun DirectoryBrowserPanel(
                     .fillMaxWidth()
                     .heightIn(max = maxHeight)
                     .thinScrollbar(browserListState),
+                flingBehavior = rememberCalmScrollableFlingBehavior(),
                 contentPadding = PaddingValues(vertical = 6.dp)
             ) {
                 if (folders.isEmpty() && files.isEmpty()) {
@@ -2275,6 +2277,7 @@ internal fun DirectoryBrowserPanelV2(
                     .fillMaxWidth()
                     .heightIn(max = maxHeight)
                     .thinScrollbar(browserListState),
+                flingBehavior = rememberCalmScrollableFlingBehavior(),
                 contentPadding = PaddingValues(horizontal = 8.dp, vertical = 4.dp)
             ) {
                 if (folders.isEmpty() && files.isEmpty()) {
@@ -2821,6 +2824,7 @@ internal fun DirectoryBrowserPanelV4(
                     .height(fixedHeight)
                     .nestedScroll(listNestedScrollConnection)
                     .thinScrollbar(browserListState),
+                flingBehavior = rememberCalmScrollableFlingBehavior(),
                 contentPadding = PaddingValues(horizontal = 8.dp, vertical = 5.dp)
             ) {
                     if (folders.isEmpty() && files.isEmpty()) {

--- a/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailDlsiteTabs.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailDlsiteTabs.kt
@@ -142,6 +142,7 @@ import com.asmr.player.ui.common.ImagePreviewPreparedItem
 import com.asmr.player.ui.common.ImagePreviewRequest
 import com.asmr.player.ui.common.collapsibleHeaderUiState
 import com.asmr.player.ui.common.rememberCollapsibleHeaderState
+import com.asmr.player.ui.common.rememberCalmScrollableFlingBehavior
 import com.asmr.player.ui.playlists.PlaylistPickerScreen
 import com.asmr.player.ui.theme.AsmrTheme
 import com.asmr.player.ui.common.LocalBottomOverlayPadding
@@ -912,6 +913,7 @@ internal fun AlbumDlsiteInfoBreadcrumbTabV2(
             .nestedScroll(chromeState.nestedScrollConnection)
             .thinScrollbar(listState),
         state = listState,
+        flingBehavior = rememberCalmScrollableFlingBehavior(),
         contentPadding = PaddingValues(top = topContentPadding, bottom = LocalBottomOverlayPadding.current)
     ) {
         item(key = "dlsite-header") { header() }
@@ -1367,6 +1369,7 @@ internal fun AlbumDlsitePlayBreadcrumbTabV2(
             .nestedScroll(chromeState.nestedScrollConnection)
             .thinScrollbar(listState),
         state = listState,
+        flingBehavior = rememberCalmScrollableFlingBehavior(),
         contentPadding = PaddingValues(top = topContentPadding, bottom = LocalBottomOverlayPadding.current)
     ) {
         item(key = "dlplay-header:$treeStateKey") { header() }

--- a/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailLocalTab.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailLocalTab.kt
@@ -127,6 +127,7 @@ import com.asmr.player.ui.common.ImagePreviewItem
 import com.asmr.player.ui.common.ImagePreviewRequest
 import com.asmr.player.ui.common.collapsibleHeaderUiState
 import com.asmr.player.ui.common.rememberCollapsibleHeaderState
+import com.asmr.player.ui.common.rememberCalmScrollableFlingBehavior
 import com.asmr.player.ui.playlists.PlaylistPickerScreen
 import com.asmr.player.ui.theme.AsmrTheme
 import com.asmr.player.ui.common.LocalBottomOverlayPadding
@@ -237,6 +238,7 @@ internal fun AlbumLocalBreadcrumbTabV2(
             .nestedScroll(chromeState.nestedScrollConnection)
             .thinScrollbar(listState),
         state = listState,
+        flingBehavior = rememberCalmScrollableFlingBehavior(),
         contentPadding = PaddingValues(top = topContentPadding, bottom = LocalBottomOverlayPadding.current)
     ) {
         item(key = "local-header:$stateKey") { header() }

--- a/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailSharedSections.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailSharedSections.kt
@@ -89,6 +89,7 @@ import com.asmr.player.data.remote.NetworkHeaders
 import com.asmr.player.cache.CacheImageModel
 import com.asmr.player.data.remote.dlsite.DlsiteLanguageEdition
 import com.asmr.player.ui.dlsite.DlsitePlayViewModel
+import com.asmr.player.ui.common.rememberCalmScrollableFlingBehavior
 import com.asmr.player.util.DlsiteAntiHotlink
 import com.asmr.player.util.SmartSortKey
 import com.google.gson.Gson
@@ -437,6 +438,7 @@ internal fun AlbumTracks(album: Album, onTrackClick: (Track) -> Unit) {
         LazyColumn(
             state = listState,
             modifier = Modifier.fillMaxSize().thinScrollbar(listState),
+            flingBehavior = rememberCalmScrollableFlingBehavior(),
             contentPadding = PaddingValues(bottom = LocalBottomOverlayPadding.current)
         ) {
             groupedTracks.forEach { (group, tracks) ->

--- a/app/src/main/java/com/asmr/player/ui/player/AppleLyricsView.kt
+++ b/app/src/main/java/com/asmr/player/ui/player/AppleLyricsView.kt
@@ -70,6 +70,7 @@ import androidx.compose.ui.unit.Constraints
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.asmr.player.data.settings.LyricsPageSettings
+import com.asmr.player.ui.common.rememberCalmScrollableFlingBehavior
 import com.asmr.player.ui.common.thinScrollbar
 import com.asmr.player.ui.theme.AsmrTheme
 import com.asmr.player.util.Formatting
@@ -384,6 +385,7 @@ internal fun AppleLyricsView(
                     .fillMaxSize()
                     .nestedScroll(nestedScrollConnection)
                     .thinScrollbar(listState),
+                flingBehavior = rememberCalmScrollableFlingBehavior(),
                 horizontalAlignment = Alignment.CenterHorizontally,
                 contentPadding = PaddingValues(
                     bottom = centeredActiveBottomDp

--- a/app/src/main/java/com/asmr/player/ui/player/LyricsScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/player/LyricsScreen.kt
@@ -14,6 +14,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.asmr.player.service.PlaybackState
+import com.asmr.player.ui.common.rememberCalmScrollableFlingBehavior
 import com.asmr.player.ui.common.thinScrollbar
 import com.asmr.player.util.SubtitleEntry
 import com.asmr.player.util.SubtitleIndexFinder
@@ -54,6 +55,7 @@ fun LyricsScreen(
             LazyColumn(
                 state = listState,
                 modifier = Modifier.fillMaxSize().thinScrollbar(listState),
+                flingBehavior = rememberCalmScrollableFlingBehavior(),
                 contentPadding = PaddingValues(vertical = if (isLandscape) 100.dp else 200.dp),
                 horizontalAlignment = Alignment.CenterHorizontally
             ) {

--- a/app/src/main/java/com/asmr/player/ui/player/NowPlayingScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/player/NowPlayingScreen.kt
@@ -92,6 +92,7 @@ import com.asmr.player.data.settings.CoverPreviewMode
 import com.asmr.player.data.settings.LyricsPageSettings
 import com.asmr.player.ui.common.AsmrAsyncImage
 import com.asmr.player.ui.common.AudioOutputRouteIcon
+import com.asmr.player.ui.common.rememberCalmScrollableFlingBehavior
 import com.asmr.player.ui.common.thinScrollbar
 import com.asmr.player.ui.common.DismissOutsideBoundsOverlay
 import com.asmr.player.ui.common.AppVolumeHearingWarningDialog
@@ -1685,6 +1686,7 @@ internal fun NowPlayingScreen(
                                 .fillMaxWidth()
                                 .weight(1f, fill = true)
                                 .thinScrollbar(sliceListState),
+                            flingBehavior = rememberCalmScrollableFlingBehavior(),
                             verticalArrangement = Arrangement.spacedBy(10.dp)
                         ) {
                             itemsIndexed(sliceUiState.slices, key = { _, s -> s.id }) { index, slice ->
@@ -1855,7 +1857,10 @@ internal fun NowPlayingScreen(
                         onPlaybackParametersChanged = { speed, pitch -> viewModel.setPlaybackParameters(speed, pitch) },
                         modifier = Modifier
                             .fillMaxSize()
-                            .verticalScroll(scrollState)
+                            .verticalScroll(
+                                state = scrollState,
+                                flingBehavior = rememberCalmScrollableFlingBehavior()
+                            )
                             .padding(bottom = 32.dp)
                     )
                     if (showEqualizerVolumeOverlay) {

--- a/app/src/main/java/com/asmr/player/ui/player/QueueSheet.kt
+++ b/app/src/main/java/com/asmr/player/ui/player/QueueSheet.kt
@@ -39,6 +39,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import com.asmr.player.ui.common.rememberCalmScrollableFlingBehavior
 import com.asmr.player.ui.common.thinScrollbar
 import com.asmr.player.ui.theme.AsmrTheme
 
@@ -70,6 +71,7 @@ fun QueueSheetContent(
                 .fillMaxWidth()
                 .weight(1f, fill = true)
                 .thinScrollbar(listState),
+            flingBehavior = rememberCalmScrollableFlingBehavior(),
             contentPadding = PaddingValues(bottom = 24.dp)
         ) {
             itemsIndexed(queue, key = { idx, it -> "${it.mediaId}#$idx" }) { index, mediaItem ->

--- a/app/src/main/java/com/asmr/player/ui/player/SleepTimerSheet.kt
+++ b/app/src/main/java/com/asmr/player/ui/player/SleepTimerSheet.kt
@@ -34,6 +34,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import com.asmr.player.ui.common.FlatTextFieldDialog
+import com.asmr.player.ui.common.rememberCalmScrollableFlingBehavior
 import com.asmr.player.ui.theme.AsmrTheme
 import kotlinx.coroutines.delay
 import java.util.Locale
@@ -74,7 +75,10 @@ fun SleepTimerSheetContent(
     Column(
         modifier = modifier
             .fillMaxWidth()
-            .verticalScroll(rememberScrollState())
+            .verticalScroll(
+                state = rememberScrollState(),
+                flingBehavior = rememberCalmScrollableFlingBehavior()
+            )
             .padding(bottom = 24.dp)
     ) {
         Row(

--- a/app/src/main/java/com/asmr/player/ui/playlists/PlaylistDetailScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/playlists/PlaylistDetailScreen.kt
@@ -70,6 +70,7 @@ import com.asmr.player.ui.common.FlatDialogActionTone
 import com.asmr.player.ui.common.LocalBottomOverlayPadding
 import com.asmr.player.ui.common.StableWindowInsets
 import com.asmr.player.ui.common.rememberAudioMeta
+import com.asmr.player.ui.common.rememberCalmScrollableFlingBehavior
 import com.asmr.player.ui.common.SubtitleStamp
 import com.asmr.player.ui.common.smoothScrollToTop
 import com.asmr.player.ui.common.thinScrollbar
@@ -218,6 +219,7 @@ internal fun PlaylistDetailContent(
                     modifier = contentModifier
                         .reorderable(reorderState)
                         .thinScrollbar(listState),
+                    flingBehavior = rememberCalmScrollableFlingBehavior(),
                     contentPadding = PaddingValues(top = 6.dp, bottom = LocalBottomOverlayPadding.current)
                 ) {
                     item(key = PLAYLIST_DETAIL_REORDER_SENTINEL_KEY) {

--- a/app/src/main/java/com/asmr/player/ui/playlists/PlaylistPickerDialog.kt
+++ b/app/src/main/java/com/asmr/player/ui/playlists/PlaylistPickerDialog.kt
@@ -44,6 +44,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.media3.common.MediaItem
+import com.asmr.player.ui.common.rememberCalmScrollableFlingBehavior
 import com.asmr.player.ui.common.thinScrollbar
 import com.asmr.player.ui.theme.AsmrTheme
 
@@ -160,6 +161,7 @@ fun PlaylistPickerScreen(
                 LazyColumn(
                     state = listState,
                     modifier = Modifier.fillMaxSize().thinScrollbar(listState),
+                    flingBehavior = rememberCalmScrollableFlingBehavior(),
                     contentPadding = PaddingValues(horizontal = 16.dp, vertical = 8.dp),
                     verticalArrangement = Arrangement.spacedBy(10.dp)
                 ) {

--- a/app/src/main/java/com/asmr/player/ui/playlists/PlaylistsScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/playlists/PlaylistsScreen.kt
@@ -57,6 +57,7 @@ import com.asmr.player.ui.common.FlatDialogAction
 import com.asmr.player.ui.common.FlatDialogActionTone
 import com.asmr.player.ui.common.FlatTextFieldDialog
 import com.asmr.player.ui.common.LocalBottomOverlayPadding
+import com.asmr.player.ui.common.rememberCalmScrollableFlingBehavior
 import com.asmr.player.ui.common.StableWindowInsets
 import com.asmr.player.ui.common.smoothScrollToTop
 import com.asmr.player.ui.common.EaraBrandedEmptyState
@@ -124,6 +125,7 @@ fun PlaylistsScreen(
                     LazyColumn(
                         state = listState,
                         modifier = Modifier.fillMaxSize().thinScrollbar(listState),
+                        flingBehavior = rememberCalmScrollableFlingBehavior(),
                         contentPadding = PaddingValues(horizontal = PlaylistsPageHorizontalPadding, vertical = 8.dp)
                             .withAddedBottomPadding(LocalBottomOverlayPadding.current + 72.dp),
                         verticalArrangement = Arrangement.spacedBy(12.dp)

--- a/app/src/main/java/com/asmr/player/ui/search/SearchAssistScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/search/SearchAssistScreen.kt
@@ -73,6 +73,7 @@ import com.asmr.player.ui.common.FlatDialogAction
 import com.asmr.player.ui.common.FlatDialogActionTone
 import com.asmr.player.ui.common.LocalBottomOverlayPadding
 import com.asmr.player.ui.common.clearFocusOnTapOutside
+import com.asmr.player.ui.common.rememberCalmScrollableFlingBehavior
 import com.asmr.player.ui.common.rememberCollapsibleHeaderState
 import com.asmr.player.ui.common.thinScrollbar
 import com.asmr.player.ui.common.withAddedBottomPadding
@@ -284,6 +285,7 @@ internal fun SearchAssistContent(
                 .clearFocusOnTapOutside()
                 .nestedScroll(chromeState.nestedScrollConnection)
                 .thinScrollbar(listState),
+            flingBehavior = rememberCalmScrollableFlingBehavior(),
             contentPadding = PaddingValues(
                 top = topPadding,
                 bottom = 24.dp

--- a/app/src/main/java/com/asmr/player/ui/search/SearchScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/search/SearchScreen.kt
@@ -115,6 +115,7 @@ import com.asmr.player.ui.common.StableWindowInsets
 import com.asmr.player.ui.common.clearFocusOnTapOutside
 import com.asmr.player.ui.common.collapsibleHeaderUiState
 import com.asmr.player.ui.common.consumeTapThrough
+import com.asmr.player.ui.common.rememberCalmScrollableFlingBehavior
 import com.asmr.player.ui.common.rememberCollapsibleHeaderState
 import com.asmr.player.ui.common.smoothScrollToTop
 import com.asmr.player.ui.common.thinScrollbar
@@ -830,7 +831,10 @@ fun SearchScreen(
                             is SearchUiState.Loading -> Column(
                                 modifier = Modifier
                                     .fillMaxSize()
-                                    .verticalScroll(rememberScrollState())
+                                    .verticalScroll(
+                                        state = rememberScrollState(),
+                                        flingBehavior = rememberCalmScrollableFlingBehavior()
+                                    )
                                     .padding(top = topPadding),
                                 horizontalAlignment = Alignment.CenterHorizontally,
                                 verticalArrangement = Arrangement.Center
@@ -857,6 +861,7 @@ fun SearchScreen(
                                             .fillMaxSize()
                                             .nestedScroll(chromeState.nestedScrollConnection)
                                             .thinScrollbar(listState),
+                                        flingBehavior = rememberCalmScrollableFlingBehavior(),
                                         contentPadding = PaddingValues(top = topPadding, bottom = 8.dp)
                                             .withAddedBottomPadding(LocalBottomOverlayPadding.current)
                                     ) {
@@ -890,6 +895,7 @@ fun SearchScreen(
                                             .fillMaxSize()
                                             .nestedScroll(chromeState.nestedScrollConnection)
                                             .thinScrollbar(gridState),
+                                        flingBehavior = rememberCalmScrollableFlingBehavior(),
                                         contentPadding = PaddingValues(
                                             top = topPadding,
                                             start = SearchPageHorizontalPadding,
@@ -950,7 +956,10 @@ fun SearchScreen(
                             else -> Column(
                                 modifier = Modifier
                                     .fillMaxSize()
-                                    .verticalScroll(rememberScrollState())
+                                    .verticalScroll(
+                                        state = rememberScrollState(),
+                                        flingBehavior = rememberCalmScrollableFlingBehavior()
+                                    )
                             ) {}
                             }
                         }

--- a/app/src/main/java/com/asmr/player/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/settings/SettingsScreen.kt
@@ -77,6 +77,7 @@ import com.asmr.player.ui.common.FlatDialogAction
 import com.asmr.player.ui.common.FlatDialogActionTone
 import com.asmr.player.ui.theme.AsmrTheme
 import com.asmr.player.ui.common.LocalBottomOverlayPadding
+import com.asmr.player.ui.common.rememberCalmScrollableFlingBehavior
 import com.asmr.player.ui.common.StableWindowInsets
 import com.asmr.player.ui.common.smoothScrollToTop
 import com.asmr.player.ui.common.thinScrollbar
@@ -192,6 +193,7 @@ fun SettingsScreen(
             LazyColumn(
                 state = listState,
                 modifier = contentModifier.thinScrollbar(listState),
+                flingBehavior = rememberCalmScrollableFlingBehavior(),
                 contentPadding = PaddingValues(horizontal = SettingsPageHorizontalPadding, vertical = 10.dp)
                     .withAddedBottomPadding(LocalBottomOverlayPadding.current),
                 verticalArrangement = Arrangement.spacedBy(16.dp)

--- a/app/src/main/java/com/asmr/player/ui/sidepanel/landscapesidepanelshost.kt
+++ b/app/src/main/java/com/asmr/player/ui/sidepanel/landscapesidepanelshost.kt
@@ -19,6 +19,7 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.material3.windowsizeclass.WindowSizeClass
 import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
+import com.asmr.player.ui.common.rememberCalmScrollableFlingBehavior
 
 @Composable
 fun LandscapeSidePanelsHost(
@@ -54,7 +55,10 @@ fun LandscapeSidePanelsHost(
                     .width(sideColumnWidth)
                     .fillMaxHeight()
                     .padding(start = sidePadding, top = sidePadding, bottom = sidePadding)
-                    .verticalScroll(rememberScrollState()),
+                    .verticalScroll(
+                        state = rememberScrollState(),
+                        flingBehavior = rememberCalmScrollableFlingBehavior()
+                    ),
                 verticalArrangement = Arrangement.spacedBy(12.dp)
             ) {
                 left()
@@ -67,7 +71,10 @@ fun LandscapeSidePanelsHost(
                     .width(sideColumnWidth)
                     .fillMaxHeight()
                     .padding(end = sidePadding, top = sidePadding, bottom = sidePadding)
-                    .verticalScroll(rememberScrollState()),
+                    .verticalScroll(
+                        state = rememberScrollState(),
+                        flingBehavior = rememberCalmScrollableFlingBehavior()
+                    ),
                 verticalArrangement = Arrangement.spacedBy(12.dp)
             ) {
                 right()

--- a/app/src/test/java/com/asmr/player/ui/common/AppScrollFlingTuningTest.kt
+++ b/app/src/test/java/com/asmr/player/ui/common/AppScrollFlingTuningTest.kt
@@ -1,0 +1,82 @@
+package com.asmr.player.ui.common
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class AppScrollFlingTuningTest {
+    @Test
+    fun calmVerticalFlingVelocity_keepsGentleFlingUnchanged() {
+        assertEquals(
+            700f,
+            calmVerticalFlingVelocity(
+                velocity = 700f,
+                dampingStartPxPerSecond = 850f,
+                maxVelocityPxPerSecond = 3200f,
+                velocityScale = 0.6f
+            ),
+            0.001f
+        )
+    }
+
+    @Test
+    fun calmVerticalFlingVelocity_dampsVelocityAboveStartThreshold() {
+        assertEquals(
+            1540f,
+            calmVerticalFlingVelocity(
+                velocity = 2000f,
+                dampingStartPxPerSecond = 850f,
+                maxVelocityPxPerSecond = 3200f,
+                velocityScale = 0.6f
+            ),
+            0.001f
+        )
+    }
+
+    @Test
+    fun calmVerticalFlingVelocity_capsFastFlingAndKeepsDirection() {
+        assertEquals(
+            -3200f,
+            calmVerticalFlingVelocity(
+                velocity = -9000f,
+                dampingStartPxPerSecond = 850f,
+                maxVelocityPxPerSecond = 3200f,
+                velocityScale = 0.6f
+            ),
+            0.001f
+        )
+    }
+
+    @Test
+    fun decayedCalmFlingVelocity_reducesVelocityWithoutFlippingDirection() {
+        val decayed = decayedCalmFlingVelocity(
+            velocity = -2400f,
+            frameSeconds = 1f / 60f,
+            decayRatePerSecond = 2.7f
+        )
+
+        assertEquals(true, decayed < 0f)
+        assertEquals(true, decayed > -2400f)
+    }
+
+    @Test
+    fun calmFlingDecayRateForVelocity_keepsMidSpeedGlideLongerThanFastAndFinalSlowdown() {
+        val fastRate = calmFlingDecayRateForVelocity(
+            velocity = 2400f,
+            fastVelocityPxPerSecond = 1800f,
+            lowMidVelocityPxPerSecond = 360f
+        )
+        val midRate = calmFlingDecayRateForVelocity(
+            velocity = 1000f,
+            fastVelocityPxPerSecond = 1800f,
+            lowMidVelocityPxPerSecond = 360f
+        )
+        val lowRate = calmFlingDecayRateForVelocity(
+            velocity = 220f,
+            fastVelocityPxPerSecond = 1800f,
+            lowMidVelocityPxPerSecond = 360f
+        )
+
+        assertEquals(true, fastRate > lowRate)
+        assertEquals(true, lowRate > midRate)
+    }
+}


### PR DESCRIPTION
## Summary
- Add shared scroll fling tuning for a calmer vertical scroll feel.
- Apply the calmer fling behavior to vertical lists, staggered grids, panels, and scrollable sheets across the app.
- Cover the velocity damping curve with unit tests.

## Verification
- .\gradlew-local.bat :app:testReleaseUnitTest --tests com.asmr.player.ui.common.AppScrollFlingTuningTest
- .\gradlew-local.bat :app:installRelease