### PR TITLE
Optimize footprint timeline and online detail loading

### DIFF
--- a/app/src/main/java/com/asmr/player/cache/LazyListPreloader.kt
+++ b/app/src/main/java/com/asmr/player/cache/LazyListPreloader.kt
@@ -7,12 +7,21 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.unit.IntSize
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.distinctUntilChanged
-import kotlinx.coroutines.flow.mapNotNull
 
 private const val MaxRememberedPreloadKeys = 96
 private const val ScrollingLeadViewportMultiplier = 2
 private const val IdleLeadViewportMultiplier = 3
+private const val IdlePreloadDelayMs = 160L
+
+private data class LazyListPreloadSnapshot(
+    val lastVisibleIndex: Int,
+    val visibleItemCount: Int,
+    val isScrolling: Boolean
+)
 
 @Composable
 fun LazyListPreloader(
@@ -29,28 +38,33 @@ fun LazyListPreloader(
         preloadedModels.clear()
         snapshotFlow {
             val visibleItems = state.layoutInfo.visibleItemsInfo
-            val scrolling = state.isScrollInProgress
-            val lastVisibleIndex = visibleItems.maxOfOrNull { it.index } ?: -1
-            scrolling to (lastVisibleIndex to visibleItems.size)
+            LazyListPreloadSnapshot(
+                lastVisibleIndex = visibleItems.maxOfOrNull { it.index } ?: -1,
+                visibleItemCount = visibleItems.size,
+                isScrolling = state.isScrollInProgress
+            )
         }
-            .mapNotNull { (scrolling, window) ->
-                val (lastVisibleIndex, visibleItemCount) = window
-                resolveLazyListPreloadRange(
-                    lastVisibleIndex = lastVisibleIndex,
-                    visibleItemCount = visibleItemCount,
+            .distinctUntilChanged()
+            .collectLatest { snapshot ->
+                val range = resolveLazyListPreloadRequest(
+                    lastVisibleIndex = snapshot.lastVisibleIndex,
+                    visibleItemCount = snapshot.visibleItemCount,
                     itemCount = models.size,
                     preloadNext = preloadNext,
                     preloadNextWhileScrolling = preloadNextWhileScrolling,
-                    isScrolling = scrolling
-                )
-            }
-            .distinctUntilChanged()
-            .collect { range ->
+                    isScrolling = snapshot.isScrolling
+                ) ?: return@collectLatest
+                delay(IdlePreloadDelayMs)
                 val toPreload = range.mapNotNull { index ->
-                    models[index].takeIf { model -> preloadedModels.add(model) }
+                    models[index].takeUnless { model -> model in preloadedModels }
                 }
-                manager.preload(toPreload, preloadSize)
-                preloadedModels.trimOldest(maxSize = MaxRememberedPreloadKeys)
+                if (toPreload.isNotEmpty()) {
+                    coroutineScope {
+                        manager.preload(this, toPreload, preloadSize).join()
+                    }
+                    preloadedModels.addAll(toPreload)
+                    preloadedModels.trimOldest(maxSize = MaxRememberedPreloadKeys)
+                }
             }
     }
 }
@@ -71,28 +85,31 @@ fun LazyListPreloader(
         preloadedModels.clear()
         snapshotFlow {
             val visibleItems = state.layoutInfo.visibleItemsInfo
-            val scrolling = state.isScrollInProgress
-            val lastVisibleIndex = visibleItems.maxOfOrNull { it.index } ?: -1
-            scrolling to (lastVisibleIndex to visibleItems.size)
+            LazyListPreloadSnapshot(
+                lastVisibleIndex = visibleItems.maxOfOrNull { it.index } ?: -1,
+                visibleItemCount = visibleItems.size,
+                isScrolling = state.isScrollInProgress
+            )
         }
-            .mapNotNull { (scrolling, window) ->
-                val (lastVisibleIndex, visibleItemCount) = window
-                resolveLazyListPreloadRange(
-                    lastVisibleIndex = lastVisibleIndex,
-                    visibleItemCount = visibleItemCount,
+            .distinctUntilChanged()
+            .collectLatest { snapshot ->
+                val range = resolveLazyListPreloadRequest(
+                    lastVisibleIndex = snapshot.lastVisibleIndex,
+                    visibleItemCount = snapshot.visibleItemCount,
                     itemCount = itemCount,
                     preloadNext = preloadNext,
                     preloadNextWhileScrolling = preloadNextWhileScrolling,
-                    isScrolling = scrolling
-                )
-            }
-            .distinctUntilChanged()
-            .collect { range ->
+                    isScrolling = snapshot.isScrolling
+                ) ?: return@collectLatest
+                delay(IdlePreloadDelayMs)
                 val toPreload = range.mapNotNull { index ->
-                    modelAt(index)?.takeIf { model -> preloadedModels.add(model) }
+                    modelAt(index)?.takeUnless { model -> model in preloadedModels }
                 }
                 if (toPreload.isNotEmpty()) {
-                    manager.preload(toPreload, preloadSize)
+                    coroutineScope {
+                        manager.preload(this, toPreload, preloadSize).join()
+                    }
+                    preloadedModels.addAll(toPreload)
                     preloadedModels.trimOldest(maxSize = MaxRememberedPreloadKeys)
                 }
             }
@@ -115,28 +132,31 @@ fun LazyStaggeredGridPreloader(
         preloadedModels.clear()
         snapshotFlow {
             val visibleItems = state.layoutInfo.visibleItemsInfo
-            val scrolling = state.isScrollInProgress
-            val lastVisibleIndex = visibleItems.maxOfOrNull { it.index } ?: -1
-            scrolling to (lastVisibleIndex to visibleItems.size)
+            LazyListPreloadSnapshot(
+                lastVisibleIndex = visibleItems.maxOfOrNull { it.index } ?: -1,
+                visibleItemCount = visibleItems.size,
+                isScrolling = state.isScrollInProgress
+            )
         }
-            .mapNotNull { (scrolling, window) ->
-                val (lastVisibleIndex, visibleItemCount) = window
-                resolveLazyListPreloadRange(
-                    lastVisibleIndex = lastVisibleIndex,
-                    visibleItemCount = visibleItemCount,
+            .distinctUntilChanged()
+            .collectLatest { snapshot ->
+                val range = resolveLazyListPreloadRequest(
+                    lastVisibleIndex = snapshot.lastVisibleIndex,
+                    visibleItemCount = snapshot.visibleItemCount,
                     itemCount = itemCount,
                     preloadNext = preloadNext,
                     preloadNextWhileScrolling = preloadNextWhileScrolling,
-                    isScrolling = scrolling
-                )
-            }
-            .distinctUntilChanged()
-            .collect { range ->
+                    isScrolling = snapshot.isScrolling
+                ) ?: return@collectLatest
+                delay(IdlePreloadDelayMs)
                 val toPreload = range.mapNotNull { index ->
-                    modelAt(index)?.takeIf { model -> preloadedModels.add(model) }
+                    modelAt(index)?.takeUnless { model -> model in preloadedModels }
                 }
                 if (toPreload.isNotEmpty()) {
-                    manager.preload(toPreload, preloadSize)
+                    coroutineScope {
+                        manager.preload(this, toPreload, preloadSize).join()
+                    }
+                    preloadedModels.addAll(toPreload)
                     preloadedModels.trimOldest(maxSize = MaxRememberedPreloadKeys)
                 }
             }
@@ -161,6 +181,27 @@ internal fun resolveLazyListPreloadRange(
     val end = (start + leadCount).coerceAtMost(itemCount)
     return if (start >= end) null else start until end
 }
+
+internal fun resolveLazyListPreloadRequest(
+    lastVisibleIndex: Int,
+    visibleItemCount: Int,
+    itemCount: Int,
+    preloadNext: Int,
+    preloadNextWhileScrolling: Int,
+    isScrolling: Boolean
+): IntRange? {
+    if (!shouldRunLazyListPreload(isScrolling)) return null
+    return resolveLazyListPreloadRange(
+        lastVisibleIndex = lastVisibleIndex,
+        visibleItemCount = visibleItemCount,
+        itemCount = itemCount,
+        preloadNext = preloadNext,
+        preloadNextWhileScrolling = preloadNextWhileScrolling,
+        isScrolling = false
+    )
+}
+
+internal fun shouldRunLazyListPreload(isScrolling: Boolean): Boolean = !isScrolling
 
 internal fun resolveLazyListPreloadLeadCount(
     visibleItemCount: Int,

--- a/app/src/main/java/com/asmr/player/data/remote/OkHttpCancellable.kt
+++ b/app/src/main/java/com/asmr/player/data/remote/OkHttpCancellable.kt
@@ -1,0 +1,34 @@
+package com.asmr.player.data.remote
+
+import java.io.IOException
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.suspendCancellableCoroutine
+import okhttp3.Call
+import okhttp3.Callback
+import okhttp3.Response
+
+@OptIn(ExperimentalCoroutinesApi::class)
+suspend fun Call.awaitResponse(): Response =
+    suspendCancellableCoroutine { continuation ->
+        continuation.invokeOnCancellation { cancel() }
+        enqueue(
+            object : Callback {
+                override fun onFailure(call: Call, e: IOException) {
+                    if (continuation.isCancelled) return
+                    continuation.resumeWithException(e)
+                }
+
+                override fun onResponse(call: Call, response: Response) {
+                    if (continuation.isActive) {
+                        continuation.resume(response) {
+                            response.close()
+                        }
+                    } else {
+                        response.close()
+                    }
+                }
+            }
+        )
+    }

--- a/app/src/main/java/com/asmr/player/data/remote/api/AsmrOneAvailabilityApi.kt
+++ b/app/src/main/java/com/asmr/player/data/remote/api/AsmrOneAvailabilityApi.kt
@@ -3,6 +3,7 @@ package com.asmr.player.data.remote.api
 import android.os.Build
 import com.asmr.player.BuildConfig
 import com.asmr.player.data.remote.NetworkHeaders
+import com.asmr.player.data.remote.awaitResponse
 import com.asmr.player.data.remote.withSearchTimeouts
 import com.asmr.player.listentogether.XxHash64
 import com.google.gson.Gson
@@ -120,7 +121,7 @@ class AsmrOneAvailabilityApi @Inject constructor(
                     .header(NetworkHeaders.HEADER_SILENT_IO_ERROR, NetworkHeaders.SILENT_IO_ERROR_ON)
                     .post(gson.toJson(AsmrOneAvailabilityRequest(normalized)).toRequestBody(JSON_MEDIA_TYPE))
                     .build()
-                requestClient.newCall(request).execute().use { response ->
+                requestClient.newCall(request).awaitResponse().use { response ->
                     if (!response.isSuccessful) return@withContext emptyMap()
                     val raw = response.body?.string().orEmpty()
                     if (raw.isBlank()) return@withContext emptyMap()
@@ -163,7 +164,7 @@ class AsmrOneAvailabilityApi @Inject constructor(
                 .header(NetworkHeaders.HEADER_SILENT_IO_ERROR, NetworkHeaders.SILENT_IO_ERROR_ON)
                 .get()
                 .build()
-            requestClient.newCall(request).execute().use { response ->
+            requestClient.newCall(request).awaitResponse().use { response ->
                 if (!response.isSuccessful) {
                     throw IOException("asmr.one search failed: HTTP ${response.code}")
                 }
@@ -195,7 +196,7 @@ class AsmrOneAvailabilityApi @Inject constructor(
                 .header(NetworkHeaders.HEADER_SILENT_IO_ERROR, NetworkHeaders.SILENT_IO_ERROR_ON)
                 .get()
                 .build()
-            trackTreeClient.newCall(request).execute().use { response ->
+            trackTreeClient.newCall(request).awaitResponse().use { response ->
                 val raw = response.body?.string().orEmpty()
                 if (response.code == 404 && raw.contains("\"tracks_not_found\"", ignoreCase = true)) {
                     throw IOException("asmr.one tracks backend not found")

--- a/app/src/main/java/com/asmr/player/data/remote/dlsite/DlsitePlayWorkClient.kt
+++ b/app/src/main/java/com/asmr/player/data/remote/dlsite/DlsitePlayWorkClient.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.util.Log
 import com.asmr.player.data.remote.NetworkHeaders
 import com.asmr.player.data.remote.api.AsmrOneTrackNodeResponse
+import com.asmr.player.data.remote.awaitResponse
 import com.asmr.player.data.remote.auth.DlsiteAuthStore
 import com.asmr.player.util.DlsiteWorkNo
 import com.asmr.player.util.RemoteSubtitleSource
@@ -230,7 +231,7 @@ class DlsitePlayWorkClient @Inject constructor(
         )
     }
 
-    private fun fetchDownloadSign(workno: String, cookie: String): Triple<String, Map<String, String>, String> {
+    private suspend fun fetchDownloadSign(workno: String, cookie: String): Triple<String, Map<String, String>, String> {
         val request = Request.Builder()
             .url("https://play.dlsite.com/api/v3/download/sign/url?workno=${URLEncoder.encode(workno, Charsets.UTF_8.name())}")
             .header("Cookie", cookie)
@@ -241,7 +242,7 @@ class DlsitePlayWorkClient @Inject constructor(
             .get()
             .build()
 
-        okHttpClient.newCall(request).execute().use { resp ->
+        okHttpClient.newCall(request).awaitResponse().use { resp ->
             if (!resp.isSuccessful) {
                 val body = resp.body?.string().orEmpty()
                 Log.w(TAG, "sign/url failed: ${resp.code}, body=${body.take(300)}")
@@ -271,7 +272,7 @@ class DlsitePlayWorkClient @Inject constructor(
         }
     }
 
-    private fun fetchZiptree(baseUrl: String, params: Map<String, String>, cookie: String): Map<String, Any?> {
+    private suspend fun fetchZiptree(baseUrl: String, params: Map<String, String>, cookie: String): Map<String, Any?> {
         val nowSec = TimeUnit.MILLISECONDS.toSeconds(System.currentTimeMillis())
         val ziptreeV = (nowSec - (nowSec % 60)).toString()
         val q = buildQuery(mapOf("v" to ziptreeV) + params)
@@ -286,7 +287,7 @@ class DlsitePlayWorkClient @Inject constructor(
             .get()
             .build()
 
-        okHttpClient.newCall(request).execute().use { resp ->
+        okHttpClient.newCall(request).awaitResponse().use { resp ->
             if (!resp.isSuccessful) {
                 val body = resp.body?.string().orEmpty()
                 Log.w(TAG, "ziptree.json failed: ${resp.code}, body=${body.take(300)}")

--- a/app/src/main/java/com/asmr/player/data/remote/dlsite/DlsiteProductInfoClient.kt
+++ b/app/src/main/java/com/asmr/player/data/remote/dlsite/DlsiteProductInfoClient.kt
@@ -1,6 +1,7 @@
 package com.asmr.player.data.remote.dlsite
 
 import com.asmr.player.data.remote.NetworkHeaders
+import com.asmr.player.data.remote.awaitResponse
 import com.google.gson.Gson
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -71,7 +72,7 @@ class DlsiteProductInfoClient @Inject constructor(
             .get()
             .build()
 
-        okHttpClient.newCall(request).execute().use { resp ->
+        okHttpClient.newCall(request).awaitResponse().use { resp ->
             val body = resp.body?.string().orEmpty()
             if (!resp.isSuccessful || body.isBlank()) return@withContext emptyList()
             parseLanguageEditions(clean, body)

--- a/app/src/main/java/com/asmr/player/main/MainContainer.kt
+++ b/app/src/main/java/com/asmr/player/main/MainContainer.kt
@@ -1209,8 +1209,8 @@ fun MainContainer(
                         Triple(Icons.AutoMirrored.Rounded.QueueMusic, "我的列表", "playlists"),
                         Triple(Icons.Rounded.Folder, "我的分组", "groups"),
                         Triple(Icons.Rounded.Download, "下载管理", "downloads"),
-                        Triple(Icons.Rounded.Settings, "设置", "settings"),
-                        Triple(Icons.Rounded.Route, "我的足迹", "listening_calendar")
+                        Triple(Icons.Rounded.Route, "我的足迹", "listening_calendar"),
+                        Triple(Icons.Rounded.Settings, "设置", "settings")
                     )
 
                     Column(modifier = Modifier.fillMaxSize()) {

--- a/app/src/main/java/com/asmr/player/ui/calendar/ListeningCalendarViewModel.kt
+++ b/app/src/main/java/com/asmr/player/ui/calendar/ListeningCalendarViewModel.kt
@@ -176,7 +176,7 @@ class ListeningCalendarViewModel @Inject constructor(
                 ListeningSummaryComparison()
             )
 
-    /** 选中日期的会话列表（垂直时间线数据）。 */
+    /** 选中日期的会话列表（垂直时间线数据），相邻同作品会合并显示。 */
     val selectedSessions: StateFlow<List<ListeningSessionEntity>> =
         _selectedDate
             .flatMapLatest { date ->
@@ -186,6 +186,7 @@ class ListeningCalendarViewModel @Inject constructor(
                     listeningRecordRepository.observeSessionsForDate(date)
                 }
             }
+            .map { sessions -> mergeAdjacentListeningSessions(sessions) }
             .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
 
     fun selectDate(date: String?) {
@@ -284,6 +285,56 @@ class ListeningCalendarViewModel @Inject constructor(
                 totalTrafficBytes = values.trafficBytes.roundToLong(),
                 activeDayCount = values.activeDayCount.roundToInt()
             )
+        }
+
+        internal fun mergeAdjacentListeningSessions(
+            sessions: List<ListeningSessionEntity>
+        ): List<ListeningSessionEntity> {
+            if (sessions.size <= 1) return sessions
+
+            val merged = ArrayList<ListeningSessionEntity>(sessions.size)
+            var current = sessions.first()
+            sessions.drop(1).forEach { next ->
+                if (isSameListeningWork(current, next)) {
+                    current = current.copy(
+                        durationMs = current.durationMs + next.durationMs,
+                        trafficBytes = current.trafficBytes + next.trafficBytes,
+                        trackCount = current.trackCount + next.trackCount,
+                        lastActiveAtMs = maxOf(current.lastActiveAtMs, next.lastActiveAtMs)
+                    )
+                } else {
+                    merged += current
+                    current = next
+                }
+            }
+            merged += current
+            return merged
+        }
+
+        private fun isSameListeningWork(
+            first: ListeningSessionEntity,
+            second: ListeningSessionEntity
+        ): Boolean {
+            val firstRj = first.rjCode.normalizedRjCode()
+            val secondRj = second.rjCode.normalizedRjCode()
+            if (firstRj != null && secondRj != null) return firstRj == secondRj
+            if (first.albumId > 0L && second.albumId > 0L) return first.albumId == second.albumId
+            if (firstRj != null || secondRj != null || first.albumId > 0L || second.albumId > 0L) return false
+
+            val firstMeta = first.normalizedFallbackWorkMeta() ?: return false
+            val secondMeta = second.normalizedFallbackWorkMeta() ?: return false
+            return firstMeta == secondMeta
+        }
+
+        private fun String.normalizedRjCode(): String? =
+            trim().uppercase(Locale.US).takeIf { it.isNotBlank() }
+
+        private fun ListeningSessionEntity.normalizedFallbackWorkMeta(): String? {
+            val normalizedTitle = title.trim().lowercase(Locale.ROOT)
+            if (normalizedTitle.isBlank()) return null
+            val normalizedCircle = circle.trim().lowercase(Locale.ROOT)
+            val normalizedCv = cv.trim().lowercase(Locale.ROOT)
+            return "$normalizedTitle|$normalizedCircle|$normalizedCv"
         }
 
         private fun currentSummaryRange(

--- a/app/src/main/java/com/asmr/player/ui/library/AlbumDetailScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/AlbumDetailScreen.kt
@@ -336,6 +336,11 @@ fun AlbumDetailScreen(
         viewModel.loadAlbum(albumId, rjCode, force = true)
         onConsumeRefreshToken?.invoke()
     }
+    DisposableEffect(screenKey, viewModel) {
+        onDispose {
+            viewModel.cancelActiveLoads()
+        }
+    }
     LaunchedEffect(pendingOnlineSaveSelection) {
         val selected = pendingOnlineSaveSelection ?: return@LaunchedEffect
         pendingOnlineSaveSelection = null

--- a/app/src/main/java/com/asmr/player/ui/library/AlbumDetailViewModel.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/AlbumDetailViewModel.kt
@@ -77,6 +77,7 @@ import java.util.concurrent.atomic.AtomicBoolean
 import javax.inject.Inject
 import javax.inject.Named
 import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.async
@@ -182,6 +183,12 @@ class AlbumDetailViewModel @Inject constructor(
     private var dlsiteTrialLoadToken: Int = 0
     private var asmrOneLoadToken: Int = 0
     private var lastAlbumKey: String? = null
+    private var albumLoadJob: Job? = null
+    private var dlsiteLoadJob: Job? = null
+    private var dlsiteRecommendationEnrichJob: Job? = null
+    private var dlsiteTrialLoadJob: Job? = null
+    private var asmrOneLoadJob: Job? = null
+    private var dlsitePlayLoadJob: Job? = null
     private var localTracksObserveJob: Job? = null
     private val asmrOneAttemptedRj = linkedSetOf<String>()
     private val dlsitePlayAttemptedRj = linkedSetOf<String>()
@@ -365,6 +372,48 @@ class AlbumDetailViewModel @Inject constructor(
         val u = url.trim()
         if (u.isBlank()) return null
         return lyricsLoader.fetchTextForPreview(u)
+    }
+
+    fun cancelActiveLoads() {
+        cancelPendingOnlineJobs(resetLoadingState = true)
+        albumLoadJob?.cancel()
+        albumLoadJob = null
+        localTracksObserveJob?.cancel()
+        localTracksObserveJob = null
+        listenTogetherRjSummaryJob?.cancel()
+        listenTogetherRjSummaryJob = null
+        lastAlbumKey = null
+    }
+
+    private fun cancelPendingOnlineJobs(resetLoadingState: Boolean) {
+        dlsiteLoadToken++
+        dlsiteTrialLoadToken++
+        asmrOneLoadToken++
+
+        dlsiteLoadJob?.cancel()
+        dlsiteLoadJob = null
+        dlsiteRecommendationEnrichJob?.cancel()
+        dlsiteRecommendationEnrichJob = null
+        dlsiteTrialLoadJob?.cancel()
+        dlsiteTrialLoadJob = null
+        asmrOneLoadJob?.cancel()
+        asmrOneLoadJob = null
+        dlsitePlayLoadJob?.cancel()
+        dlsitePlayLoadJob = null
+
+        asmrOneAttemptedRj.clear()
+        dlsitePlayAttemptedRj.clear()
+
+        if (!resetLoadingState) return
+        val current = _uiState.value as? AlbumDetailUiState.Success ?: return
+        _uiState.value = AlbumDetailUiState.Success(
+            model = current.model.copy(
+                isLoadingDlsite = false,
+                isLoadingDlsiteTrial = false,
+                isLoadingAsmrOne = false,
+                isLoadingDlsitePlay = false
+            )
+        )
     }
 
     suspend fun prepareDlsitePlayImagePreview(
@@ -568,6 +617,8 @@ class AlbumDetailViewModel @Inject constructor(
         val key = if (normalizedRj.isNotBlank()) "rj:$normalizedRj" else "id:${albumId ?: 0L}"
         val current = _uiState.value as? AlbumDetailUiState.Success
         if (!force && current != null && lastAlbumKey == key) return
+        cancelPendingOnlineJobs(resetLoadingState = false)
+        albumLoadJob?.cancel()
         lastAlbumKey = key
         val initialHint = AlbumCoverHintStore.peekHint(albumId, normalizedRj)
         val initialRj = normalizedRj.ifBlank { initialHint?.rjCode.orEmpty() }
@@ -580,7 +631,7 @@ class AlbumDetailViewModel @Inject constructor(
                 preserveHeaderAlbumMetadata = shouldPreserveHeaderAlbumMetadata(initialHint)
             )
         )
-        viewModelScope.launch {
+        albumLoadJob = viewModelScope.launch {
             try {
                 val localAlbum = if (albumId != null && albumId > 0) {
                     loadLocalAlbumById(albumId)
@@ -639,6 +690,8 @@ class AlbumDetailViewModel @Inject constructor(
                             }
                     }
                 }
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 _uiState.value = AlbumDetailUiState.Error(e.message ?: "加载失败")
             }
@@ -1142,9 +1195,11 @@ class AlbumDetailViewModel @Inject constructor(
         if (current.model.hasLoadedInitialDlsiteContent) return
         if (current.model.isLoadingDlsite) return
         
+        dlsiteLoadJob?.cancel()
+        dlsiteRecommendationEnrichJob?.cancel()
         // 如果还没有拉取过多语言列表，先拉取一次
         val token = ++dlsiteLoadToken
-        viewModelScope.launch {
+        dlsiteLoadJob = viewModelScope.launch {
             val latestBefore = (_uiState.value as? AlbumDetailUiState.Success)?.model ?: return@launch
             _uiState.value = AlbumDetailUiState.Success(
                 model = latestBefore.copy(
@@ -1300,7 +1355,8 @@ class AlbumDetailViewModel @Inject constructor(
                     )
                 )
 
-                viewModelScope.launch enrichLaunch@{
+                dlsiteRecommendationEnrichJob?.cancel()
+                dlsiteRecommendationEnrichJob = viewModelScope.launch enrichLaunch@{
                     val current2 = _uiState.value as? AlbumDetailUiState.Success ?: return@enrichLaunch
                     if (token != dlsiteLoadToken) return@enrichLaunch
                     val recs = current2.model.dlsiteRecommendations
@@ -1311,6 +1367,8 @@ class AlbumDetailViewModel @Inject constructor(
                     if (token != dlsiteLoadToken) return@enrichLaunch
                     _uiState.value = AlbumDetailUiState.Success(model = updated2.copy(dlsiteRecommendations = enriched))
                 }
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 val updated = (_uiState.value as? AlbumDetailUiState.Success)?.model ?: return@launch
                 _uiState.value = AlbumDetailUiState.Success(model = updated.copy(isLoadingDlsite = false))
@@ -1339,6 +1397,7 @@ class AlbumDetailViewModel @Inject constructor(
         if (workno.isBlank()) return
         if (normalized == current.model.dlsiteSelectedLang.trim().uppercase() && workno == current.model.dlsiteWorkno.trim().uppercase()) return
 
+        cancelPendingOnlineJobs(resetLoadingState = false)
         dlsiteLoadToken++
         asmrOneLoadToken++
         asmrOneAttemptedRj.clear()
@@ -1456,7 +1515,8 @@ class AlbumDetailViewModel @Inject constructor(
 
         val token = ++dlsiteTrialLoadToken
         val locale = dlsiteLocaleForLang(current.model.dlsiteSelectedLang)
-        viewModelScope.launch {
+        dlsiteTrialLoadJob?.cancel()
+        dlsiteTrialLoadJob = viewModelScope.launch {
             val latestBefore = _uiState.value as? AlbumDetailUiState.Success ?: return@launch
             val latestWorkno = latestBefore.model.dlsiteWorkno.trim().uppercase().ifBlank { latestBefore.model.rjCode.trim().uppercase() }
             if (!latestWorkno.equals(workno, ignoreCase = true)) return@launch
@@ -1473,6 +1533,8 @@ class AlbumDetailViewModel @Inject constructor(
                         isLoadingDlsiteTrial = false
                     )
                 )
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 val updated = (_uiState.value as? AlbumDetailUiState.Success)?.model ?: return@launch
                 val updatedWorkno = updated.dlsiteWorkno.trim().uppercase().ifBlank { updated.rjCode.trim().uppercase() }
@@ -1497,7 +1559,8 @@ class AlbumDetailViewModel @Inject constructor(
         ) return
         asmrOneAttemptedRj.add(keyRj)
         val token = ++asmrOneLoadToken
-        viewModelScope.launch {
+        asmrOneLoadJob?.cancel()
+        asmrOneLoadJob = viewModelScope.launch {
             val latestBefore = _uiState.value as? AlbumDetailUiState.Success ?: return@launch
             val latestKey = latestBefore.model.rjCode.trim().uppercase()
             if (!latestKey.equals(keyRj, ignoreCase = true)) {
@@ -1665,7 +1728,7 @@ class AlbumDetailViewModel @Inject constructor(
                 }
                 if (tree.isEmpty() && loadBackendFallbackAndFinishIfFound()) return@launch
                 finishWithResolvedAsmrOneTree(workId = workId, site = site, tree = tree)
-            } catch (e: kotlinx.coroutines.CancellationException) {
+            } catch (e: CancellationException) {
                 asmrOneAttemptedRj.remove(keyRj)
                 finishAsmrOneLoad(keyRj, resolved = false)
             } catch (e: Exception) {
@@ -1696,7 +1759,8 @@ class AlbumDetailViewModel @Inject constructor(
             dlsitePlayAttemptedRj.contains(attemptKey)
         ) return
         dlsitePlayAttemptedRj.add(attemptKey)
-        viewModelScope.launch {
+        dlsitePlayLoadJob?.cancel()
+        dlsitePlayLoadJob = viewModelScope.launch {
             _uiState.value = AlbumDetailUiState.Success(
                 model = current.model.copy(
                     isLoadingDlsitePlay = true,
@@ -1764,6 +1828,8 @@ class AlbumDetailViewModel @Inject constructor(
                         isLoadingDlsitePlay = false
                     )
                 )
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 dlsitePlayAttemptedRj.remove(attemptKey)
                 val updated = (_uiState.value as? AlbumDetailUiState.Success)?.model ?: return@launch
@@ -2937,6 +3003,7 @@ class AlbumDetailViewModel @Inject constructor(
     }
 
     override fun onCleared() {
+        cancelActiveLoads()
         cancelCloudSyncSelection()
         super.onCleared()
     }

--- a/app/src/main/java/com/asmr/player/ui/nav/BottomChrome.kt
+++ b/app/src/main/java/com/asmr/player/ui/nav/BottomChrome.kt
@@ -290,8 +290,8 @@ fun bottomChromeNavItems(): List<BottomChromeNavItem> = listOf(
     BottomChromeNavItem(Icons.Rounded.Favorite, "我的收藏", "playlist_system/favorites"),
     BottomChromeNavItem(Icons.AutoMirrored.Rounded.QueueMusic, "我的列表", "playlists"),
     BottomChromeNavItem(Icons.Rounded.Folder, "我的分组", "groups"),
-    BottomChromeNavItem(Icons.Rounded.Settings, "设置", "settings"),
-    BottomChromeNavItem(Icons.Rounded.Route, "我的足迹", "listening_calendar")
+    BottomChromeNavItem(Icons.Rounded.Route, "我的足迹", "listening_calendar"),
+    BottomChromeNavItem(Icons.Rounded.Settings, "设置", "settings")
 )
 
 fun isPrimaryRoute(route: String?): Boolean {

--- a/app/src/test/java/com/asmr/player/MainNavigationSupportTest.kt
+++ b/app/src/test/java/com/asmr/player/MainNavigationSupportTest.kt
@@ -132,8 +132,10 @@ class MainNavigationSupportTest {
         val items = bottomChromeNavItems()
         val routes = items.map { it.route }
 
-        assertEquals("我的足迹", items.last().label)
-        assertEquals("listening_calendar", items.last().route)
+        assertEquals("我的足迹", items[items.lastIndex - 1].label)
+        assertEquals("listening_calendar", items[items.lastIndex - 1].route)
+        assertEquals("设置", items.last().label)
+        assertEquals("settings", items.last().route)
         assertEquals(true, routes.contains("listening_calendar"))
         assertEquals(false, routes.contains("dlsite_login"))
     }

--- a/app/src/test/java/com/asmr/player/cache/LazyListPreloaderTest.kt
+++ b/app/src/test/java/com/asmr/player/cache/LazyListPreloaderTest.kt
@@ -92,4 +92,30 @@ class LazyListPreloaderTest {
             )
         )
     }
+
+    @Test
+    fun preloadRequest_pausesWhileListIsScrolling() {
+        assertNull(
+            resolveLazyListPreloadRequest(
+                lastVisibleIndex = 4,
+                visibleItemCount = 6,
+                itemCount = 30,
+                preloadNext = 24,
+                preloadNextWhileScrolling = 16,
+                isScrolling = true
+            )
+        )
+
+        assertEquals(
+            5..28,
+            resolveLazyListPreloadRequest(
+                lastVisibleIndex = 4,
+                visibleItemCount = 6,
+                itemCount = 30,
+                preloadNext = 24,
+                preloadNextWhileScrolling = 16,
+                isScrolling = false
+            )
+        )
+    }
 }

--- a/app/src/test/java/com/asmr/player/ui/calendar/ListeningCalendarViewModelTest.kt
+++ b/app/src/test/java/com/asmr/player/ui/calendar/ListeningCalendarViewModelTest.kt
@@ -1,5 +1,6 @@
 package com.asmr.player.ui.calendar
 
+import com.asmr.player.data.local.db.entities.ListeningSessionEntity
 import com.asmr.player.data.local.db.entities.DailyStatEntity
 import com.asmr.player.util.ListeningDay
 import org.junit.After
@@ -113,6 +114,55 @@ class ListeningCalendarViewModelTest {
     }
 
     @Test
+    fun mergeAdjacentListeningSessions_combinesOnlyNeighboringSameWorks() {
+        val minute = 60_000L
+        val firstA = listeningSession(
+            id = 1L,
+            rjCode = "RJ123456",
+            title = "作品 A",
+            startAtMs = 3_000L,
+            durationMs = 3L * minute,
+            trafficBytes = 300L,
+            trackCount = 1
+        )
+        val secondA = listeningSession(
+            id = 2L,
+            rjCode = "rj123456",
+            title = "作品 A",
+            startAtMs = 2_000L,
+            durationMs = 2L * minute,
+            trafficBytes = 200L,
+            trackCount = 2
+        )
+        val workB = listeningSession(
+            id = 3L,
+            rjCode = "RJ654321",
+            title = "作品 B",
+            startAtMs = 1_000L,
+            durationMs = minute
+        )
+        val laterA = listeningSession(
+            id = 4L,
+            rjCode = "RJ123456",
+            title = "作品 A",
+            startAtMs = 500L,
+            durationMs = minute
+        )
+
+        val merged = ListeningCalendarViewModel.mergeAdjacentListeningSessions(
+            listOf(firstA, secondA, workB, laterA)
+        )
+
+        assertEquals(3, merged.size)
+        assertEquals(1L, merged[0].id)
+        assertEquals(5L * minute, merged[0].durationMs)
+        assertEquals(500L, merged[0].trafficBytes)
+        assertEquals(3, merged[0].trackCount)
+        assertEquals(workB.id, merged[1].id)
+        assertEquals(laterA.id, merged[2].id)
+    }
+
+    @Test
     fun buildSummaryComparison_dayUsesSelectedHeatmapDate() {
         val minute = 60_000L
         val comparison = ListeningCalendarViewModel.buildSummaryComparison(
@@ -197,3 +247,30 @@ class ListeningCalendarViewModelTest {
         assertEquals(-1.0, comparison.activeDayCount.difference, 0.1)
     }
 }
+
+private fun listeningSession(
+    id: Long,
+    rjCode: String = "",
+    title: String = "",
+    albumId: Long = -1L,
+    circle: String = "",
+    cv: String = "",
+    startAtMs: Long,
+    durationMs: Long,
+    trafficBytes: Long = 0L,
+    trackCount: Int = 0
+): ListeningSessionEntity =
+    ListeningSessionEntity(
+        id = id,
+        albumId = albumId,
+        rjCode = rjCode,
+        title = title,
+        circle = circle,
+        cv = cv,
+        listeningDate = "2026-07-22",
+        startAtMs = startAtMs,
+        lastActiveAtMs = startAtMs + durationMs,
+        durationMs = durationMs,
+        trafficBytes = trafficBytes,
+        trackCount = trackCount
+    )


### PR DESCRIPTION
## Summary
- 合并我的足迹时间线中相邻且相同的作品记录，并交换我的足迹和设置的页面/导航顺序
- 滚动时暂停列表封面预加载，停稳后以可取消任务进行预热，减少冷启动列表卡顿
- 在线专辑详情退出时取消未完成的详情加载，并让相关 OkHttp 请求响应协程取消

## Verification
- .\\gradlew-local.bat :app:testReleaseUnitTest --tests com.asmr.player.MainNavigationSupportTest.bottomChromeNavItems_useListeningCalendarAsPrimaryEntry --tests com.asmr.player.ui.calendar.ListeningCalendarViewModelTest.mergeAdjacentListeningSessions_combinesOnlyNeighboringSameWorks
- .\\gradlew-local.bat :app:testReleaseUnitTest --tests com.asmr.player.cache.LazyListPreloaderTest
- .\\gradlew-local.bat :app:testReleaseUnitTest --tests com.asmr.player.ui.library.AlbumDetailViewModelSupportTest --tests com.asmr.player.data.remote.dlsite.DlsiteProductInfoClientTest
- .\\gradlew-local.bat :app:installRelease