### PR TITLE
feat: refine now playing expanded layout

### DIFF
--- a/app/src/main/java/com/asmr/player/MainActivity.kt
+++ b/app/src/main/java/com/asmr/player/MainActivity.kt
@@ -153,6 +153,7 @@ import com.asmr.player.data.local.datastore.SettingsDataStore
 import com.asmr.player.data.local.datastore.ThemeBootstrapPreferences
 import com.asmr.player.data.settings.CoverPreviewMode
 import com.asmr.player.data.settings.LyricsPageSettings
+import com.asmr.player.data.settings.NowPlayingHomeLayoutMode
 import com.asmr.player.util.MessageManager
 import com.asmr.player.ui.common.NonTouchableAppMessageOverlay
 import com.asmr.player.ui.common.StableWindowInsets
@@ -280,6 +281,9 @@ class MainActivity : ComponentActivity() {
             val coverBackgroundEnabled by settingsDataStore.coverBackgroundEnabled.collectAsState(initial = true)
             val coverBackgroundClarity by settingsDataStore.coverBackgroundClarity.collectAsState(initial = 0.35f)
             val coverPreviewMode by settingsDataStore.coverPreviewMode.collectAsState(initial = CoverPreviewMode.Disabled)
+            val nowPlayingHomeLayoutMode by settingsDataStore.nowPlayingHomeLayoutMode.collectAsState(
+                initial = NowPlayingHomeLayoutMode.Classic
+            )
             val lyricsPageSettings by settingsDataStore.lyricsPageSettings.collectAsState(initial = LyricsPageSettings())
             val showMiniPlayerBar by settingsRepository.showMiniPlayerBar.collectAsState(initial = true)
             val neutral = remember(mode) { neutralPaletteForMode(mode) }
@@ -576,6 +580,7 @@ class MainActivity : ComponentActivity() {
                         coverBackgroundEnabled = coverBackgroundEnabled,
                         coverBackgroundClarity = coverBackgroundClarity,
                         coverPreviewMode = coverPreviewMode,
+                        nowPlayingHomeLayoutMode = nowPlayingHomeLayoutMode,
                         lyricsPageSettings = lyricsPageSettings,
                         forceImmersive = showSplash,
                         volumeKeyEventTick = volumeKeyTick

--- a/app/src/main/java/com/asmr/player/MainActivity.kt
+++ b/app/src/main/java/com/asmr/player/MainActivity.kt
@@ -148,6 +148,7 @@ import androidx.compose.material.icons.automirrored.rounded.QueueMusic
 import com.asmr.player.ui.player.QueueSheetContent
 import com.asmr.player.ui.player.SleepTimerSheetContent
 import com.asmr.player.ui.player.MiniPlayerDisplayMode
+import kotlinx.coroutines.flow.first
 
 import com.asmr.player.data.local.datastore.SettingsDataStore
 import com.asmr.player.data.local.datastore.ThemeBootstrapPreferences
@@ -284,6 +285,9 @@ class MainActivity : ComponentActivity() {
             val nowPlayingHomeLayoutMode by settingsDataStore.nowPlayingHomeLayoutMode.collectAsState(
                 initial = NowPlayingHomeLayoutMode.Classic
             )
+            val nowPlayingHomeLayoutHintDismissed by produceState(initialValue = false, settingsDataStore) {
+                value = settingsDataStore.nowPlayingHomeLayoutHintDismissed.first()
+            }
             val lyricsPageSettings by settingsDataStore.lyricsPageSettings.collectAsState(initial = LyricsPageSettings())
             val showMiniPlayerBar by settingsRepository.showMiniPlayerBar.collectAsState(initial = true)
             val neutral = remember(mode) { neutralPaletteForMode(mode) }
@@ -581,6 +585,7 @@ class MainActivity : ComponentActivity() {
                         coverBackgroundClarity = coverBackgroundClarity,
                         coverPreviewMode = coverPreviewMode,
                         nowPlayingHomeLayoutMode = nowPlayingHomeLayoutMode,
+                        nowPlayingHomeLayoutHintDismissed = nowPlayingHomeLayoutHintDismissed,
                         lyricsPageSettings = lyricsPageSettings,
                         forceImmersive = showSplash,
                         volumeKeyEventTick = volumeKeyTick

--- a/app/src/main/java/com/asmr/player/data/local/datastore/SettingsDataStore.kt
+++ b/app/src/main/java/com/asmr/player/data/local/datastore/SettingsDataStore.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import androidx.datastore.preferences.core.*
 import com.asmr.player.data.settings.CoverPreviewMode
 import com.asmr.player.data.settings.LyricsPageSettings
+import com.asmr.player.data.settings.NowPlayingHomeLayoutMode
 import com.asmr.player.data.settings.settingsDataStore
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.Dispatchers
@@ -38,6 +39,7 @@ class SettingsDataStore @Inject constructor(
     private val coverBackgroundEnabledKey = booleanPreferencesKey("cover_background_enabled")
     private val coverBackgroundClarityKey = floatPreferencesKey("cover_background_clarity")
     private val coverPreviewModeKey = stringPreferencesKey("cover_preview_mode")
+    private val nowPlayingHomeLayoutModeKey = stringPreferencesKey("now_playing_home_layout_mode")
     private val lyricsPageFontSizeKey = floatPreferencesKey("lyrics_page_font_size")
     private val lyricsPageStrokeWidthKey = floatPreferencesKey("lyrics_page_stroke_width")
     private val lyricsPageLineHeightMultiplierKey = floatPreferencesKey("lyrics_page_line_height_multiplier")
@@ -84,6 +86,9 @@ class SettingsDataStore @Inject constructor(
     val coverBackgroundClarity: Flow<Float> = context.settingsDataStore.data.map { it[coverBackgroundClarityKey] ?: 0.35f }
     val coverPreviewMode: Flow<CoverPreviewMode> = context.settingsDataStore.data.map {
         CoverPreviewMode.fromStorageValue(it[coverPreviewModeKey])
+    }
+    val nowPlayingHomeLayoutMode: Flow<NowPlayingHomeLayoutMode> = context.settingsDataStore.data.map {
+        NowPlayingHomeLayoutMode.fromStorageValue(it[nowPlayingHomeLayoutModeKey])
     }
     val lyricsPageSettings: Flow<LyricsPageSettings> = context.settingsDataStore.data.map { prefs ->
         LyricsPageSettings(
@@ -162,6 +167,10 @@ class SettingsDataStore @Inject constructor(
 
     suspend fun setCoverPreviewMode(mode: CoverPreviewMode) {
         context.settingsDataStore.edit { it[coverPreviewModeKey] = mode.storageValue }
+    }
+
+    suspend fun setNowPlayingHomeLayoutMode(mode: NowPlayingHomeLayoutMode) {
+        context.settingsDataStore.edit { it[nowPlayingHomeLayoutModeKey] = mode.storageValue }
     }
 
     suspend fun setLyricsPageSettings(settings: LyricsPageSettings) {

--- a/app/src/main/java/com/asmr/player/data/local/datastore/SettingsDataStore.kt
+++ b/app/src/main/java/com/asmr/player/data/local/datastore/SettingsDataStore.kt
@@ -40,6 +40,7 @@ class SettingsDataStore @Inject constructor(
     private val coverBackgroundClarityKey = floatPreferencesKey("cover_background_clarity")
     private val coverPreviewModeKey = stringPreferencesKey("cover_preview_mode")
     private val nowPlayingHomeLayoutModeKey = stringPreferencesKey("now_playing_home_layout_mode")
+    private val nowPlayingHomeLayoutHintDismissedKey = booleanPreferencesKey("now_playing_home_layout_hint_dismissed")
     private val lyricsPageFontSizeKey = floatPreferencesKey("lyrics_page_font_size")
     private val lyricsPageStrokeWidthKey = floatPreferencesKey("lyrics_page_stroke_width")
     private val lyricsPageLineHeightMultiplierKey = floatPreferencesKey("lyrics_page_line_height_multiplier")
@@ -89,6 +90,9 @@ class SettingsDataStore @Inject constructor(
     }
     val nowPlayingHomeLayoutMode: Flow<NowPlayingHomeLayoutMode> = context.settingsDataStore.data.map {
         NowPlayingHomeLayoutMode.fromStorageValue(it[nowPlayingHomeLayoutModeKey])
+    }
+    val nowPlayingHomeLayoutHintDismissed: Flow<Boolean> = context.settingsDataStore.data.map {
+        it[nowPlayingHomeLayoutHintDismissedKey] ?: false
     }
     val lyricsPageSettings: Flow<LyricsPageSettings> = context.settingsDataStore.data.map { prefs ->
         LyricsPageSettings(
@@ -169,8 +173,16 @@ class SettingsDataStore @Inject constructor(
         context.settingsDataStore.edit { it[coverPreviewModeKey] = mode.storageValue }
     }
 
-    suspend fun setNowPlayingHomeLayoutMode(mode: NowPlayingHomeLayoutMode) {
-        context.settingsDataStore.edit { it[nowPlayingHomeLayoutModeKey] = mode.storageValue }
+    suspend fun setNowPlayingHomeLayoutMode(
+        mode: NowPlayingHomeLayoutMode,
+        dismissHint: Boolean = false
+    ) {
+        context.settingsDataStore.edit { prefs ->
+            prefs[nowPlayingHomeLayoutModeKey] = mode.storageValue
+            if (dismissHint) {
+                prefs[nowPlayingHomeLayoutHintDismissedKey] = true
+            }
+        }
     }
 
     suspend fun setLyricsPageSettings(settings: LyricsPageSettings) {

--- a/app/src/main/java/com/asmr/player/data/settings/NowPlayingHomeLayoutMode.kt
+++ b/app/src/main/java/com/asmr/player/data/settings/NowPlayingHomeLayoutMode.kt
@@ -1,0 +1,12 @@
+package com.asmr.player.data.settings
+
+enum class NowPlayingHomeLayoutMode(val storageValue: String) {
+    Classic("classic"),
+    Expanded("expanded");
+
+    companion object {
+        fun fromStorageValue(value: String?): NowPlayingHomeLayoutMode {
+            return entries.firstOrNull { it.storageValue == value } ?: Classic
+        }
+    }
+}

--- a/app/src/main/java/com/asmr/player/main/MainContainer.kt
+++ b/app/src/main/java/com/asmr/player/main/MainContainer.kt
@@ -513,6 +513,7 @@ fun MainContainer(
     coverBackgroundClarity: Float,
     coverPreviewMode: CoverPreviewMode,
     nowPlayingHomeLayoutMode: NowPlayingHomeLayoutMode,
+    nowPlayingHomeLayoutHintDismissed: Boolean,
     lyricsPageSettings: LyricsPageSettings,
     forceImmersive: Boolean,
     volumeKeyEventTick: Long
@@ -2462,8 +2463,11 @@ fun MainContainer(
                     coverBackgroundClarity = coverBackgroundClarity,
                     coverPreviewMode = coverPreviewMode,
                     nowPlayingHomeLayoutMode = nowPlayingHomeLayoutMode,
+                    nowPlayingHomeLayoutHintDismissed = nowPlayingHomeLayoutHintDismissed,
                     onNowPlayingHomeLayoutModeChange = { mode ->
-                        scope.launch { settingsDataStore.setNowPlayingHomeLayoutMode(mode) }
+                        scope.launch {
+                            settingsDataStore.setNowPlayingHomeLayoutMode(mode, dismissHint = true)
+                        }
                     },
                     lyricsPageSettings = lyricsPageSettings,
                     audioOutputRouteKind = audioOutputRouteKind,

--- a/app/src/main/java/com/asmr/player/main/MainContainer.kt
+++ b/app/src/main/java/com/asmr/player/main/MainContainer.kt
@@ -186,6 +186,7 @@ import com.asmr.player.ui.player.MiniPlayerDisplayMode
 import com.asmr.player.data.local.datastore.SettingsDataStore
 import com.asmr.player.data.settings.CoverPreviewMode
 import com.asmr.player.data.settings.LyricsPageSettings
+import com.asmr.player.data.settings.NowPlayingHomeLayoutMode
 import com.asmr.player.util.MessageManager
 import com.asmr.player.ui.common.NonTouchableAppMessageOverlay
 import com.asmr.player.ui.common.StableWindowInsets
@@ -511,6 +512,7 @@ fun MainContainer(
     coverBackgroundEnabled: Boolean,
     coverBackgroundClarity: Float,
     coverPreviewMode: CoverPreviewMode,
+    nowPlayingHomeLayoutMode: NowPlayingHomeLayoutMode,
     lyricsPageSettings: LyricsPageSettings,
     forceImmersive: Boolean,
     volumeKeyEventTick: Long
@@ -2459,6 +2461,10 @@ fun MainContainer(
                     coverBackgroundEnabled = coverBackgroundEnabled,
                     coverBackgroundClarity = coverBackgroundClarity,
                     coverPreviewMode = coverPreviewMode,
+                    nowPlayingHomeLayoutMode = nowPlayingHomeLayoutMode,
+                    onNowPlayingHomeLayoutModeChange = { mode ->
+                        scope.launch { settingsDataStore.setNowPlayingHomeLayoutMode(mode) }
+                    },
                     lyricsPageSettings = lyricsPageSettings,
                     audioOutputRouteKind = audioOutputRouteKind,
                     warningSessionState = appVolumeWarningSessionState,

--- a/app/src/main/java/com/asmr/player/ui/player/AppleLyricsView.kt
+++ b/app/src/main/java/com/asmr/player/ui/player/AppleLyricsView.kt
@@ -47,6 +47,7 @@ import androidx.compose.runtime.mutableStateMapOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.withFrameNanos
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -76,10 +77,8 @@ import com.asmr.player.ui.theme.AsmrTheme
 import com.asmr.player.util.Formatting
 import com.asmr.player.util.SubtitleEntry
 import com.asmr.player.util.SubtitleIndexFinder
-import androidx.compose.runtime.withFrameNanos
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
-import kotlin.math.absoluteValue
 import kotlin.math.abs
 import kotlin.math.roundToInt
 
@@ -94,7 +93,9 @@ internal fun AppleLyricsView(
     colors: LyricReadableColors,
     modifier: Modifier = Modifier,
     isLandscape: Boolean = false,
-    settings: LyricsPageSettings = LyricsPageSettings()
+    settings: LyricsPageSettings = LyricsPageSettings(),
+    interactionEnabled: Boolean = true,
+    stableFocusAnchor: Boolean = false
 ) {
     val indexFinder = remember(lyrics) { SubtitleIndexFinder(lyrics) }
     val activeIndex = remember(currentPosition, indexFinder) {
@@ -118,7 +119,6 @@ internal fun AppleLyricsView(
     val baseLyricTextStyle = MaterialTheme.typography.titleLarge
     val itemOffsets = remember { mutableStateMapOf<Int, Animatable<Float, AnimationVector1D>>() }
     val textMeasurer = rememberTextMeasurer()
-    var previousActiveIndex by remember { mutableIntStateOf(activeIndex) }
     var autoFocusSuspended by remember { mutableStateOf(false) }
     var lastUserScrollAt by remember { mutableLongStateOf(0L) }
     var pendingAnimatedRefocus by remember { mutableStateOf(false) }
@@ -159,7 +159,7 @@ internal fun AppleLyricsView(
         }
         val measurementStyle = remember(baseLyricTextStyle, fontSize, wrappedLineHeight, textAlign) {
             baseLyricTextStyle.copy(
-                fontWeight = FontWeight.Bold,
+                fontWeight = FontWeight.ExtraBold,
                 fontSize = fontSize,
                 lineHeight = wrappedLineHeight,
                 textAlign = textAlign
@@ -222,9 +222,7 @@ internal fun AppleLyricsView(
         }
         val viewportWindowHeightDp = with(density) { viewportLayout.viewportWindowHeightPx.toDp() }
         val viewportTopOffsetDp = with(density) { viewportLayout.viewportTopOffsetPx.toDp() }
-        val centeredActiveTopPx = ((viewportLayout.viewportWindowHeightPx - activeItemHeightPx) / 2f).coerceAtLeast(0f)
         val centeredActiveBottomDp = viewportWindowHeightDp / 2f
-        val viewportCenterY = viewportLayout.viewportWindowHeightPx / 2f
         val timelineCenterInViewportPx = (viewportHeightPx / 2f - viewportLayout.viewportTopOffsetPx)
             .coerceIn(0f, viewportLayout.viewportWindowHeightPx)
         val maxWaveOffsetPx = viewportLayout.viewportWindowHeightPx * 0.22f
@@ -257,41 +255,43 @@ internal fun AppleLyricsView(
         }
 
         LaunchedEffect(lyrics) {
-            previousActiveIndex = activeIndex
             pendingSmoothFocusIndex = -1
         }
 
-        LaunchedEffect(activeIndex, autoFocusSuspended, lyricItemHeightsPx, viewportLayout, pendingSmoothFocusIndex) {
+        LaunchedEffect(activeIndex, autoFocusSuspended, lyricItemHeightsPx, viewportLayout, pendingSmoothFocusIndex, stableFocusAnchor) {
             if (lyrics.isEmpty() || activeIndex < 0 || autoFocusSuspended) return@LaunchedEffect
 
-            val targetScrollOffset = -centeredActiveTopPx.roundToInt()
             var didReposition = false
-            val indexDelta = activeIndex - previousActiveIndex
+            var repositionDeltaPx: Float? = null
             val visibleItems = listState.layoutInfo.visibleItemsInfo
             val activeItemInfo = visibleItems.firstOrNull { it.index == activeIndex }
             val activeTopPx = activeItemInfo?.offset?.toFloat()
+            val activeFocusHeightPx = if (stableFocusAnchor) {
+                nominalItemHeightPx
+            } else {
+                activeItemInfo?.size?.toFloat() ?: activeItemHeightPx
+            }
+            val centeredActiveTopPx = centeredLyricFocusTop(
+                viewportWindowHeightPx = viewportLayout.viewportWindowHeightPx,
+                activeItemHeightPx = activeFocusHeightPx,
+                nominalItemHeightPx = nominalItemHeightPx,
+                stableFocusAnchor = false
+            )
+            val targetScrollOffset = -centeredActiveTopPx.roundToInt()
             val isPinnedAtTop = listState.firstVisibleItemIndex == 0 && listState.firstVisibleItemScrollOffset == 0
-            val hasReachedViewportCenter = activeTopPx?.let { top ->
-                top + activeItemHeightPx / 2f >= viewportCenterY
-            } ?: false
-            val isFirstCenterTransition = indexDelta != 0 &&
-                indexDelta.absoluteValue <= 2 &&
-                isPinnedAtTop &&
-                hasReachedViewportCenter &&
-                activeTopPx != null
-            val shouldUseSmoothFocus = pendingAnimatedRefocus || pendingSmoothFocusIndex == activeIndex
+            val shouldUseSmoothFocus = stableFocusAnchor ||
+                pendingAnimatedRefocus ||
+                pendingSmoothFocusIndex == activeIndex
             val defaultAffectedIndices = (
                 visibleItems.map { it.index } +
                     targetWindowRange.toList()
                 ).distinct().sorted()
-            val shouldPlayNeighborWave = !shouldUseSmoothFocus &&
-                indexDelta != 0 &&
-                indexDelta.absoluteValue <= 2
 
             if (activeTopPx != null) {
                 if (!(isPinnedAtTop && activeTopPx <= centeredActiveTopPx)) {
                     val desiredTopPx = centeredActiveTopPx
                     if (kotlin.math.abs(activeTopPx - desiredTopPx) > 1f) {
+                        repositionDeltaPx = activeTopPx - desiredTopPx
                         if (shouldUseSmoothFocus) {
                             listState.animateLyricFocusToIndex(
                                 index = activeIndex,
@@ -319,17 +319,11 @@ internal fun AppleLyricsView(
                 didReposition = true
             }
 
-            val resolvedWave = when {
-                !didReposition || shouldUseSmoothFocus -> null
-                isFirstCenterTransition -> activeTopPx?.plus(activeItemHeightPx / 2f)?.minus(viewportCenterY)
-                shouldPlayNeighborWave -> lyricCenterDistancePx(
-                    lyricItemHeightsPx = lyricItemHeightsPx,
-                    fromIndex = previousActiveIndex,
-                    toIndex = activeIndex,
-                    nominalItemHeightPx = nominalItemHeightPx
-                )
-                else -> null
-            }?.coerceIn(-maxWaveOffsetPx, maxWaveOffsetPx)
+            val resolvedWave = if (didReposition && !shouldUseSmoothFocus) {
+                repositionDeltaPx?.coerceIn(-maxWaveOffsetPx, maxWaveOffsetPx)
+            } else {
+                null
+            }
 
             if (resolvedWave != null) {
                 resetLyricWaveOffsets(
@@ -369,7 +363,6 @@ internal fun AppleLyricsView(
             if (pendingSmoothFocusIndex == activeIndex) {
                 pendingSmoothFocusIndex = -1
             }
-            previousActiveIndex = activeIndex
         }
 
         Box(
@@ -383,9 +376,10 @@ internal fun AppleLyricsView(
                 state = listState,
                 modifier = Modifier
                     .fillMaxSize()
-                    .nestedScroll(nestedScrollConnection)
+                    .then(if (interactionEnabled) Modifier.nestedScroll(nestedScrollConnection) else Modifier)
                     .thinScrollbar(listState),
                 flingBehavior = rememberCalmScrollableFlingBehavior(),
+                userScrollEnabled = interactionEnabled,
                 horizontalAlignment = Alignment.CenterHorizontally,
                 contentPadding = PaddingValues(
                     bottom = centeredActiveBottomDp
@@ -396,6 +390,9 @@ internal fun AppleLyricsView(
                     key = { index, entry -> lyricItemKey(index, entry) },
                     contentType = { _, _ -> "appleLyricLine" }
                 ) { index, entry ->
+                    val reservedItemHeightDp = with(density) {
+                        (lyricItemHeightsPx.getOrNull(index) ?: nominalItemHeightPx).toDp()
+                    }
                     val isActive = index == activeIndex
                     val scale by animateFloatAsState(
                         targetValue = 1f,
@@ -425,6 +422,7 @@ internal fun AppleLyricsView(
                     Box(
                         modifier = Modifier
                             .fillMaxWidth()
+                            .height(reservedItemHeightDp)
                             .padding(
                                 start = itemOuterHorizontalPadding,
                                 top = itemOuterVerticalPadding,
@@ -437,7 +435,7 @@ internal fun AppleLyricsView(
                                 this.scaleY = scale
                                 this.alpha = alpha
                             }
-                            .clickable {
+                            .clickable(enabled = interactionEnabled) {
                                 pendingSmoothFocusIndex = if (activeIndex >= 0 && activeIndex != index) index else -1
                                 autoFocusSuspended = false
                                 pendingAnimatedRefocus = false
@@ -523,26 +521,6 @@ private fun measuredWindowHeight(
     return targetRange.sumOf { index ->
         lyricItemHeightsPx.getOrNull(index)?.toDouble() ?: nominalItemHeightPx.toDouble()
     }.toFloat()
-}
-
-private fun lyricCenterDistancePx(
-    lyricItemHeightsPx: List<Float>,
-    fromIndex: Int,
-    toIndex: Int,
-    nominalItemHeightPx: Float
-): Float {
-    if (fromIndex == toIndex) return 0f
-    val step = if (toIndex > fromIndex) 1 else -1
-    var distancePx = 0f
-    var currentIndex = fromIndex
-    while (currentIndex != toIndex) {
-        val nextIndex = currentIndex + step
-        val currentHeight = lyricItemHeightsPx.getOrNull(currentIndex) ?: nominalItemHeightPx
-        val nextHeight = lyricItemHeightsPx.getOrNull(nextIndex) ?: nominalItemHeightPx
-        distancePx += (currentHeight + nextHeight) / 2f * step
-        currentIndex = nextIndex
-    }
-    return distancePx
 }
 
 private fun buildLyricItemOffsets(

--- a/app/src/main/java/com/asmr/player/ui/player/AppleLyricsView.kt
+++ b/app/src/main/java/com/asmr/player/ui/player/AppleLyricsView.kt
@@ -68,6 +68,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.rememberTextMeasurer
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.Constraints
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.asmr.player.data.settings.LyricsPageSettings
@@ -95,7 +96,9 @@ internal fun AppleLyricsView(
     isLandscape: Boolean = false,
     settings: LyricsPageSettings = LyricsPageSettings(),
     interactionEnabled: Boolean = true,
-    stableFocusAnchor: Boolean = false
+    stableFocusAnchor: Boolean = false,
+    itemOuterHorizontalPadding: Dp = if (isLandscape) 10.dp else 14.dp,
+    itemInnerHorizontalPadding: Dp = if (isLandscape) 8.dp else 10.dp
 ) {
     val indexFinder = remember(lyrics) { SubtitleIndexFinder(lyrics) }
     val activeIndex = remember(currentPosition, indexFinder) {
@@ -105,8 +108,6 @@ internal fun AppleLyricsView(
     val density = LocalDensity.current
     val itemOuterVerticalPadding = 0.dp
     val itemInnerVerticalPadding = if (isLandscape) 2.dp else 3.dp
-    val itemOuterHorizontalPadding = if (isLandscape) 10.dp else 14.dp
-    val itemInnerHorizontalPadding = if (isLandscape) 8.dp else 10.dp
     val fontSize = settings.fontSizeSp.sp
     val wrappedLineHeight = (settings.fontSizeSp * 1.2f).sp
     val fontSizePx = with(density) { fontSize.toPx() }

--- a/app/src/main/java/com/asmr/player/ui/player/LyricsPageLayout.kt
+++ b/app/src/main/java/com/asmr/player/ui/player/LyricsPageLayout.kt
@@ -59,6 +59,16 @@ internal fun calculateRuntimeMaxVisibleLines(
     return max(1, floor(viewportHeightPx / lineBlockHeightPx).toInt())
 }
 
+internal fun centeredLyricFocusTop(
+    viewportWindowHeightPx: Float,
+    activeItemHeightPx: Float,
+    nominalItemHeightPx: Float,
+    stableFocusAnchor: Boolean
+): Float {
+    val focusHeightPx = if (stableFocusAnchor) nominalItemHeightPx else activeItemHeightPx
+    return ((viewportWindowHeightPx - focusHeightPx) / 2f).coerceAtLeast(0f)
+}
+
 internal fun lyricTextAlign(align: Int): TextAlign = when (align) {
     0 -> TextAlign.Start
     2 -> TextAlign.End

--- a/app/src/main/java/com/asmr/player/ui/player/NowPlayingHomeLayoutGesture.kt
+++ b/app/src/main/java/com/asmr/player/ui/player/NowPlayingHomeLayoutGesture.kt
@@ -1,0 +1,85 @@
+package com.asmr.player.ui.player
+
+import androidx.compose.foundation.gestures.awaitEachGesture
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.input.pointer.positionChanged
+import androidx.compose.ui.unit.dp
+import com.asmr.player.data.settings.NowPlayingHomeLayoutMode
+import kotlin.math.abs
+
+private val NowPlayingHomeLayoutSwipeThreshold = 56.dp
+private const val NowPlayingHomeLayoutVerticalDominance = 1.15f
+
+internal fun Modifier.nowPlayingHomeLayoutSwipeGesture(
+    enabled: Boolean,
+    currentMode: NowPlayingHomeLayoutMode,
+    onModeChange: (NowPlayingHomeLayoutMode) -> Unit
+): Modifier {
+    if (!enabled) return this
+    return pointerInput(enabled, currentMode, onModeChange) {
+        val thresholdPx = NowPlayingHomeLayoutSwipeThreshold.toPx()
+        awaitEachGesture {
+            var totalDragX = 0f
+            var totalDragY = 0f
+            var multiPointerGesture = false
+            while (true) {
+                val event = awaitPointerEvent()
+                val pressed = event.changes.filter { it.pressed }
+                if (pressed.isEmpty()) break
+                if (pressed.size > 1) {
+                    multiPointerGesture = true
+                    continue
+                }
+                val change = pressed.first()
+                totalDragX += change.position.x - change.previousPosition.x
+                totalDragY += change.position.y - change.previousPosition.y
+                if (isNowPlayingHomeLayoutSwipeCandidate(totalDragX, totalDragY, thresholdPx * 0.4f) &&
+                    change.positionChanged()
+                ) {
+                    change.consume()
+                }
+            }
+            if (!multiPointerGesture) {
+                val nextMode = resolveNowPlayingHomeLayoutModeAfterSwipe(
+                    currentMode = currentMode,
+                    totalDragX = totalDragX,
+                    totalDragY = totalDragY,
+                    thresholdPx = thresholdPx
+                )
+                if (nextMode != currentMode) {
+                    onModeChange(nextMode)
+                }
+            }
+        }
+    }
+}
+
+internal fun resolveNowPlayingHomeLayoutModeAfterSwipe(
+    currentMode: NowPlayingHomeLayoutMode,
+    totalDragX: Float,
+    totalDragY: Float,
+    thresholdPx: Float
+): NowPlayingHomeLayoutMode {
+    if (!isNowPlayingHomeLayoutSwipeCandidate(totalDragX, totalDragY, thresholdPx)) {
+        return currentMode
+    }
+    return if (totalDragY < 0f) {
+        NowPlayingHomeLayoutMode.Expanded
+    } else {
+        NowPlayingHomeLayoutMode.Classic
+    }
+}
+
+private fun isNowPlayingHomeLayoutSwipeCandidate(
+    totalDragX: Float,
+    totalDragY: Float,
+    thresholdPx: Float
+): Boolean {
+    if (!totalDragX.isFinite() || !totalDragY.isFinite() || !thresholdPx.isFinite()) return false
+    val verticalDistance = abs(totalDragY)
+    val horizontalDistance = abs(totalDragX)
+    val safeThreshold = thresholdPx.coerceAtLeast(1f)
+    return verticalDistance >= safeThreshold &&
+        verticalDistance >= horizontalDistance * NowPlayingHomeLayoutVerticalDominance
+}

--- a/app/src/main/java/com/asmr/player/ui/player/NowPlayingScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/player/NowPlayingScreen.kt
@@ -50,6 +50,7 @@ import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Shadow
+import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.graphics.drawscope.drawIntoCanvas
 import androidx.compose.ui.graphics.graphicsLayer
@@ -133,6 +134,7 @@ private enum class NowPlayingSurfaceMode {
 }
 
 private const val VideoProgressUiTickMs = 1_000L
+private const val NowPlayingHomeLayoutAnimationDurationMillis = 620
 
 private data class NowPlayingStaticPlayback(
     val isConnected: Boolean,
@@ -617,6 +619,98 @@ private fun ExpandedPlayerIdentityOverlay(
 }
 
 @Composable
+private fun NowPlayingHomeLayoutSwipeHint(
+    modifier: Modifier = Modifier
+) {
+    val transition = rememberInfiniteTransition(label = "nowPlayingHomeLayoutSwipeHint")
+    val waveProgress by transition.animateFloat(
+        initialValue = 0f,
+        targetValue = 1f,
+        animationSpec = infiniteRepeatable(
+            animation = tween(durationMillis = 2800, easing = LinearEasing),
+            repeatMode = RepeatMode.Restart
+        ),
+        label = "nowPlayingHomeLayoutSwipeHintProgress"
+    )
+    val textShadow = remember {
+        Shadow(
+            color = Color.Black.copy(alpha = 0.72f),
+            offset = Offset(0f, 1.2f),
+            blurRadius = 4f
+        )
+    }
+
+    Column(
+        modifier = modifier
+            .padding(horizontal = 8.dp, vertical = 4.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(1.dp)
+    ) {
+        Canvas(
+            modifier = Modifier
+                .width(44.dp)
+                .height(24.dp)
+        ) {
+            repeat(4) { index ->
+                val phase = (waveProgress + index * 0.25f) % 1f
+                val edgeFade = when {
+                    phase < 0.22f -> phase / 0.22f
+                    phase > 0.78f -> (1f - phase) / 0.22f
+                    else -> 1f
+                }.coerceIn(0f, 1f)
+                val pulse = edgeFade * edgeFade * (3f - 2f * edgeFade)
+                val centerX = size.width / 2f
+                val centerY = size.height * (0.88f - phase * 0.70f)
+                val halfWidth = size.width * 0.15f
+                val halfHeight = size.height * 0.14f
+                val color = Color.White.copy(alpha = pulse * 0.66f)
+                val shadowColor = Color.Black.copy(alpha = pulse * 0.24f)
+                val strokeWidth = 1.45.dp.toPx()
+                drawLine(
+                    color = shadowColor,
+                    start = Offset(centerX - halfWidth, centerY + halfHeight + 1.2f),
+                    end = Offset(centerX, centerY - halfHeight + 1.2f),
+                    strokeWidth = strokeWidth + 1.2f,
+                    cap = StrokeCap.Round
+                )
+                drawLine(
+                    color = shadowColor,
+                    start = Offset(centerX + halfWidth, centerY + halfHeight + 1.2f),
+                    end = Offset(centerX, centerY - halfHeight + 1.2f),
+                    strokeWidth = strokeWidth + 1.2f,
+                    cap = StrokeCap.Round
+                )
+                drawLine(
+                    color = color,
+                    start = Offset(centerX - halfWidth, centerY + halfHeight),
+                    end = Offset(centerX, centerY - halfHeight),
+                    strokeWidth = strokeWidth,
+                    cap = StrokeCap.Round
+                )
+                drawLine(
+                    color = color,
+                    start = Offset(centerX + halfWidth, centerY + halfHeight),
+                    end = Offset(centerX, centerY - halfHeight),
+                    strokeWidth = strokeWidth,
+                    cap = StrokeCap.Round
+                )
+            }
+        }
+        Text(
+            text = "上滑切换封面排布",
+            style = MaterialTheme.typography.labelMedium.copy(
+                fontWeight = FontWeight.SemiBold,
+                shadow = textShadow
+            ),
+            color = Color.White.copy(alpha = 0.86f),
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+            textAlign = TextAlign.Center
+        )
+    }
+}
+
+@Composable
 @androidx.media3.common.util.UnstableApi
 @OptIn(ExperimentalFoundationApi::class, ExperimentalMaterial3Api::class, ExperimentalComposeUiApi::class)
 internal fun NowPlayingScreen(
@@ -634,6 +728,7 @@ internal fun NowPlayingScreen(
     coverBackgroundClarity: Float,
     coverPreviewMode: CoverPreviewMode,
     nowPlayingHomeLayoutMode: NowPlayingHomeLayoutMode,
+    nowPlayingHomeLayoutHintDismissed: Boolean,
     onNowPlayingHomeLayoutModeChange: (NowPlayingHomeLayoutMode) -> Unit,
     lyricsPageSettings: LyricsPageSettings,
     audioOutputRouteKind: AudioOutputRouteKind,
@@ -698,13 +793,29 @@ internal fun NowPlayingScreen(
 
     val haptic = LocalHapticFeedback.current
     val context = LocalContext.current
+    var homeLayoutHintDismissedInSession by rememberSaveable { mutableStateOf(false) }
+    val homeLayoutHintScope = rememberCoroutineScope()
+    LaunchedEffect(nowPlayingHomeLayoutHintDismissed) {
+        if (nowPlayingHomeLayoutHintDismissed) {
+            homeLayoutHintDismissedInSession = true
+        }
+    }
     val changeNowPlayingHomeLayoutMode = remember(
         haptic,
         nowPlayingHomeLayoutMode,
+        nowPlayingHomeLayoutHintDismissed,
+        homeLayoutHintDismissedInSession,
+        homeLayoutHintScope,
         onNowPlayingHomeLayoutModeChange
     ) {
         { mode: NowPlayingHomeLayoutMode ->
             if (mode != nowPlayingHomeLayoutMode) {
+                if (!nowPlayingHomeLayoutHintDismissed && !homeLayoutHintDismissedInSession) {
+                    homeLayoutHintScope.launch {
+                        delay(NowPlayingHomeLayoutAnimationDurationMillis.toLong())
+                        homeLayoutHintDismissedInSession = true
+                    }
+                }
                 haptic.performHapticFeedback(HapticFeedbackType.LongPress)
                 onNowPlayingHomeLayoutModeChange(mode)
             }
@@ -1468,9 +1579,12 @@ internal fun NowPlayingScreen(
             val controlsMotion = routeTransition.nowPlayingMotionModifier(motionLayout, NowPlayingMotionSlot.CONTROLS)
             val volumeMotion = routeTransition.nowPlayingMotionModifier(motionLayout, NowPlayingMotionSlot.VOLUME)
             val expandedHomeLayout = nowPlayingHomeLayoutMode == NowPlayingHomeLayoutMode.Expanded && !isVideo
+            val homeLayoutSwipeHintAllowed = !nowPlayingHomeLayoutHintDismissed &&
+                !homeLayoutHintDismissedInSession &&
+                !isVideo
             val portraitContentHorizontalPadding = 24.dp
             val homeBezier = remember { CubicBezierEasing(0.20f, 0f, 0f, 1f) }
-            val homeLayoutDurationMillis = 620
+            val homeLayoutDurationMillis = NowPlayingHomeLayoutAnimationDurationMillis
             val homeFadeInDurationMillis = 240
             val homeFadeOutDurationMillis = 160
             val expandedHomeLyricsSettings = remember(lyricsPageSettings) {
@@ -1481,6 +1595,8 @@ internal fun NowPlayingScreen(
                 targetState = expandedHomeLayout,
                 label = "nowPlayingHomeLayoutMode"
             )
+            val showHomeLayoutSwipeHint = homeLayoutSwipeHintAllowed &&
+                !homeLayoutTransition.currentState
             val portraitTopPadding by homeLayoutTransition.animateDp(
                 transitionSpec = {
                     tween(durationMillis = homeLayoutDurationMillis, easing = homeBezier)
@@ -1504,6 +1620,14 @@ internal fun NowPlayingScreen(
                 label = "nowPlayingHomeLyricsTopPadding"
             ) { expanded ->
                 if (expanded) 14.dp else 6.dp
+            }
+            val lyricsHorizontalPadding by homeLayoutTransition.animateDp(
+                transitionSpec = {
+                    tween(durationMillis = homeLayoutDurationMillis, easing = homeBezier)
+                },
+                label = "nowPlayingHomeLyricsHorizontalPadding"
+            ) { expanded ->
+                if (expanded) 0.dp else portraitContentHorizontalPadding
             }
             val homeCoverAspectRatio by homeLayoutTransition.animateFloat(
                 transitionSpec = {
@@ -1697,6 +1821,14 @@ internal fun NowPlayingScreen(
                                             dragPreviewEnabled = useDragPreview,
                                             dragPreviewState = coverDragPreviewState
                                         )
+                                        if (showHomeLayoutSwipeHint) {
+                                            NowPlayingHomeLayoutSwipeHint(
+                                                modifier = Modifier
+                                                    .align(Alignment.BottomCenter)
+                                                    .padding(bottom = 16.dp)
+                                                    .graphicsLayer { alpha = classicIdentityAlpha }
+                                            )
+                                        }
                                         if (expandedIdentityAlpha > 0.001f) {
                                             Box(
                                                 modifier = Modifier
@@ -1721,7 +1853,7 @@ internal fun NowPlayingScreen(
                                     modifier = Modifier
                                         .fillMaxWidth()
                                         .weight(1f)
-                                        .padding(horizontal = portraitContentHorizontalPadding)
+                                        .padding(horizontal = lyricsHorizontalPadding)
                                         .then(lyricsMotion),
                                     contentAlignment = Alignment.TopCenter
                                 ) {
@@ -1748,6 +1880,8 @@ internal fun NowPlayingScreen(
                                                 onAddLyrics = openManualLyricsAction,
                                                 interactionEnabled = lyricsExpandedInteractionEnabled,
                                                 stableFocusAnchor = true,
+                                                lyricItemOuterHorizontalPadding = 6.dp,
+                                                lyricItemInnerHorizontalPadding = 8.dp,
                                                 modifier = Modifier.fillMaxSize()
                                             )
                                         }

--- a/app/src/main/java/com/asmr/player/ui/player/NowPlayingScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/player/NowPlayingScreen.kt
@@ -53,6 +53,7 @@ import androidx.compose.ui.graphics.Shadow
 import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.graphics.drawscope.drawIntoCanvas
 import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.graphics.luminance
 import androidx.compose.ui.graphics.nativeCanvas
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.input.pointer.pointerInput
@@ -87,9 +88,12 @@ import androidx.media3.common.VideoSize
 import androidx.media3.ui.PlayerView
 import com.asmr.player.R
 import com.asmr.player.HardwareVolumeOverlay
+import com.asmr.player.cache.CachePolicy
+import com.asmr.player.cache.ImageCacheEntryPoint
 import com.asmr.player.data.lyrics.lyricsTargetContextFromMediaItem
 import com.asmr.player.data.settings.CoverPreviewMode
 import com.asmr.player.data.settings.LyricsPageSettings
+import com.asmr.player.data.settings.NowPlayingHomeLayoutMode
 import com.asmr.player.ui.common.AsmrAsyncImage
 import com.asmr.player.ui.common.AudioOutputRouteIcon
 import com.asmr.player.ui.common.rememberCalmScrollableFlingBehavior
@@ -113,6 +117,7 @@ import com.asmr.player.util.SubtitleEntry
 import com.asmr.player.util.SubtitleIndexFinder
 import com.asmr.player.listentogether.ListenTogetherStatus
 import com.asmr.player.listentogether.ListenTogetherUiState
+import dagger.hilt.android.EntryPointAccessors
 import kotlin.math.abs
 import kotlin.math.roundToInt
 import kotlin.math.roundToLong
@@ -254,6 +259,34 @@ private fun Modifier.fitVideoPreviewAspectRatio(
     }
 }
 
+@Composable
+private fun rememberArtworkAspectRatio(artworkModel: Any?): Float {
+    val context = LocalContext.current.applicationContext
+    val manager = remember(context) {
+        EntryPointAccessors.fromApplication(context, ImageCacheEntryPoint::class.java)
+            .imageCacheManager()
+    }
+    var aspectRatio by remember(artworkModel) { mutableFloatStateOf(1f) }
+
+    LaunchedEffect(artworkModel, manager) {
+        val model = artworkModel ?: run {
+            aspectRatio = 1f
+            return@LaunchedEffect
+        }
+        runCatching {
+            manager.loadImage(model = model, size = null, cachePolicy = CachePolicy.DEFAULT)
+        }.onSuccess { image ->
+            val width = image.width
+            val height = image.height
+            if (width > 0 && height > 0) {
+                aspectRatio = (width.toFloat() / height.toFloat()).coerceIn(0.25f, 4f)
+            }
+        }
+    }
+
+    return aspectRatio
+}
+
 private fun AnimatedContentTransitionScope<NowPlayingSurfaceMode>.nowPlayingSurfaceTransform(): ContentTransform {
     val enter = fadeIn(
         animationSpec = tween(
@@ -296,6 +329,27 @@ private fun AnimatedContentTransitionScope<NowPlayingSurfaceMode>.nowPlayingSurf
         )
     )
     return enter togetherWith exit using SizeTransform(clip = false)
+}
+
+private fun coverOverlayTextColor(backdropColor: Color): Color {
+    return if (backdropColor.luminance() < 0.5f) {
+        Color.White.copy(alpha = 0.94f)
+    } else {
+        Color.Black.copy(alpha = 0.88f)
+    }
+}
+
+private fun coverOverlayTextShadow(textColor: Color): Shadow {
+    val shadowColor = if (textColor.luminance() > 0.5f) {
+        Color.Black.copy(alpha = 0.74f)
+    } else {
+        Color.White.copy(alpha = 0.62f)
+    }
+    return Shadow(
+        color = shadowColor,
+        offset = Offset(0f, 1.5f),
+        blurRadius = 5f
+    )
 }
 
 internal sealed interface ListenTogetherAudiencePresentation {
@@ -368,9 +422,10 @@ private fun AnimatedContentTransitionScope<Int>.listenTogetherCounterTransform()
 private fun ListenTogetherAudienceCountText(
     companionCount: Int,
     color: Color,
+    textShadow: Shadow?,
     modifier: Modifier = Modifier
 ) {
-    val textStyle = MaterialTheme.typography.labelSmall
+    val textStyle = MaterialTheme.typography.labelSmall.copy(shadow = textShadow)
     val displayCount = companionCount.coerceAtLeast(0)
 
     AnimatedContent(
@@ -422,9 +477,10 @@ private fun ListenTogetherAudienceLine(
     state: ListenTogetherUiState,
     modifier: Modifier = Modifier,
     accentColor: Color = AsmrTheme.colorScheme.primary,
+    textColor: Color = AsmrTheme.colorScheme.textTertiary,
+    textShadow: Shadow? = null,
     pageEntranceSettled: Boolean = true
 ) {
-    val colorScheme = AsmrTheme.colorScheme
     val presentation = resolveListenTogetherAudiencePresentation(state)
 
     val displayTarget = if (pageEntranceSettled) presentation else null
@@ -460,14 +516,15 @@ private fun ListenTogetherAudienceLine(
                 when (target) {
                     is ListenTogetherAudiencePresentation.Status -> Text(
                         text = target.text,
-                        style = MaterialTheme.typography.labelSmall,
-                        color = colorScheme.textTertiary,
+                        style = MaterialTheme.typography.labelSmall.copy(shadow = textShadow),
+                        color = textColor,
                         maxLines = 1,
                         overflow = TextOverflow.Ellipsis
                     )
                     is ListenTogetherAudiencePresentation.Audience -> ListenTogetherAudienceCountText(
                         companionCount = target.companionCount,
-                        color = colorScheme.textTertiary
+                        color = textColor,
+                        textShadow = textShadow
                     )
                     null -> {}
                 }
@@ -511,6 +568,55 @@ private fun ArtistWithListenTogetherInfo(
 }
 
 @Composable
+private fun ExpandedPlayerIdentityOverlay(
+    artist: String,
+    listenTogetherState: ListenTogetherUiState,
+    accentColor: Color,
+    backdropColor: Color,
+    pageEntranceSettled: Boolean,
+    modifier: Modifier = Modifier
+) {
+    val textColor = remember(backdropColor) { coverOverlayTextColor(backdropColor) }
+    val textShadow = remember(textColor) { coverOverlayTextShadow(textColor) }
+    val overlayAccentColor = remember(textColor, accentColor) {
+        if (textColor.luminance() > 0.5f) {
+            accentColor.copy(alpha = 0.90f)
+        } else {
+            Color.Black.copy(alpha = 0.76f)
+        }
+    }
+
+    Box(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(start = 24.dp, end = 24.dp, top = 8.dp, bottom = 10.dp),
+        contentAlignment = Alignment.BottomCenter
+    ) {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(2.dp)
+        ) {
+            ListenTogetherAudienceLine(
+                state = listenTogetherState,
+                accentColor = overlayAccentColor,
+                textColor = textColor.copy(alpha = 0.84f),
+                textShadow = textShadow,
+                pageEntranceSettled = pageEntranceSettled
+            )
+            Text(
+                text = artist,
+                style = MaterialTheme.typography.bodySmall.copy(shadow = textShadow),
+                color = textColor,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                textAlign = TextAlign.Center,
+                modifier = Modifier.fillMaxWidth()
+            )
+        }
+    }
+}
+
+@Composable
 @androidx.media3.common.util.UnstableApi
 @OptIn(ExperimentalFoundationApi::class, ExperimentalMaterial3Api::class, ExperimentalComposeUiApi::class)
 internal fun NowPlayingScreen(
@@ -527,6 +633,8 @@ internal fun NowPlayingScreen(
     coverBackgroundEnabled: Boolean,
     coverBackgroundClarity: Float,
     coverPreviewMode: CoverPreviewMode,
+    nowPlayingHomeLayoutMode: NowPlayingHomeLayoutMode,
+    onNowPlayingHomeLayoutModeChange: (NowPlayingHomeLayoutMode) -> Unit,
     lyricsPageSettings: LyricsPageSettings,
     audioOutputRouteKind: AudioOutputRouteKind,
     warningSessionState: AppVolumeWarningSessionState,
@@ -590,6 +698,18 @@ internal fun NowPlayingScreen(
 
     val haptic = LocalHapticFeedback.current
     val context = LocalContext.current
+    val changeNowPlayingHomeLayoutMode = remember(
+        haptic,
+        nowPlayingHomeLayoutMode,
+        onNowPlayingHomeLayoutModeChange
+    ) {
+        { mode: NowPlayingHomeLayoutMode ->
+            if (mode != nowPlayingHomeLayoutMode) {
+                haptic.performHapticFeedback(HapticFeedbackType.LongPress)
+                onNowPlayingHomeLayoutModeChange(mode)
+            }
+        }
+    }
     val lyricsPickerMimeTypes = remember {
         arrayOf(
             "*/*",
@@ -1341,13 +1461,124 @@ internal fun NowPlayingScreen(
                 }
             }
         } else {
-            val headerMotion = routeTransition.nowPlayingMotionModifier(motionLayout, NowPlayingMotionSlot.HEADER)
             val coverMotion = routeTransition.nowPlayingMotionModifier(motionLayout, NowPlayingMotionSlot.COVER)
             val lyricsMotion = routeTransition.nowPlayingMotionModifier(motionLayout, NowPlayingMotionSlot.LYRICS)
             val progressMotion = routeTransition.nowPlayingMotionModifier(motionLayout, NowPlayingMotionSlot.PROGRESS)
             val actionRowMotion = routeTransition.nowPlayingMotionModifier(motionLayout, NowPlayingMotionSlot.ACTION_ROW)
             val controlsMotion = routeTransition.nowPlayingMotionModifier(motionLayout, NowPlayingMotionSlot.CONTROLS)
             val volumeMotion = routeTransition.nowPlayingMotionModifier(motionLayout, NowPlayingMotionSlot.VOLUME)
+            val expandedHomeLayout = nowPlayingHomeLayoutMode == NowPlayingHomeLayoutMode.Expanded && !isVideo
+            val portraitContentHorizontalPadding = 24.dp
+            val homeBezier = remember { CubicBezierEasing(0.20f, 0f, 0f, 1f) }
+            val homeLayoutDurationMillis = 620
+            val homeFadeInDurationMillis = 240
+            val homeFadeOutDurationMillis = 160
+            val expandedHomeLyricsSettings = remember(lyricsPageSettings) {
+                lyricsPageSettings.copy(displayAreaMode = 0)
+            }
+            val artworkAspectRatio = rememberArtworkAspectRatio(artworkModel)
+            val homeLayoutTransition = updateTransition(
+                targetState = expandedHomeLayout,
+                label = "nowPlayingHomeLayoutMode"
+            )
+            val portraitTopPadding by homeLayoutTransition.animateDp(
+                transitionSpec = {
+                    tween(durationMillis = homeLayoutDurationMillis, easing = homeBezier)
+                },
+                label = "nowPlayingHomeTopPadding"
+            ) { expanded ->
+                if (expanded) 0.dp else 24.dp
+            }
+            val coverVerticalPadding by homeLayoutTransition.animateDp(
+                transitionSpec = {
+                    tween(durationMillis = homeLayoutDurationMillis, easing = homeBezier)
+                },
+                label = "nowPlayingHomeCoverVerticalPadding"
+            ) { expanded ->
+                if (expanded) 0.dp else if (widthClass == WindowWidthSizeClass.Compact) 16.dp else 32.dp
+            }
+            val lyricsTopPadding by homeLayoutTransition.animateDp(
+                transitionSpec = {
+                    tween(durationMillis = homeLayoutDurationMillis, easing = homeBezier)
+                },
+                label = "nowPlayingHomeLyricsTopPadding"
+            ) { expanded ->
+                if (expanded) 14.dp else 6.dp
+            }
+            val homeCoverAspectRatio by homeLayoutTransition.animateFloat(
+                transitionSpec = {
+                    tween(durationMillis = homeLayoutDurationMillis, easing = homeBezier)
+                },
+                label = "nowPlayingHomeCoverAspectRatio"
+            ) { expanded ->
+                if (expanded) artworkAspectRatio else 1f
+            }
+            val homeCoverCornerRadius by homeLayoutTransition.animateDp(
+                transitionSpec = {
+                    tween(durationMillis = homeLayoutDurationMillis, easing = homeBezier)
+                },
+                label = "nowPlayingHomeCoverCornerRadius"
+            ) { expanded ->
+                if (expanded) 0.dp else 28.dp
+            }
+            val classicIdentityHeight by homeLayoutTransition.animateDp(
+                transitionSpec = {
+                    tween(durationMillis = homeLayoutDurationMillis, easing = homeBezier)
+                },
+                label = "nowPlayingHomeClassicIdentityHeight"
+            ) { expanded ->
+                if (expanded) 0.dp else 28.dp
+            }
+            val classicIdentityAlpha by homeLayoutTransition.animateFloat(
+                transitionSpec = {
+                    if (targetState) {
+                        tween(durationMillis = homeFadeOutDurationMillis, easing = FastOutLinearInEasing)
+                    } else {
+                        tween(durationMillis = homeFadeInDurationMillis, easing = LinearOutSlowInEasing)
+                    }
+                },
+                label = "nowPlayingHomeClassicIdentityAlpha"
+            ) { expanded ->
+                if (expanded) 0f else 1f
+            }
+            val expandedIdentityAlpha by homeLayoutTransition.animateFloat(
+                transitionSpec = {
+                    if (targetState) {
+                        tween(durationMillis = homeFadeInDurationMillis, easing = LinearOutSlowInEasing)
+                    } else {
+                        tween(durationMillis = homeFadeOutDurationMillis, easing = FastOutLinearInEasing)
+                    }
+                },
+                label = "nowPlayingHomeExpandedIdentityAlpha"
+            ) { expanded ->
+                if (expanded) 1f else 0f
+            }
+            val expandedLyricsAlpha by homeLayoutTransition.animateFloat(
+                transitionSpec = {
+                    if (targetState) {
+                        tween(durationMillis = homeFadeInDurationMillis, easing = LinearOutSlowInEasing)
+                    } else {
+                        tween(durationMillis = homeFadeOutDurationMillis, easing = FastOutLinearInEasing)
+                    }
+                },
+                label = "nowPlayingHomeExpandedLyricsAlpha"
+            ) { expanded ->
+                if (expanded) 1f else 0f
+            }
+            val classicLyricsAlpha by homeLayoutTransition.animateFloat(
+                transitionSpec = {
+                    if (targetState) {
+                        tween(durationMillis = homeFadeOutDurationMillis, easing = FastOutLinearInEasing)
+                    } else {
+                        tween(durationMillis = homeFadeInDurationMillis, easing = LinearOutSlowInEasing)
+                    }
+                },
+                label = "nowPlayingHomeClassicLyricsAlpha"
+            ) { expanded ->
+                if (expanded) 0f else 1f
+            }
+            val lyricsExpandedInteractionEnabled = expandedLyricsAlpha > 0.5f
+            val lyricsClassicInteractionEnabled = classicLyricsAlpha > 0.5f
             // --- 垂直布局 (手机 或 平板竖屏) ---
             Box(
                 modifier = Modifier.fillMaxSize(),
@@ -1363,206 +1594,266 @@ internal fun NowPlayingScreen(
                             .widthIn(max = 600.dp)
                             .fillMaxWidth()
                     }
-                    .padding(horizontal = 24.dp, vertical = 16.dp),
-                    verticalArrangement = Arrangement.spacedBy(16.dp)
+                    .padding(horizontal = 0.dp)
                 ) {
-                    // 顶部导航栏
-                    Row(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(horizontal = 4.dp, vertical = 8.dp)
-                            .then(headerMotion)
-                            .requiredHeight(0.dp)
-                            .alpha(0f),
-                        verticalAlignment = Alignment.CenterVertically
-                    ) {
-                        IconButton(onClick = requestClose, enabled = !pendingRouteExit) {
-                            Icon(
-                                Icons.Rounded.KeyboardArrowDown,
-                                contentDescription = null,
-                                tint = colorScheme.onSurface,
-                                modifier = Modifier.size(32.dp)
-                            )
-                        }
-                        val textShadow = if (colorScheme.isDark) {
-                            Shadow(color = Color.Black.copy(alpha = 0.5f), offset = Offset(0f, 2f), blurRadius = 4f)
-                        } else {
-                            Shadow(color = Color.Black.copy(alpha = 0.15f), offset = Offset(0f, 1f), blurRadius = 2f)
-                        }
-
-                        Text(
-                            text = metadata?.title?.toString().orEmpty().ifBlank { "未播放" },
-                            modifier = Modifier
-                                .weight(1f)
-                                .basicMarquee(),
-                            style = MaterialTheme.typography.titleMedium.copy(
-                                fontWeight = FontWeight.Bold,
-                                shadow = textShadow
-                            ),
-                            color = colorScheme.textPrimary,
-                            maxLines = 1,
-                            textAlign = TextAlign.Center
-                        )
-                        Row(verticalAlignment = Alignment.CenterVertically) {
-                            IconButton(onClick = onShowSleepTimer) {
-                                Icon(
-                                    Icons.Rounded.Timer,
-                                    contentDescription = null,
-                                    tint = colorScheme.onSurface,
-                                    modifier = Modifier.size(26.dp)
-                                )
-                            }
-                            IconButton(onClick = onShowQueue) {
-                                Icon(
-                                    Icons.AutoMirrored.Rounded.PlaylistPlay,
-                                    contentDescription = null,
-                                    tint = colorScheme.onSurface,
-                                    modifier = Modifier.size(28.dp)
-                                )
-                            }
-                        }
-                    }
-
-                    // 艺术家
-                    ArtistWithListenTogetherInfo(
-                        artist = metadata?.artist?.toString().orEmpty(),
-                        listenTogetherState = listenTogetherUiState,
-                        style = MaterialTheme.typography.bodySmall.copy(
-                            shadow = if (colorScheme.isDark) {
-                                Shadow(color = Color.Black.copy(alpha = 0.4f), offset = Offset(0f, 1f), blurRadius = 2f)
-                            } else {
-                                Shadow(color = Color.Black.copy(alpha = 0.12f), offset = Offset(0f, 0.5f), blurRadius = 1.5f)
-                            }
-                        ),
-                        color = colorScheme.textSecondary,
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .then(coverMotion),
-                        textAlign = TextAlign.Center,
-                        badgeAlignment = Alignment.TopCenter,
-                        textAlignment = Alignment.Center,
-                        accentColor = accentColor,
-                        pageEntranceSettled = pageEntranceSettled
-                    )
-
-                    // 封面
                     Box(
                         modifier = Modifier
                             .fillMaxWidth()
-                            .weight(1f) // 让封面占据剩余可用空间，自动收缩
-                            .padding(vertical = if (widthClass == WindowWidthSizeClass.Compact) 16.dp else 32.dp)
-                            .then(coverMotion),
-                        contentAlignment = Alignment.Center
+                            .weight(1f)
+                            .clipToBounds()
                     ) {
-                        Box(
+                        Column(
                             modifier = Modifier
-                                .then(
-                                    if (isVideo) {
-                                        Modifier
-                                            .widthIn(max = if (widthClass == WindowWidthSizeClass.Compact) 1000.dp else 400.dp)
-                                            .fitVideoPreviewAspectRatio(videoAspectRatio)
-                                    } else {
-                                        Modifier
-                                            .fillMaxHeight()
-                                            .aspectRatio(1f)
-                                            .widthIn(max = if (widthClass == WindowWidthSizeClass.Compact) 1000.dp else 400.dp)
-                                    }
-                                ) // 平板竖屏限制最大宽度
+                                .fillMaxSize()
+                                .padding(top = portraitTopPadding),
+                            horizontalAlignment = Alignment.CenterHorizontally
                         ) {
-                            ArtworkBox(
-                                isVideo = isVideo,
-                                metadata = metadata,
-                                viewModel = viewModel,
-                                onOpenLyrics = showLyricsSurface,
-                                edgeBlendEnabled = false,
-                                edgeBlendColor = if (playerArtworkBackdropEnabled) playerThemeColors.backdropTintColor else colorScheme.background,
-                                videoBackdropColor = videoBackdropColor,
-                                artworkAlignment = coverPreviewAlignment,
-                                dragPreviewEnabled = useDragPreview,
-                                dragPreviewState = coverDragPreviewState
-                            )
-                        }
-                    }
-
-                    if (!isVideo) {
-                        PlaybackProgressContent(viewModel, isVideo) { progress ->
-                            SingleLineLyrics(
-                                lyrics = lyricsState.lyrics,
-                                currentPosition = progress.positionMs,
-                                onOpenLyrics = showLyricsSurface,
-                                colors = lyricColors,
+                            Box(
                                 modifier = Modifier
                                     .fillMaxWidth()
-                                    .then(lyricsMotion)
-                            )
-                        }
-                    }
-
-                    key(item?.mediaId) {
-                        Box(
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .then(progressMotion)
-                        ) {
-                            PlaybackProgressContent(viewModel, isVideo) { progress ->
-                                PlayerProgress(
-                                    positionMs = progress.positionMs,
-                                    durationMs = progressDurationMs,
-                                    sliceUiState = sliceUiState,
-                                    onSeekTo = { viewModel.seekTo(it) },
-                                    onCutPressed = { viewModel.onCutPressed(progressDurationMs) },
-                                    onScrubbingChanged = { viewModel.setUserScrubbing(it) },
-                                    onSelectSlice = { viewModel.selectSlice(it) },
-                                    onLongPressSlice = {
-                                        viewModel.selectSlice(it)
-                                        showSliceSheet = true
-                                    },
-                                    onUpdateSliceRange = { sliceId, startMs, endMs ->
-                                        viewModel.updateSliceRange(sliceId, startMs, endMs, progressDurationMs)
-                                    },
-                                    activeColor = accentColor,
-                                    inactiveColor = accentColor.copy(alpha = 0.2f)
+                                    .height(classicIdentityHeight)
+                                    .graphicsLayer { alpha = classicIdentityAlpha }
+                            ) {
+                                ArtistWithListenTogetherInfo(
+                                    artist = metadata?.artist?.toString().orEmpty(),
+                                    listenTogetherState = listenTogetherUiState,
+                                    style = MaterialTheme.typography.bodySmall.copy(
+                                        shadow = if (colorScheme.isDark) {
+                                            Shadow(color = Color.Black.copy(alpha = 0.4f), offset = Offset(0f, 1f), blurRadius = 2f)
+                                        } else {
+                                            Shadow(color = Color.Black.copy(alpha = 0.12f), offset = Offset(0f, 0.5f), blurRadius = 1.5f)
+                                        }
+                                    ),
+                                    color = colorScheme.textSecondary,
+                                    modifier = Modifier
+                                        .fillMaxSize()
+                                        .then(coverMotion),
+                                    textAlign = TextAlign.Center,
+                                    badgeAlignment = Alignment.TopCenter,
+                                    textAlignment = Alignment.Center,
+                                    accentColor = accentColor,
+                                    pageEntranceSettled = pageEntranceSettled
                                 )
+                            }
+
+                            // 封面
+                            Box(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .padding(vertical = coverVerticalPadding)
+                                    .then(coverMotion)
+                                    .nowPlayingHomeLayoutSwipeGesture(
+                                        enabled = !isVideo && !pendingRouteExit,
+                                        currentMode = nowPlayingHomeLayoutMode,
+                                        onModeChange = changeNowPlayingHomeLayoutMode
+                                    ),
+                                contentAlignment = Alignment.Center
+                            ) {
+                                BoxWithConstraints(
+                                    modifier = Modifier.fillMaxWidth(),
+                                    contentAlignment = Alignment.Center
+                                ) {
+                                    val classicCoverWidth = if (widthClass == WindowWidthSizeClass.Compact) {
+                                        (maxWidth - portraitContentHorizontalPadding * 2).coerceAtLeast(1.dp)
+                                    } else {
+                                        (maxWidth - portraitContentHorizontalPadding * 2)
+                                            .coerceAtMost(400.dp)
+                                            .coerceAtLeast(1.dp)
+                                    }
+                                    val homeCoverWidth by homeLayoutTransition.animateDp(
+                                        transitionSpec = {
+                                            tween(durationMillis = homeLayoutDurationMillis, easing = homeBezier)
+                                        },
+                                        label = "nowPlayingHomeCoverWidth"
+                                    ) { expanded ->
+                                        if (expanded) maxWidth else classicCoverWidth
+                                    }
+                                    Box(
+                                        modifier = Modifier
+                                            .then(
+                                                if (isVideo) {
+                                                    Modifier
+                                                        .widthIn(max = if (widthClass == WindowWidthSizeClass.Compact) 1000.dp else 400.dp)
+                                                        .fitVideoPreviewAspectRatio(videoAspectRatio)
+                                                } else {
+                                                    Modifier
+                                                        .width(homeCoverWidth)
+                                                        .aspectRatio(homeCoverAspectRatio)
+                                                }
+                                            )
+                                    ) {
+                                        ArtworkBox(
+                                            isVideo = isVideo,
+                                            metadata = metadata,
+                                            viewModel = viewModel,
+                                            onOpenLyrics = showLyricsSurface,
+                                            edgeBlendEnabled = false,
+                                            edgeBlendColor = if (playerArtworkBackdropEnabled) playerThemeColors.backdropTintColor else colorScheme.background,
+                                            videoBackdropColor = videoBackdropColor,
+                                            artworkAlignment = coverPreviewAlignment,
+                                            artworkContentScale = ContentScale.Crop,
+                                            artworkCornerRadius = homeCoverCornerRadius,
+                                            artworkLoadAtOriginalSize = true,
+                                            dragPreviewEnabled = useDragPreview,
+                                            dragPreviewState = coverDragPreviewState
+                                        )
+                                        if (expandedIdentityAlpha > 0.001f) {
+                                            Box(
+                                                modifier = Modifier
+                                                    .align(Alignment.BottomCenter)
+                                                    .graphicsLayer { alpha = expandedIdentityAlpha }
+                                            ) {
+                                                ExpandedPlayerIdentityOverlay(
+                                                    artist = metadata?.artist?.toString().orEmpty(),
+                                                    listenTogetherState = listenTogetherUiState,
+                                                    accentColor = accentColor,
+                                                    backdropColor = playerThemeColors.backdropTintColor,
+                                                    pageEntranceSettled = pageEntranceSettled
+                                                )
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+
+                            if (!isVideo) {
+                                Box(
+                                    modifier = Modifier
+                                        .fillMaxWidth()
+                                        .weight(1f)
+                                        .padding(horizontal = portraitContentHorizontalPadding)
+                                        .then(lyricsMotion),
+                                    contentAlignment = Alignment.TopCenter
+                                ) {
+                                    Box(
+                                        modifier = Modifier
+                                            .fillMaxSize()
+                                            .offset(y = lyricsTopPadding)
+                                            .graphicsLayer { alpha = expandedLyricsAlpha }
+                                    ) {
+                                        PlaybackProgressContent(viewModel, isVideo) { progress ->
+                                            NowPlayingLyricsSurface(
+                                                isLandscape = false,
+                                                playbackPositionMs = progress.positionMs,
+                                                lyrics = lyricsState.lyrics,
+                                                lyricColors = lyricColors,
+                                                accentColor = accentColor,
+                                                onAccentColor = onAccentColor,
+                                                lyricsPageSettings = expandedHomeLyricsSettings,
+                                                onSeekTo = { viewModel.seekTo(it) },
+                                                onTimelinePlay = { targetMs ->
+                                                    viewModel.seekTo(targetMs)
+                                                    viewModel.play()
+                                                },
+                                                onAddLyrics = openManualLyricsAction,
+                                                interactionEnabled = lyricsExpandedInteractionEnabled,
+                                                stableFocusAnchor = true,
+                                                modifier = Modifier.fillMaxSize()
+                                            )
+                                        }
+                                    }
+                                    Box(
+                                        modifier = Modifier
+                                            .fillMaxWidth()
+                                            .height(58.dp)
+                                            .align(Alignment.TopCenter)
+                                            .offset(y = lyricsTopPadding)
+                                            .graphicsLayer { alpha = classicLyricsAlpha },
+                                        contentAlignment = Alignment.Center
+                                    ) {
+                                        PlaybackProgressContent(viewModel, isVideo) { progress ->
+                                            SingleLineLyrics(
+                                                lyrics = lyricsState.lyrics,
+                                                currentPosition = progress.positionMs,
+                                                onOpenLyrics = showLyricsSurface,
+                                                colors = lyricColors,
+                                                interactionEnabled = lyricsClassicInteractionEnabled,
+                                                modifier = Modifier.fillMaxWidth()
+                                            )
+                                        }
+                                    }
+                                }
+                            } else {
+                                Spacer(modifier = Modifier.weight(1f))
                             }
                         }
                     }
 
-                    PlaybackControls(
-                        playback = playback,
-                        isFavorite = isFavorite,
-                        viewModel = viewModel,
-                        onShowPlaylistPicker = {
-                            val current = playback.currentMediaItem ?: return@PlaybackControls
-                            onOpenPlaylistPicker(current)
-                        },
-                        onShowEqualizer = { showEqualizer = true },
-                        onManageTags = {
-                            val mediaId = item?.mediaId.orEmpty()
-                            val fallback = metadata?.title?.toString().orEmpty()
-                            tagViewModel.openForMediaId(mediaId, fallback)
-                        },
-                        sliceUiState = sliceUiState,
-                        actionRowModifier = actionRowMotion,
-                        coreControlsModifier = controlsMotion,
-                        primaryColor = accentColor,
-                        onPrimaryColor = onAccentColor
-                    )
-
-                    VolumeControl(
+                    Column(
                         modifier = Modifier
                             .fillMaxWidth()
-                            .then(volumeMotion)
-                            .onGloballyPositioned { coordinates ->
-                                volumeControlBounds = coordinates.boundsInRoot()
+                            .padding(bottom = 16.dp),
+                        verticalArrangement = Arrangement.spacedBy(4.dp)
+                    ) {
+                        key(item?.mediaId) {
+                            Box(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .padding(horizontal = portraitContentHorizontalPadding)
+                                    .then(progressMotion)
+                            ) {
+                                PlaybackProgressContent(viewModel, isVideo) { progress ->
+                                    PlayerProgress(
+                                        positionMs = progress.positionMs,
+                                        durationMs = progressDurationMs,
+                                        sliceUiState = sliceUiState,
+                                        onSeekTo = { viewModel.seekTo(it) },
+                                        onCutPressed = { viewModel.onCutPressed(progressDurationMs) },
+                                        onScrubbingChanged = { viewModel.setUserScrubbing(it) },
+                                        onSelectSlice = { viewModel.selectSlice(it) },
+                                        onLongPressSlice = {
+                                            viewModel.selectSlice(it)
+                                            showSliceSheet = true
+                                        },
+                                        onUpdateSliceRange = { sliceId, startMs, endMs ->
+                                            viewModel.updateSliceRange(sliceId, startMs, endMs, progressDurationMs)
+                                        },
+                                        activeColor = accentColor,
+                                        inactiveColor = accentColor.copy(alpha = 0.2f)
+                                    )
+                                }
+                            }
+                        }
+
+                        PlaybackControls(
+                            playback = playback,
+                            isFavorite = isFavorite,
+                            viewModel = viewModel,
+                            onShowPlaylistPicker = {
+                                val current = playback.currentMediaItem ?: return@PlaybackControls
+                                onOpenPlaylistPicker(current)
                             },
-                        accentColor = accentColor,
-                        viewModel = viewModel,
-                        hardwareVolumeEventTick = hardwareVolumeEventTick,
-                        audioOutputRouteKind = audioOutputRouteKind,
-                        warningSessionState = warningSessionState,
-                        expanded = volumeControlExpanded,
-                        onExpandedChange = { volumeControlExpanded = it }
-                    )
+                            onShowEqualizer = { showEqualizer = true },
+                            onManageTags = {
+                                val mediaId = item?.mediaId.orEmpty()
+                                val fallback = metadata?.title?.toString().orEmpty()
+                                tagViewModel.openForMediaId(mediaId, fallback)
+                            },
+                            sliceUiState = sliceUiState,
+                            modifier = Modifier.padding(horizontal = portraitContentHorizontalPadding),
+                            actionRowModifier = actionRowMotion,
+                            coreControlsModifier = controlsMotion,
+                            primaryColor = accentColor,
+                            onPrimaryColor = onAccentColor
+                        )
+
+                        VolumeControl(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(horizontal = portraitContentHorizontalPadding)
+                                .then(volumeMotion)
+                                .onGloballyPositioned { coordinates ->
+                                    volumeControlBounds = coordinates.boundsInRoot()
+                                },
+                            accentColor = accentColor,
+                            viewModel = viewModel,
+                            hardwareVolumeEventTick = hardwareVolumeEventTick,
+                            audioOutputRouteKind = audioOutputRouteKind,
+                            warningSessionState = warningSessionState,
+                            expanded = volumeControlExpanded,
+                            onExpandedChange = { volumeControlExpanded = it }
+                        )
+                    }
                 }
             }
             }

--- a/app/src/main/java/com/asmr/player/ui/player/nowplaying/NowPlayingControls.kt
+++ b/app/src/main/java/com/asmr/player/ui/player/nowplaying/NowPlayingControls.kt
@@ -339,6 +339,7 @@ internal fun SingleLineLyrics(
     currentPosition: Long,
     onOpenLyrics: () -> Unit,
     colors: LyricReadableColors,
+    interactionEnabled: Boolean = true,
     modifier: Modifier = Modifier,
 ) {
     val sortedLyrics = remember(lyrics) {
@@ -377,7 +378,7 @@ internal fun SingleLineLyrics(
 
     Column(
         modifier = modifier
-            .clickable { onOpenLyrics() }
+            .clickable(enabled = interactionEnabled) { onOpenLyrics() }
             .padding(horizontal = 16.dp, vertical = 4.dp),
         verticalArrangement = Arrangement.spacedBy(4.dp),
         horizontalAlignment = Alignment.CenterHorizontally

--- a/app/src/main/java/com/asmr/player/ui/player/nowplaying/NowPlayingSurfaceComponents.kt
+++ b/app/src/main/java/com/asmr/player/ui/player/nowplaying/NowPlayingSurfaceComponents.kt
@@ -205,6 +205,8 @@ internal fun NowPlayingLyricsSurface(
     onAddLyrics: (() -> Unit)? = null,
     interactionEnabled: Boolean = true,
     stableFocusAnchor: Boolean = false,
+    lyricItemOuterHorizontalPadding: Dp = if (isLandscape) 10.dp else 14.dp,
+    lyricItemInnerHorizontalPadding: Dp = if (isLandscape) 8.dp else 10.dp,
     modifier: Modifier = Modifier
 ) {
     Box(modifier = modifier) {
@@ -246,7 +248,9 @@ internal fun NowPlayingLyricsSurface(
                 isLandscape = isLandscape,
                 settings = lyricsPageSettings,
                 interactionEnabled = interactionEnabled,
-                stableFocusAnchor = stableFocusAnchor
+                stableFocusAnchor = stableFocusAnchor,
+                itemOuterHorizontalPadding = lyricItemOuterHorizontalPadding,
+                itemInnerHorizontalPadding = lyricItemInnerHorizontalPadding
             )
         }
     }

--- a/app/src/main/java/com/asmr/player/ui/player/nowplaying/NowPlayingSurfaceComponents.kt
+++ b/app/src/main/java/com/asmr/player/ui/player/nowplaying/NowPlayingSurfaceComponents.kt
@@ -203,6 +203,8 @@ internal fun NowPlayingLyricsSurface(
     onSeekTo: (Long) -> Unit,
     onTimelinePlay: ((Long) -> Unit)? = null,
     onAddLyrics: (() -> Unit)? = null,
+    interactionEnabled: Boolean = true,
+    stableFocusAnchor: Boolean = false,
     modifier: Modifier = Modifier
 ) {
     Box(modifier = modifier) {
@@ -242,7 +244,9 @@ internal fun NowPlayingLyricsSurface(
                 colors = lyricColors,
                 modifier = Modifier.fillMaxSize(),
                 isLandscape = isLandscape,
-                settings = lyricsPageSettings
+                settings = lyricsPageSettings,
+                interactionEnabled = interactionEnabled,
+                stableFocusAnchor = stableFocusAnchor
             )
         }
     }
@@ -258,11 +262,15 @@ internal fun ArtworkBox(
     edgeBlendColor: Color,
     videoBackdropColor: Color,
     artworkAlignment: Alignment = Alignment.Center,
+    artworkContentScale: ContentScale = ContentScale.Crop,
+    artworkCornerRadius: Dp = 28.dp,
+    artworkLoadAtOriginalSize: Boolean = false,
     dragPreviewEnabled: Boolean = false,
     dragPreviewState: CoverDragPreviewState? = null,
     modifier: Modifier = Modifier
 ) {
-    val shape = RoundedCornerShape(28.dp)
+    val shape = RoundedCornerShape(artworkCornerRadius)
+    val placeholderCornerRadius = artworkCornerRadius.value.roundToInt()
     val videoSurfaceHandle = remember(viewModel) {
         VideoSurfaceVisibilityHandle { visible -> viewModel.setVideoSurfaceVisible(visible) }
     }
@@ -331,6 +339,7 @@ internal fun ArtworkBox(
                             artworkModel = artwork,
                             blendColor = edgeBlendColor,
                             modifier = Modifier.fillMaxSize(),
+                            cornerRadius = artworkCornerRadius,
                             artworkAlignment = artworkAlignment
                         )
                     }
@@ -339,20 +348,21 @@ internal fun ArtworkBox(
                 AsmrAsyncImage(
                     model = metadata?.artworkUri,
                     contentDescription = null,
-                    contentScale = ContentScale.Crop,
+                    contentScale = artworkContentScale,
                     alignment = artworkAlignment,
-                    placeholderCornerRadius = 28,
+                    placeholderCornerRadius = placeholderCornerRadius,
                     placeholder = {},
                     loading = { modifier ->
                         AsmrImageLoadingPlaceholder(
                             modifier = modifier,
-                            cornerRadius = 28,
+                            cornerRadius = placeholderCornerRadius,
                             indicatorSize = 36.dp
                         )
                     },
                     empty = {},
                     peekAnySizeForInitial = true,
                     retainPainterDuringReload = true,
+                    loadAtOriginalSize = artworkLoadAtOriginalSize,
                     loadWhenSizeStableForMillis = 120L,
                     modifier = Modifier
                         .fillMaxSize()

--- a/app/src/test/java/com/asmr/player/data/settings/NowPlayingHomeLayoutModeTest.kt
+++ b/app/src/test/java/com/asmr/player/data/settings/NowPlayingHomeLayoutModeTest.kt
@@ -1,0 +1,18 @@
+package com.asmr.player.data.settings
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class NowPlayingHomeLayoutModeTest {
+    @Test
+    fun fromStorageValue_defaultsToClassic() {
+        assertEquals(NowPlayingHomeLayoutMode.Classic, NowPlayingHomeLayoutMode.fromStorageValue(null))
+        assertEquals(NowPlayingHomeLayoutMode.Classic, NowPlayingHomeLayoutMode.fromStorageValue("unknown"))
+    }
+
+    @Test
+    fun fromStorageValue_mapsStoredValues() {
+        assertEquals(NowPlayingHomeLayoutMode.Classic, NowPlayingHomeLayoutMode.fromStorageValue("classic"))
+        assertEquals(NowPlayingHomeLayoutMode.Expanded, NowPlayingHomeLayoutMode.fromStorageValue("expanded"))
+    }
+}

--- a/app/src/test/java/com/asmr/player/ui/player/LyricsPageLayoutTest.kt
+++ b/app/src/test/java/com/asmr/player/ui/player/LyricsPageLayoutTest.kt
@@ -14,6 +14,39 @@ class LyricsPageLayoutTest {
     }
 
     @Test
+    fun centeredLyricFocusTop_usesActiveHeightByDefault() {
+        assertEquals(
+            210f,
+            centeredLyricFocusTop(
+                viewportWindowHeightPx = 520f,
+                activeItemHeightPx = 100f,
+                nominalItemHeightPx = 60f,
+                stableFocusAnchor = false
+            ),
+            0.001f
+        )
+    }
+
+    @Test
+    fun centeredLyricFocusTop_canKeepStableAnchorForVariableLineCounts() {
+        val singleLineTop = centeredLyricFocusTop(
+            viewportWindowHeightPx = 520f,
+            activeItemHeightPx = 60f,
+            nominalItemHeightPx = 60f,
+            stableFocusAnchor = true
+        )
+        val multiLineTop = centeredLyricFocusTop(
+            viewportWindowHeightPx = 520f,
+            activeItemHeightPx = 132f,
+            nominalItemHeightPx = 60f,
+            stableFocusAnchor = true
+        )
+
+        assertEquals(singleLineTop, multiLineTop, 0.001f)
+        assertEquals(230f, multiLineTop, 0.001f)
+    }
+
+    @Test
     fun viewportLayout_clampsVisibleLinesAndTopOffset() {
         val layout = buildLyricsViewportLayout(
             settings = LyricsPageSettings(

--- a/app/src/test/java/com/asmr/player/ui/player/NowPlayingHomeLayoutGestureTest.kt
+++ b/app/src/test/java/com/asmr/player/ui/player/NowPlayingHomeLayoutGestureTest.kt
@@ -1,0 +1,55 @@
+package com.asmr.player.ui.player
+
+import com.asmr.player.data.settings.NowPlayingHomeLayoutMode
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class NowPlayingHomeLayoutGestureTest {
+    @Test
+    fun upwardSwipeSwitchesToExpanded() {
+        val result = resolveNowPlayingHomeLayoutModeAfterSwipe(
+            currentMode = NowPlayingHomeLayoutMode.Classic,
+            totalDragX = 12f,
+            totalDragY = -72f,
+            thresholdPx = 56f
+        )
+
+        assertEquals(NowPlayingHomeLayoutMode.Expanded, result)
+    }
+
+    @Test
+    fun downwardSwipeSwitchesToClassic() {
+        val result = resolveNowPlayingHomeLayoutModeAfterSwipe(
+            currentMode = NowPlayingHomeLayoutMode.Expanded,
+            totalDragX = 10f,
+            totalDragY = 80f,
+            thresholdPx = 56f
+        )
+
+        assertEquals(NowPlayingHomeLayoutMode.Classic, result)
+    }
+
+    @Test
+    fun shortSwipeKeepsCurrentMode() {
+        val result = resolveNowPlayingHomeLayoutModeAfterSwipe(
+            currentMode = NowPlayingHomeLayoutMode.Expanded,
+            totalDragX = 0f,
+            totalDragY = 24f,
+            thresholdPx = 56f
+        )
+
+        assertEquals(NowPlayingHomeLayoutMode.Expanded, result)
+    }
+
+    @Test
+    fun mostlyHorizontalSwipeKeepsCurrentMode() {
+        val result = resolveNowPlayingHomeLayoutModeAfterSwipe(
+            currentMode = NowPlayingHomeLayoutMode.Classic,
+            totalDragX = 90f,
+            totalDragY = -70f,
+            thresholdPx = 56f
+        )
+
+        assertEquals(NowPlayingHomeLayoutMode.Classic, result)
+    }
+}


### PR DESCRIPTION
﻿## Summary
- add persisted home layout switch between classic rounded and expanded tiled cover
- keep lyrics and controls stable while animating the cover layout transition
- add a one-time swipe hint for switching cover layout, with lighter animation and persistence

## Verification
- .\gradlew-local.bat :app:testReleaseUnitTest --tests "com.asmr.player.ui.player.LyricsPageLayoutTest" --tests "com.asmr.player.data.settings.NowPlayingHomeLayoutModeTest" --tests "com.asmr.player.ui.player.NowPlayingHomeLayoutGestureTest"
- .\gradlew-local.bat :app:installRelease
