### PR TITLE
fix: improve listen together listener count

### DIFF
--- a/app/src/main/java/com/asmr/player/listentogether/ListenTogetherModels.kt
+++ b/app/src/main/java/com/asmr/player/listentogether/ListenTogetherModels.kt
@@ -37,12 +37,14 @@ data class ListenTogetherPresencePayload(
     val isPlaying: Boolean,
     val sentAtEpochMs: Long,
     val clientSessionId: String,
+    val deviceId: String,
     val appVersion: String? = null
 )
 
 data class ListenTogetherLeavePayload(
     val sessionKey: String,
     val clientSessionId: String,
+    val deviceId: String,
     val sentAtEpochMs: Long
 )
 

--- a/app/src/main/java/com/asmr/player/listentogether/ListenTogetherRepository.kt
+++ b/app/src/main/java/com/asmr/player/listentogether/ListenTogetherRepository.kt
@@ -2,6 +2,7 @@ package com.asmr.player.listentogether
 
 import android.os.Build
 import com.asmr.player.BuildConfig
+import com.asmr.player.data.local.DeviceIdentityStore
 import com.asmr.player.data.remote.NetworkHeaders
 import com.google.gson.Gson
 import kotlinx.coroutines.Dispatchers
@@ -20,7 +21,8 @@ import javax.inject.Singleton
 @Singleton
 class ListenTogetherRepository @Inject constructor(
     private val okHttpClient: OkHttpClient,
-    private val gson: Gson
+    private val gson: Gson,
+    private val deviceIdentityStore: DeviceIdentityStore
 ) {
     private val clientSessionId = UUID.randomUUID().toString()
     private val appHeaderValue = "com.asmr.player/${BuildConfig.VERSION_NAME} (${BuildConfig.VERSION_CODE})"
@@ -36,6 +38,7 @@ class ListenTogetherRepository @Inject constructor(
         isPlaying: Boolean
     ): ListenTogetherPresenceResponse? {
         if (!isBackendConfigured) return null
+        val deviceId = deviceIdentityStore.getOrCreateDeviceId()
         val payload = ListenTogetherPresencePayload(
             sessionKey = identity.sessionKey,
             albumKey = identity.albumKey,
@@ -52,19 +55,22 @@ class ListenTogetherRepository @Inject constructor(
             isPlaying = isPlaying,
             sentAtEpochMs = System.currentTimeMillis(),
             clientSessionId = clientSessionId,
+            deviceId = deviceId,
             appVersion = "${BuildConfig.VERSION_NAME} (${BuildConfig.VERSION_CODE}) / Android ${Build.VERSION.SDK_INT}"
         )
-        return postJson("presence/upsert", payload, ListenTogetherPresenceResponse::class.java)
+        return postJson("presence/upsert", payload, ListenTogetherPresenceResponse::class.java, deviceId)
     }
 
     suspend fun leave(identity: ListenTogetherTrackIdentity) {
         if (!isBackendConfigured) return
+        val deviceId = deviceIdentityStore.getOrCreateDeviceId()
         val payload = ListenTogetherLeavePayload(
             sessionKey = identity.sessionKey,
             clientSessionId = clientSessionId,
+            deviceId = deviceId,
             sentAtEpochMs = System.currentTimeMillis()
         )
-        postJson<Unit>("presence/leave", payload, null)
+        postJson<Unit>("presence/leave", payload, null, deviceId)
     }
 
     suspend fun getRjSummary(rjCode: String): ListenTogetherRjSummaryResponse? {
@@ -78,11 +84,17 @@ class ListenTogetherRepository @Inject constructor(
         )
     }
 
-    private suspend fun <T : Any> postJson(path: String, body: Any, responseClass: Class<T>?): T? {
+    private suspend fun <T : Any> postJson(
+        path: String,
+        body: Any,
+        responseClass: Class<T>?,
+        deviceId: String
+    ): T? {
         return withContext(Dispatchers.IO) {
             val request = Request.Builder()
                 .url(resolveUrl(path))
                 .header("User-Agent", userAgent)
+                .header(NetworkHeaders.HEADER_EARA_DEVICE_ID, deviceId)
                 .header("X-Listen-Together-App", appHeaderValue)
                 .header("X-Listen-Together-Client-Session-Id", clientSessionId)
                 .header("X-Listen-Together-Device-Fingerprint", deviceFingerprint)
@@ -121,6 +133,7 @@ class ListenTogetherRepository @Inject constructor(
             val request = Request.Builder()
                 .url(url)
                 .header("User-Agent", userAgent)
+                .header(NetworkHeaders.HEADER_EARA_DEVICE_ID, deviceIdentityStore.getOrCreateDeviceId())
                 .header("X-Listen-Together-App", appHeaderValue)
                 .header("X-Listen-Together-Client-Session-Id", clientSessionId)
                 .header("X-Listen-Together-Device-Fingerprint", deviceFingerprint)

--- a/app/src/main/java/com/asmr/player/ui/library/AlbumDetailScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/AlbumDetailScreen.kt
@@ -16,8 +16,10 @@ import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.spring
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.expandVertically
+import androidx.compose.animation.expandHorizontally
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
+import androidx.compose.animation.shrinkHorizontally
 import androidx.compose.animation.shrinkVertically
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
@@ -1353,46 +1355,66 @@ private fun AlbumHeroIdentityOverlay(
                         appearance = AlbumMetaAppearance.OnImage,
                         leadingVisual = AlbumMetaLeadingVisual.Icon,
                     )
-                    if (listenTogetherRjListenerCount != null && rj.isNotBlank()) {
-                        Spacer(modifier = Modifier.width(8.dp))
-                        val listenerContainer = colorScheme.primary.copy(alpha = if (colorScheme.isDark) 0.36f else 0.30f)
-                        val listenerContent = if (colorScheme.isDark) {
-                            Color.White.copy(alpha = 0.96f)
-                        } else {
-                            colorScheme.textPrimary.copy(alpha = 0.88f)
-                        }
-                        val listenerBorder = colorScheme.primary.copy(alpha = if (colorScheme.isDark) 0.52f else 0.42f)
-                        Surface(
-                            color = listenerContainer,
-                            contentColor = listenerContent,
-                            shape = RoundedCornerShape(999.dp),
-                            border = androidx.compose.foundation.BorderStroke(
-                                width = 0.5.dp,
-                                color = listenerBorder
-                            )
-                        ) {
-                            Row(
-                                modifier = Modifier.padding(horizontal = 7.dp, vertical = 2.dp),
-                                horizontalArrangement = Arrangement.spacedBy(4.dp),
-                                verticalAlignment = Alignment.CenterVertically
-                            ) {
-                                Icon(
-                                    painter = painterResource(id = com.asmr.player.R.drawable.ic_users_round),
-                                    contentDescription = null,
-                                    tint = listenerContent,
-                                    modifier = Modifier.size(12.dp)
-                                )
-                                Text(
-                                    text = "${listenTogetherRjListenerCount.coerceAtLeast(0)} 人正在听",
-                                    style = MaterialTheme.typography.labelSmall,
-                                    color = listenerContent,
-                                    maxLines = 1,
-                                    overflow = TextOverflow.Ellipsis,
-                                )
-                            }
-                        }
-                    }
+                    AlbumOnlineListenerInfo(
+                        listenerCount = listenTogetherRjListenerCount,
+                        visible = rj.isNotBlank(),
+                        modifier = Modifier.padding(start = 8.dp)
+                    )
                 }
+            }
+        }
+    }
+}
+
+@Composable
+private fun AlbumOnlineListenerInfo(
+    listenerCount: Int?,
+    visible: Boolean,
+    modifier: Modifier = Modifier
+) {
+    val count = listenerCount?.coerceAtLeast(0)
+    val colorScheme = AsmrTheme.colorScheme
+    val contentColor = if (colorScheme.isDark) {
+        Color.White.copy(alpha = 0.96f)
+    } else {
+        colorScheme.textPrimary.copy(alpha = 0.90f)
+    }
+    val textShadow = Shadow(
+        color = if (colorScheme.isDark) Color.Black.copy(alpha = 0.42f) else Color.White.copy(alpha = 0.58f),
+        offset = Offset(0f, 1f),
+        blurRadius = 5f
+    )
+
+    AnimatedVisibility(
+        visible = visible && count != null,
+        enter = fadeIn(animationSpec = AlbumHeaderEnterTweenSpec) + expandHorizontally(
+            animationSpec = AlbumHeaderExpandTweenSpec,
+            expandFrom = Alignment.Start
+        ),
+        exit = fadeOut(animationSpec = tween(durationMillis = 120)) + shrinkHorizontally(
+            animationSpec = tween(durationMillis = 160, easing = FastOutLinearInEasing),
+            shrinkTowards = Alignment.Start
+        )
+    ) {
+        if (count != null) {
+            Row(
+                modifier = modifier,
+                horizontalArrangement = Arrangement.spacedBy(4.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Icon(
+                    painter = painterResource(id = com.asmr.player.R.drawable.ic_users_round),
+                    contentDescription = null,
+                    tint = contentColor,
+                    modifier = Modifier.size(12.dp)
+                )
+                Text(
+                    text = "$count 人正在听",
+                    style = MaterialTheme.typography.labelSmall.copy(shadow = textShadow),
+                    color = contentColor,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
             }
         }
     }

--- a/app/src/main/java/com/asmr/player/ui/player/NowPlayingScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/player/NowPlayingScreen.kt
@@ -371,16 +371,7 @@ private fun ListenTogetherAudienceCountText(
     modifier: Modifier = Modifier
 ) {
     val textStyle = MaterialTheme.typography.labelSmall
-    var lastNonZeroCount by remember { mutableIntStateOf(0) }
-
-    val displayCount = when {
-        companionCount > 0 -> {
-            lastNonZeroCount = companionCount
-            companionCount
-        }
-        lastNonZeroCount > 0 -> lastNonZeroCount
-        else -> 0
-    }
+    val displayCount = companionCount.coerceAtLeast(0)
 
     AnimatedContent(
         targetState = displayCount > 0,

--- a/app/src/main/java/com/asmr/player/ui/player/playerviewmodel.kt
+++ b/app/src/main/java/com/asmr/player/ui/player/playerviewmodel.kt
@@ -15,6 +15,7 @@ import com.asmr.player.domain.model.Track
 import com.asmr.player.data.local.db.dao.TrackDao
 import com.asmr.player.data.settings.SettingsRepository
 import com.asmr.player.listentogether.ListenTogetherIdentityResolver
+import com.asmr.player.listentogether.ListenTogetherPresenceResponse
 import com.asmr.player.listentogether.ListenTogetherRepository
 import com.asmr.player.listentogether.ListenTogetherStatus
 import com.asmr.player.listentogether.ListenTogetherTrackIdentity
@@ -72,6 +73,21 @@ import java.util.Locale
 
 private const val ONLINE_MANUAL_LYRICS_MESSAGE = "在线音频如需替换歌词，请先下载音频到本地"
 private const val LISTEN_TOGETHER_POLL_INTERVAL_MS = 60_000L
+private const val LISTEN_TOGETHER_MIN_POLL_INTERVAL_MS = 5_000L
+
+internal fun resolveListenTogetherHeartbeatDelayMs(response: ListenTogetherPresenceResponse?): Long {
+    val requestedInterval = response?.heartbeatIntervalMs
+        ?.takeIf { it > 0L }
+        ?: LISTEN_TOGETHER_POLL_INTERVAL_MS
+    val boundedInterval = requestedInterval.coerceIn(
+        LISTEN_TOGETHER_MIN_POLL_INTERVAL_MS,
+        LISTEN_TOGETHER_POLL_INTERVAL_MS
+    )
+    val expiryBound = response?.expiresInMs
+        ?.takeIf { it > 0L }
+        ?.let { (it * 2L / 3L).coerceIn(LISTEN_TOGETHER_MIN_POLL_INTERVAL_MS, LISTEN_TOGETHER_POLL_INTERVAL_MS) }
+    return expiryBound?.let { minOf(boundedInterval, it) } ?: boundedInterval
+}
 
 @HiltViewModel
 @OptIn(FlowPreview::class)
@@ -937,7 +953,7 @@ class PlayerViewModel @Inject constructor(
                         backendConfigured = true,
                         status = ListenTogetherStatus.Ready
                     )
-                    delay(response?.heartbeatIntervalMs?.coerceAtLeast(LISTEN_TOGETHER_POLL_INTERVAL_MS) ?: LISTEN_TOGETHER_POLL_INTERVAL_MS)
+                    delay(resolveListenTogetherHeartbeatDelayMs(response))
                 }.onFailure {
                     _listenTogetherUiState.value = _listenTogetherUiState.value.copy(
                         available = true,

--- a/app/src/test/java/com/asmr/player/ui/player/ListenTogetherHeartbeatDelayTest.kt
+++ b/app/src/test/java/com/asmr/player/ui/player/ListenTogetherHeartbeatDelayTest.kt
@@ -1,0 +1,42 @@
+package com.asmr.player.ui.player
+
+import com.asmr.player.listentogether.ListenTogetherPresenceResponse
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ListenTogetherHeartbeatDelayTest {
+
+    @Test
+    fun respectsBackendHeartbeatInterval() {
+        val response = response(heartbeatIntervalMs = 15_000L)
+
+        assertEquals(15_000L, resolveListenTogetherHeartbeatDelayMs(response))
+    }
+
+    @Test
+    fun keepsHeartbeatBelowExpiryWindow() {
+        val response = response(
+            heartbeatIntervalMs = 30_000L,
+            expiresInMs = 18_000L
+        )
+
+        assertEquals(12_000L, resolveListenTogetherHeartbeatDelayMs(response))
+    }
+
+    @Test
+    fun fallsBackToOneMinuteWhenBackendOmitsInterval() {
+        assertEquals(60_000L, resolveListenTogetherHeartbeatDelayMs(null))
+    }
+
+    private fun response(
+        heartbeatIntervalMs: Long,
+        expiresInMs: Long? = null
+    ): ListenTogetherPresenceResponse {
+        return ListenTogetherPresenceResponse(
+            listenerCount = 1,
+            sessionKey = "RJ000000:track",
+            heartbeatIntervalMs = heartbeatIntervalMs,
+            expiresInMs = expiresInMs
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- Send persistent device identity for listen-together presence so listener counts can be deduped by device.
- Update album detail listener info to wait for real counts, use icon + text styling, and animate consistently.
- Avoid stale/non-zero companion counts and derive heartbeat delay from backend timing with client-side bounds.

## Verification
- `.\gradlew-local.bat :app:testReleaseUnitTest --tests com.asmr.player.ui.player.ListenTogetherHeartbeatDelayTest`
- `.\gradlew-local.bat :app:compileReleaseKotlin`
- `.\gradlew-local.bat :app:installRelease`