### PR TITLE
fix: improve album cover scroll preloading

### DIFF
--- a/app/src/main/java/com/asmr/player/cache/CacheConfig.kt
+++ b/app/src/main/java/com/asmr/player/cache/CacheConfig.kt
@@ -7,7 +7,7 @@ data class CacheConfig(
     val diskTtlMs: Long = 14L * 24 * 60 * 60 * 1000,
     val decodeParallelism: Int = 3,
     val loadParallelism: Int = 3,
-    val preloadParallelism: Int = 1,
+    val preloadParallelism: Int = 3,
     val logStats: Boolean = false
 )
 

--- a/app/src/main/java/com/asmr/player/cache/ImageCacheManager.kt
+++ b/app/src/main/java/com/asmr/player/cache/ImageCacheManager.kt
@@ -269,7 +269,7 @@ class ImageCacheManager(
         models.forEach { m ->
             scope.launch {
                 preloadSemaphore.withPermit {
-                    runCatching { loadImageFromCache(model = m, size = size, cachePolicy = CachePolicy.CACHE_WARMUP) }
+                    runCatching { loadImage(model = m, size = size, cachePolicy = CachePolicy.CACHE_WARMUP) }
                 }
             }
         }
@@ -283,7 +283,7 @@ class ImageCacheManager(
         return scope.launch(Dispatchers.IO) {
             models.forEach { m ->
                 preloadSemaphore.withPermit {
-                    runCatching { loadImageFromCache(model = m, size = size, cachePolicy = CachePolicy.CACHE_WARMUP) }
+                    runCatching { loadImage(model = m, size = size, cachePolicy = CachePolicy.CACHE_WARMUP) }
                 }
             }
         }
@@ -316,6 +316,7 @@ class ImageCacheManager(
 
     private suspend fun decodeBytes(bytes: ByteArray): Bitmap = withContext(decodeDispatcher) {
         BitmapFactory.decodeByteArray(bytes, 0, bytes.size)
+            ?.also { it.prepareToDraw() }
             ?: throw IllegalStateException("Disk cache decode failed")
     }
 

--- a/app/src/main/java/com/asmr/player/cache/LazyListPreloader.kt
+++ b/app/src/main/java/com/asmr/player/cache/LazyListPreloader.kt
@@ -1,48 +1,52 @@
 package com.asmr.player.cache
 
 import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.foundation.lazy.staggeredgrid.LazyStaggeredGridState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.unit.IntSize
 import kotlinx.coroutines.flow.distinctUntilChanged
-import kotlinx.coroutines.flow.filter
-import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.mapNotNull
 
 private const val MaxRememberedPreloadKeys = 96
+private const val ScrollingLeadViewportMultiplier = 2
+private const val IdleLeadViewportMultiplier = 3
 
 @Composable
 fun LazyListPreloader(
     state: LazyListState,
     models: List<Any>,
-    preloadNext: Int = 8,
+    preloadNext: Int = 24,
+    preloadNextWhileScrolling: Int = 16,
     preloadSize: IntSize? = null,
     cacheManagerProvider: () -> ImageCacheManager
 ) {
     val manager = remember { cacheManagerProvider() }
     val preloadedModels = remember { LinkedHashSet<Any>() }
-    LaunchedEffect(state, models, preloadNext, preloadSize) {
+    LaunchedEffect(state, models, preloadNext, preloadNextWhileScrolling, preloadSize) {
         preloadedModels.clear()
         snapshotFlow {
-            if (state.isScrollInProgress) {
-                null
-            } else {
-                state.layoutInfo.visibleItemsInfo.maxOfOrNull { it.index } ?: -1
-            }
+            val visibleItems = state.layoutInfo.visibleItemsInfo
+            val scrolling = state.isScrollInProgress
+            val lastVisibleIndex = visibleItems.maxOfOrNull { it.index } ?: -1
+            scrolling to (lastVisibleIndex to visibleItems.size)
         }
-            .mapNotNull { it }
-            .map { last ->
-                val start = (last + 1).coerceAtLeast(0)
-                val end = (start + preloadNext).coerceAtMost(models.size)
-                if (start >= end) null else start until end
+            .mapNotNull { (scrolling, window) ->
+                val (lastVisibleIndex, visibleItemCount) = window
+                resolveLazyListPreloadRange(
+                    lastVisibleIndex = lastVisibleIndex,
+                    visibleItemCount = visibleItemCount,
+                    itemCount = models.size,
+                    preloadNext = preloadNext,
+                    preloadNextWhileScrolling = preloadNextWhileScrolling,
+                    isScrolling = scrolling
+                )
             }
-            .filter { it != null }
             .distinctUntilChanged()
             .collect { range ->
-                val r = range ?: return@collect
-                val toPreload = r.mapNotNull { index ->
+                val toPreload = range.mapNotNull { index ->
                     models[index].takeIf { model -> preloadedModels.add(model) }
                 }
                 manager.preload(toPreload, preloadSize)
@@ -55,33 +59,36 @@ fun LazyListPreloader(
 fun LazyListPreloader(
     state: LazyListState,
     itemCount: Int,
-    preloadNext: Int = 8,
+    preloadNext: Int = 24,
+    preloadNextWhileScrolling: Int = 16,
     preloadSize: IntSize? = null,
     cacheManagerProvider: () -> ImageCacheManager,
     modelAt: (Int) -> Any?
 ) {
     val manager = remember { cacheManagerProvider() }
     val preloadedModels = remember { LinkedHashSet<Any>() }
-    LaunchedEffect(state, itemCount, preloadNext, preloadSize) {
+    LaunchedEffect(state, itemCount, preloadNext, preloadNextWhileScrolling, preloadSize) {
         preloadedModels.clear()
         snapshotFlow {
-            if (state.isScrollInProgress) {
-                null
-            } else {
-                state.layoutInfo.visibleItemsInfo.maxOfOrNull { it.index } ?: -1
-            }
+            val visibleItems = state.layoutInfo.visibleItemsInfo
+            val scrolling = state.isScrollInProgress
+            val lastVisibleIndex = visibleItems.maxOfOrNull { it.index } ?: -1
+            scrolling to (lastVisibleIndex to visibleItems.size)
         }
-            .mapNotNull { it }
-            .map { last ->
-                val start = (last + 1).coerceAtLeast(0)
-                val end = (start + preloadNext).coerceAtMost(itemCount)
-                if (start >= end) null else start until end
+            .mapNotNull { (scrolling, window) ->
+                val (lastVisibleIndex, visibleItemCount) = window
+                resolveLazyListPreloadRange(
+                    lastVisibleIndex = lastVisibleIndex,
+                    visibleItemCount = visibleItemCount,
+                    itemCount = itemCount,
+                    preloadNext = preloadNext,
+                    preloadNextWhileScrolling = preloadNextWhileScrolling,
+                    isScrolling = scrolling
+                )
             }
-            .filter { it != null }
             .distinctUntilChanged()
             .collect { range ->
-                val r = range ?: return@collect
-                val toPreload = r.mapNotNull { index ->
+                val toPreload = range.mapNotNull { index ->
                     modelAt(index)?.takeIf { model -> preloadedModels.add(model) }
                 }
                 if (toPreload.isNotEmpty()) {
@@ -90,6 +97,81 @@ fun LazyListPreloader(
                 }
             }
     }
+}
+
+@Composable
+fun LazyStaggeredGridPreloader(
+    state: LazyStaggeredGridState,
+    itemCount: Int,
+    preloadNext: Int = 24,
+    preloadNextWhileScrolling: Int = 16,
+    preloadSize: IntSize? = null,
+    cacheManagerProvider: () -> ImageCacheManager,
+    modelAt: (Int) -> Any?
+) {
+    val manager = remember { cacheManagerProvider() }
+    val preloadedModels = remember { LinkedHashSet<Any>() }
+    LaunchedEffect(state, itemCount, preloadNext, preloadNextWhileScrolling, preloadSize) {
+        preloadedModels.clear()
+        snapshotFlow {
+            val visibleItems = state.layoutInfo.visibleItemsInfo
+            val scrolling = state.isScrollInProgress
+            val lastVisibleIndex = visibleItems.maxOfOrNull { it.index } ?: -1
+            scrolling to (lastVisibleIndex to visibleItems.size)
+        }
+            .mapNotNull { (scrolling, window) ->
+                val (lastVisibleIndex, visibleItemCount) = window
+                resolveLazyListPreloadRange(
+                    lastVisibleIndex = lastVisibleIndex,
+                    visibleItemCount = visibleItemCount,
+                    itemCount = itemCount,
+                    preloadNext = preloadNext,
+                    preloadNextWhileScrolling = preloadNextWhileScrolling,
+                    isScrolling = scrolling
+                )
+            }
+            .distinctUntilChanged()
+            .collect { range ->
+                val toPreload = range.mapNotNull { index ->
+                    modelAt(index)?.takeIf { model -> preloadedModels.add(model) }
+                }
+                if (toPreload.isNotEmpty()) {
+                    manager.preload(toPreload, preloadSize)
+                    preloadedModels.trimOldest(maxSize = MaxRememberedPreloadKeys)
+                }
+            }
+    }
+}
+
+internal fun resolveLazyListPreloadRange(
+    lastVisibleIndex: Int,
+    visibleItemCount: Int,
+    itemCount: Int,
+    preloadNext: Int,
+    preloadNextWhileScrolling: Int,
+    isScrolling: Boolean
+): IntRange? {
+    val leadCount = resolveLazyListPreloadLeadCount(
+        visibleItemCount = visibleItemCount,
+        preloadNext = preloadNext,
+        preloadNextWhileScrolling = preloadNextWhileScrolling,
+        isScrolling = isScrolling
+    )
+    val start = (lastVisibleIndex + 1).coerceAtLeast(0)
+    val end = (start + leadCount).coerceAtMost(itemCount)
+    return if (start >= end) null else start until end
+}
+
+internal fun resolveLazyListPreloadLeadCount(
+    visibleItemCount: Int,
+    preloadNext: Int,
+    preloadNextWhileScrolling: Int,
+    isScrolling: Boolean
+): Int {
+    val viewportLead = visibleItemCount.coerceAtLeast(1) *
+        if (isScrolling) ScrollingLeadViewportMultiplier else IdleLeadViewportMultiplier
+    val baseLead = if (isScrolling) preloadNextWhileScrolling else preloadNext
+    return maxOf(baseLead, viewportLead)
 }
 
 private fun <T> LinkedHashSet<T>.trimOldest(maxSize: Int) {

--- a/app/src/main/java/com/asmr/player/ui/common/AlbumCoverHelpers.kt
+++ b/app/src/main/java/com/asmr/player/ui/common/AlbumCoverHelpers.kt
@@ -1,0 +1,53 @@
+package com.asmr.player.ui.common
+
+import com.asmr.player.cache.CacheImageModel
+import com.asmr.player.domain.model.Album
+import com.asmr.player.util.DlsiteAntiHotlink
+import kotlin.math.absoluteValue
+
+fun albumStableKey(album: Album): String {
+    val id = album.rjCode.ifBlank { album.workId }.trim()
+    if (id.isNotEmpty()) return id
+    val seed = "${album.coverUrl}|${album.title}|${album.circle}|${album.cv}"
+    return "h${seed.hashCode().absoluteValue}"
+}
+
+fun shouldFadeInCover(isScrollInProgress: Boolean, baseEnabled: Boolean = true): Boolean {
+    return baseEnabled && !isScrollInProgress
+}
+
+fun albumCoverImageModel(album: Album): Any? {
+    return albumCoverImageModel(
+        coverThumbPath = album.coverThumbPath,
+        coverPath = album.coverPath,
+        coverUrl = album.coverUrl
+    )
+}
+
+fun albumCoverImageModel(
+    coverThumbPath: String,
+    coverPath: String,
+    coverUrl: String
+): Any? {
+    val data = albumCoverData(
+        coverThumbPath = coverThumbPath,
+        coverPath = coverPath,
+        coverUrl = coverUrl
+    ) ?: return null
+    val headers = if (data.startsWith("http", ignoreCase = true)) {
+        DlsiteAntiHotlink.headersForImageUrl(data)
+    } else {
+        emptyMap()
+    }
+    return if (headers.isEmpty()) data else CacheImageModel(data = data, headers = headers, keyTag = "dlsite")
+}
+
+private fun albumCoverData(
+    coverThumbPath: String,
+    coverPath: String,
+    coverUrl: String
+): String? {
+    return coverThumbPath.takeIf { it.isNotBlank() && it.contains("_v2") }
+        ?: coverPath.takeIf { it.isNotBlank() }
+        ?: coverUrl.takeIf { it.isNotBlank() }
+}

--- a/app/src/main/java/com/asmr/player/ui/common/AsmrAsyncImage.kt
+++ b/app/src/main/java/com/asmr/player/ui/common/AsmrAsyncImage.kt
@@ -8,8 +8,10 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.ColorFilter
@@ -82,6 +84,7 @@ fun AsmrAsyncImage(
     val loadedSize: MutableState<IntSize?> = remember(normalizedModel, reloadKey) { mutableStateOf(null) }
     val crossfade = remember(normalizedModel, reloadKey) { Animatable(if (seededPainter != null) 1f else 0f) }
     val crossfadeRunning = remember(normalizedModel, reloadKey) { mutableStateOf(false) }
+    val latestFadeIn by rememberUpdatedState(fadeIn)
     val containerModifier = modifier.onSizeChanged { sz ->
         if (sz.width > 0 && sz.height > 0) measuredSize.value = IntSize(sz.width, sz.height)
     }
@@ -132,7 +135,7 @@ fun AsmrAsyncImage(
             loadedSize.value = sz
             seededPlaceholder.value = false
             state.value = AsmrAsyncImageState.Success
-            if (fadeIn && !shouldRetainPainter) {
+            if (latestFadeIn && !shouldRetainPainter) {
                 crossfadeRunning.value = true
                 try {
                     crossfade.animateTo(1f, tween(durationMillis = fadeInMillis))
@@ -154,6 +157,12 @@ fun AsmrAsyncImage(
     }
 
     val p = painter.value
+    LaunchedEffect(fadeIn, p) {
+        if (!fadeIn && p != null) {
+            crossfadeRunning.value = false
+            crossfade.snapTo(1f)
+        }
+    }
     val currentState = state.value
     val hasSeededPainter = p != null && seededPlaceholder.value
     Box(modifier = containerModifier) {

--- a/app/src/main/java/com/asmr/player/ui/hotlistening/HotListeningScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/hotlistening/HotListeningScreen.kt
@@ -48,16 +48,26 @@ import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import com.asmr.player.cache.ImageCacheEntryPoint
+import com.asmr.player.cache.LazyListPreloader
+import com.asmr.player.cache.LazyStaggeredGridPreloader
 import com.asmr.player.domain.model.Album
 import com.asmr.player.hotlistening.HotListeningSortMode
 import com.asmr.player.ui.common.EaraBrandedEmptyState
 import com.asmr.player.ui.common.EaraLogoLoadingIndicator
 import com.asmr.player.ui.common.LocalBottomOverlayPadding
+import com.asmr.player.ui.common.albumCoverImageModel
+import com.asmr.player.ui.common.albumStableKey
 import com.asmr.player.ui.common.rememberCalmScrollableFlingBehavior
 import com.asmr.player.ui.common.smoothScrollToTop
+import com.asmr.player.ui.common.shouldFadeInCover
 import com.asmr.player.ui.common.thinScrollbar
 import com.asmr.player.ui.common.withAddedBottomPadding
 import com.asmr.player.ui.library.AlbumGridItem
@@ -66,21 +76,14 @@ import com.asmr.player.ui.library.AlbumCoverBadge
 import com.asmr.player.ui.library.AlbumItem
 import com.asmr.player.ui.library.rememberAlbumMetaCopyAction
 import com.asmr.player.ui.theme.AsmrTheme
+import dagger.hilt.android.EntryPointAccessors
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.map
-import kotlin.math.absoluteValue
 
-private fun stableAlbumKey(album: Album): String {
-    val id = album.rjCode.ifBlank { album.workId }.trim()
-    if (id.isNotEmpty()) return id
-    val seed = "${album.coverUrl}|${album.title}|${album.circle}|${album.cv}"
-    return "h${seed.hashCode().absoluteValue}"
-}
-
-private fun hotListeningItemKey(section: String, index: Int, album: Album): String {
-    return "hot-listening:$section:${stableAlbumKey(album)}:$index"
+private fun hotListeningItemKey(section: String, album: Album): String {
+    return "hot-listening:$section:${albumStableKey(album)}"
 }
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -269,6 +272,28 @@ fun HotListeningScreen(
                         contentPadding = PaddingValues(bottom = LocalBottomOverlayPadding.current + 24.dp)
                     )
                 } else if (viewMode == 0) {
+                    val app = LocalContext.current.applicationContext
+                    val cacheManager = remember(app) {
+                        EntryPointAccessors.fromApplication(app, ImageCacheEntryPoint::class.java)
+                            .imageCacheManager()
+                    }
+                    val density = LocalDensity.current
+                    val screenWidthDp = LocalConfiguration.current.screenWidthDp
+                    val listItemHeight = (screenWidthDp.dp * 0.24f).coerceIn(112.dp, 140.dp)
+                    val coverPx = remember(listItemHeight, density) { with(density) { listItemHeight.roundToPx() } }
+                    val preloadSize = remember(coverPx) { IntSize(coverPx, coverPx) }
+                    val listCoverFadeIn = shouldFadeInCover(listState.isScrollInProgress)
+                    LazyListPreloader(
+                        state = listState,
+                        itemCount = state.entries.size,
+                        preloadNext = 24,
+                        preloadNextWhileScrolling = 16,
+                        preloadSize = preloadSize,
+                        cacheManagerProvider = { cacheManager },
+                        modelAt = { idx ->
+                            state.entries.getOrNull(idx)?.album?.let { albumCoverImageModel(it) }
+                        }
+                    )
                     LazyColumn(
                         state = listState,
                         modifier = Modifier
@@ -280,13 +305,14 @@ fun HotListeningScreen(
                     ) {
                         lazyItemsIndexed(
                             items = state.entries,
-                            key = { index, entry -> hotListeningItemKey("visible", index, entry.album) },
+                            key = { _, entry -> hotListeningItemKey("visible", entry.album) },
                             contentType = { _, _ -> "album" }
                         ) { _, entry ->
                             HotListeningListItem(
                                 entry = entry,
                                 onAlbumClick = onAlbumClick,
-                                copyMeta = copyMeta
+                                copyMeta = copyMeta,
+                                coverFadeIn = listCoverFadeIn
                             )
                         }
                         if (state.blockedEntries.isNotEmpty()) {
@@ -303,13 +329,14 @@ fun HotListeningScreen(
                             if (showBlockedEntries) {
                                 lazyItemsIndexed(
                                     items = state.blockedEntries,
-                                    key = { index, entry -> hotListeningItemKey("blocked", index, entry.album) },
+                                    key = { _, entry -> hotListeningItemKey("blocked", entry.album) },
                                     contentType = { _, _ -> "album" }
                                 ) { _, entry ->
                                     HotListeningListItem(
                                         entry = entry,
                                         onAlbumClick = onAlbumClick,
-                                        copyMeta = copyMeta
+                                        copyMeta = copyMeta,
+                                        coverFadeIn = listCoverFadeIn
                                     )
                                 }
                             }
@@ -317,6 +344,26 @@ fun HotListeningScreen(
                     }
                 } else {
                     val adaptiveCellSize = if (isCompactWidth) 150.dp else 200.dp
+                    val app = LocalContext.current.applicationContext
+                    val cacheManager = remember(app) {
+                        EntryPointAccessors.fromApplication(app, ImageCacheEntryPoint::class.java)
+                            .imageCacheManager()
+                    }
+                    val density = LocalDensity.current
+                    val gridCoverPx = remember(adaptiveCellSize, density) { with(density) { adaptiveCellSize.roundToPx() } }
+                    val gridPreloadSize = remember(gridCoverPx) { IntSize(gridCoverPx, gridCoverPx) }
+                    val gridCoverFadeIn = shouldFadeInCover(gridState.isScrollInProgress)
+                    LazyStaggeredGridPreloader(
+                        state = gridState,
+                        itemCount = state.entries.size,
+                        preloadNext = 24,
+                        preloadNextWhileScrolling = 16,
+                        preloadSize = gridPreloadSize,
+                        cacheManagerProvider = { cacheManager },
+                        modelAt = { idx ->
+                            state.entries.getOrNull(idx)?.album?.let { albumCoverImageModel(it) }
+                        }
+                    )
                     LazyVerticalStaggeredGrid(
                         columns = StaggeredGridCells.Adaptive(adaptiveCellSize),
                         state = gridState,
@@ -334,13 +381,14 @@ fun HotListeningScreen(
                     ) {
                         items(
                             state.entries.size,
-                            key = { index -> hotListeningItemKey("visible", index, state.entries[index].album) },
+                            key = { index -> hotListeningItemKey("visible", state.entries[index].album) },
                             contentType = { "albumGrid" }
                         ) { index ->
                             HotListeningGridItem(
                                 entry = state.entries[index],
                                 onAlbumClick = onAlbumClick,
-                                copyMeta = copyMeta
+                                copyMeta = copyMeta,
+                                coverFadeIn = gridCoverFadeIn
                             )
                         }
                         if (state.blockedEntries.isNotEmpty()) {
@@ -359,14 +407,15 @@ fun HotListeningScreen(
                                 items(
                                     state.blockedEntries.size,
                                     key = { index ->
-                                        hotListeningItemKey("blocked", index, state.blockedEntries[index].album)
+                                        hotListeningItemKey("blocked", state.blockedEntries[index].album)
                                     },
                                     contentType = { "albumGrid" }
                                 ) { index ->
                                     HotListeningGridItem(
                                         entry = state.blockedEntries[index],
                                         onAlbumClick = onAlbumClick,
-                                        copyMeta = copyMeta
+                                        copyMeta = copyMeta,
+                                        coverFadeIn = gridCoverFadeIn
                                     )
                                 }
                             }
@@ -382,7 +431,8 @@ fun HotListeningScreen(
 private fun HotListeningListItem(
     entry: HotListeningEntry,
     onAlbumClick: (Album) -> Unit,
-    copyMeta: (String, String) -> Unit
+    copyMeta: (String, String) -> Unit,
+    coverFadeIn: Boolean = true
 ) {
     val album = entry.album
     AlbumItem(
@@ -390,6 +440,7 @@ private fun HotListeningListItem(
         onClick = { onAlbumClick(album) },
         coverRetainPainterDuringReload = true,
         coverBadge = entry.toCoverBadge(),
+        coverFadeIn = coverFadeIn,
         onRjClick = { copyMeta("RJ", it) },
         onCircleClick = { copyMeta("社团", it) },
         onCvClick = { copyMeta("CV", it) },
@@ -401,7 +452,8 @@ private fun HotListeningListItem(
 private fun HotListeningGridItem(
     entry: HotListeningEntry,
     onAlbumClick: (Album) -> Unit,
-    copyMeta: (String, String) -> Unit
+    copyMeta: (String, String) -> Unit,
+    coverFadeIn: Boolean = true
 ) {
     val album = entry.album
     AlbumGridItem(
@@ -409,6 +461,7 @@ private fun HotListeningGridItem(
         onClick = { onAlbumClick(album) },
         coverRetainPainterDuringReload = true,
         coverBadge = entry.toCoverBadge(),
+        coverFadeIn = coverFadeIn,
         onRjClick = { copyMeta("RJ", it) },
         onCircleClick = { copyMeta("社团", it) },
         onCvClick = { copyMeta("CV", it) },

--- a/app/src/main/java/com/asmr/player/ui/library/AlbumItem.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/AlbumItem.kt
@@ -56,14 +56,12 @@ import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.asmr.player.domain.model.Album
-import com.asmr.player.cache.CacheImageModel
 import com.asmr.player.ui.common.AsmrAsyncImage
 import com.asmr.player.ui.common.CoverContentRow
+import com.asmr.player.ui.common.albumCoverImageModel
 import com.asmr.player.ui.common.NoImageLoadingIndicator
 import com.asmr.player.ui.common.AsmrShimmerPlaceholder
 import com.asmr.player.ui.library.AlbumMetaLeadingVisual.Icon
-import com.asmr.player.util.DlsiteAntiHotlink
-
 import com.asmr.player.ui.theme.AsmrTheme
 import kotlinx.coroutines.delay
 
@@ -102,6 +100,7 @@ fun AlbumItem(
     coverBadge: AlbumCoverBadge? = null,
     onlineDetailLoading: Boolean = false,
     onlineCvLoading: Boolean = onlineDetailLoading,
+    coverFadeIn: Boolean = true,
     coverReloadKey: Any? = null,
     coverRetainPainterDuringReload: Boolean = false,
 ) {
@@ -115,13 +114,8 @@ fun AlbumItem(
             bottomEnd = 0.dp
         )
     }
-    val data = album.coverThumbPath.takeIf { it.isNotBlank() && it.contains("_v2") }
-        .orEmpty()
-        .ifBlank { album.coverPath }
-        .ifEmpty { album.coverUrl }
-    val imageModel = remember(data) {
-        val headers = if (data.startsWith("http", ignoreCase = true)) DlsiteAntiHotlink.headersForImageUrl(data) else emptyMap()
-        if (headers.isEmpty()) data else CacheImageModel(data = data, headers = headers, keyTag = "dlsite")
+    val imageModel = remember(album.coverThumbPath, album.coverPath, album.coverUrl) {
+        albumCoverImageModel(album)
     }
     val screenWidthDp = LocalConfiguration.current.screenWidthDp
     val listItemHeight = (screenWidthDp.dp * 0.24f).coerceIn(112.dp, 140.dp)
@@ -157,6 +151,7 @@ fun AlbumItem(
                         contentDescription = null,
                         contentScale = ContentScale.Crop,
                         placeholderCornerRadius = 0,
+                        fadeIn = coverFadeIn,
                         reloadKey = coverReloadKey,
                         retainPainterDuringReload = coverRetainPainterDuringReload,
                         peekAnySizeForInitial = true,
@@ -359,6 +354,7 @@ fun AlbumGridItem(
     coverBadge: AlbumCoverBadge? = null,
     onlineDetailLoading: Boolean = false,
     onlineCvLoading: Boolean = onlineDetailLoading,
+    coverFadeIn: Boolean = true,
     coverReloadKey: Any? = null,
     coverRetainPainterDuringReload: Boolean = false,
 ) {
@@ -372,13 +368,8 @@ fun AlbumGridItem(
             bottomEnd = 0.dp
         )
     }
-    val data = album.coverThumbPath.takeIf { it.isNotBlank() && it.contains("_v2") }
-        .orEmpty()
-        .ifBlank { album.coverPath }
-        .ifEmpty { album.coverUrl }
-    val imageModel = remember(data) {
-        val headers = if (data.startsWith("http", ignoreCase = true)) DlsiteAntiHotlink.headersForImageUrl(data) else emptyMap()
-        if (headers.isEmpty()) data else CacheImageModel(data = data, headers = headers, keyTag = "dlsite")
+    val imageModel = remember(album.coverThumbPath, album.coverPath, album.coverUrl) {
+        albumCoverImageModel(album)
     }
     Column(
         modifier = modifier
@@ -395,6 +386,7 @@ fun AlbumGridItem(
                 contentDescription = null,
                 contentScale = ContentScale.Crop,
                 placeholderCornerRadius = 0,
+                fadeIn = coverFadeIn,
                 reloadKey = coverReloadKey,
                 retainPainterDuringReload = coverRetainPainterDuringReload,
                 peekAnySizeForInitial = true,

--- a/app/src/main/java/com/asmr/player/ui/library/LibraryScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/LibraryScreen.kt
@@ -134,7 +134,7 @@ import com.asmr.player.ui.sidepanel.LandscapeRightPanelHost
 import com.asmr.player.ui.sidepanel.RecentAlbumsPanel
 import com.asmr.player.cache.ImageCacheEntryPoint
 import com.asmr.player.cache.LazyListPreloader
-import com.asmr.player.cache.CacheImageModel
+import com.asmr.player.cache.LazyStaggeredGridPreloader
 import dagger.hilt.android.EntryPointAccessors
 
 import androidx.compose.foundation.combinedClickable
@@ -172,10 +172,11 @@ import com.asmr.player.ui.common.ActiveDropdownMenuItem
 import com.asmr.player.ui.common.ActionButton
 import com.asmr.player.ui.common.clearFocusOnTapOutside
 import com.asmr.player.ui.common.collapsibleHeaderUiState
+import com.asmr.player.ui.common.albumCoverImageModel
+import com.asmr.player.ui.common.shouldFadeInCover
 import com.asmr.player.ui.common.rememberCollapsibleHeaderState
 import com.asmr.player.ui.common.thinScrollbar
 import com.asmr.player.playback.MediaItemFactory
-import com.asmr.player.util.DlsiteAntiHotlink
 
 internal const val LIBRARY_CHROME_TAG = "library_chrome"
 internal const val LIBRARY_SEARCH_INPUT_TAG = "library_search_input"
@@ -197,34 +198,6 @@ private const val LibraryTrackPagingHintDistance = 10
 private fun Album.withUserTags(userTags: List<String>): Album {
     if (userTags.isEmpty()) return this
     return copy(tags = (tags + userTags).distinct())
-}
-
-private fun albumCoverData(
-    coverThumbPath: String,
-    coverPath: String,
-    coverUrl: String
-): String? {
-    return coverThumbPath.takeIf { it.isNotBlank() && it.contains("_v2") }
-        ?: coverPath.takeIf { it.isNotBlank() }
-        ?: coverUrl.takeIf { it.isNotBlank() }
-}
-
-private fun albumCoverImageModel(
-    coverThumbPath: String,
-    coverPath: String,
-    coverUrl: String
-): Any? {
-    val data = albumCoverData(
-        coverThumbPath = coverThumbPath,
-        coverPath = coverPath,
-        coverUrl = coverUrl
-    ) ?: return null
-    val headers = if (data.startsWith("http", ignoreCase = true)) {
-        DlsiteAntiHotlink.headersForImageUrl(data)
-    } else {
-        emptyMap()
-    }
-    return if (headers.isEmpty()) data else CacheImageModel(data = data, headers = headers, keyTag = "dlsite")
 }
 
 @Composable
@@ -774,8 +747,29 @@ fun LibraryScreen(
                                         }
                                     }
                                 } else if (isGrid) {
+                                    val app = LocalContext.current.applicationContext
+                                    val cacheManager = remember(app) {
+                                        EntryPointAccessors.fromApplication(app, ImageCacheEntryPoint::class.java)
+                                            .imageCacheManager()
+                                    }
+                                    val density = LocalDensity.current
+                                    val gridCellSize = if (isCompact) 150.dp else 200.dp
+                                    val gridCoverPx = remember(gridCellSize, density) { with(density) { gridCellSize.roundToPx() } }
+                                    val gridPreloadSize = remember(gridCoverPx) { IntSize(gridCoverPx, gridCoverPx) }
+                                    val coverFadeIn = shouldFadeInCover(gridState.isScrollInProgress)
+                                    LazyStaggeredGridPreloader(
+                                        state = gridState,
+                                        itemCount = pagedAlbums.itemCount,
+                                        preloadNext = 24,
+                                        preloadNextWhileScrolling = 16,
+                                        preloadSize = gridPreloadSize,
+                                        cacheManagerProvider = { cacheManager },
+                                        modelAt = { idx ->
+                                            pagedAlbums.itemSnapshotList.getOrNull(idx)?.let { albumCoverImageModel(it) }
+                                        }
+                                    )
                                     LazyVerticalStaggeredGrid(
-                                        columns = StaggeredGridCells.Adaptive(if (isCompact) 150.dp else 200.dp),
+                                        columns = StaggeredGridCells.Adaptive(gridCellSize),
                                         state = gridState,
                                         modifier = Modifier
                                             .fillMaxSize()
@@ -807,6 +801,7 @@ fun LibraryScreen(
                                                 onCircleClick = { copyMeta("社团", it) },
                                                 onCvClick = { copyMeta("CV", it) },
                                                 onTagClick = { copyMeta("标签", it) },
+                                                coverFadeIn = coverFadeIn,
                                             )
                                         }
                                     }
@@ -821,23 +816,16 @@ fun LibraryScreen(
                                     val listItemHeight = (screenWidthDp.dp * 0.24f).coerceIn(112.dp, 140.dp)
                                     val coverPx = remember(listItemHeight, density) { with(density) { listItemHeight.roundToPx() } }
                                     val preloadSize = remember(coverPx) { IntSize(coverPx, coverPx) }
+                                    val coverFadeIn = shouldFadeInCover(listState.isScrollInProgress)
                                     LazyListPreloader(
                                         state = listState,
                                         itemCount = pagedAlbums.itemCount,
-                                        preloadNext = 4,
+                                        preloadNext = 24,
+                                        preloadNextWhileScrolling = 16,
                                         preloadSize = preloadSize,
                                         cacheManagerProvider = { cacheManager },
                                         modelAt = { idx ->
-                                            val a = pagedAlbums.itemSnapshotList.getOrNull(idx)
-                                            if (a == null) {
-                                                null
-                                            } else {
-                                                albumCoverImageModel(
-                                                    coverThumbPath = a.coverThumbPath,
-                                                    coverPath = a.coverPath,
-                                                    coverUrl = a.coverUrl
-                                                )
-                                            }
+                                            pagedAlbums.itemSnapshotList.getOrNull(idx)?.let { albumCoverImageModel(it) }
                                         }
                                     )
                                     LazyColumn(
@@ -870,6 +858,7 @@ fun LibraryScreen(
                                                 onCircleClick = { copyMeta("社团", it) },
                                                 onCvClick = { copyMeta("CV", it) },
                                                 onTagClick = { copyMeta("标签", it) },
+                                                coverFadeIn = coverFadeIn,
                                             )
                                         }
                                     }
@@ -1434,6 +1423,7 @@ private fun AlbumGridItem(
     onCircleClick: ((String) -> Unit)? = null,
     onCvClick: ((String) -> Unit)? = null,
     onTagClick: ((String) -> Unit)? = null,
+    coverFadeIn: Boolean = true,
 ) {
     val colorScheme = AsmrTheme.colorScheme
     val coverShape = remember {
@@ -1467,6 +1457,7 @@ private fun AlbumGridItem(
                 contentDescription = null,
                 contentScale = ContentScale.Crop,
                 placeholderCornerRadius = 0,
+                fadeIn = coverFadeIn,
                 peekAnySizeForInitial = true,
                 loading = NoImageLoadingIndicator,
                 modifier = Modifier.fillMaxSize().clip(coverShape),
@@ -1611,6 +1602,7 @@ private fun AlbumItem(
     onCircleClick: ((String) -> Unit)? = null,
     onCvClick: ((String) -> Unit)? = null,
     onTagClick: ((String) -> Unit)? = null,
+    coverFadeIn: Boolean = true,
 ) {
     val colorScheme = AsmrTheme.colorScheme
     val coverShape = remember {
@@ -1661,6 +1653,7 @@ private fun AlbumItem(
                         contentDescription = null,
                         contentScale = ContentScale.Crop,
                         placeholderCornerRadius = 0,
+                        fadeIn = coverFadeIn,
                         peekAnySizeForInitial = true,
                         loading = NoImageLoadingIndicator,
                         modifier = Modifier.fillMaxSize().clip(coverShape),

--- a/app/src/main/java/com/asmr/player/ui/search/SearchScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/search/SearchScreen.kt
@@ -93,6 +93,9 @@ import androidx.compose.ui.graphics.vector.rememberVectorPainter
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.input.pointer.PointerEventPass
 import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
@@ -106,11 +109,16 @@ import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.asmr.player.domain.model.Album
+import com.asmr.player.cache.ImageCacheEntryPoint
+import com.asmr.player.cache.LazyListPreloader
+import com.asmr.player.cache.LazyStaggeredGridPreloader
 import com.asmr.player.ui.common.CustomSearchBar
 import com.asmr.player.ui.common.ActiveDropdownMenuItem
 import com.asmr.player.ui.common.EaraBrandedEmptyState
 import com.asmr.player.ui.common.EaraLogoLoadingIndicator
 import com.asmr.player.ui.common.LocalBottomOverlayPadding
+import com.asmr.player.ui.common.albumCoverImageModel
+import com.asmr.player.ui.common.albumStableKey
 import com.asmr.player.ui.common.StableWindowInsets
 import com.asmr.player.ui.common.clearFocusOnTapOutside
 import com.asmr.player.ui.common.collapsibleHeaderUiState
@@ -118,6 +126,7 @@ import com.asmr.player.ui.common.consumeTapThrough
 import com.asmr.player.ui.common.rememberCalmScrollableFlingBehavior
 import com.asmr.player.ui.common.rememberCollapsibleHeaderState
 import com.asmr.player.ui.common.smoothScrollToTop
+import com.asmr.player.ui.common.shouldFadeInCover
 import com.asmr.player.ui.common.thinScrollbar
 import com.asmr.player.ui.common.withAddedBottomPadding
 import com.asmr.player.ui.library.AlbumGridItem
@@ -127,6 +136,7 @@ import com.asmr.player.ui.library.rememberAlbumMetaCopyAction
 import com.asmr.player.ui.sidepanel.LandscapeRightPanelHost
 import com.asmr.player.ui.sidepanel.RecentAlbumsPanel
 import com.asmr.player.ui.theme.AsmrTheme
+import dagger.hilt.android.EntryPointAccessors
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.flow.distinctUntilChanged
 import androidx.compose.runtime.snapshotFlow
@@ -166,15 +176,8 @@ private val SearchResultPlacementSpring = spring<IntOffset>(
     stiffness = Spring.StiffnessMediumLow
 )
 
-private fun stableAlbumKey(album: Album): String {
-    val id = album.rjCode.ifBlank { album.workId }.trim()
-    if (id.isNotEmpty()) return id
-    val seed = "${album.coverUrl}|${album.title}|${album.circle}|${album.cv}"
-    return "h${seed.hashCode().absoluteValue}"
-}
-
-private fun searchResultItemKey(index: Int, album: Album): String {
-    return "search-result:${stableAlbumKey(album)}:$index"
+private fun searchResultItemKey(album: Album): String {
+    return "search-result:${albumStableKey(album)}"
 }
 
 private fun onlineDetailLoadingFor(album: Album, state: SearchUiState.Success): Boolean {
@@ -855,6 +858,28 @@ fun SearchScreen(
                                         )
                                     )
                                 } else if (viewMode == 0) {
+                                    val app = LocalContext.current.applicationContext
+                                    val cacheManager = remember(app) {
+                                        EntryPointAccessors.fromApplication(app, ImageCacheEntryPoint::class.java)
+                                            .imageCacheManager()
+                                    }
+                                    val density = LocalDensity.current
+                                    val screenWidthDp = LocalConfiguration.current.screenWidthDp
+                                    val listItemHeight = (screenWidthDp.dp * 0.24f).coerceIn(112.dp, 140.dp)
+                                    val coverPx = remember(listItemHeight, density) { with(density) { listItemHeight.roundToPx() } }
+                                    val preloadSize = remember(coverPx) { IntSize(coverPx, coverPx) }
+                                    val coverFadeIn = shouldFadeInCover(listState.isScrollInProgress)
+                                    LazyListPreloader(
+                                        state = listState,
+                                        itemCount = state.results.size,
+                                        preloadNext = 24,
+                                        preloadNextWhileScrolling = 16,
+                                        preloadSize = preloadSize,
+                                        cacheManagerProvider = { cacheManager },
+                                        modelAt = { idx ->
+                                            state.results.getOrNull(idx)?.let { albumCoverImageModel(it) }
+                                        }
+                                    )
                                     LazyColumn(
                                         state = listState,
                                         modifier = Modifier
@@ -867,7 +892,7 @@ fun SearchScreen(
                                     ) {
                                         lazyItemsIndexed(
                                             items = state.results,
-                                            key = { index, album -> searchResultItemKey(index, album) },
+                                            key = { _, album -> searchResultItemKey(album) },
                                             contentType = { _, _ -> "album" }
                                         ) { _, album ->
                                             val onlineDetailLoading = onlineDetailLoadingFor(album, state)
@@ -879,6 +904,7 @@ fun SearchScreen(
                                                 modifier = Modifier.animateItemPlacement(SearchResultPlacementSpring),
                                                 onlineDetailLoading = onlineDetailLoading,
                                                 onlineCvLoading = onlineDetailLoading,
+                                                coverFadeIn = coverFadeIn,
                                                 coverReloadKey = state.resultRevision,
                                                 onRjClick = { copyMeta("RJ", it) },
                                                 onCircleClick = { copyMeta("社团", it) },
@@ -888,8 +914,29 @@ fun SearchScreen(
                                         }
                                     }
                                 } else {
+                                    val app = LocalContext.current.applicationContext
+                                    val cacheManager = remember(app) {
+                                        EntryPointAccessors.fromApplication(app, ImageCacheEntryPoint::class.java)
+                                            .imageCacheManager()
+                                    }
+                                    val density = LocalDensity.current
+                                    val gridCellSize = if (isCompact) 150.dp else 200.dp
+                                    val gridCoverPx = remember(gridCellSize, density) { with(density) { gridCellSize.roundToPx() } }
+                                    val gridPreloadSize = remember(gridCoverPx) { IntSize(gridCoverPx, gridCoverPx) }
+                                    val coverFadeIn = shouldFadeInCover(gridState.isScrollInProgress)
+                                    LazyStaggeredGridPreloader(
+                                        state = gridState,
+                                        itemCount = state.results.size,
+                                        preloadNext = 24,
+                                        preloadNextWhileScrolling = 16,
+                                        preloadSize = gridPreloadSize,
+                                        cacheManagerProvider = { cacheManager },
+                                        modelAt = { idx ->
+                                            state.results.getOrNull(idx)?.let { albumCoverImageModel(it) }
+                                        }
+                                    )
                                     LazyVerticalStaggeredGrid(
-                                        columns = StaggeredGridCells.Adaptive(if (isCompact) 150.dp else 200.dp),
+                                        columns = StaggeredGridCells.Adaptive(gridCellSize),
                                         state = gridState,
                                         modifier = Modifier
                                             .fillMaxSize()
@@ -907,7 +954,7 @@ fun SearchScreen(
                                     ) {
                                         items(
                                             state.results.size,
-                                            key = { index -> searchResultItemKey(index, state.results[index]) },
+                                            key = { index -> searchResultItemKey(state.results[index]) },
                                             contentType = { "albumGrid" }
                                         ) { index ->
                                             val album = state.results[index]
@@ -920,6 +967,7 @@ fun SearchScreen(
                                                 modifier = Modifier.animateItemPlacement(SearchResultPlacementSpring),
                                                 onlineDetailLoading = onlineDetailLoading,
                                                 onlineCvLoading = onlineDetailLoading,
+                                                coverFadeIn = coverFadeIn,
                                                 coverReloadKey = state.resultRevision,
                                                 onRjClick = { copyMeta("RJ", it) },
                                                 onCircleClick = { copyMeta("社团", it) },

--- a/app/src/test/java/com/asmr/player/cache/LazyListPreloaderTest.kt
+++ b/app/src/test/java/com/asmr/player/cache/LazyListPreloaderTest.kt
@@ -1,0 +1,95 @@
+package com.asmr.player.cache
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class LazyListPreloaderTest {
+    @Test
+    fun preloadLeadCount_expandsWithVisibleItemsWhileScrolling() {
+        assertEquals(
+            16,
+            resolveLazyListPreloadLeadCount(
+                visibleItemCount = 6,
+                preloadNext = 24,
+                preloadNextWhileScrolling = 16,
+                isScrolling = true
+            )
+        )
+    }
+
+    @Test
+    fun preloadLeadCount_keepsIdleWindowWiderThanScrollingWindow() {
+        assertEquals(
+            24,
+            resolveLazyListPreloadLeadCount(
+                visibleItemCount = 6,
+                preloadNext = 24,
+                preloadNextWhileScrolling = 16,
+                isScrolling = false
+            )
+        )
+    }
+
+    @Test
+    fun preloadLeadCount_usesConfiguredMinimumForTinyViewports() {
+        assertEquals(
+            16,
+            resolveLazyListPreloadLeadCount(
+                visibleItemCount = 1,
+                preloadNext = 24,
+                preloadNextWhileScrolling = 16,
+                isScrolling = true
+            )
+        )
+        assertEquals(
+            24,
+            resolveLazyListPreloadLeadCount(
+                visibleItemCount = 1,
+                preloadNext = 24,
+                preloadNextWhileScrolling = 16,
+                isScrolling = false
+            )
+        )
+    }
+
+    @Test
+    fun preloadRange_startsAfterLastVisibleItemAndClipsAtEnd() {
+        assertEquals(
+            5..20,
+            resolveLazyListPreloadRange(
+                lastVisibleIndex = 4,
+                visibleItemCount = 6,
+                itemCount = 30,
+                preloadNext = 24,
+                preloadNextWhileScrolling = 16,
+                isScrolling = true
+            )
+        )
+        assertEquals(
+            8..9,
+            resolveLazyListPreloadRange(
+                lastVisibleIndex = 7,
+                visibleItemCount = 6,
+                itemCount = 10,
+                preloadNext = 24,
+                preloadNextWhileScrolling = 16,
+                isScrolling = false
+            )
+        )
+    }
+
+    @Test
+    fun preloadRange_returnsNullWhenThereAreNoAheadItems() {
+        assertNull(
+            resolveLazyListPreloadRange(
+                lastVisibleIndex = 9,
+                visibleItemCount = 6,
+                itemCount = 10,
+                preloadNext = 24,
+                preloadNextWhileScrolling = 16,
+                isScrolling = true
+            )
+        )
+    }
+}

--- a/app/src/test/java/com/asmr/player/ui/common/AlbumCoverHelpersTest.kt
+++ b/app/src/test/java/com/asmr/player/ui/common/AlbumCoverHelpersTest.kt
@@ -1,0 +1,51 @@
+package com.asmr.player.ui.common
+
+import com.asmr.player.domain.model.Album
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class AlbumCoverHelpersTest {
+    @Test
+    fun albumStableKey_prefersRjOrWorkId() {
+        val album = Album(
+            title = "Title",
+            path = "",
+            rjCode = "RJ123456",
+            coverUrl = "https://example.com/a.jpg",
+            circle = "Circle",
+            cv = "CV"
+        )
+
+        assertEquals("RJ123456", albumStableKey(album))
+        assertEquals(
+            albumStableKey(album),
+            albumStableKey(album.copy(id = 99L, title = "Other", circle = "Other Circle", cv = "Other CV"))
+        )
+    }
+
+    @Test
+    fun albumStableKey_usesFallbackIdentityWhenNoRjOrWorkId() {
+        val album = Album(
+            title = "Title",
+            path = "",
+            coverUrl = "https://example.com/a.jpg",
+            circle = "Circle",
+            cv = "CV"
+        )
+        val sameIdentityDifferentId = album.copy(id = 42L, description = "Something else")
+        val changedTitle = album.copy(title = "Different")
+
+        assertEquals(albumStableKey(album), albumStableKey(sameIdentityDifferentId))
+        assertNotEquals(albumStableKey(album), albumStableKey(changedTitle))
+    }
+
+    @Test
+    fun shouldFadeInCover_disablesWhileScrolling() {
+        assertTrue(shouldFadeInCover(false))
+        assertFalse(shouldFadeInCover(true))
+        assertFalse(shouldFadeInCover(true, baseEnabled = false))
+    }
+}


### PR DESCRIPTION
Summary
- Keep lazy loading and fade-in, but gate fade-in while scrolling and resume when idle.
- Make cover warmup actually fetch network images and expand the warmup window.
- Reintroduce now-playing home layout swipe support from release/v1.1.6 history.

Verification
- ./gradlew-local.bat :app:testReleaseUnitTest --tests com.asmr.player.cache.LazyListPreloaderTest --tests com.asmr.player.ui.common.AlbumCoverHelpersTest --tests com.asmr.player.data.settings.NowPlayingHomeLayoutModeTest --tests com.asmr.player.ui.player.NowPlayingHomeLayoutGestureTest
- ./gradlew-local.bat :app:installRelease