### PR TITLE
Fix list fling click handling

### DIFF
--- a/app/src/main/java/com/asmr/player/main/MainContainer.kt
+++ b/app/src/main/java/com/asmr/player/main/MainContainer.kt
@@ -2389,8 +2389,9 @@ fun MainContainer(
                         },
                         onOpenQueue = onShowQueue,
                         onNavigate = { route ->
-                            if (pendingPrimaryNavigationRoute == null && shouldScrollPrimaryRouteToTop(
+                            if (pendingPrimaryNavigationRoute == null && shouldTriggerPrimaryRouteScrollToTop(
                                     requestedRoute = route,
+                                    visualPrimaryRoute = visualPrimaryRoute,
                                     activePrimaryRoute = activePrimaryRoute,
                                     currentPrimaryRoute = currentPrimaryRoute
                                 )) {

--- a/app/src/main/java/com/asmr/player/main/MainNavigationSupport.kt
+++ b/app/src/main/java/com/asmr/player/main/MainNavigationSupport.kt
@@ -335,7 +335,8 @@ internal fun shouldScrollPrimaryRouteToTop(
     requestedRoute: String,
     activePrimaryRoute: String,
     currentPrimaryRoute: String?
-): Boolean = requestedRoute == activePrimaryRoute && currentPrimaryRoute == requestedRoute
+): Boolean = requestedRoute == activePrimaryRoute &&
+    (currentPrimaryRoute == requestedRoute || currentPrimaryRoute == null)
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable

--- a/app/src/main/java/com/asmr/player/main/MainNavigationSupport.kt
+++ b/app/src/main/java/com/asmr/player/main/MainNavigationSupport.kt
@@ -338,6 +338,20 @@ internal fun shouldScrollPrimaryRouteToTop(
 ): Boolean = requestedRoute == activePrimaryRoute &&
     (currentPrimaryRoute == requestedRoute || currentPrimaryRoute == null)
 
+internal fun shouldTriggerPrimaryRouteScrollToTop(
+    requestedRoute: String,
+    visualPrimaryRoute: String,
+    activePrimaryRoute: String,
+    currentPrimaryRoute: String?
+): Boolean {
+    if (requestedRoute == visualPrimaryRoute) return true
+    return shouldScrollPrimaryRouteToTop(
+        requestedRoute = requestedRoute,
+        activePrimaryRoute = activePrimaryRoute,
+        currentPrimaryRoute = currentPrimaryRoute
+    )
+}
+
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 internal fun PrimaryTopBarBrand(

--- a/app/src/main/java/com/asmr/player/ui/common/AppScrollFlingTuning.kt
+++ b/app/src/main/java/com/asmr/player/ui/common/AppScrollFlingTuning.kt
@@ -2,12 +2,15 @@ package com.asmr.player.ui.common
 
 import androidx.compose.foundation.gestures.FlingBehavior
 import androidx.compose.foundation.gestures.ScrollScope
+import androidx.compose.foundation.gestures.awaitFirstDown
+import androidx.compose.foundation.gestures.awaitEachGesture
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.withFrameNanos
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
 import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.Velocity
 import androidx.compose.ui.unit.dp
@@ -19,12 +22,13 @@ import kotlinx.coroutines.CancellationException
 private const val VerticalFlingDampingStartDpPerSecond = 850f
 private const val MaxVerticalFlingVelocityDpPerSecond = 3200f
 private const val VerticalFlingVelocityScale = 0.6f
+private const val CalmFlingStartVelocityDpPerSecond = 260f
 private const val FastFlingVelocityDpPerSecond = 1800f
 private const val LowMidFlingVelocityDpPerSecond = 360f
 private const val FastFlingDecayRatePerSecond = 2.6f
 private const val MidFlingDecayRatePerSecond = 0.95f
-private const val LowFlingDecayRatePerSecond = 1.25f
-private const val CalmFlingStopVelocityDpPerSecond = 10f
+private const val LowFlingDecayRatePerSecond = 2.0f
+private const val CalmFlingStopVelocityDpPerSecond = 32f
 private const val MaxFlingFrameSeconds = 1f / 30f
 
 @Composable
@@ -53,11 +57,23 @@ fun Modifier.calmVerticalFling(): Modifier {
     return nestedScroll(nestedScrollConnection)
 }
 
+fun Modifier.interruptScrollableFlingOnPointerDown(onPointerDown: () -> Unit): Modifier {
+    return pointerInput(onPointerDown) {
+        awaitEachGesture {
+            awaitFirstDown(requireUnconsumed = false)
+            onPointerDown()
+        }
+    }
+}
+
 @Composable
 fun rememberCalmScrollableFlingBehavior(): FlingBehavior {
     val density = LocalDensity.current
     return remember(density) {
         CalmScrollableFlingBehavior(
+            startVelocityPxPerSecond = with(density) {
+                CalmFlingStartVelocityDpPerSecond.dp.toPx()
+            },
             stopVelocityPxPerSecond = with(density) {
                 CalmFlingStopVelocityDpPerSecond.dp.toPx()
             },
@@ -69,6 +85,14 @@ fun rememberCalmScrollableFlingBehavior(): FlingBehavior {
             }
         )
     }
+}
+
+internal fun shouldStartCalmFling(
+    velocity: Float,
+    startVelocityPxPerSecond: Float
+): Boolean {
+    if (!velocity.isFinite()) return false
+    return abs(velocity) > startVelocityPxPerSecond.coerceAtLeast(0f)
 }
 
 internal fun calmVerticalFlingVelocity(
@@ -119,6 +143,7 @@ internal fun calmFlingDecayRateForVelocity(
 }
 
 private class CalmScrollableFlingBehavior(
+    private val startVelocityPxPerSecond: Float,
     private val stopVelocityPxPerSecond: Float,
     private val fastVelocityPxPerSecond: Float,
     private val lowMidVelocityPxPerSecond: Float
@@ -127,6 +152,7 @@ private class CalmScrollableFlingBehavior(
         if (!initialVelocity.isFinite()) return initialVelocity
         var velocity = initialVelocity
         val stopVelocity = stopVelocityPxPerSecond.coerceAtLeast(0f)
+        if (!shouldStartCalmFling(velocity, startVelocityPxPerSecond)) return 0f
         if (abs(velocity) <= stopVelocity) return velocity
 
         try {

--- a/app/src/main/java/com/asmr/player/ui/common/AppScrollFlingTuning.kt
+++ b/app/src/main/java/com/asmr/player/ui/common/AppScrollFlingTuning.kt
@@ -10,6 +10,7 @@ import androidx.compose.runtime.withFrameNanos
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
 import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.input.pointer.PointerEventPass
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.Velocity
@@ -60,7 +61,7 @@ fun Modifier.calmVerticalFling(): Modifier {
 fun Modifier.interruptScrollableFlingOnPointerDown(onPointerDown: () -> Unit): Modifier {
     return pointerInput(onPointerDown) {
         awaitEachGesture {
-            awaitFirstDown(requireUnconsumed = false)
+            awaitFirstDown(requireUnconsumed = false, pass = PointerEventPass.Initial)
             onPointerDown()
         }
     }

--- a/app/src/main/java/com/asmr/player/ui/hotlistening/HotListeningScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/hotlistening/HotListeningScreen.kt
@@ -127,16 +127,16 @@ fun HotListeningScreen(
     }
 
     suspend fun stopScrollAndJumpToTop() {
-        runCatching { listState.stopScroll(MutatePriority.UserInput) }
-        runCatching { gridState.stopScroll(MutatePriority.UserInput) }
+        runCatching { listState.stopScroll(MutatePriority.PreventUserInput) }
+        runCatching { gridState.stopScroll(MutatePriority.PreventUserInput) }
         runCatching { listState.scrollToItem(0) }
         runCatching { gridState.scrollToItem(0) }
     }
 
     fun stopActiveScroll() {
         scope.launch {
-            runCatching { listState.stopScroll(MutatePriority.UserInput) }
-            runCatching { gridState.stopScroll(MutatePriority.UserInput) }
+            runCatching { listState.stopScroll(MutatePriority.PreventUserInput) }
+            runCatching { gridState.stopScroll(MutatePriority.PreventUserInput) }
         }
     }
 
@@ -323,7 +323,6 @@ fun HotListeningScreen(
                         state = listState,
                         modifier = Modifier
                             .fillMaxSize()
-                            .interruptScrollableFlingOnPointerDown { stopActiveScroll() }
                             .thinScrollbar(listState),
                         flingBehavior = rememberCalmScrollableFlingBehavior(),
                         contentPadding = PaddingValues(bottom = 8.dp)
@@ -395,7 +394,6 @@ fun HotListeningScreen(
                         state = gridState,
                         modifier = Modifier
                             .fillMaxSize()
-                            .interruptScrollableFlingOnPointerDown { stopActiveScroll() }
                             .thinScrollbar(gridState),
                         flingBehavior = rememberCalmScrollableFlingBehavior(),
                         contentPadding = PaddingValues(

--- a/app/src/main/java/com/asmr/player/ui/hotlistening/HotListeningScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/hotlistening/HotListeningScreen.kt
@@ -120,11 +120,6 @@ fun HotListeningScreen(
     }
 
     val periods = listOf("day" to "过去一天", "week" to "过去一周", "month" to "过去一月")
-    var pendingScrollToTopKey by rememberSaveable { mutableStateOf<String?>(null) }
-
-    fun scrollToTopKey(period: String, sortMode: HotListeningSortMode): String {
-        return "$period:${sortMode.name}"
-    }
 
     suspend fun stopScrollAndJumpToTop() {
         runCatching { listState.stopScroll(MutatePriority.PreventUserInput) }
@@ -140,8 +135,7 @@ fun HotListeningScreen(
         }
     }
 
-    fun requestScrollToTop(period: String, sortMode: HotListeningSortMode) {
-        pendingScrollToTopKey = scrollToTopKey(period, sortMode)
+    fun requestScrollToTop() {
         viewModel.resetScrollPosition()
         scope.launch {
             stopScrollAndJumpToTop()
@@ -214,7 +208,7 @@ fun HotListeningScreen(
                         selected = selectedPeriod == period,
                         onClick = {
                             viewModel.selectPeriod(period)
-                            requestScrollToTop(period, selectedSortMode)
+                            requestScrollToTop()
                         },
                         label = { Text(label) },
                         colors = FilterChipDefaults.filterChipColors(
@@ -233,7 +227,7 @@ fun HotListeningScreen(
                         ) {
                             val nextMode = selectedSortMode.nextMode
                             viewModel.selectSortMode(nextMode)
-                            requestScrollToTop(selectedPeriod, nextMode)
+                            requestScrollToTop()
                         }
                         .padding(horizontal = 4.dp, vertical = 4.dp),
                     horizontalArrangement = Arrangement.spacedBy(3.dp),
@@ -279,13 +273,8 @@ fun HotListeningScreen(
             )
 
             is HotListeningUiState.Success -> {
-                LaunchedEffect(state.period, state.sortMode, pendingScrollToTopKey) {
+                LaunchedEffect(state.period, state.sortMode) {
                     showBlockedEntries = false
-                    if (pendingScrollToTopKey == scrollToTopKey(state.period, state.sortMode)) {
-                        viewModel.resetScrollPosition()
-                        stopScrollAndJumpToTop()
-                        pendingScrollToTopKey = null
-                    }
                 }
 
                 if (state.entries.isEmpty() && state.blockedEntries.isEmpty()) {

--- a/app/src/main/java/com/asmr/player/ui/hotlistening/HotListeningScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/hotlistening/HotListeningScreen.kt
@@ -10,10 +10,10 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.gestures.stopScroll
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.itemsIndexed as lazyItemsIndexed
-import androidx.compose.foundation.gestures.stopScroll
 import androidx.compose.foundation.lazy.staggeredgrid.LazyStaggeredGridState
 import androidx.compose.foundation.lazy.staggeredgrid.LazyVerticalStaggeredGrid
 import androidx.compose.foundation.lazy.staggeredgrid.StaggeredGridCells
@@ -36,16 +36,15 @@ import androidx.compose.material3.TextButton
 import androidx.compose.material3.windowsizeclass.WindowSizeClass
 import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
-import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalConfiguration
@@ -78,9 +77,6 @@ import com.asmr.player.ui.library.rememberAlbumMetaCopyAction
 import com.asmr.player.ui.theme.AsmrTheme
 import dagger.hilt.android.EntryPointAccessors
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.flow.distinctUntilChanged
-import kotlinx.coroutines.flow.filter
-import kotlinx.coroutines.flow.map
 
 private fun hotListeningItemKey(section: String, album: Album): String {
     return "hot-listening:$section:${albumStableKey(album)}"
@@ -104,29 +100,18 @@ fun HotListeningScreen(
     val scope = rememberCoroutineScope()
     val isCompactWidth = windowSizeClass.widthSizeClass == WindowWidthSizeClass.Compact
     var showBlockedEntries by rememberSaveable { mutableStateOf(false) }
-
-    val savedScrollPosition = viewModel.scrollPosition
-    val listState = rememberSaveable(saver = LazyListState.Saver) {
-        LazyListState(
-            savedScrollPosition.listFirstVisibleItemIndex,
-            savedScrollPosition.listFirstVisibleItemScrollOffset
-        )
+    var scrollResetNonce by rememberSaveable { mutableIntStateOf(0) }
+    val contentScrollKey = remember(selectedPeriod, selectedSortMode, scrollResetNonce) {
+        "hot-listening:$selectedPeriod:${selectedSortMode.name}:$scrollResetNonce"
     }
-    val gridState = rememberSaveable(saver = LazyStaggeredGridState.Saver) {
-        LazyStaggeredGridState(
-            savedScrollPosition.gridFirstVisibleItemIndex,
-            savedScrollPosition.gridFirstVisibleItemScrollOffset
-        )
+    val listState = rememberSaveable(contentScrollKey, saver = LazyListState.Saver) {
+        LazyListState(0, 0)
+    }
+    val gridState = rememberSaveable(contentScrollKey, saver = LazyStaggeredGridState.Saver) {
+        LazyStaggeredGridState()
     }
 
     val periods = listOf("day" to "过去一天", "week" to "过去一周", "month" to "过去一月")
-
-    suspend fun stopScrollAndJumpToTop() {
-        runCatching { listState.stopScroll(MutatePriority.PreventUserInput) }
-        runCatching { gridState.stopScroll(MutatePriority.PreventUserInput) }
-        runCatching { listState.scrollToItem(0) }
-        runCatching { gridState.scrollToItem(0) }
-    }
 
     fun stopActiveScroll() {
         scope.launch {
@@ -136,49 +121,16 @@ fun HotListeningScreen(
     }
 
     fun requestScrollToTop() {
-        viewModel.resetScrollPosition()
+        scrollResetNonce += 1
         scope.launch {
-            stopScrollAndJumpToTop()
-        }
-    }
-
-    LaunchedEffect(listState) {
-        snapshotFlow { listState.isScrollInProgress }
-            .filter { scrolling -> !scrolling }
-            .map { listState.firstVisibleItemIndex to listState.firstVisibleItemScrollOffset }
-            .distinctUntilChanged()
-            .collect { (index, offset) ->
-                viewModel.updateListScrollPosition(index, offset)
-            }
-    }
-
-    LaunchedEffect(gridState) {
-        snapshotFlow { gridState.isScrollInProgress }
-            .filter { scrolling -> !scrolling }
-            .map { gridState.firstVisibleItemIndex to gridState.firstVisibleItemScrollOffset }
-            .distinctUntilChanged()
-            .collect { (index, offset) ->
-                viewModel.updateGridScrollPosition(index, offset)
-            }
-    }
-
-    DisposableEffect(listState, gridState, viewModel) {
-        onDispose {
-            viewModel.updateListScrollPosition(
-                listState.firstVisibleItemIndex,
-                listState.firstVisibleItemScrollOffset
-            )
-            viewModel.updateGridScrollPosition(
-                gridState.firstVisibleItemIndex,
-                gridState.firstVisibleItemScrollOffset
-            )
+            runCatching { listState.stopScroll(MutatePriority.PreventUserInput) }
+            runCatching { gridState.stopScroll(MutatePriority.PreventUserInput) }
         }
     }
 
     LaunchedEffect(scrollToTopSignal) {
         if (scrollToTopSignal == 0L) return@LaunchedEffect
-        viewModel.resetScrollPosition()
-        stopScrollAndJumpToTop()
+        requestScrollToTop()
     }
     LaunchedEffect(isActive, viewMode) {
         if (isActive) return@LaunchedEffect

--- a/app/src/main/java/com/asmr/player/ui/hotlistening/HotListeningScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/hotlistening/HotListeningScreen.kt
@@ -76,6 +76,7 @@ import com.asmr.player.ui.library.AlbumItem
 import com.asmr.player.ui.library.rememberAlbumMetaCopyAction
 import com.asmr.player.ui.theme.AsmrTheme
 import dagger.hilt.android.EntryPointAccessors
+import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.launch
 
 private fun hotListeningItemKey(section: String, album: Album): String {
@@ -114,9 +115,9 @@ fun HotListeningScreen(
     val periods = listOf("day" to "过去一天", "week" to "过去一周", "month" to "过去一月")
 
     fun stopActiveScroll() {
-        scope.launch {
-            runCatching { listState.stopScroll(MutatePriority.PreventUserInput) }
-            runCatching { gridState.stopScroll(MutatePriority.PreventUserInput) }
+        scope.launch(start = CoroutineStart.UNDISPATCHED) {
+            runCatching { listState.stopScroll(MutatePriority.UserInput) }
+            runCatching { gridState.stopScroll(MutatePriority.UserInput) }
         }
     }
 

--- a/app/src/main/java/com/asmr/player/ui/hotlistening/HotListeningScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/hotlistening/HotListeningScreen.kt
@@ -65,8 +65,8 @@ import com.asmr.player.ui.common.EaraLogoLoadingIndicator
 import com.asmr.player.ui.common.LocalBottomOverlayPadding
 import com.asmr.player.ui.common.albumCoverImageModel
 import com.asmr.player.ui.common.albumStableKey
+import com.asmr.player.ui.common.interruptScrollableFlingOnPointerDown
 import com.asmr.player.ui.common.rememberCalmScrollableFlingBehavior
-import com.asmr.player.ui.common.smoothScrollToTop
 import com.asmr.player.ui.common.shouldFadeInCover
 import com.asmr.player.ui.common.thinScrollbar
 import com.asmr.player.ui.common.withAddedBottomPadding
@@ -120,12 +120,31 @@ fun HotListeningScreen(
     }
 
     val periods = listOf("day" to "过去一天", "week" to "过去一周", "month" to "过去一月")
+    var pendingScrollToTopKey by rememberSaveable { mutableStateOf<String?>(null) }
 
-    fun scrollToTop() {
+    fun scrollToTopKey(period: String, sortMode: HotListeningSortMode): String {
+        return "$period:${sortMode.name}"
+    }
+
+    suspend fun stopScrollAndJumpToTop() {
+        runCatching { listState.stopScroll(MutatePriority.UserInput) }
+        runCatching { gridState.stopScroll(MutatePriority.UserInput) }
+        runCatching { listState.scrollToItem(0) }
+        runCatching { gridState.scrollToItem(0) }
+    }
+
+    fun stopActiveScroll() {
+        scope.launch {
+            runCatching { listState.stopScroll(MutatePriority.UserInput) }
+            runCatching { gridState.stopScroll(MutatePriority.UserInput) }
+        }
+    }
+
+    fun requestScrollToTop(period: String, sortMode: HotListeningSortMode) {
+        pendingScrollToTopKey = scrollToTopKey(period, sortMode)
         viewModel.resetScrollPosition()
         scope.launch {
-            runCatching { listState.scrollToItem(0) }
-            runCatching { gridState.scrollToItem(0) }
+            stopScrollAndJumpToTop()
         }
     }
 
@@ -165,10 +184,7 @@ fun HotListeningScreen(
     LaunchedEffect(scrollToTopSignal) {
         if (scrollToTopSignal == 0L) return@LaunchedEffect
         viewModel.resetScrollPosition()
-        when (viewMode) {
-            0 -> listState.smoothScrollToTop()
-            else -> gridState.smoothScrollToTop()
-        }
+        stopScrollAndJumpToTop()
     }
     LaunchedEffect(isActive, viewMode) {
         if (isActive) return@LaunchedEffect
@@ -182,7 +198,10 @@ fun HotListeningScreen(
         modifier = Modifier.fillMaxSize()
     ) {
         Row(
-            modifier = Modifier.fillMaxWidth().padding(horizontal = 8.dp, vertical = 8.dp),
+            modifier = Modifier
+                .fillMaxWidth()
+                .interruptScrollableFlingOnPointerDown { stopActiveScroll() }
+                .padding(horizontal = 8.dp, vertical = 8.dp),
             horizontalArrangement = Arrangement.Center,
             verticalAlignment = Alignment.CenterVertically
         ) {
@@ -195,7 +214,7 @@ fun HotListeningScreen(
                         selected = selectedPeriod == period,
                         onClick = {
                             viewModel.selectPeriod(period)
-                            scrollToTop()
+                            requestScrollToTop(period, selectedSortMode)
                         },
                         label = { Text(label) },
                         colors = FilterChipDefaults.filterChipColors(
@@ -212,8 +231,9 @@ fun HotListeningScreen(
                             interactionSource = remember { MutableInteractionSource() },
                             indication = null
                         ) {
-                            viewModel.selectSortMode(selectedSortMode.nextMode)
-                            scrollToTop()
+                            val nextMode = selectedSortMode.nextMode
+                            viewModel.selectSortMode(nextMode)
+                            requestScrollToTop(selectedPeriod, nextMode)
                         }
                         .padding(horizontal = 4.dp, vertical = 4.dp),
                     horizontalArrangement = Arrangement.spacedBy(3.dp),
@@ -259,8 +279,13 @@ fun HotListeningScreen(
             )
 
             is HotListeningUiState.Success -> {
-                LaunchedEffect(state.period, state.sortMode) {
+                LaunchedEffect(state.period, state.sortMode, pendingScrollToTopKey) {
                     showBlockedEntries = false
+                    if (pendingScrollToTopKey == scrollToTopKey(state.period, state.sortMode)) {
+                        viewModel.resetScrollPosition()
+                        stopScrollAndJumpToTop()
+                        pendingScrollToTopKey = null
+                    }
                 }
 
                 if (state.entries.isEmpty() && state.blockedEntries.isEmpty()) {
@@ -298,6 +323,7 @@ fun HotListeningScreen(
                         state = listState,
                         modifier = Modifier
                             .fillMaxSize()
+                            .interruptScrollableFlingOnPointerDown { stopActiveScroll() }
                             .thinScrollbar(listState),
                         flingBehavior = rememberCalmScrollableFlingBehavior(),
                         contentPadding = PaddingValues(bottom = 8.dp)
@@ -369,6 +395,7 @@ fun HotListeningScreen(
                         state = gridState,
                         modifier = Modifier
                             .fillMaxSize()
+                            .interruptScrollableFlingOnPointerDown { stopActiveScroll() }
                             .thinScrollbar(gridState),
                         flingBehavior = rememberCalmScrollableFlingBehavior(),
                         contentPadding = PaddingValues(

--- a/app/src/main/java/com/asmr/player/ui/hotlistening/HotListeningViewModel.kt
+++ b/app/src/main/java/com/asmr/player/ui/hotlistening/HotListeningViewModel.kt
@@ -39,9 +39,6 @@ class HotListeningViewModel @Inject constructor(
     private val _selectedPeriod = MutableStateFlow("day")
     val selectedPeriod: StateFlow<String> = _selectedPeriod.asStateFlow()
 
-    var scrollPosition: HotListeningScrollPosition = HotListeningScrollPosition()
-        private set
-
     val viewMode: StateFlow<Int> = settingsRepository.hotListeningViewMode
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), 1)
 
@@ -71,24 +68,6 @@ class HotListeningViewModel @Inject constructor(
         viewModelScope.launch {
             settingsRepository.setHotListeningViewMode(mode.coerceIn(0, 1))
         }
-    }
-
-    fun updateListScrollPosition(firstVisibleItemIndex: Int, firstVisibleItemScrollOffset: Int) {
-        scrollPosition = scrollPosition.copy(
-            listFirstVisibleItemIndex = firstVisibleItemIndex.coerceAtLeast(0),
-            listFirstVisibleItemScrollOffset = firstVisibleItemScrollOffset.coerceAtLeast(0)
-        )
-    }
-
-    fun updateGridScrollPosition(firstVisibleItemIndex: Int, firstVisibleItemScrollOffset: Int) {
-        scrollPosition = scrollPosition.copy(
-            gridFirstVisibleItemIndex = firstVisibleItemIndex.coerceAtLeast(0),
-            gridFirstVisibleItemScrollOffset = firstVisibleItemScrollOffset.coerceAtLeast(0)
-        )
-    }
-
-    fun resetScrollPosition() {
-        scrollPosition = HotListeningScrollPosition()
     }
 
     fun refresh() {
@@ -159,13 +138,6 @@ private sealed class HotListeningRawUiState {
     ) : HotListeningRawUiState()
     data class Error(val message: String) : HotListeningRawUiState()
 }
-
-data class HotListeningScrollPosition(
-    val listFirstVisibleItemIndex: Int = 0,
-    val listFirstVisibleItemScrollOffset: Int = 0,
-    val gridFirstVisibleItemIndex: Int = 0,
-    val gridFirstVisibleItemScrollOffset: Int = 0
-)
 
 data class HotListeningEntry(
     val album: Album,

--- a/app/src/main/java/com/asmr/player/ui/library/AlbumDetailViewModel.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/AlbumDetailViewModel.kt
@@ -576,8 +576,8 @@ class AlbumDetailViewModel @Inject constructor(
             model = createInitialAlbumDetailModel(
                 rj = initialRj,
                 displayAlbum = initialHintAlbum,
-                dlsiteInfo = initialHintAlbum.takeIf { initialHint?.hasResolvedDlsiteInfo == true },
-                preserveHeaderAlbumMetadata = initialHint != null
+                dlsiteInfo = initialHintAlbum.takeIf { shouldPreserveHeaderAlbumMetadata(initialHint) },
+                preserveHeaderAlbumMetadata = shouldPreserveHeaderAlbumMetadata(initialHint)
             )
         )
         viewModelScope.launch {
@@ -596,7 +596,8 @@ class AlbumDetailViewModel @Inject constructor(
 
                 val hint = AlbumCoverHintStore.peekHint(albumId, rj) ?: initialHint
                 val hintAlbum = albumFromInitialHint(rj, hint)
-                val dlsiteInfo = hintAlbum.takeIf { hint?.hasResolvedDlsiteInfo == true }
+                val preserveHeaderAlbumMetadata = shouldPreserveHeaderAlbumMetadata(hint)
+                val dlsiteInfo = hintAlbum.takeIf { preserveHeaderAlbumMetadata }
                 // 种入列表点击时记录的封面与元信息：让 hero 与列表卡片使用相同图片 model，
                 // 在网络解析完成前即可命中跨尺寸内存缓存，避免重复请求封面。
                 val displayAlbum = if (hint != null) hintAlbum else localAlbum ?: hintAlbum
@@ -606,7 +607,7 @@ class AlbumDetailViewModel @Inject constructor(
                         displayAlbum = displayAlbum,
                         localAlbum = localAlbum,
                         dlsiteInfo = dlsiteInfo,
-                        preserveHeaderAlbumMetadata = hint != null
+                        preserveHeaderAlbumMetadata = preserveHeaderAlbumMetadata
                     )
                 )
                 localTracksObserveJob?.cancel()

--- a/app/src/main/java/com/asmr/player/ui/library/LibraryScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/LibraryScreen.kt
@@ -65,12 +65,12 @@ import com.asmr.player.ui.common.FlatActionDialog
 import com.asmr.player.ui.common.FlatDialogAction
 import com.asmr.player.ui.common.FlatDialogActionTone
 import com.asmr.player.ui.common.StableWindowInsets
+import com.asmr.player.ui.common.interruptScrollableFlingOnPointerDown
 import com.asmr.player.ui.common.rememberAudioMeta
 import com.asmr.player.ui.common.rememberAudioMetaText
 import com.asmr.player.ui.common.rememberCalmScrollableFlingBehavior
 import com.asmr.player.ui.common.rememberTrackMetaLine
 import com.asmr.player.ui.common.queryCachedTrackFileSize
-import com.asmr.player.ui.common.smoothScrollToTop
 import com.asmr.player.ui.common.withAddedBottomPadding
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.ListItem
@@ -305,6 +305,14 @@ fun LibraryScreen(
         animationSpec = tween(durationMillis = 220, easing = FastOutSlowInEasing),
         label = "libraryChromeOffset"
     )
+    fun stopActiveScroll() {
+        scope.launch {
+            when (mode) {
+                1 -> gridState.stopScroll(MutatePriority.UserInput)
+                else -> listState.stopScroll(MutatePriority.UserInput)
+            }
+        }
+    }
     val chromeReservedHeightPx = if (chromeState.heightPx > 0f) {
         chromeState.heightPx
     } else {
@@ -351,8 +359,12 @@ fun LibraryScreen(
     LaunchedEffect(scrollToTopSignal) {
         if (scrollToTopSignal == 0L) return@LaunchedEffect
         when (mode) {
-            1 -> gridState.smoothScrollToTop()
-            else -> listState.smoothScrollToTop()
+            1 -> gridState.stopScroll(MutatePriority.UserInput)
+            else -> listState.stopScroll(MutatePriority.UserInput)
+        }
+        when (mode) {
+            1 -> gridState.scrollToItem(0)
+            else -> listState.scrollToItem(0)
         }
         chromeState.expand()
     }
@@ -566,6 +578,7 @@ fun LibraryScreen(
                                         modifier = Modifier
                                             .fillMaxSize()
                                             .clearFocusOnTapOutside()
+                                            .interruptScrollableFlingOnPointerDown { stopActiveScroll() }
                                             .nestedScroll(chromeState.nestedScrollConnection)
                                             .thinScrollbar(listState),
                                         flingBehavior = rememberCalmScrollableFlingBehavior(),
@@ -774,6 +787,7 @@ fun LibraryScreen(
                                         modifier = Modifier
                                             .fillMaxSize()
                                             .clearFocusOnTapOutside()
+                                            .interruptScrollableFlingOnPointerDown { stopActiveScroll() }
                                             .nestedScroll(chromeState.nestedScrollConnection)
                                             .thinScrollbar(gridState),
                                         flingBehavior = rememberCalmScrollableFlingBehavior(),
@@ -833,6 +847,7 @@ fun LibraryScreen(
                                         modifier = Modifier
                                             .fillMaxSize()
                                             .clearFocusOnTapOutside()
+                                            .interruptScrollableFlingOnPointerDown { stopActiveScroll() }
                                             .nestedScroll(chromeState.nestedScrollConnection)
                                             .thinScrollbar(listState),
                                         flingBehavior = rememberCalmScrollableFlingBehavior(),
@@ -865,7 +880,9 @@ fun LibraryScreen(
                                 }
 
                                 LibraryChrome(
-                                    modifier = Modifier.align(Alignment.TopCenter),
+                                    modifier = Modifier
+                                        .align(Alignment.TopCenter)
+                                        .interruptScrollableFlingOnPointerDown { stopActiveScroll() },
                                     searchText = searchText,
                                     onSearchTextChange = {
                                         searchText = it

--- a/app/src/main/java/com/asmr/player/ui/library/LibraryScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/LibraryScreen.kt
@@ -157,6 +157,7 @@ import com.asmr.player.ui.common.AsmrAsyncImage
 import androidx.paging.LoadState
 import androidx.paging.compose.collectAsLazyPagingItems
 import com.asmr.player.ui.theme.dynamicPageContainerColor
+import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.distinctUntilChanged
@@ -306,10 +307,10 @@ fun LibraryScreen(
         label = "libraryChromeOffset"
     )
     fun stopActiveScroll() {
-        scope.launch {
+        scope.launch(start = CoroutineStart.UNDISPATCHED) {
             when (mode) {
-                1 -> gridState.stopScroll(MutatePriority.PreventUserInput)
-                else -> listState.stopScroll(MutatePriority.PreventUserInput)
+                1 -> runCatching { gridState.stopScroll(MutatePriority.UserInput) }
+                else -> runCatching { listState.stopScroll(MutatePriority.UserInput) }
             }
         }
     }

--- a/app/src/main/java/com/asmr/player/ui/library/LibraryScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/LibraryScreen.kt
@@ -308,8 +308,8 @@ fun LibraryScreen(
     fun stopActiveScroll() {
         scope.launch {
             when (mode) {
-                1 -> gridState.stopScroll(MutatePriority.UserInput)
-                else -> listState.stopScroll(MutatePriority.UserInput)
+                1 -> gridState.stopScroll(MutatePriority.PreventUserInput)
+                else -> listState.stopScroll(MutatePriority.PreventUserInput)
             }
         }
     }
@@ -359,8 +359,8 @@ fun LibraryScreen(
     LaunchedEffect(scrollToTopSignal) {
         if (scrollToTopSignal == 0L) return@LaunchedEffect
         when (mode) {
-            1 -> gridState.stopScroll(MutatePriority.UserInput)
-            else -> listState.stopScroll(MutatePriority.UserInput)
+            1 -> gridState.stopScroll(MutatePriority.PreventUserInput)
+            else -> listState.stopScroll(MutatePriority.PreventUserInput)
         }
         when (mode) {
             1 -> gridState.scrollToItem(0)
@@ -578,7 +578,6 @@ fun LibraryScreen(
                                         modifier = Modifier
                                             .fillMaxSize()
                                             .clearFocusOnTapOutside()
-                                            .interruptScrollableFlingOnPointerDown { stopActiveScroll() }
                                             .nestedScroll(chromeState.nestedScrollConnection)
                                             .thinScrollbar(listState),
                                         flingBehavior = rememberCalmScrollableFlingBehavior(),
@@ -787,7 +786,6 @@ fun LibraryScreen(
                                         modifier = Modifier
                                             .fillMaxSize()
                                             .clearFocusOnTapOutside()
-                                            .interruptScrollableFlingOnPointerDown { stopActiveScroll() }
                                             .nestedScroll(chromeState.nestedScrollConnection)
                                             .thinScrollbar(gridState),
                                         flingBehavior = rememberCalmScrollableFlingBehavior(),
@@ -847,7 +845,6 @@ fun LibraryScreen(
                                         modifier = Modifier
                                             .fillMaxSize()
                                             .clearFocusOnTapOutside()
-                                            .interruptScrollableFlingOnPointerDown { stopActiveScroll() }
                                             .nestedScroll(chromeState.nestedScrollConnection)
                                             .thinScrollbar(listState),
                                         flingBehavior = rememberCalmScrollableFlingBehavior(),

--- a/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailDlsiteTabs.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailDlsiteTabs.kt
@@ -156,6 +156,7 @@ import com.asmr.player.util.RemoteSubtitleSource
 private val DlsiteGalleryThumbWidth = 140.dp
 private val DlsiteGalleryThumbHeight = 100.dp
 private val DlsiteGalleryThumbGap = 10.dp
+private val DlsiteGallerySectionHeight = 120.dp
 private const val DlsiteGalleryThumbCornerRadius = 12
 
 @Composable
@@ -164,6 +165,7 @@ private fun DlsiteGalleryLoadingRow() {
     LazyRow(
         modifier = Modifier
             .fillMaxWidth()
+            .height(DlsiteGallerySectionHeight)
             .padding(horizontal = AlbumDetailHorizontalPadding),
         horizontalArrangement = Arrangement.spacedBy(DlsiteGalleryThumbGap),
         contentPadding = PaddingValues(vertical = 10.dp)
@@ -202,7 +204,7 @@ private fun rememberDlsiteDirectoryListHeight(): Dp {
 
 @Composable
 private fun rememberStableOneDirectoryContainerHeight(): Dp {
-    return rememberDlsiteDirectoryListHeight() + 152.dp
+    return rememberDlsiteDirectoryListHeight() + 104.dp
 }
 
 @Composable
@@ -919,66 +921,77 @@ internal fun AlbumDlsiteInfoBreadcrumbTabV2(
         item(key = "dlsite-header") { header() }
         item(key = "dlsite-gallery-section") {
             Column(modifier = dlsiteAnimatedSectionModifier(Modifier.fillMaxWidth(), animateIntro)) {
-            Text(
-                text = "Gallery",
-                modifier = Modifier.padding(horizontal = AlbumDetailHorizontalPadding, vertical = 8.dp),
-                style = MaterialTheme.typography.titleMedium,
-                fontWeight = FontWeight.Bold
-            )
-            if (galleryUrls.isEmpty() && isInitialDlsiteLoading) {
-                DlsiteGalleryLoadingRow()
-            } else if (galleryUrls.isEmpty()) {
-                DlsiteSectionEmptyState(
-                    text = "暂无样图",
-                    artworkKind = DlsiteEmptyArtworkKind.Gallery,
-                    modifier = Modifier.then(dlsiteAnimatedSectionModifier(Modifier, animateIntro))
+                Text(
+                    text = "Gallery",
+                    modifier = Modifier.padding(horizontal = AlbumDetailHorizontalPadding, vertical = 8.dp),
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.Bold
                 )
-            } else {
-                LazyRow(
-                    modifier = Modifier.fillMaxWidth().padding(horizontal = AlbumDetailHorizontalPadding),
-                    horizontalArrangement = Arrangement.spacedBy(DlsiteGalleryThumbGap),
-                    contentPadding = PaddingValues(vertical = 10.dp)
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(DlsiteGallerySectionHeight),
+                    contentAlignment = Alignment.Center
                 ) {
-                    items(items = galleryUrls, key = { it }, contentType = { "galleryThumb" }) { url ->
-                        val model = remember(url) {
-                            val headers = DlsiteAntiHotlink.headersForImageUrl(url)
-                            if (headers.isEmpty()) url else CacheImageModel(data = url, headers = headers, keyTag = "dlsite")
+                    when {
+                        galleryUrls.isEmpty() && isInitialDlsiteLoading -> {
+                            DlsiteGalleryLoadingRow()
                         }
-                        Card(
-                            modifier = Modifier.size(width = DlsiteGalleryThumbWidth, height = DlsiteGalleryThumbHeight).clickable {
-                                buildGalleryImagePreviewRequest(
-                                    galleryUrls = galleryUrls,
-                                    clickedUrl = url,
-                                    toPreviewItem = { galleryUrl ->
-                                        val headers = DlsiteAntiHotlink.headersForImageUrl(galleryUrl)
-                                        val previewModel: Any = if (headers.isEmpty()) {
-                                            galleryUrl
-                                        } else {
-                                            CacheImageModel(data = galleryUrl, headers = headers, keyTag = "dlsite")
-                                        }
-                                        ImagePreviewItem(
-                                            key = galleryUrl,
-                                            title = galleryUrl.substringBefore('?').substringAfterLast('/').ifBlank { "Gallery" },
-                                            imageModel = previewModel,
-                                            openPathOrUrl = galleryUrl
+                        galleryUrls.isEmpty() -> {
+                            DlsiteSectionEmptyState(
+                                text = "暂无样图",
+                                artworkKind = DlsiteEmptyArtworkKind.Gallery,
+                                modifier = Modifier.then(dlsiteAnimatedSectionModifier(Modifier, animateIntro))
+                            )
+                        }
+                        else -> {
+                            LazyRow(
+                                modifier = Modifier.fillMaxWidth().padding(horizontal = AlbumDetailHorizontalPadding),
+                                horizontalArrangement = Arrangement.spacedBy(DlsiteGalleryThumbGap),
+                                contentPadding = PaddingValues(vertical = 10.dp)
+                            ) {
+                                items(items = galleryUrls, key = { it }, contentType = { "galleryThumb" }) { url ->
+                                    val model = remember(url) {
+                                        val headers = DlsiteAntiHotlink.headersForImageUrl(url)
+                                        if (headers.isEmpty()) url else CacheImageModel(data = url, headers = headers, keyTag = "dlsite")
+                                    }
+                                    Card(
+                                        modifier = Modifier.size(width = DlsiteGalleryThumbWidth, height = DlsiteGalleryThumbHeight).clickable {
+                                            buildGalleryImagePreviewRequest(
+                                                galleryUrls = galleryUrls,
+                                                clickedUrl = url,
+                                                toPreviewItem = { galleryUrl ->
+                                                    val headers = DlsiteAntiHotlink.headersForImageUrl(galleryUrl)
+                                                    val previewModel: Any = if (headers.isEmpty()) {
+                                                        galleryUrl
+                                                    } else {
+                                                        CacheImageModel(data = galleryUrl, headers = headers, keyTag = "dlsite")
+                                                    }
+                                                    ImagePreviewItem(
+                                                        key = galleryUrl,
+                                                        title = galleryUrl.substringBefore('?').substringAfterLast('/').ifBlank { "Gallery" },
+                                                        imageModel = previewModel,
+                                                        openPathOrUrl = galleryUrl
+                                                    )
+                                                }
+                                            )?.let(onPreviewImages)
+                                        },
+                                        shape = RoundedCornerShape(10.dp)
+                                    ) {
+                                        AsmrAsyncImage(
+                                            model = model,
+                                            contentDescription = null,
+                                            contentScale = ContentScale.Crop,
+                                            placeholderCornerRadius = DlsiteGalleryThumbCornerRadius,
+                                            loading = NoImageLoadingIndicator,
+                                            modifier = Modifier.fillMaxSize()
                                         )
                                     }
-                                )?.let(onPreviewImages)
-                            },
-                            shape = RoundedCornerShape(10.dp)
-                        ) {
-                            AsmrAsyncImage(
-                                model = model,
-                                contentDescription = null,
-                                contentScale = ContentScale.Crop,
-                                placeholderCornerRadius = DlsiteGalleryThumbCornerRadius,
-                                loading = NoImageLoadingIndicator,
-                                modifier = Modifier.fillMaxSize()
-                            )
+                                }
+                            }
                         }
                     }
                 }
-            }
             }
         }
         item(key = "dlsite-one-header") {

--- a/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailViewModelSupport.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailViewModelSupport.kt
@@ -36,6 +36,7 @@ import com.asmr.player.data.remote.NetworkHeaders
 import com.asmr.player.data.lyrics.LyricsLoader
 import com.asmr.player.domain.model.Album
 import com.asmr.player.domain.model.Track
+import com.asmr.player.ui.nav.AlbumCoverHint
 import com.asmr.player.util.OnlineLyricsStore
 import com.asmr.player.util.RemoteSubtitleSource
 import com.asmr.player.util.SyncCoordinator
@@ -267,6 +268,10 @@ internal fun mergeDetailHeaderAlbum(
             asmrOneWorkId = asmrOneWorkId
         )
     }
+}
+
+internal fun shouldPreserveHeaderAlbumMetadata(hint: AlbumCoverHint?): Boolean {
+    return hint?.hasResolvedDlsiteInfo == true
 }
 
 internal enum class DlsiteChinesePreference {

--- a/app/src/main/java/com/asmr/player/ui/nav/BottomChrome.kt
+++ b/app/src/main/java/com/asmr/player/ui/nav/BottomChrome.kt
@@ -1030,8 +1030,11 @@ private fun BottomNavigationPillSurface(
                             Modifier
                         },
                         onClick = {
-                            if (!expanded && !entry.isOverflow && entry.item.route != activeRoute) {
+                            if (!expanded && !entry.isOverflow) {
                                 onExpandRequest()
+                                if (entry.item.route == activeRoute) {
+                                    onNavigate(entry.item.route)
+                                }
                             } else if (entry.isOverflow) {
                                 if (navGroups.size > 1) {
                                     displayedGroupIndex = (resolvedGroupIndex + 1) % navGroups.size

--- a/app/src/main/java/com/asmr/player/ui/nav/BottomChrome.kt
+++ b/app/src/main/java/com/asmr/player/ui/nav/BottomChrome.kt
@@ -1030,7 +1030,7 @@ private fun BottomNavigationPillSurface(
                             Modifier
                         },
                         onClick = {
-                            if (!expanded && !entry.isOverflow) {
+                            if (!expanded && !entry.isOverflow && entry.item.route != activeRoute) {
                                 onExpandRequest()
                             } else if (entry.isOverflow) {
                                 if (navGroups.size > 1) {

--- a/app/src/main/java/com/asmr/player/ui/player/nowplaying/NowPlayingControls.kt
+++ b/app/src/main/java/com/asmr/player/ui/player/nowplaying/NowPlayingControls.kt
@@ -463,62 +463,49 @@ private fun SlowMarqueeText(
         modifier = modifier.fillMaxWidth().clipToBounds(),
         contentAlignment = Alignment.Center
     ) {
+        val density = LocalDensity.current
         val containerWidth = constraints.maxWidth
-        val velocity = remember(textWidth, containerWidth, durationMs) {
-            if (textWidth <= containerWidth) {
-                30.dp // Default slow velocity if no scroll needed
+        val horizontalPaddingPx = with(density) { 10.dp.roundToPx() * 2 }
+        val availableWidth = (containerWidth - horizontalPaddingPx).coerceAtLeast(0)
+        val needsMarquee = textWidth > availableWidth
+        val finalVelocity = remember(textWidth, availableWidth, durationMs, density, needsMarquee) {
+            if (!needsMarquee) {
+                0.dp
             } else {
-                // Velocity = Distance / Time. basicMarquee expects Dp (implicitly Dp/s).
-                // We need to convert px/s to dp/s.
-                // 1 dp = density * px. 1 px = 1/density dp.
-                // Wait, velocity in basicMarquee is Dp. It means Dp per second.
-                // So: velocityDp = (distancePx / density) / timeSeconds
-                // Actually we can't easily access density here inside remember block without LocalDensity
-                // But we can do it outside.
-                null // Return null to signal calculation needed
+                val distancePx = (textWidth - availableWidth).toFloat()
+                val targetTimeSeconds = (durationMs - 1000).coerceAtLeast(2000) / 1000f
+                val distanceDp = with(density) { distancePx.toDp() }
+                (distanceDp / targetTimeSeconds)
             }
         }
-        
-        val density = LocalDensity.current
-        val finalVelocity = remember(velocity, density, textWidth, containerWidth, durationMs) {
-             velocity ?: run {
-                 val distancePx = (textWidth - containerWidth).toFloat()
-                 val targetTimeSeconds = (durationMs - 1000).coerceAtLeast(2000) / 1000f
-                 val distanceDp = with(density) { distancePx.toDp() }
-                 // BasicMarquee velocity is in Dp/s.
-                 // We want to cover 'distanceDp' in 'targetTimeSeconds'.
-                 // BUT basicMarquee scrolls the WHOLE content width + gap?
-                 // No, basicMarquee scrolls until the end is visible, then repeats.
-                 // The distance it travels is (ContentWidth - ContainerWidth) per cycle?
-                 // Actually basicMarquee behavior:
-                 // It scrolls the content.
-                 // If velocity is 50.dp, it moves 50dp per second.
-                 // We want to finish the scroll in `targetTimeSeconds`.
-                 // So velocity = distanceDp / targetTimeSeconds.
-                 // We add a small buffer to velocity to ensure it finishes.
-                 (distanceDp / targetTimeSeconds)
-             }
-        }
 
-        Text(
-            text = content,
-            style = style.copy(
-                fontWeight = fontWeight,
-                shadow = shadow
-            ),
-            color = colors.activeText,
-            maxLines = 1,
-            softWrap = false,
-            overflow = TextOverflow.Clip,
-            textAlign = TextAlign.Center,
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(horizontal = 10.dp, vertical = 2.dp)
-                .basicMarquee(
-                    iterations = Int.MAX_VALUE,
-                    velocity = finalVelocity.coerceAtLeast(10.dp)
-                )
-        )
+        key(content, availableWidth, needsMarquee, finalVelocity) {
+            Text(
+                text = content,
+                style = style.copy(
+                    fontWeight = fontWeight,
+                    shadow = shadow
+                ),
+                color = colors.activeText,
+                maxLines = 1,
+                softWrap = false,
+                overflow = TextOverflow.Clip,
+                textAlign = TextAlign.Center,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 10.dp, vertical = 2.dp)
+                    .then(
+                        if (needsMarquee) {
+                            Modifier.basicMarquee(
+                                iterations = Int.MAX_VALUE,
+                                velocity = finalVelocity.coerceAtLeast(10.dp)
+                            )
+                        } else {
+                            Modifier
+                        }
+                    )
+            )
+        }
     }
 }
 

--- a/app/src/main/java/com/asmr/player/ui/search/SearchScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/search/SearchScreen.kt
@@ -120,7 +120,6 @@ import com.asmr.player.ui.common.LocalBottomOverlayPadding
 import com.asmr.player.ui.common.albumCoverImageModel
 import com.asmr.player.ui.common.albumStableKey
 import com.asmr.player.ui.common.interruptScrollableFlingOnPointerDown
-import com.asmr.player.ui.common.smoothScrollToTop
 import com.asmr.player.ui.common.StableWindowInsets
 import com.asmr.player.ui.common.clearFocusOnTapOutside
 import com.asmr.player.ui.common.collapsibleHeaderUiState
@@ -373,8 +372,8 @@ fun SearchScreen(
 
     fun scrollResultsToTop() {
         scope.launch {
-            runCatching { listState.stopScroll(MutatePriority.UserInput) }
-            runCatching { gridState.stopScroll(MutatePriority.UserInput) }
+            runCatching { listState.stopScroll(MutatePriority.PreventUserInput) }
+            runCatching { gridState.stopScroll(MutatePriority.PreventUserInput) }
             runCatching { listState.scrollToItem(0) }
             runCatching { gridState.scrollToItem(0) }
         }
@@ -575,8 +574,8 @@ fun SearchScreen(
     val latestHorizontalPagerScrollLockChanged = rememberUpdatedState(onHorizontalPagerScrollLockChanged)
     fun stopActiveScroll() {
         scope.launch {
-            runCatching { listState.stopScroll(MutatePriority.UserInput) }
-            runCatching { gridState.stopScroll(MutatePriority.UserInput) }
+            runCatching { listState.stopScroll(MutatePriority.PreventUserInput) }
+            runCatching { gridState.stopScroll(MutatePriority.PreventUserInput) }
             pullNextPageDragPx = 0f
             latestHorizontalPagerScrollLockChanged.value(false)
         }
@@ -653,8 +652,14 @@ fun SearchScreen(
         if (scrollToTopSignal == 0L) return@LaunchedEffect
         pullNextPageDragPx = 0f
         when (viewMode) {
-            0 -> listState.smoothScrollToTop()
-            else -> gridState.smoothScrollToTop()
+            0 -> {
+                runCatching { listState.stopScroll(MutatePriority.PreventUserInput) }
+                runCatching { listState.scrollToItem(0) }
+            }
+            else -> {
+                runCatching { gridState.stopScroll(MutatePriority.PreventUserInput) }
+                runCatching { gridState.scrollToItem(0) }
+            }
         }
         chromeState.expand()
     }
@@ -895,7 +900,6 @@ fun SearchScreen(
                                         state = listState,
                                         modifier = Modifier
                                             .fillMaxSize()
-                                            .interruptScrollableFlingOnPointerDown { stopActiveScroll() }
                                             .nestedScroll(chromeState.nestedScrollConnection)
                                             .thinScrollbar(listState),
                                         flingBehavior = rememberCalmScrollableFlingBehavior(),
@@ -952,7 +956,6 @@ fun SearchScreen(
                                         state = gridState,
                                         modifier = Modifier
                                             .fillMaxSize()
-                                            .interruptScrollableFlingOnPointerDown { stopActiveScroll() }
                                             .nestedScroll(chromeState.nestedScrollConnection)
                                             .thinScrollbar(gridState),
                                         flingBehavior = rememberCalmScrollableFlingBehavior(),

--- a/app/src/main/java/com/asmr/player/ui/search/SearchScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/search/SearchScreen.kt
@@ -137,6 +137,7 @@ import com.asmr.player.ui.sidepanel.LandscapeRightPanelHost
 import com.asmr.player.ui.sidepanel.RecentAlbumsPanel
 import com.asmr.player.ui.theme.AsmrTheme
 import dagger.hilt.android.EntryPointAccessors
+import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.flow.distinctUntilChanged
 import androidx.compose.runtime.snapshotFlow
@@ -178,6 +179,32 @@ private val SearchResultPlacementSpring = spring<IntOffset>(
 
 private fun searchResultItemKey(album: Album): String {
     return "search-result:${albumStableKey(album)}"
+}
+
+internal fun searchResultScrollKey(success: SearchUiState.Success?): String {
+    if (success == null) return "search-results:none"
+    return buildString {
+        append("search-results:")
+        append(success.resultRevision)
+        append(':')
+        append(success.page)
+        append(':')
+        append(success.keyword)
+        append(':')
+        append(success.order.name)
+        append(':')
+        append(success.collectedSort.name)
+        append(':')
+        append(success.purchasedOnly)
+        append(':')
+        append(success.presaleOnly)
+        append(':')
+        append(success.chineseTranslatedOnly)
+        append(':')
+        append(success.collectedOnly)
+        append(':')
+        append(success.locale.orEmpty())
+    }
 }
 
 private fun onlineDetailLoadingFor(album: Album, state: SearchUiState.Success): Boolean {
@@ -293,16 +320,16 @@ fun SearchScreen(
         showFallback = showHotKeywordFallback
     )
     val success = uiState as? SearchUiState.Success
-    val currentPageKey = success?.page ?: 0
-    val listState = rememberSaveable(currentPageKey, saver = LazyListState.Saver) { LazyListState(0, 0) }
-    val gridState = rememberSaveable(currentPageKey, saver = LazyStaggeredGridState.Saver) { LazyStaggeredGridState() }
+    val resultScrollKey = searchResultScrollKey(success)
+    val listState = rememberSaveable(resultScrollKey, saver = LazyListState.Saver) { LazyListState(0, 0) }
+    val gridState = rememberSaveable(resultScrollKey, saver = LazyStaggeredGridState.Saver) { LazyStaggeredGridState() }
     val colorScheme = AsmrTheme.colorScheme
     val copyMeta = rememberAlbumMetaCopyAction(viewModel.messageManager)
     val scope = rememberCoroutineScope()
     val keyboardController = LocalSoftwareKeyboardController.current
     val isCompact = windowSizeClass.widthSizeClass == WindowWidthSizeClass.Compact
     val chromeState = rememberCollapsibleHeaderState()
-    val chromeResetKey = remember(currentPageKey, viewMode) { "$currentPageKey:$viewMode" }
+    val chromeResetKey = remember(resultScrollKey, viewMode) { "$resultScrollKey:$viewMode" }
     var lastChromeResetKey by rememberSaveable { mutableStateOf(chromeResetKey) }
 
     var keywordSyncedFromState by rememberSaveable { mutableStateOf(false) }
@@ -481,7 +508,7 @@ fun SearchScreen(
         with(androidx.compose.ui.platform.LocalDensity.current) { SearchPullNextPageMaxDistance.toPx() }
     val pullNextPageMaxLiftPx =
         with(androidx.compose.ui.platform.LocalDensity.current) { SearchPullNextPageMaxLift.toPx() }
-    var pullNextPageDragPx by remember(currentPageKey, viewMode) { mutableFloatStateOf(0f) }
+    var pullNextPageDragPx by remember(resultScrollKey, viewMode) { mutableFloatStateOf(0f) }
     val pullNextPageArmed = pullNextPageDragPx >= pullNextPageTriggerDistancePx
     val latestPullNextPageEnabled = rememberUpdatedState(pullNextPageEnabled)
     val latestIsAtBottom = rememberUpdatedState(
@@ -573,11 +600,11 @@ fun SearchScreen(
     val latestKeyword by rememberUpdatedState(keyword)
     val latestHorizontalPagerScrollLockChanged = rememberUpdatedState(onHorizontalPagerScrollLockChanged)
     fun stopActiveScroll() {
-        scope.launch {
-            runCatching { listState.stopScroll(MutatePriority.PreventUserInput) }
-            runCatching { gridState.stopScroll(MutatePriority.PreventUserInput) }
+        scope.launch(start = CoroutineStart.UNDISPATCHED) {
             pullNextPageDragPx = 0f
             latestHorizontalPagerScrollLockChanged.value(false)
+            runCatching { listState.stopScroll(MutatePriority.UserInput) }
+            runCatching { gridState.stopScroll(MutatePriority.UserInput) }
         }
     }
     LaunchedEffect(pullToRefreshState.isRefreshing) {
@@ -604,7 +631,7 @@ fun SearchScreen(
         }
         if (canEnd) pullToRefreshState.endRefresh()
     }
-    LaunchedEffect(currentPageKey, pullNextPageEnabled) {
+    LaunchedEffect(resultScrollKey, pullNextPageEnabled) {
         if (!pullNextPageEnabled) {
             if (pullNextPageDragPx != 0f) {
                 pullNextPageDragPx = 0f
@@ -729,7 +756,7 @@ fun SearchScreen(
                     Box(
                         modifier = Modifier
                             .fillMaxSize()
-                            .pointerInput(currentPageKey, viewMode) {
+                            .pointerInput(resultScrollKey, viewMode) {
                                 awaitEachGesture {
                                     val down = awaitFirstDown(requireUnconsumed = false, pass = PointerEventPass.Initial)
                                     var trackedPointerId = down.id
@@ -1110,7 +1137,7 @@ fun SearchScreen(
                         },
                         onLocaleSelected = { locale ->
                             selectedLocale = locale
-                            viewModel.updateSearchOptions(
+                            val accepted = viewModel.updateSearchOptions(
                                 order = selectedOrder,
                                 collectedSort = selectedCollectedSort,
                                 purchasedOnly = purchasedOnly,
@@ -1119,6 +1146,10 @@ fun SearchScreen(
                                 collectedOnly = collectedOnly,
                                 locale = locale
                             )
+                            if (accepted) {
+                                scrollResultsToTop()
+                                chromeState.expand()
+                            }
                         },
                         onCollectedSortSelected = { sort ->
                             selectedCollectedSortName = sort.name

--- a/app/src/main/java/com/asmr/player/ui/search/SearchScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/search/SearchScreen.kt
@@ -119,13 +119,14 @@ import com.asmr.player.ui.common.EaraLogoLoadingIndicator
 import com.asmr.player.ui.common.LocalBottomOverlayPadding
 import com.asmr.player.ui.common.albumCoverImageModel
 import com.asmr.player.ui.common.albumStableKey
+import com.asmr.player.ui.common.interruptScrollableFlingOnPointerDown
+import com.asmr.player.ui.common.smoothScrollToTop
 import com.asmr.player.ui.common.StableWindowInsets
 import com.asmr.player.ui.common.clearFocusOnTapOutside
 import com.asmr.player.ui.common.collapsibleHeaderUiState
 import com.asmr.player.ui.common.consumeTapThrough
 import com.asmr.player.ui.common.rememberCalmScrollableFlingBehavior
 import com.asmr.player.ui.common.rememberCollapsibleHeaderState
-import com.asmr.player.ui.common.smoothScrollToTop
 import com.asmr.player.ui.common.shouldFadeInCover
 import com.asmr.player.ui.common.thinScrollbar
 import com.asmr.player.ui.common.withAddedBottomPadding
@@ -372,6 +373,8 @@ fun SearchScreen(
 
     fun scrollResultsToTop() {
         scope.launch {
+            runCatching { listState.stopScroll(MutatePriority.UserInput) }
+            runCatching { gridState.stopScroll(MutatePriority.UserInput) }
             runCatching { listState.scrollToItem(0) }
             runCatching { gridState.scrollToItem(0) }
         }
@@ -570,6 +573,14 @@ fun SearchScreen(
     val pullRefreshHintEdgeOffsetPx = topPaddingPx + pullContentOffsetPx - pullRefreshHintHeightPx
     val latestKeyword by rememberUpdatedState(keyword)
     val latestHorizontalPagerScrollLockChanged = rememberUpdatedState(onHorizontalPagerScrollLockChanged)
+    fun stopActiveScroll() {
+        scope.launch {
+            runCatching { listState.stopScroll(MutatePriority.UserInput) }
+            runCatching { gridState.stopScroll(MutatePriority.UserInput) }
+            pullNextPageDragPx = 0f
+            latestHorizontalPagerScrollLockChanged.value(false)
+        }
+    }
     LaunchedEffect(pullToRefreshState.isRefreshing) {
         if (!pullToRefreshState.isRefreshing) return@LaunchedEffect
         when (val state = uiState) {
@@ -884,6 +895,7 @@ fun SearchScreen(
                                         state = listState,
                                         modifier = Modifier
                                             .fillMaxSize()
+                                            .interruptScrollableFlingOnPointerDown { stopActiveScroll() }
                                             .nestedScroll(chromeState.nestedScrollConnection)
                                             .thinScrollbar(listState),
                                         flingBehavior = rememberCalmScrollableFlingBehavior(),
@@ -940,6 +952,7 @@ fun SearchScreen(
                                         state = gridState,
                                         modifier = Modifier
                                             .fillMaxSize()
+                                            .interruptScrollableFlingOnPointerDown { stopActiveScroll() }
                                             .nestedScroll(chromeState.nestedScrollConnection)
                                             .thinScrollbar(gridState),
                                         flingBehavior = rememberCalmScrollableFlingBehavior(),
@@ -1043,7 +1056,9 @@ fun SearchScreen(
                     }
 
                     SearchChrome(
-                        modifier = Modifier.align(Alignment.TopCenter),
+                        modifier = Modifier
+                            .align(Alignment.TopCenter)
+                            .interruptScrollableFlingOnPointerDown { stopActiveScroll() },
                         keyword = keyword,
                         onKeywordChange = { keyword = it },
                         placeholder = hotKeywordCarouselItem.placeholder,

--- a/app/src/test/java/com/asmr/player/MainNavigationSupportTest.kt
+++ b/app/src/test/java/com/asmr/player/MainNavigationSupportTest.kt
@@ -131,9 +131,9 @@ class MainNavigationSupportTest {
     }
 
     @Test
-    fun shouldScrollPrimaryRouteToTop_onlyWhenAlreadyAtPrimaryRoot() {
+    fun shouldScrollPrimaryRouteToTop_whenRequestedRouteIsCurrentPrimaryRoute() {
         assertEquals(true, shouldScrollPrimaryRouteToTop("playlists", "playlists", "playlists"))
-        assertEquals(false, shouldScrollPrimaryRouteToTop("playlists", "playlists", null))
+        assertEquals(true, shouldScrollPrimaryRouteToTop("playlists", "playlists", null))
         assertEquals(false, shouldScrollPrimaryRouteToTop("groups", "playlists", "playlists"))
     }
 

--- a/app/src/test/java/com/asmr/player/MainNavigationSupportTest.kt
+++ b/app/src/test/java/com/asmr/player/MainNavigationSupportTest.kt
@@ -138,6 +138,28 @@ class MainNavigationSupportTest {
     }
 
     @Test
+    fun shouldTriggerPrimaryRouteScrollToTop_whenVisualRouteIsAlreadySelected() {
+        assertEquals(
+            true,
+            shouldTriggerPrimaryRouteScrollToTop(
+                requestedRoute = "hot",
+                visualPrimaryRoute = "hot",
+                activePrimaryRoute = "library",
+                currentPrimaryRoute = "library"
+            )
+        )
+        assertEquals(
+            false,
+            shouldTriggerPrimaryRouteScrollToTop(
+                requestedRoute = "groups",
+                visualPrimaryRoute = "hot",
+                activePrimaryRoute = "library",
+                currentPrimaryRoute = "library"
+            )
+        )
+    }
+
+    @Test
     fun shouldHideStatusBarForImmersivePage_hidesAlbumDetailRoutes() {
         assertEquals(true, shouldHideStatusBarForImmersivePage("album_detail/{albumId}?rjCode={rjCode}", false))
         assertEquals(true, shouldHideStatusBarForImmersivePage("album_detail_rj/{rj}?initialTab={initialTab}", false))

--- a/app/src/test/java/com/asmr/player/ui/common/AppScrollFlingTuningTest.kt
+++ b/app/src/test/java/com/asmr/player/ui/common/AppScrollFlingTuningTest.kt
@@ -5,6 +5,28 @@ import org.junit.Test
 
 class AppScrollFlingTuningTest {
     @Test
+    fun shouldStartCalmFling_ignoresTinyLiftVelocity() {
+        assertEquals(
+            false,
+            shouldStartCalmFling(
+                velocity = 180f,
+                startVelocityPxPerSecond = 260f
+            )
+        )
+    }
+
+    @Test
+    fun shouldStartCalmFling_allowsIntentionalSwipeVelocity() {
+        assertEquals(
+            true,
+            shouldStartCalmFling(
+                velocity = -700f,
+                startVelocityPxPerSecond = 260f
+            )
+        )
+    }
+
+    @Test
     fun calmVerticalFlingVelocity_keepsGentleFlingUnchanged() {
         assertEquals(
             700f,

--- a/app/src/test/java/com/asmr/player/ui/library/AlbumDetailViewModelSupportTest.kt
+++ b/app/src/test/java/com/asmr/player/ui/library/AlbumDetailViewModelSupportTest.kt
@@ -1,8 +1,10 @@
 package com.asmr.player.ui.library
 
 import com.asmr.player.domain.model.Album
+import com.asmr.player.ui.nav.AlbumCoverHint
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
+import org.junit.Assert.assertFalse
 import org.junit.Test
 
 class AlbumDetailViewModelSupportTest {
@@ -88,6 +90,30 @@ class AlbumDetailViewModelSupportTest {
         assertEquals("抓取标题", result.title)
         assertEquals("抓取CV", result.cv)
         assertEquals(listOf("抓取标签"), result.tags)
+    }
+
+    @Test
+    fun shouldPreserveHeaderAlbumMetadata_requiresResolvedDlsiteHint() {
+        val partialHint = AlbumCoverHint(
+            title = "列表标题",
+            rjCode = "RJ123456",
+            circle = "社团",
+            cv = "CV",
+            tags = listOf("标签"),
+            coverUrl = "https://example.com/list.jpg",
+            ratingValue = null,
+            ratingCount = 0,
+            releaseDate = "",
+            dlCount = 0,
+            priceJpy = 0,
+            hasAsmrOne = false,
+            description = "",
+            hasResolvedDlsiteInfo = false
+        )
+        val resolvedHint = partialHint.copy(hasResolvedDlsiteInfo = true)
+
+        assertFalse(shouldPreserveHeaderAlbumMetadata(partialHint))
+        assertTrue(shouldPreserveHeaderAlbumMetadata(resolvedHint))
     }
 
     @Test

--- a/app/src/test/java/com/asmr/player/ui/search/SearchResultScrollKeyTest.kt
+++ b/app/src/test/java/com/asmr/player/ui/search/SearchResultScrollKeyTest.kt
@@ -1,0 +1,59 @@
+package com.asmr.player.ui.search
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Test
+
+class SearchResultScrollKeyTest {
+    @Test
+    fun searchResultScrollKey_changesWhenSamePageGetsNewResults() {
+        val before = success(resultRevision = 1L)
+        val after = success(resultRevision = 2L)
+
+        assertNotEquals(searchResultScrollKey(before), searchResultScrollKey(after))
+    }
+
+    @Test
+    fun searchResultScrollKey_changesWhenSearchQueryChangesOnSamePage() {
+        val before = success(keyword = "RJ123456", resultRevision = 1L)
+        val after = success(keyword = "", resultRevision = 1L)
+
+        assertNotEquals(searchResultScrollKey(before), searchResultScrollKey(after))
+    }
+
+    @Test
+    fun searchResultScrollKey_ignoresBackgroundLoadingProgress() {
+        val before = success(resultRevision = 3L)
+        val after = before.copy(
+            isEnriching = true,
+            enrichingRjCodes = setOf("RJ123456"),
+            isAsmrOneChecking = true,
+            asmrOneChecked = 8,
+            asmrOneTotal = 30
+        )
+
+        assertEquals(searchResultScrollKey(before), searchResultScrollKey(after))
+    }
+
+    private fun success(
+        keyword: String = "RJ123456",
+        page: Int = 1,
+        resultRevision: Long = 1L
+    ): SearchUiState.Success {
+        return SearchUiState.Success(
+            results = emptyList(),
+            keyword = keyword,
+            page = page,
+            order = SearchSortOption.Trend,
+            collectedSort = SearchCollectedSortOption.ReleaseNew,
+            purchasedOnly = false,
+            presaleOnly = false,
+            chineseTranslatedOnly = false,
+            collectedOnly = true,
+            locale = "ja_JP",
+            canGoPrev = page > 1,
+            canGoNext = false,
+            resultRevision = resultRevision
+        )
+    }
+}


### PR DESCRIPTION
Summary:
- Stop active list flings before top chrome and pagination controls handle the same tap.
- Reset online search scroll state when the search result identity changes.
- Add regression coverage for search result scroll keys.

Verification:
- .\gradlew-local.bat :app:testReleaseUnitTest --tests com.asmr.player.ui.common.AppScrollFlingTuningTest --tests com.asmr.player.ui.search.SearchResultScrollKeyTest --tests com.asmr.player.ui.search.SearchChromeLockStateTest
- .\gradlew-local.bat :app:installRelease