### PR TITLE
fix: decouple cover image loading from layout wait

### DIFF
--- a/app/src/main/java/com/asmr/player/ui/common/AsmrAsyncImage.kt
+++ b/app/src/main/java/com/asmr/player/ui/common/AsmrAsyncImage.kt
@@ -90,12 +90,14 @@ fun AsmrAsyncImage(
     }
     val contentModifier = Modifier.fillMaxSize()
 
-    LaunchedEffect(normalizedModel, measuredSize.value, reloadKey) {
-        val initialSize = measuredSize.value ?: return@LaunchedEffect
-        if (loadWhenSizeStableForMillis > 0L) {
+    val loadSizeKey = if (loadAtOriginalSize) Unit else measuredSize.value
+    LaunchedEffect(normalizedModel, loadSizeKey, reloadKey) {
+        val initialSize = measuredSize.value
+        if (!loadAtOriginalSize && initialSize == null) return@LaunchedEffect
+        if (!loadAtOriginalSize && loadWhenSizeStableForMillis > 0L) {
             delay(loadWhenSizeStableForMillis)
         }
-        val sz = measuredSize.value ?: initialSize
+        val sz = measuredSize.value ?: initialSize ?: IntSize.Zero
         suspend fun finishWithExistingPainter() {
             state.value = AsmrAsyncImageState.Success
             crossfadeRunning.value = false


### PR DESCRIPTION
## Summary
- let original-size image requests start immediately without waiting for measured size stability
- keep playback page entry/exit animation behavior unchanged

## Verification
- .\gradlew-local.bat :app:testReleaseUnitTest --tests "com.asmr.player.ui.player.NowPlayingHomeLayoutCoverTest"
- .\gradlew-local.bat :app:installRelease
