### PR TITLE
优化播放页标签操作与歌词显示效果

### DIFF
--- a/app/src/main/java/com/asmr/player/main/MainContainer.kt
+++ b/app/src/main/java/com/asmr/player/main/MainContainer.kt
@@ -856,6 +856,22 @@ fun MainContainer(
         navController.popBackStack(Routes.Search, false)
     }
 
+    fun submitMetaSearchKeyword(keyword: String) {
+        val normalized = keyword.trim()
+        if (normalized.isBlank()) return
+        val request = SearchAssistSearchRequest(keyword = normalized)
+        submittedSearchKeyword = request.keyword
+        submittedSearchOrderName = request.orderName
+        submittedSearchPurchasedOnly = request.purchasedOnly
+        submittedSearchPresaleOnly = request.presaleOnly
+        submittedSearchChineseTranslatedOnly = request.chineseTranslatedOnly
+        submittedSearchCollectedOnly = request.collectedOnly
+        submittedSearchCollectedSortName = request.collectedSortName
+        submittedSearchLocale = request.locale
+        submittedSearchSignal = System.currentTimeMillis()
+        openPrimaryRoute(Routes.Search)
+    }
+
     fun handleAutomaticInstallResult(result: AppUpdateInstallResult, apkPath: String) {
         when (result) {
             AppUpdateInstallResult.Started -> {
@@ -1723,6 +1739,7 @@ fun MainContainer(
                                                     navController.navigateSingleTop("group_picker?albumId=$albumId")
                                                 },
                                                 onOpenFilterScreen = { navController.navigateSingleTop("library_filter") },
+                                                onSearchKeyword = ::submitMetaSearchKeyword,
                                                 viewModel = libraryViewModel
                                             )
                                         }
@@ -1801,6 +1818,7 @@ fun MainContainer(
                                                     )
                                                     navigator.openAlbumDetailByRj(album.rjCode.ifBlank { album.workId })
                                                 },
+                                                onSearchKeyword = ::submitMetaSearchKeyword,
                                                 viewModel = hotListeningViewModel
                                             )
                                         }
@@ -2093,7 +2111,8 @@ fun MainContainer(
                                 coverUrl = work?.coverUrl
                             )
                             navigator.openAlbumDetailByRjStacked(targetRj)
-                        }
+                        },
+                        onSearchKeyword = ::submitMetaSearchKeyword
                     )
                 }
                 composable(
@@ -2147,7 +2166,8 @@ fun MainContainer(
                                 coverUrl = work?.coverUrl
                             )
                             navigator.openAlbumDetailByRjStacked(targetRj)
-                        }
+                        },
+                        onSearchKeyword = ::submitMetaSearchKeyword
                     )
                 }
                 composable(
@@ -2188,7 +2208,8 @@ fun MainContainer(
                                 coverUrl = work?.coverUrl
                             )
                             navigator.openAlbumDetailByRjStacked(targetRj)
-                        }
+                        },
+                        onSearchKeyword = ::submitMetaSearchKeyword
                     )
                 }
                 composable(

--- a/app/src/main/java/com/asmr/player/ui/hotlistening/HotListeningScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/hotlistening/HotListeningScreen.kt
@@ -73,7 +73,11 @@ import com.asmr.player.ui.library.AlbumGridItem
 import com.asmr.player.ui.library.AlbumGridItemSpacing
 import com.asmr.player.ui.library.AlbumCoverBadge
 import com.asmr.player.ui.library.AlbumItem
+import com.asmr.player.ui.library.AlbumMetaActionDialog
 import com.asmr.player.ui.library.rememberAlbumMetaCopyAction
+import com.asmr.player.ui.groups.AlbumGroupsViewModel
+import com.asmr.player.ui.playlists.PlaylistsViewModel
+import com.asmr.player.ui.settings.SettingsViewModel
 import com.asmr.player.ui.theme.AsmrTheme
 import dagger.hilt.android.EntryPointAccessors
 import kotlinx.coroutines.CoroutineStart
@@ -89,6 +93,7 @@ fun HotListeningScreen(
     windowSizeClass: WindowSizeClass,
     isActive: Boolean = true,
     onAlbumClick: (Album) -> Unit,
+    onSearchKeyword: (String) -> Unit = {},
     scrollToTopSignal: Long = 0L,
     viewModel: HotListeningViewModel = hiltViewModel()
 ) {
@@ -98,10 +103,15 @@ fun HotListeningScreen(
     val selectedPeriod by viewModel.selectedPeriod.collectAsState()
     val colorScheme = AsmrTheme.colorScheme
     val copyMeta = rememberAlbumMetaCopyAction(viewModel.messageManager)
+    val playlistsViewModel: PlaylistsViewModel = hiltViewModel()
+    val albumGroupsViewModel: AlbumGroupsViewModel = hiltViewModel()
+    val settingsViewModel: SettingsViewModel = hiltViewModel()
+    val searchBlockedKeywords by settingsViewModel.searchBlockedKeywords.collectAsState()
     val scope = rememberCoroutineScope()
     val isCompactWidth = windowSizeClass.widthSizeClass == WindowWidthSizeClass.Compact
     var showBlockedEntries by rememberSaveable { mutableStateOf(false) }
     var scrollResetNonce by rememberSaveable { mutableIntStateOf(0) }
+    var metaActionKeyword by rememberSaveable { mutableStateOf<String?>(null) }
     val contentScrollKey = remember(selectedPeriod, selectedSortMode, scrollResetNonce) {
         "hot-listening:$selectedPeriod:${selectedSortMode.name}:$scrollResetNonce"
     }
@@ -126,6 +136,23 @@ fun HotListeningScreen(
         scope.launch {
             runCatching { listState.stopScroll(MutatePriority.PreventUserInput) }
             runCatching { gridState.stopScroll(MutatePriority.PreventUserInput) }
+        }
+    }
+
+    fun openMetaActions(value: String) {
+        val normalized = value.trim()
+        if (normalized.isNotBlank()) metaActionKeyword = normalized
+    }
+
+    fun addMetaBlockedKeyword(value: String) {
+        val normalized = value.trim()
+        if (normalized.isBlank()) return
+        val exists = searchBlockedKeywords.any { it.equals(normalized, ignoreCase = true) }
+        settingsViewModel.addSearchBlockedKeyword(normalized)
+        if (exists) {
+            viewModel.messageManager.showInfo("屏蔽词已存在：$normalized")
+        } else {
+            viewModel.messageManager.showSuccess("已添加屏蔽词：$normalized")
         }
     }
 
@@ -279,6 +306,7 @@ fun HotListeningScreen(
                                 entry = entry,
                                 onAlbumClick = onAlbumClick,
                                 copyMeta = copyMeta,
+                                onMetaLongClick = ::openMetaActions,
                                 coverFadeIn = listCoverFadeIn
                             )
                         }
@@ -303,6 +331,7 @@ fun HotListeningScreen(
                                         entry = entry,
                                         onAlbumClick = onAlbumClick,
                                         copyMeta = copyMeta,
+                                        onMetaLongClick = ::openMetaActions,
                                         coverFadeIn = listCoverFadeIn
                                     )
                                 }
@@ -355,6 +384,7 @@ fun HotListeningScreen(
                                 entry = state.entries[index],
                                 onAlbumClick = onAlbumClick,
                                 copyMeta = copyMeta,
+                                onMetaLongClick = ::openMetaActions,
                                 coverFadeIn = gridCoverFadeIn
                             )
                         }
@@ -382,6 +412,7 @@ fun HotListeningScreen(
                                         entry = state.blockedEntries[index],
                                         onAlbumClick = onAlbumClick,
                                         copyMeta = copyMeta,
+                                        onMetaLongClick = ::openMetaActions,
                                         coverFadeIn = gridCoverFadeIn
                                     )
                                 }
@@ -392,6 +423,17 @@ fun HotListeningScreen(
             }
         }
     }
+
+    metaActionKeyword?.let { keyword ->
+        AlbumMetaActionDialog(
+            keyword = keyword,
+            onDismissRequest = { metaActionKeyword = null },
+            onSearch = onSearchKeyword,
+            onCreatePlaylist = playlistsViewModel::createPlaylist,
+            onCreateGroup = albumGroupsViewModel::createGroup,
+            onAddBlockedKeyword = ::addMetaBlockedKeyword,
+        )
+    }
 }
 
 @Composable
@@ -399,6 +441,7 @@ private fun HotListeningListItem(
     entry: HotListeningEntry,
     onAlbumClick: (Album) -> Unit,
     copyMeta: (String, String) -> Unit,
+    onMetaLongClick: (String) -> Unit,
     coverFadeIn: Boolean = true
 ) {
     val album = entry.album
@@ -410,8 +453,11 @@ private fun HotListeningListItem(
         coverFadeIn = coverFadeIn,
         onRjClick = { copyMeta("RJ", it) },
         onCircleClick = { copyMeta("社团", it) },
+        onCircleLongClick = onMetaLongClick,
         onCvClick = { copyMeta("CV", it) },
+        onCvLongClick = onMetaLongClick,
         onTagClick = { copyMeta("标签", it) },
+        onTagLongClick = onMetaLongClick,
     )
 }
 
@@ -420,6 +466,7 @@ private fun HotListeningGridItem(
     entry: HotListeningEntry,
     onAlbumClick: (Album) -> Unit,
     copyMeta: (String, String) -> Unit,
+    onMetaLongClick: (String) -> Unit,
     coverFadeIn: Boolean = true
 ) {
     val album = entry.album
@@ -431,8 +478,11 @@ private fun HotListeningGridItem(
         coverFadeIn = coverFadeIn,
         onRjClick = { copyMeta("RJ", it) },
         onCircleClick = { copyMeta("社团", it) },
+        onCircleLongClick = onMetaLongClick,
         onCvClick = { copyMeta("CV", it) },
+        onCvLongClick = onMetaLongClick,
         onTagClick = { copyMeta("标签", it) },
+        onTagLongClick = onMetaLongClick,
     )
 }
 

--- a/app/src/main/java/com/asmr/player/ui/library/AlbumDetailScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/AlbumDetailScreen.kt
@@ -144,8 +144,11 @@ import com.asmr.player.ui.common.ImagePreviewRequest
 import com.asmr.player.ui.common.collapsibleHeaderUiState
 import com.asmr.player.ui.common.consumeTapThrough
 import com.asmr.player.ui.common.rememberCollapsibleHeaderState
+import com.asmr.player.ui.groups.AlbumGroupsViewModel
 import com.asmr.player.ui.groups.AlbumGroupPickerScreen
 import com.asmr.player.ui.playlists.PlaylistPickerScreen
+import com.asmr.player.ui.playlists.PlaylistsViewModel
+import com.asmr.player.ui.settings.SettingsViewModel
 import com.asmr.player.ui.theme.AsmrTheme
 import com.asmr.player.ui.common.LocalBottomOverlayPadding
 import com.asmr.player.ui.common.thinScrollbar
@@ -303,11 +306,16 @@ fun AlbumDetailScreen(
     onOpenPlaylistPicker: (MediaItem) -> Unit = {},
     onOpenDlsiteLogin: () -> Unit = {},
     onOpenAlbumByRj: (String, DlsiteRecommendedWork?) -> Unit = { _, _ -> },
+    onSearchKeyword: (String) -> Unit = {},
     initialTab: Int? = null,
     viewModel: AlbumDetailViewModel = hiltViewModel()
 ) {
     val uiState by viewModel.uiState.collectAsState()
     val cloudSyncSelectionDialogState by viewModel.cloudSyncSelectionDialogState.collectAsState()
+    val playlistsViewModel: PlaylistsViewModel = hiltViewModel()
+    val albumGroupsViewModel: AlbumGroupsViewModel = hiltViewModel()
+    val settingsViewModel: SettingsViewModel = hiltViewModel()
+    val searchBlockedKeywords by settingsViewModel.searchBlockedKeywords.collectAsState()
     val colorScheme = AsmrTheme.colorScheme
     val screenKey = remember(albumId, rjCode) {
         val idPart = albumId?.takeIf { it > 0 }?.toString().orEmpty()
@@ -327,6 +335,24 @@ fun AlbumDetailScreen(
     var batchPlaylistItems by remember { mutableStateOf<List<MediaItem>?>(null) }
     var groupPickerAlbumId by remember { mutableStateOf<Long?>(null) }
     var downloadSource by remember { mutableStateOf(OnlineDownloadSource.AsmrOne) }
+    var metaActionKeyword by rememberSaveable { mutableStateOf<String?>(null) }
+
+    fun openMetaActions(value: String) {
+        val keyword = value.trim()
+        if (keyword.isNotBlank()) metaActionKeyword = keyword
+    }
+
+    fun addMetaBlockedKeyword(value: String) {
+        val keyword = value.trim()
+        if (keyword.isBlank()) return
+        val exists = searchBlockedKeywords.any { it.equals(keyword, ignoreCase = true) }
+        settingsViewModel.addSearchBlockedKeyword(keyword)
+        if (exists) {
+            viewModel.messageManager.showInfo("屏蔽词已存在：$keyword")
+        } else {
+            viewModel.messageManager.showSuccess("已添加屏蔽词：$keyword")
+        }
+    }
 
     LaunchedEffect(albumId, rjCode) {
         viewModel.loadAlbum(albumId, rjCode, force = false)
@@ -670,7 +696,8 @@ fun AlbumDetailScreen(
                                 introSessionKey = introSessionKey,
                                 animateIntro = shouldAnimateHeaderIntro,
                                 deferMetaRevealExpected = !isLocalTab,
-                                messageManager = viewModel.messageManager
+                                messageManager = viewModel.messageManager,
+                                onMetaLongClick = ::openMetaActions
                             )
                         }
 
@@ -697,6 +724,7 @@ fun AlbumDetailScreen(
                                 listenTogetherRjListenerCount = model.listenTogetherRjListenerCount,
                                 showCoverLoadingState = showHeroCoverLoadingState,
                                 messageManager = viewModel.messageManager,
+                                onMetaLongClick = ::openMetaActions,
                                 collapsePx = { heroCollapsePx },
                                 collapseMaxPx = heroCollapseMaxPx,
                                 visualOvershootPx = { heroVisualOvershootPx },
@@ -1032,6 +1060,17 @@ fun AlbumDetailScreen(
                     )
                 }
 
+                metaActionKeyword?.let { keyword ->
+                    AlbumMetaActionDialog(
+                        keyword = keyword,
+                        onDismissRequest = { metaActionKeyword = null },
+                        onSearch = onSearchKeyword,
+                        onCreatePlaylist = playlistsViewModel::createPlaylist,
+                        onCreateGroup = albumGroupsViewModel::createGroup,
+                        onAddBlockedKeyword = ::addMetaBlockedKeyword,
+                    )
+                }
+
                 val track = tagManageTrack
                 if (track != null && track.id > 0L) {
                     TagAssignDialog(
@@ -1096,6 +1135,7 @@ private fun AlbumDetailHeroBackground(
     listenTogetherRjListenerCount: Int?,
     showCoverLoadingState: Boolean,
     messageManager: MessageManager,
+    onMetaLongClick: (String) -> Unit,
     modifier: Modifier = Modifier,
     collapsePx: () -> Float = { 0f },
     collapseMaxPx: Float = 0f,
@@ -1283,6 +1323,7 @@ private fun AlbumDetailHeroBackground(
             animateIntro = animateIntro,
             listenTogetherRjListenerCount = listenTogetherRjListenerCount,
             messageManager = messageManager,
+            onMetaLongClick = onMetaLongClick,
             modifier = Modifier.align(Alignment.BottomStart)
         )
     }
@@ -1295,6 +1336,7 @@ private fun AlbumHeroIdentityOverlay(
     animateIntro: Boolean,
     listenTogetherRjListenerCount: Int?,
     messageManager: MessageManager,
+    onMetaLongClick: (String) -> Unit,
     modifier: Modifier = Modifier
 ) {
     val colorScheme = AsmrTheme.colorScheme
@@ -1357,6 +1399,7 @@ private fun AlbumHeroIdentityOverlay(
                         modifier = Modifier.weight(1f),
                         rjOnClick = { copyMeta("RJ", rj) },
                         circleOnClick = { copyMeta("社团", circle) },
+                        circleOnLongClick = { onMetaLongClick(circle) },
                         appearance = AlbumMetaAppearance.OnImage,
                         leadingVisual = AlbumMetaLeadingVisual.Icon,
                     )
@@ -1533,7 +1576,8 @@ private fun AlbumHeader(
     introSessionKey: String,
     animateIntro: Boolean,
     deferMetaRevealExpected: Boolean,
-    messageManager: MessageManager
+    messageManager: MessageManager,
+    onMetaLongClick: (String) -> Unit
 ) {
     val context = LocalContext.current
     val colorScheme = AsmrTheme.colorScheme
@@ -1602,6 +1646,7 @@ private fun AlbumHeader(
                                 horizontalArrangement = Arrangement.spacedBy(8.dp),
                                 verticalArrangement = Arrangement.spacedBy(6.dp),
                                 onCvClick = { cv -> copyMeta("CV", cv) },
+                                onCvLongClick = onMetaLongClick,
                                 leadingVisual = AlbumMetaLeadingVisual.Icon,
                             )
                         }
@@ -1621,6 +1666,7 @@ private fun AlbumHeader(
                                 horizontalArrangement = Arrangement.spacedBy(8.dp),
                                 verticalArrangement = Arrangement.spacedBy(6.dp),
                                 onTagClick = { tag -> copyMeta("标签", tag) },
+                                onTagLongClick = onMetaLongClick,
                                 leadingVisual = AlbumMetaLeadingVisual.Icon,
                             )
                         }

--- a/app/src/main/java/com/asmr/player/ui/library/AlbumItem.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/AlbumItem.kt
@@ -96,8 +96,11 @@ fun AlbumItem(
     modifier: Modifier = Modifier,
     onRjClick: ((String) -> Unit)? = null,
     onCircleClick: ((String) -> Unit)? = null,
+    onCircleLongClick: ((String) -> Unit)? = null,
     onCvClick: ((String) -> Unit)? = null,
+    onCvLongClick: ((String) -> Unit)? = null,
     onTagClick: ((String) -> Unit)? = null,
+    onTagLongClick: ((String) -> Unit)? = null,
     coverBadge: AlbumCoverBadge? = null,
     onlineDetailLoading: Boolean = false,
     onlineCvLoading: Boolean = onlineDetailLoading,
@@ -241,6 +244,7 @@ fun AlbumItem(
                         modifier = Modifier.fillMaxWidth(),
                         rjOnClick = onRjClick?.let { click -> { click(rj) } },
                         circleOnClick = onCircleClick?.let { click -> { click(album.circle) } },
+                        circleOnLongClick = onCircleLongClick?.let { longClick -> { longClick(album.circle) } },
                         leadingVisual = Icon,
                         order = AlbumPrimaryMetaOrder.CircleThenRj,
                     )
@@ -253,6 +257,7 @@ fun AlbumItem(
                             cvText = album.cv,
                             modifier = Modifier.fillMaxWidth(),
                             onCvClick = onCvClick,
+                            onCvLongClick = onCvLongClick,
                             leadingVisual = Icon,
                         )
                     }
@@ -269,6 +274,7 @@ fun AlbumItem(
                                 .fillMaxWidth()
                                 .testTag(ALBUM_ITEM_TAGS_TAG),
                             onTagClick = onTagClick,
+                            onTagLongClick = onTagLongClick,
                             leadingVisual = Icon,
                         )
                     }
@@ -352,8 +358,11 @@ fun AlbumGridItem(
     modifier: Modifier = Modifier,
     onRjClick: ((String) -> Unit)? = null,
     onCircleClick: ((String) -> Unit)? = null,
+    onCircleLongClick: ((String) -> Unit)? = null,
     onCvClick: ((String) -> Unit)? = null,
+    onCvLongClick: ((String) -> Unit)? = null,
     onTagClick: ((String) -> Unit)? = null,
+    onTagLongClick: ((String) -> Unit)? = null,
     coverBadge: AlbumCoverBadge? = null,
     onlineDetailLoading: Boolean = false,
     onlineCvLoading: Boolean = onlineDetailLoading,
@@ -490,6 +499,7 @@ fun AlbumGridItem(
                 circle = album.circle,
                 modifier = Modifier.fillMaxWidth(),
                 circleOnClick = onCircleClick?.let { click -> { click(album.circle) } },
+                circleOnLongClick = onCircleLongClick?.let { longClick -> { longClick(album.circle) } },
                 leadingVisual = Icon,
             )
 
@@ -503,6 +513,7 @@ fun AlbumGridItem(
                 AlbumCvChipsFlow(
                     cvText = album.cv,
                     onCvClick = onCvClick,
+                    onCvLongClick = onCvLongClick,
                     leadingVisual = Icon,
                 )
             }
@@ -533,6 +544,7 @@ fun AlbumGridItem(
                     tags = album.tags,
                     modifier = Modifier.padding(top = 2.dp),
                     onTagClick = onTagClick,
+                    onTagLongClick = onTagLongClick,
                     leadingVisual = Icon,
                 )
             }

--- a/app/src/main/java/com/asmr/player/ui/library/AlbumMetaActionDialog.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/AlbumMetaActionDialog.kt
@@ -1,0 +1,126 @@
+package com.asmr.player.ui.library
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.rounded.PlaylistAdd
+import androidx.compose.material.icons.rounded.Block
+import androidx.compose.material.icons.rounded.CreateNewFolder
+import androidx.compose.material.icons.rounded.Search
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import com.asmr.player.ui.theme.AsmrTheme
+
+@Composable
+internal fun AlbumMetaActionDialog(
+    keyword: String,
+    onDismissRequest: () -> Unit,
+    onSearch: (String) -> Unit,
+    onCreatePlaylist: (String) -> Unit,
+    onCreateGroup: (String) -> Unit,
+    onAddBlockedKeyword: (String) -> Unit,
+) {
+    val normalizedKeyword = remember(keyword) { keyword.trim() }
+    if (normalizedKeyword.isBlank()) return
+
+    fun runAction(action: (String) -> Unit) {
+        onDismissRequest()
+        action(normalizedKeyword)
+    }
+
+    val colorScheme = AsmrTheme.colorScheme
+    Dialog(onDismissRequest = onDismissRequest) {
+        Column(
+            modifier = Modifier
+                .widthIn(max = 380.dp)
+                .fillMaxWidth()
+                .clip(RoundedCornerShape(18.dp))
+                .background(colorScheme.surface)
+                .padding(horizontal = 12.dp, vertical = 14.dp),
+            verticalArrangement = Arrangement.spacedBy(4.dp),
+        ) {
+            Text(
+                text = "将「$normalizedKeyword」：",
+                style = MaterialTheme.typography.titleSmall.copy(fontWeight = FontWeight.SemiBold),
+                color = colorScheme.textPrimary,
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 8.dp, vertical = 6.dp),
+            )
+            AlbumMetaActionRow(
+                icon = Icons.Rounded.Search,
+                text = "作为关键词进行搜索",
+                onClick = { runAction(onSearch) },
+            )
+            AlbumMetaActionRow(
+                icon = Icons.AutoMirrored.Rounded.PlaylistAdd,
+                text = "作为名称创建列表",
+                onClick = { runAction(onCreatePlaylist) },
+            )
+            AlbumMetaActionRow(
+                icon = Icons.Rounded.CreateNewFolder,
+                text = "作为名称创建分组",
+                onClick = { runAction(onCreateGroup) },
+            )
+            AlbumMetaActionRow(
+                icon = Icons.Rounded.Block,
+                text = "作为屏蔽词屏蔽",
+                onClick = { runAction(onAddBlockedKeyword) },
+            )
+        }
+    }
+}
+
+@Composable
+private fun AlbumMetaActionRow(
+    icon: ImageVector,
+    text: String,
+    onClick: () -> Unit,
+) {
+    val colorScheme = AsmrTheme.colorScheme
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(12.dp))
+            .clickable(onClick = onClick)
+            .padding(horizontal = 12.dp, vertical = 11.dp),
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Icon(
+            imageVector = icon,
+            contentDescription = null,
+            tint = colorScheme.primary,
+            modifier = Modifier.size(20.dp),
+        )
+        Text(
+            text = text,
+            style = MaterialTheme.typography.bodyMedium,
+            color = colorScheme.textPrimary,
+            maxLines = 2,
+            overflow = TextOverflow.Ellipsis,
+            modifier = Modifier.weight(1f),
+        )
+    }
+}

--- a/app/src/main/java/com/asmr/player/ui/library/AlbumMetaChips.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/AlbumMetaChips.kt
@@ -2,7 +2,8 @@ package com.asmr.player.ui.library
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
-import androidx.compose.foundation.clickable
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
@@ -99,6 +100,7 @@ internal fun AlbumPrimaryMetaRow(
     modifier: Modifier = Modifier,
     rjOnClick: (() -> Unit)? = null,
     circleOnClick: (() -> Unit)? = null,
+    circleOnLongClick: (() -> Unit)? = null,
     appearance: AlbumMetaAppearance = AlbumMetaAppearance.Default,
     leadingVisual: AlbumMetaLeadingVisual = AlbumMetaLeadingVisual.None,
     order: AlbumPrimaryMetaOrder = AlbumPrimaryMetaOrder.RjThenCircle,
@@ -125,6 +127,7 @@ internal fun AlbumPrimaryMetaRow(
                 tone = AlbumMetaTone.Circle,
                 shape = AlbumMetaPillShape,
                 onClick = circleOnClick,
+                onLongClick = circleOnLongClick,
                 appearance = appearance,
                 leadingIcon = if (leadingVisual == AlbumMetaLeadingVisual.Icon) AlbumMetaLeadingIconKind.Club else null,
             )
@@ -157,6 +160,7 @@ internal fun AlbumCvChipsSingleLine(
     modifier: Modifier = Modifier,
     showLabel: Boolean = true,
     onCvClick: ((String) -> Unit)? = null,
+    onCvLongClick: ((String) -> Unit)? = null,
     leadingVisual: AlbumMetaLeadingVisual = AlbumMetaLeadingVisual.None,
 ) {
     val cvs = remember(cvText) { parseAlbumCvNames(cvText) }
@@ -193,6 +197,7 @@ internal fun AlbumCvChipsSingleLine(
                 shape = AlbumMetaPillShape,
                 maxWidth = 200.dp,
                 onClick = { onCvClick?.invoke(cv) },
+                onLongClick = onCvLongClick?.let { longClick -> { longClick(cv) } },
             )
         }
     }
@@ -207,6 +212,7 @@ internal fun AlbumCvChipsFlow(
     verticalArrangement: Arrangement.Vertical = Arrangement.spacedBy(4.dp),
     showLabel: Boolean = true,
     onCvClick: ((String) -> Unit)? = null,
+    onCvLongClick: ((String) -> Unit)? = null,
     leadingVisual: AlbumMetaLeadingVisual = AlbumMetaLeadingVisual.None,
 ) {
     val cvs = remember(cvText) { parseAlbumCvNames(cvText) }
@@ -241,6 +247,7 @@ internal fun AlbumCvChipsFlow(
                 shape = AlbumMetaPillShape,
                 maxWidth = 200.dp,
                 onClick = { onCvClick?.invoke(cv) },
+                onLongClick = onCvLongClick?.let { longClick -> { longClick(cv) } },
             )
         }
     }
@@ -251,6 +258,7 @@ internal fun AlbumTagsSingleLine(
     tags: List<String>,
     modifier: Modifier = Modifier,
     onTagClick: ((String) -> Unit)? = null,
+    onTagLongClick: ((String) -> Unit)? = null,
     leadingVisual: AlbumMetaLeadingVisual = AlbumMetaLeadingVisual.None,
 ) {
     val normalizedTags = remember(tags) { normalizeAlbumTags(tags) }
@@ -278,6 +286,7 @@ internal fun AlbumTagsSingleLine(
                 shape = AlbumMetaTagShape,
                 maxWidth = 220.dp,
                 onClick = { onTagClick?.invoke(tag) },
+                onLongClick = onTagLongClick?.let { longClick -> { longClick(tag) } },
             )
         }
     }
@@ -291,6 +300,7 @@ internal fun AlbumTagsFlow(
     horizontalArrangement: Arrangement.Horizontal = Arrangement.spacedBy(4.dp),
     verticalArrangement: Arrangement.Vertical = Arrangement.spacedBy(4.dp),
     onTagClick: ((String) -> Unit)? = null,
+    onTagLongClick: ((String) -> Unit)? = null,
     leadingVisual: AlbumMetaLeadingVisual = AlbumMetaLeadingVisual.None,
 ) {
     val normalizedTags = remember(tags) { normalizeAlbumTags(tags) }
@@ -316,6 +326,7 @@ internal fun AlbumTagsFlow(
                 shape = AlbumMetaTagShape,
                 maxWidth = 220.dp,
                 onClick = { onTagClick?.invoke(tag) },
+                onLongClick = onTagLongClick?.let { longClick -> { longClick(tag) } },
             )
         }
     }
@@ -358,6 +369,7 @@ private fun AlbumMetaLeadingIcon(
     )
 }
 
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
 private fun AlbumMetaBadge(
     text: String,
@@ -366,6 +378,7 @@ private fun AlbumMetaBadge(
     modifier: Modifier = Modifier,
     maxWidth: androidx.compose.ui.unit.Dp? = null,
     onClick: (() -> Unit)? = null,
+    onLongClick: (() -> Unit)? = null,
     textWeight: FontWeight? = null,
     appearance: AlbumMetaAppearance = AlbumMetaAppearance.Default,
     leadingIcon: AlbumMetaLeadingIconKind? = null,
@@ -375,7 +388,16 @@ private fun AlbumMetaBadge(
     val styledModifier = modifier
         .then(if (maxWidth != null) Modifier.widthIn(max = maxWidth) else Modifier)
         .clip(shape)
-        .let { if (onClick != null) it.clickable(onClick = onClick) else it }
+        .let {
+            if (onClick != null || onLongClick != null) {
+                it.combinedClickable(
+                    onClick = { onClick?.invoke() },
+                    onLongClick = onLongClick,
+                )
+            } else {
+                it
+            }
+        }
         .background(palette.container, shape)
         .border(0.5.dp, palette.border, shape)
         .padding(

--- a/app/src/main/java/com/asmr/player/ui/library/LibraryScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/LibraryScreen.kt
@@ -135,6 +135,9 @@ import com.asmr.player.ui.sidepanel.RecentAlbumsPanel
 import com.asmr.player.cache.ImageCacheEntryPoint
 import com.asmr.player.cache.LazyListPreloader
 import com.asmr.player.cache.LazyStaggeredGridPreloader
+import com.asmr.player.ui.groups.AlbumGroupsViewModel
+import com.asmr.player.ui.playlists.PlaylistsViewModel
+import com.asmr.player.ui.settings.SettingsViewModel
 import dagger.hilt.android.EntryPointAccessors
 
 import androidx.compose.foundation.combinedClickable
@@ -253,6 +256,7 @@ fun LibraryScreen(
     onOpenPlaylistPicker: (MediaItem) -> Unit = {},
     onOpenGroupPicker: (albumId: Long) -> Unit = { _ -> },
     onOpenFilterScreen: () -> Unit = {},
+    onSearchKeyword: (String) -> Unit = {},
     scrollToTopSignal: Long = 0L,
     viewModel: LibraryViewModel = hiltViewModel()
 ) {
@@ -268,12 +272,34 @@ fun LibraryScreen(
     val userTagsByTrackId by viewModel.userTagsByTrackId.collectAsState()
     val isGlobalSyncRunning by viewModel.isGlobalSyncRunning.collectAsState()
     val copyMeta = rememberAlbumMetaCopyAction(viewModel.messageManager)
+    val playlistsViewModel: PlaylistsViewModel = hiltViewModel()
+    val albumGroupsViewModel: AlbumGroupsViewModel = hiltViewModel()
+    val settingsViewModel: SettingsViewModel = hiltViewModel()
+    val searchBlockedKeywords by settingsViewModel.searchBlockedKeywords.collectAsState()
     val playerViewModel: PlayerViewModel = hiltViewModel()
     val scope = rememberCoroutineScope()
     var searchText by rememberSaveable { mutableStateOf(querySpec.textQuery.orEmpty()) }
     var sortMenuExpanded by remember { mutableStateOf(false) }
     var showTagManager by remember { mutableStateOf(false) }
     var tagAssignTarget by remember { mutableStateOf<TagAssignTarget?>(null) }
+    var metaActionKeyword by rememberSaveable { mutableStateOf<String?>(null) }
+
+    fun openMetaActions(value: String) {
+        val keyword = value.trim()
+        if (keyword.isNotBlank()) metaActionKeyword = keyword
+    }
+
+    fun addMetaBlockedKeyword(value: String) {
+        val keyword = value.trim()
+        if (keyword.isBlank()) return
+        val exists = searchBlockedKeywords.any { it.equals(keyword, ignoreCase = true) }
+        settingsViewModel.addSearchBlockedKeyword(keyword)
+        if (exists) {
+            viewModel.messageManager.showInfo("屏蔽词已存在：$keyword")
+        } else {
+            viewModel.messageManager.showSuccess("已添加屏蔽词：$keyword")
+        }
+    }
 
     LaunchedEffect(querySpec.textQuery) {
         val newText = querySpec.textQuery.orEmpty()
@@ -812,8 +838,11 @@ fun LibraryScreen(
                                                 },
                                                 onRjClick = { copyMeta("RJ", it) },
                                                 onCircleClick = { copyMeta("社团", it) },
+                                                onCircleLongClick = ::openMetaActions,
                                                 onCvClick = { copyMeta("CV", it) },
+                                                onCvLongClick = ::openMetaActions,
                                                 onTagClick = { copyMeta("标签", it) },
+                                                onTagLongClick = ::openMetaActions,
                                                 coverFadeIn = coverFadeIn,
                                             )
                                         }
@@ -869,8 +898,11 @@ fun LibraryScreen(
                                                 },
                                                 onRjClick = { copyMeta("RJ", it) },
                                                 onCircleClick = { copyMeta("社团", it) },
+                                                onCircleLongClick = ::openMetaActions,
                                                 onCvClick = { copyMeta("CV", it) },
+                                                onCvLongClick = ::openMetaActions,
                                                 onTagClick = { copyMeta("标签", it) },
+                                                onTagLongClick = ::openMetaActions,
                                                 coverFadeIn = coverFadeIn,
                                             )
                                         }
@@ -1077,6 +1109,17 @@ fun LibraryScreen(
                 )
             }
         }
+    }
+
+    metaActionKeyword?.let { keyword ->
+        AlbumMetaActionDialog(
+            keyword = keyword,
+            onDismissRequest = { metaActionKeyword = null },
+            onSearch = onSearchKeyword,
+            onCreatePlaylist = playlistsViewModel::createPlaylist,
+            onCreateGroup = albumGroupsViewModel::createGroup,
+            onAddBlockedKeyword = ::addMetaBlockedKeyword,
+        )
     }
 
 }
@@ -1329,6 +1372,7 @@ private fun TrackAlbumHeader(
             }
         }
     }
+
 }
 
 @Composable
@@ -1436,8 +1480,11 @@ private fun AlbumGridItem(
     onLongClick: () -> Unit,
     onRjClick: ((String) -> Unit)? = null,
     onCircleClick: ((String) -> Unit)? = null,
+    onCircleLongClick: ((String) -> Unit)? = null,
     onCvClick: ((String) -> Unit)? = null,
+    onCvLongClick: ((String) -> Unit)? = null,
     onTagClick: ((String) -> Unit)? = null,
+    onTagLongClick: ((String) -> Unit)? = null,
     coverFadeIn: Boolean = true,
 ) {
     val colorScheme = AsmrTheme.colorScheme
@@ -1561,12 +1608,14 @@ private fun AlbumGridItem(
                 circle = album.circle,
                 modifier = Modifier.fillMaxWidth(),
                 circleOnClick = onCircleClick?.let { click -> { click(album.circle) } },
+                circleOnLongClick = onCircleLongClick?.let { longClick -> { longClick(album.circle) } },
                 leadingVisual = AlbumMetaLeadingVisual.Icon,
             )
 
             AlbumCvChipsFlow(
                 cvText = album.cv,
                 onCvClick = onCvClick,
+                onCvLongClick = onCvLongClick,
                 leadingVisual = AlbumMetaLeadingVisual.Icon,
             )
 
@@ -1599,6 +1648,7 @@ private fun AlbumGridItem(
                     tags = album.tags,
                     modifier = Modifier.padding(top = 2.dp),
                     onTagClick = onTagClick,
+                    onTagLongClick = onTagLongClick,
                     leadingVisual = AlbumMetaLeadingVisual.Icon,
                 )
             }
@@ -1615,8 +1665,11 @@ private fun AlbumItem(
     onLongClick: () -> Unit,
     onRjClick: ((String) -> Unit)? = null,
     onCircleClick: ((String) -> Unit)? = null,
+    onCircleLongClick: ((String) -> Unit)? = null,
     onCvClick: ((String) -> Unit)? = null,
+    onCvLongClick: ((String) -> Unit)? = null,
     onTagClick: ((String) -> Unit)? = null,
+    onTagLongClick: ((String) -> Unit)? = null,
     coverFadeIn: Boolean = true,
 ) {
     val colorScheme = AsmrTheme.colorScheme
@@ -1757,6 +1810,7 @@ private fun AlbumItem(
                         modifier = Modifier.fillMaxWidth(),
                         rjOnClick = onRjClick?.let { click -> { click(rj) } },
                         circleOnClick = onCircleClick?.let { click -> { click(album.circle) } },
+                        circleOnLongClick = onCircleLongClick?.let { longClick -> { longClick(album.circle) } },
                         leadingVisual = AlbumMetaLeadingVisual.Icon,
                         order = AlbumPrimaryMetaOrder.CircleThenRj,
                     )
@@ -1766,6 +1820,7 @@ private fun AlbumItem(
                             cvText = album.cv,
                             modifier = Modifier.fillMaxWidth(),
                             onCvClick = onCvClick,
+                            onCvLongClick = onCvLongClick,
                             leadingVisual = AlbumMetaLeadingVisual.Icon,
                         )
                     }
@@ -1785,6 +1840,7 @@ private fun AlbumItem(
                             tags = album.tags,
                             modifier = Modifier.fillMaxWidth(),
                             onTagClick = onTagClick,
+                            onTagLongClick = onTagLongClick,
                             leadingVisual = AlbumMetaLeadingVisual.Icon,
                         )
                     }

--- a/app/src/main/java/com/asmr/player/ui/player/AppleLyricsView.kt
+++ b/app/src/main/java/com/asmr/player/ui/player/AppleLyricsView.kt
@@ -26,8 +26,8 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.itemsIndexed
-import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
@@ -119,6 +119,17 @@ internal fun lyricFocusVisualEffectForLine(
     )
 }
 
+internal fun lyricContentKey(lyrics: List<SubtitleEntry>, contentKey: String? = null): Int {
+    var result = contentKey?.hashCode() ?: 0
+    result = 31 * result + lyrics.size
+    lyrics.forEach { entry ->
+        result = 31 * result + entry.startMs.hashCode()
+        result = 31 * result + entry.endMs.hashCode()
+        result = 31 * result + entry.text.hashCode()
+    }
+    return result
+}
+
 @Composable
 internal fun AppleLyricsView(
     lyrics: List<SubtitleEntry>,
@@ -135,13 +146,40 @@ internal fun AppleLyricsView(
     stableFocusAnchor: Boolean = false,
     itemOuterHorizontalPadding: Dp = if (isLandscape) 10.dp else 14.dp,
     itemInnerHorizontalPadding: Dp = if (isLandscape) 8.dp else 10.dp,
+    contentKey: String? = null,
     expandedHomeVisualEffects: Boolean = false
 ) {
-    val indexFinder = remember(lyrics) { SubtitleIndexFinder(lyrics) }
+    var displayedLyrics by remember { mutableStateOf(lyrics) }
+    var displayedContentKey by remember { mutableStateOf(contentKey) }
+    var lyricsVisible by remember { mutableStateOf(true) }
+    LaunchedEffect(lyrics, contentKey) {
+        if (lyrics == displayedLyrics && contentKey == displayedContentKey) {
+            lyricsVisible = true
+            return@LaunchedEffect
+        }
+        lyricsVisible = false
+        delay(120)
+        displayedLyrics = lyrics
+        displayedContentKey = contentKey
+        lyricsVisible = true
+    }
+
+    val renderedLyrics = displayedLyrics
+    val renderedContentKey = displayedContentKey
+    val lyricsContentKey = remember(renderedLyrics, renderedContentKey) {
+        lyricContentKey(renderedLyrics, renderedContentKey)
+    }
+    val indexFinder = remember(renderedLyrics) { SubtitleIndexFinder(renderedLyrics) }
     val activeIndex = remember(currentPosition, indexFinder) {
         indexFinder.findActiveIndex(currentPosition)
     }
-    val listState = rememberLazyListState()
+    val listState = remember(lyricsContentKey) { LazyListState() }
+    var pendingInitialFocus by remember(lyricsContentKey) { mutableStateOf(true) }
+    val lyricsContentAlpha by animateFloatAsState(
+        targetValue = if (lyricsVisible && !pendingInitialFocus) 1f else 0f,
+        animationSpec = tween(durationMillis = if (lyricsVisible) 220 else 120),
+        label = "lyricsContentAlpha"
+    )
     val density = LocalDensity.current
     val itemOuterVerticalPadding = 0.dp
     val itemInnerVerticalPadding = if (isLandscape) 2.dp else 3.dp
@@ -185,9 +223,9 @@ internal fun AppleLyricsView(
             viewportHeightPx = estimatedViewportHeightPx,
             lineBlockHeightPx = nominalItemHeightPx
         ).coerceAtLeast(1) + 1
-        val targetWindowRange = remember(lyrics.size, activeIndex, effectiveVisibleLines) {
+        val targetWindowRange = remember(renderedLyrics.size, activeIndex, effectiveVisibleLines) {
             targetLyricsWindowRange(
-                totalCount = lyrics.size,
+                totalCount = renderedLyrics.size,
                 activeIndex = activeIndex,
                 visibleItemCount = effectiveVisibleLines
             )
@@ -204,7 +242,7 @@ internal fun AppleLyricsView(
             )
         }
         val lyricItemHeightsPx = remember(
-            lyrics,
+            renderedLyrics,
             itemTextMaxWidthPx,
             measurementStyle,
             nominalItemHeightPx,
@@ -215,7 +253,7 @@ internal fun AppleLyricsView(
         ) {
             val innerVerticalPaddingPx = with(density) { itemInnerVerticalPadding.toPx() }
             val outerVerticalPaddingPx = with(density) { itemOuterVerticalPadding.toPx() }
-            lyrics.map { entry ->
+            renderedLyrics.map { entry ->
                 measuredLyricItemHeight(
                     entry = entry,
                     textMeasurer = textMeasurer,
@@ -299,7 +337,7 @@ internal fun AppleLyricsView(
         val timelineCenterInViewportPx = (viewportHeightPx / 2f - viewportLayout.viewportTopOffsetPx)
             .coerceIn(0f, viewportLayout.viewportWindowHeightPx)
         val maxWaveOffsetPx = viewportLayout.viewportWindowHeightPx * 0.22f
-        val timelineTargetIndex by remember(lyrics.size, timelineCenterInViewportPx, listState) {
+        val timelineTargetIndex by remember(renderedLyrics.size, timelineCenterInViewportPx, listState) {
             derivedStateOf {
                 centeredLyricIndexForTimeline(
                     visibleItems = listState.layoutInfo.visibleItemsInfo.map { item ->
@@ -310,12 +348,12 @@ internal fun AppleLyricsView(
                         )
                     },
                     viewportCenterPx = timelineCenterInViewportPx,
-                    totalCount = lyrics.size
+                    totalCount = renderedLyrics.size
                 )
             }
         }
-        val timelineTargetPositionMs = lyrics.getOrNull(timelineTargetIndex)?.startMs
-        val timelineVisible = showPlaybackTimeline && lyrics.isNotEmpty() && autoFocusSuspended
+        val timelineTargetPositionMs = renderedLyrics.getOrNull(timelineTargetIndex)?.startMs
+        val timelineVisible = showPlaybackTimeline && renderedLyrics.isNotEmpty() && autoFocusSuspended
         LaunchedEffect(lastUserScrollAt, autoFocusSuspended) {
             if (autoFocusSuspended) {
                 val scheduledAt = lastUserScrollAt
@@ -327,12 +365,30 @@ internal fun AppleLyricsView(
             }
         }
 
-        LaunchedEffect(lyrics) {
+        LaunchedEffect(lyricsContentKey) {
             pendingSmoothFocusIndex = -1
+            autoFocusSuspended = false
+            pendingAnimatedRefocus = false
+            itemOffsets.clear()
         }
 
-        LaunchedEffect(activeIndex, autoFocusSuspended, lyricItemHeightsPx, viewportLayout, pendingSmoothFocusIndex, stableFocusAnchor) {
-            if (lyrics.isEmpty() || activeIndex < 0 || autoFocusSuspended) return@LaunchedEffect
+        LaunchedEffect(
+            activeIndex,
+            autoFocusSuspended,
+            lyricItemHeightsPx,
+            viewportLayout,
+            pendingSmoothFocusIndex,
+            stableFocusAnchor,
+            lyricsContentKey,
+            lyricsVisible
+        ) {
+            if (!lyricsVisible) return@LaunchedEffect
+            if (renderedLyrics.isEmpty() || activeIndex < 0 || autoFocusSuspended) {
+                if (pendingInitialFocus && (renderedLyrics.isEmpty() || activeIndex < 0)) {
+                    pendingInitialFocus = false
+                }
+                return@LaunchedEffect
+            }
 
             var didReposition = false
             var repositionDeltaPx: Float? = null
@@ -352,9 +408,11 @@ internal fun AppleLyricsView(
             )
             val targetScrollOffset = -centeredActiveTopPx.roundToInt()
             val isPinnedAtTop = listState.firstVisibleItemIndex == 0 && listState.firstVisibleItemScrollOffset == 0
-            val shouldUseSmoothFocus = stableFocusAnchor ||
-                pendingAnimatedRefocus ||
-                pendingSmoothFocusIndex == activeIndex
+            val shouldUseSmoothFocus = !pendingInitialFocus && (
+                stableFocusAnchor ||
+                    pendingAnimatedRefocus ||
+                    pendingSmoothFocusIndex == activeIndex
+                )
             val defaultAffectedIndices = (
                 visibleItems.map { it.index } +
                     targetWindowRange.toList()
@@ -436,6 +494,7 @@ internal fun AppleLyricsView(
             if (pendingSmoothFocusIndex == activeIndex) {
                 pendingSmoothFocusIndex = -1
             }
+            pendingInitialFocus = false
         }
 
         Box(
@@ -457,6 +516,7 @@ internal fun AppleLyricsView(
                     .fillMaxSize()
                     .then(edgeFadeModifier)
                     .then(if (expandedHomeVisualEffects) Modifier.graphicsLayer { clip = false } else Modifier)
+                    .graphicsLayer { alpha = lyricsContentAlpha }
                     .then(if (interactionEnabled) Modifier.nestedScroll(nestedScrollConnection) else Modifier)
                     .thinScrollbar(listState),
                 flingBehavior = rememberCalmScrollableFlingBehavior(),
@@ -467,7 +527,7 @@ internal fun AppleLyricsView(
                 )
             ) {
                 itemsIndexed(
-                    items = lyrics,
+                    items = renderedLyrics,
                     key = { index, entry -> lyricItemKey(index, entry) },
                     contentType = { _, _ -> "appleLyricLine" }
                 ) { index, entry ->
@@ -577,7 +637,7 @@ internal fun AppleLyricsView(
                 colors = colors,
                 isLandscape = isLandscape,
                 onPlayClick = { targetMs ->
-                    if (timelineTargetIndex in lyrics.indices) {
+                    if (timelineTargetIndex in renderedLyrics.indices) {
                         pendingSmoothFocusIndex = timelineTargetIndex
                     }
                     autoFocusSuspended = false

--- a/app/src/main/java/com/asmr/player/ui/player/AppleLyricsView.kt
+++ b/app/src/main/java/com/asmr/player/ui/player/AppleLyricsView.kt
@@ -130,6 +130,11 @@ internal fun lyricContentKey(lyrics: List<SubtitleEntry>, contentKey: String? = 
     return result
 }
 
+internal fun lyricDisplayActiveIndex(activeIndex: Int, totalCount: Int): Int {
+    if (totalCount <= 0) return -1
+    return activeIndex.coerceIn(0, totalCount - 1)
+}
+
 @Composable
 internal fun AppleLyricsView(
     lyrics: List<SubtitleEntry>,
@@ -147,6 +152,7 @@ internal fun AppleLyricsView(
     itemOuterHorizontalPadding: Dp = if (isLandscape) 10.dp else 14.dp,
     itemInnerHorizontalPadding: Dp = if (isLandscape) 8.dp else 10.dp,
     contentKey: String? = null,
+    contentVisible: Boolean = true,
     expandedHomeVisualEffects: Boolean = false
 ) {
     var displayedLyrics by remember { mutableStateOf(lyrics) }
@@ -170,14 +176,21 @@ internal fun AppleLyricsView(
         lyricContentKey(renderedLyrics, renderedContentKey)
     }
     val indexFinder = remember(renderedLyrics) { SubtitleIndexFinder(renderedLyrics) }
-    val activeIndex = remember(currentPosition, indexFinder) {
+    val playbackActiveIndex = remember(currentPosition, indexFinder) {
         indexFinder.findActiveIndex(currentPosition)
     }
-    val listState = remember(lyricsContentKey) { LazyListState() }
+    val activeIndex = remember(playbackActiveIndex, renderedLyrics.size) {
+        lyricDisplayActiveIndex(playbackActiveIndex, renderedLyrics.size)
+    }
+    val listState = remember(lyricsContentKey) {
+        LazyListState(firstVisibleItemIndex = activeIndex.coerceAtLeast(0))
+    }
     var pendingInitialFocus by remember(lyricsContentKey) { mutableStateOf(true) }
+    val lyricsRenderVisible = contentVisible && lyricsVisible
+    val effectiveInteractionEnabled = interactionEnabled && lyricsRenderVisible
     val lyricsContentAlpha by animateFloatAsState(
-        targetValue = if (lyricsVisible && !pendingInitialFocus) 1f else 0f,
-        animationSpec = tween(durationMillis = if (lyricsVisible) 220 else 120),
+        targetValue = if (lyricsRenderVisible && !pendingInitialFocus) 1f else 0f,
+        animationSpec = tween(durationMillis = if (lyricsRenderVisible) 220 else 120),
         label = "lyricsContentAlpha"
     )
     val density = LocalDensity.current
@@ -353,7 +366,7 @@ internal fun AppleLyricsView(
             }
         }
         val timelineTargetPositionMs = renderedLyrics.getOrNull(timelineTargetIndex)?.startMs
-        val timelineVisible = showPlaybackTimeline && renderedLyrics.isNotEmpty() && autoFocusSuspended
+        val timelineVisible = showPlaybackTimeline && renderedLyrics.isNotEmpty() && lyricsRenderVisible && autoFocusSuspended
         LaunchedEffect(lastUserScrollAt, autoFocusSuspended) {
             if (autoFocusSuspended) {
                 val scheduledAt = lastUserScrollAt
@@ -380,9 +393,9 @@ internal fun AppleLyricsView(
             pendingSmoothFocusIndex,
             stableFocusAnchor,
             lyricsContentKey,
-            lyricsVisible
+            lyricsRenderVisible
         ) {
-            if (!lyricsVisible) return@LaunchedEffect
+            if (!lyricsRenderVisible) return@LaunchedEffect
             if (renderedLyrics.isEmpty() || activeIndex < 0 || autoFocusSuspended) {
                 if (pendingInitialFocus && (renderedLyrics.isEmpty() || activeIndex < 0)) {
                     pendingInitialFocus = false
@@ -408,6 +421,7 @@ internal fun AppleLyricsView(
             )
             val targetScrollOffset = -centeredActiveTopPx.roundToInt()
             val isPinnedAtTop = listState.firstVisibleItemIndex == 0 && listState.firstVisibleItemScrollOffset == 0
+            val isInitialFocus = pendingInitialFocus
             val shouldUseSmoothFocus = !pendingInitialFocus && (
                 stableFocusAnchor ||
                     pendingAnimatedRefocus ||
@@ -450,7 +464,7 @@ internal fun AppleLyricsView(
                 didReposition = true
             }
 
-            val resolvedWave = if (didReposition && !shouldUseSmoothFocus) {
+            val resolvedWave = if (didReposition && !shouldUseSmoothFocus && !isInitialFocus) {
                 repositionDeltaPx?.coerceIn(-maxWaveOffsetPx, maxWaveOffsetPx)
             } else {
                 null
@@ -517,10 +531,10 @@ internal fun AppleLyricsView(
                     .then(edgeFadeModifier)
                     .then(if (expandedHomeVisualEffects) Modifier.graphicsLayer { clip = false } else Modifier)
                     .graphicsLayer { alpha = lyricsContentAlpha }
-                    .then(if (interactionEnabled) Modifier.nestedScroll(nestedScrollConnection) else Modifier)
+                    .then(if (effectiveInteractionEnabled) Modifier.nestedScroll(nestedScrollConnection) else Modifier)
                     .thinScrollbar(listState),
                 flingBehavior = rememberCalmScrollableFlingBehavior(),
-                userScrollEnabled = interactionEnabled,
+                userScrollEnabled = effectiveInteractionEnabled,
                 horizontalAlignment = Alignment.CenterHorizontally,
                 contentPadding = PaddingValues(
                     bottom = centeredActiveBottomDp
@@ -588,7 +602,7 @@ internal fun AppleLyricsView(
                                     Modifier
                                 }
                             )
-                            .clickable(enabled = interactionEnabled) {
+                            .clickable(enabled = effectiveInteractionEnabled) {
                                 pendingSmoothFocusIndex = if (activeIndex >= 0 && activeIndex != index) index else -1
                                 autoFocusSuspended = false
                                 pendingAnimatedRefocus = false

--- a/app/src/main/java/com/asmr/player/ui/player/AppleLyricsView.kt
+++ b/app/src/main/java/com/asmr/player/ui/player/AppleLyricsView.kt
@@ -50,14 +50,19 @@ import androidx.compose.runtime.setValue
 import androidx.compose.runtime.withFrameNanos
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.blur
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.BlendMode
+import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.CompositingStrategy
 import androidx.compose.ui.graphics.PathEffect
 import androidx.compose.ui.graphics.Shadow
 import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.luminance
+import androidx.compose.ui.draw.drawWithCache
 import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
 import androidx.compose.ui.input.nestedscroll.NestedScrollSource
 import androidx.compose.ui.input.nestedscroll.nestedScroll
@@ -83,6 +88,37 @@ import kotlinx.coroutines.launch
 import kotlin.math.abs
 import kotlin.math.roundToInt
 
+internal data class LyricFocusVisualEffect(
+    val blurDp: Float,
+    val dispersionProgress: Float,
+    val dispersionOffsetXDp: Float,
+    val dispersionOffsetYDp: Float
+)
+
+private val NoLyricFocusVisualEffect = LyricFocusVisualEffect(
+    blurDp = 0f,
+    dispersionProgress = 0f,
+    dispersionOffsetXDp = 0f,
+    dispersionOffsetYDp = 0f
+)
+
+internal fun lyricFocusVisualEffectForLine(
+    index: Int,
+    activeIndex: Int,
+    enabled: Boolean
+): LyricFocusVisualEffect {
+    if (!enabled || activeIndex < 0 || index == activeIndex) return NoLyricFocusVisualEffect
+    val distance = abs(index - activeIndex).coerceAtMost(4)
+    val progress = (distance / 4f).coerceIn(0.18f, 1f)
+    val direction = if (index < activeIndex) -1f else 1f
+    return LyricFocusVisualEffect(
+        blurDp = 0.25f + progress * 2.15f,
+        dispersionProgress = progress,
+        dispersionOffsetXDp = 0.45f + progress * 1.35f,
+        dispersionOffsetYDp = direction * (0.2f + progress * 0.8f)
+    )
+}
+
 @Composable
 internal fun AppleLyricsView(
     lyrics: List<SubtitleEntry>,
@@ -98,7 +134,8 @@ internal fun AppleLyricsView(
     interactionEnabled: Boolean = true,
     stableFocusAnchor: Boolean = false,
     itemOuterHorizontalPadding: Dp = if (isLandscape) 10.dp else 14.dp,
-    itemInnerHorizontalPadding: Dp = if (isLandscape) 8.dp else 10.dp
+    itemInnerHorizontalPadding: Dp = if (isLandscape) 8.dp else 10.dp,
+    expandedHomeVisualEffects: Boolean = false
 ) {
     val indexFinder = remember(lyrics) { SubtitleIndexFinder(lyrics) }
     val activeIndex = remember(currentPosition, indexFinder) {
@@ -224,6 +261,41 @@ internal fun AppleLyricsView(
         val viewportWindowHeightDp = with(density) { viewportLayout.viewportWindowHeightPx.toDp() }
         val viewportTopOffsetDp = with(density) { viewportLayout.viewportTopOffsetPx.toDp() }
         val centeredActiveBottomDp = viewportWindowHeightDp / 2f
+        val edgeFadeHeightPx = if (expandedHomeVisualEffects) {
+            with(density) { 40.dp.toPx() }
+        } else {
+            0f
+        }
+        val edgeFadeModifier = if (expandedHomeVisualEffects) {
+            Modifier
+                .graphicsLayer { compositingStrategy = CompositingStrategy.Offscreen }
+                .drawWithCache {
+                    if (size.height <= 0f) {
+                        return@drawWithCache onDrawWithContent { drawContent() }
+                    }
+                    val fadeHeight = edgeFadeHeightPx
+                        .coerceAtMost(size.height * 0.42f)
+                        .coerceAtLeast(1f)
+                    val fadeStop = (fadeHeight / size.height).coerceIn(0.01f, 0.48f)
+                    val shoulder = (fadeStop * 0.42f).coerceIn(0.005f, fadeStop)
+                    val brush = Brush.verticalGradient(
+                        colorStops = arrayOf(
+                            0f to Color.Transparent,
+                            shoulder to Color.White.copy(alpha = 0.42f),
+                            fadeStop to Color.White,
+                            (1f - fadeStop) to Color.White,
+                            (1f - shoulder) to Color.White.copy(alpha = 0.42f),
+                            1f to Color.Transparent
+                        )
+                    )
+                    onDrawWithContent {
+                        drawContent()
+                        drawRect(brush = brush, blendMode = BlendMode.DstIn)
+                    }
+                }
+        } else {
+            Modifier
+        }
         val timelineCenterInViewportPx = (viewportHeightPx / 2f - viewportLayout.viewportTopOffsetPx)
             .coerceIn(0f, viewportLayout.viewportWindowHeightPx)
         val maxWaveOffsetPx = viewportLayout.viewportWindowHeightPx * 0.22f
@@ -371,12 +443,20 @@ internal fun AppleLyricsView(
                 .fillMaxWidth()
                 .height(viewportWindowHeightDp)
                 .offset(y = viewportTopOffsetDp)
-                .clip(RoundedCornerShape(12.dp))
+                .then(
+                    if (expandedHomeVisualEffects) {
+                        Modifier.graphicsLayer { clip = false }
+                    } else {
+                        Modifier.clip(RoundedCornerShape(12.dp))
+                    }
+                )
         ) {
             LazyColumn(
                 state = listState,
                 modifier = Modifier
                     .fillMaxSize()
+                    .then(edgeFadeModifier)
+                    .then(if (expandedHomeVisualEffects) Modifier.graphicsLayer { clip = false } else Modifier)
                     .then(if (interactionEnabled) Modifier.nestedScroll(nestedScrollConnection) else Modifier)
                     .thinScrollbar(listState),
                 flingBehavior = rememberCalmScrollableFlingBehavior(),
@@ -419,6 +499,11 @@ internal fun AppleLyricsView(
                     } else {
                         null
                     }
+                    val focusEffect = lyricFocusVisualEffectForLine(
+                        index = index,
+                        activeIndex = activeIndex,
+                        enabled = expandedHomeVisualEffects
+                    )
 
                     Box(
                         modifier = Modifier
@@ -434,8 +519,15 @@ internal fun AppleLyricsView(
                                 this.translationY = itemOffsets[index]?.value ?: 0f
                                 this.scaleX = scale
                                 this.scaleY = scale
-                                this.alpha = alpha
+                                this.alpha = alpha * (1f - focusEffect.dispersionProgress * 0.08f)
                             }
+                            .then(
+                                if (focusEffect.blurDp > 0f) {
+                                    Modifier.blur(focusEffect.blurDp.dp)
+                                } else {
+                                    Modifier
+                                }
+                            )
                             .clickable(enabled = interactionEnabled) {
                                 pendingSmoothFocusIndex = if (activeIndex >= 0 && activeIndex != index) index else -1
                                 autoFocusSuspended = false
@@ -451,6 +543,9 @@ internal fun AppleLyricsView(
                             color = color,
                             shadowColor = shadowColor,
                             strokeWidthPx = strokeWidthPx,
+                            dispersionProgress = focusEffect.dispersionProgress,
+                            dispersionOffsetX = focusEffect.dispersionOffsetXDp.dp,
+                            dispersionOffsetY = focusEffect.dispersionOffsetYDp.dp,
                             style = MaterialTheme.typography.titleLarge.copy(
                                 fontWeight = if (isActive) FontWeight.ExtraBold else FontWeight.Bold,
                                 fontSize = fontSize,
@@ -736,6 +831,9 @@ private fun LyricLineText(
     color: Color,
     shadowColor: Color,
     strokeWidthPx: Float,
+    dispersionProgress: Float,
+    dispersionOffsetX: Dp,
+    dispersionOffsetY: Dp,
     style: TextStyle,
     textAlign: TextAlign
 ) {
@@ -746,13 +844,36 @@ private fun LyricLineText(
             shadowStrengthPx = strokeWidthPx
         )
     }
-    Text(
-        text = text,
-        modifier = Modifier.fillMaxWidth(),
-        style = style.copy(shadow = effectiveShadow),
-        color = color,
-        textAlign = textAlign
-    )
+    Box(modifier = Modifier.fillMaxWidth()) {
+        if (dispersionProgress > 0.01f) {
+            val ghostStyle = style.copy(shadow = null)
+            Text(
+                text = text,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .offset(x = -dispersionOffsetX, y = -dispersionOffsetY),
+                style = ghostStyle,
+                color = Color(0xFFFF5D7A).copy(alpha = 0.16f * dispersionProgress),
+                textAlign = textAlign
+            )
+            Text(
+                text = text,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .offset(x = dispersionOffsetX, y = dispersionOffsetY),
+                style = ghostStyle,
+                color = Color(0xFF42E8FF).copy(alpha = 0.18f * dispersionProgress),
+                textAlign = textAlign
+            )
+        }
+        Text(
+            text = text,
+            modifier = Modifier.fillMaxWidth(),
+            style = style.copy(shadow = effectiveShadow),
+            color = color,
+            textAlign = textAlign
+        )
+    }
 }
 
 private fun lyricTextShadow(

--- a/app/src/main/java/com/asmr/player/ui/player/LyricsPage.kt
+++ b/app/src/main/java/com/asmr/player/ui/player/LyricsPage.kt
@@ -154,7 +154,8 @@ internal fun LyricsPage(
                     modifier = Modifier.fillMaxSize(),
                     isLandscape = isLandscape,
                     settings = lyricsPageSettings,
-                    contentKey = playback.currentMediaItem?.mediaId
+                    contentKey = uiState.contentKey,
+                    contentVisible = !uiState.isLoading
                 )
             }
         }

--- a/app/src/main/java/com/asmr/player/ui/player/LyricsPage.kt
+++ b/app/src/main/java/com/asmr/player/ui/player/LyricsPage.kt
@@ -153,7 +153,8 @@ internal fun LyricsPage(
                     colors = lyricColors,
                     modifier = Modifier.fillMaxSize(),
                     isLandscape = isLandscape,
-                    settings = lyricsPageSettings
+                    settings = lyricsPageSettings,
+                    contentKey = playback.currentMediaItem?.mediaId
                 )
             }
         }

--- a/app/src/main/java/com/asmr/player/ui/player/LyricsViewModel.kt
+++ b/app/src/main/java/com/asmr/player/ui/player/LyricsViewModel.kt
@@ -2,6 +2,9 @@ package com.asmr.player.ui.player
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import androidx.media3.common.MediaItem
+import com.asmr.player.data.lyrics.EXTRA_ALBUM_WORK_ID
+import com.asmr.player.data.lyrics.EXTRA_LYRICS_RELATIVE_PATH_NO_EXT
 import com.asmr.player.data.lyrics.LyricsLoader
 import com.asmr.player.util.SubtitleEntry
 import com.asmr.player.playback.PlayerConnection
@@ -14,6 +17,8 @@ import javax.inject.Inject
 
 data class LyricsUiState(
     val title: String = "",
+    val contentKey: String = "",
+    val isLoading: Boolean = false,
     val lyrics: List<SubtitleEntry> = emptyList()
 )
 
@@ -27,14 +32,21 @@ class LyricsViewModel @Inject constructor(
 
     val playback = playerConnection.snapshot
 
-    private suspend fun reloadForItem(item: androidx.media3.common.MediaItem?) {
+    private suspend fun reloadForItem(item: MediaItem?) {
         val mediaId = item?.mediaId.orEmpty()
         if (mediaId.isBlank()) {
-            _uiState.value = _uiState.value.copy(title = "", lyrics = emptyList())
+            _uiState.value = LyricsUiState()
             return
         }
+        val mediaKey = lyricsContentKeyForItem(item)
+        _uiState.value = _uiState.value.copy(isLoading = true)
         val result = lyricsLoader.load(item)
-        _uiState.value = _uiState.value.copy(title = result.title, lyrics = result.lyrics)
+        _uiState.value = LyricsUiState(
+            title = result.title,
+            contentKey = mediaKey,
+            isLoading = false,
+            lyrics = result.lyrics
+        )
     }
 
     fun refreshCurrentLyrics() {
@@ -54,15 +66,9 @@ class LyricsViewModel @Inject constructor(
             playerConnection.snapshot.collect { snap ->
                 val item = snap.currentMediaItem
                 val mediaId = item?.mediaId.orEmpty()
-                val extras = item?.mediaMetadata?.extras
-                val mediaKey = listOf(
-                    mediaId,
-                    extras?.getString(com.asmr.player.data.lyrics.EXTRA_LYRICS_RELATIVE_PATH_NO_EXT).orEmpty(),
-                    extras?.getString("rj_code").orEmpty(),
-                    extras?.getString(com.asmr.player.data.lyrics.EXTRA_ALBUM_WORK_ID).orEmpty()
-                ).joinToString("|")
+                val mediaKey = lyricsContentKeyForItem(item)
                 if (mediaId.isBlank()) {
-                    _uiState.value = _uiState.value.copy(title = "", lyrics = emptyList())
+                    _uiState.value = LyricsUiState()
                     return@collect
                 }
                 if (lastMediaKey == mediaKey) return@collect
@@ -70,5 +76,16 @@ class LyricsViewModel @Inject constructor(
                 reloadForItem(item)
             }
         }
+    }
+
+    private fun lyricsContentKeyForItem(item: MediaItem?): String {
+        val mediaId = item?.mediaId.orEmpty()
+        val extras = item?.mediaMetadata?.extras
+        return listOf(
+            mediaId,
+            extras?.getString(EXTRA_LYRICS_RELATIVE_PATH_NO_EXT).orEmpty(),
+            extras?.getString("rj_code").orEmpty(),
+            extras?.getString(EXTRA_ALBUM_WORK_ID).orEmpty()
+        ).joinToString("|")
     }
 }

--- a/app/src/main/java/com/asmr/player/ui/player/NowPlayingScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/player/NowPlayingScreen.kt
@@ -147,6 +147,7 @@ private val NowPlayingHomeExpandedLyricsReserveHeight = 118.dp
 private val NowPlayingHomeCompactMinCoverWidth = 180.dp
 private val NowPlayingHomeRegularMinCoverWidth = 240.dp
 private val NowPlayingHomeClassicRegularMaxCoverWidth = 360.dp
+private val NowPlayingHomeClassicLyricsBottomPadding = 6.dp
 private const val NowPlayingHomeClassicCompactCoverScale = 0.92f
 
 internal fun nowPlayingHomeTopPadding(
@@ -283,6 +284,15 @@ private fun PlaybackProgressContent(
     isVideo: Boolean,
     content: @Composable (NowPlayingProgressState) -> Unit
 ) {
+    val initialProgressState = remember(viewModel, isVideo) {
+        val snapshot = viewModel.playback.value
+        val positionMs = if (isVideo) {
+            (snapshot.positionMs / VideoProgressUiTickMs) * VideoProgressUiTickMs
+        } else {
+            snapshot.positionMs
+        }
+        NowPlayingProgressState(positionMs, snapshot.durationMs)
+    }
     val progressState by remember(viewModel, isVideo) {
         viewModel.playback
             .map { snapshot ->
@@ -294,7 +304,7 @@ private fun PlaybackProgressContent(
                 NowPlayingProgressState(positionMs, snapshot.durationMs)
             }
             .distinctUntilChanged()
-    }.collectAsState(initial = NowPlayingProgressState())
+    }.collectAsState(initial = initialProgressState)
 
     content(progressState)
 }
@@ -1399,7 +1409,8 @@ internal fun NowPlayingScreen(
                                             colors = lyricColors,
                                             modifier = Modifier.fillMaxSize(),
                                             isLandscape = true,
-                                            contentKey = item?.mediaId
+                                            contentKey = lyricsState.contentKey,
+                                            contentVisible = !lyricsState.isLoading
                                         )
                                     }
                                 }
@@ -1626,7 +1637,8 @@ internal fun NowPlayingScreen(
                                             colors = lyricColors,
                                             modifier = Modifier.fillMaxSize(),
                                             isLandscape = true,
-                                            contentKey = item?.mediaId
+                                            contentKey = lyricsState.contentKey,
+                                            contentVisible = !lyricsState.isLoading
                                         )
                                     }
                                 }
@@ -1735,7 +1747,6 @@ internal fun NowPlayingScreen(
                 )
             }
             val expandedLyricsTopPadding = 14.dp
-            val classicLyricsTopPadding = 6.dp
             val homeCoverAspectRatio by homeLayoutTransition.animateFloat(
                 transitionSpec = {
                     tween(durationMillis = homeLayoutDurationMillis, easing = homeBezier)
@@ -1996,7 +2007,8 @@ internal fun NowPlayingScreen(
                                                     expandedHomeVisualEffects = true,
                                                     lyricItemOuterHorizontalPadding = 6.dp,
                                                     lyricItemInnerHorizontalPadding = 8.dp,
-                                                    contentKey = item?.mediaId,
+                                                    contentKey = lyricsState.contentKey,
+                                                    contentVisible = !lyricsState.isLoading,
                                                     modifier = Modifier.fillMaxSize()
                                                 )
                                             }
@@ -2007,9 +2019,9 @@ internal fun NowPlayingScreen(
                                             modifier = Modifier
                                                 .fillMaxWidth()
                                                 .height(58.dp)
-                                                .align(Alignment.TopCenter)
+                                                .align(Alignment.BottomCenter)
                                                 .padding(horizontal = portraitContentHorizontalPadding)
-                                                .padding(top = classicLyricsTopPadding)
+                                                .padding(bottom = NowPlayingHomeClassicLyricsBottomPadding)
                                                 .graphicsLayer { alpha = classicLyricsAlpha },
                                             contentAlignment = Alignment.Center
                                         ) {
@@ -2126,7 +2138,8 @@ internal fun NowPlayingScreen(
                             viewModel.play()
                         },
                         onAddLyrics = openManualLyricsAction,
-                        contentKey = item?.mediaId,
+                        contentKey = lyricsState.contentKey,
+                        contentVisible = !lyricsState.isLoading,
                         modifier = Modifier
                             .fillMaxSize()
                             .then(routeTransition.nowPlayingMotionModifier(currentMotionLayout, NowPlayingMotionSlot.COVER))

--- a/app/src/main/java/com/asmr/player/ui/player/NowPlayingScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/player/NowPlayingScreen.kt
@@ -123,6 +123,7 @@ import kotlin.math.abs
 import kotlin.math.roundToInt
 import kotlin.math.roundToLong
 
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.map
@@ -135,6 +136,8 @@ private enum class NowPlayingSurfaceMode {
 
 private const val VideoProgressUiTickMs = 1_000L
 private const val NowPlayingHomeLayoutAnimationDurationMillis = 620
+private const val NowPlayingHomeLyricsFadeInDurationMillis = 240
+private const val NowPlayingHomeLyricsFadeOutDurationMillis = 160
 private val NowPlayingPortraitMaxContentWidth = 600.dp
 private val NowPlayingCompactShortScreenHeight = 620.dp
 private val NowPlayingHomeAudienceTopSafePadding = 20.dp
@@ -143,6 +146,8 @@ private val NowPlayingHomeClassicLyricsReserveHeight = 72.dp
 private val NowPlayingHomeExpandedLyricsReserveHeight = 118.dp
 private val NowPlayingHomeCompactMinCoverWidth = 180.dp
 private val NowPlayingHomeRegularMinCoverWidth = 240.dp
+private val NowPlayingHomeClassicRegularMaxCoverWidth = 360.dp
+private const val NowPlayingHomeClassicCompactCoverScale = 0.92f
 
 internal fun nowPlayingHomeTopPadding(
     expanded: Boolean,
@@ -190,9 +195,9 @@ internal fun nowPlayingHomeCoverWidth(
     } else {
         val paddedWidth = (fullWidth - contentHorizontalPadding * 2).coerceAtLeast(1.dp)
         if (widthClass == WindowWidthSizeClass.Compact) {
-            paddedWidth
+            paddedWidth * NowPlayingHomeClassicCompactCoverScale
         } else {
-            paddedWidth.coerceAtMost(400.dp)
+            paddedWidth.coerceAtMost(NowPlayingHomeClassicRegularMaxCoverWidth)
         }
     }
     if (!availableHeight.isFiniteDp()) return widthBound
@@ -878,7 +883,14 @@ internal fun NowPlayingScreen(
     val haptic = LocalHapticFeedback.current
     val context = LocalContext.current
     var homeLayoutHintDismissedInSession by rememberSaveable { mutableStateOf(false) }
+    var homeLayoutLyricsVisible by remember { mutableStateOf(true) }
+    var homeLayoutChangeJob by remember { mutableStateOf<Job?>(null) }
     val homeLayoutHintScope = rememberCoroutineScope()
+    DisposableEffect(Unit) {
+        onDispose {
+            homeLayoutChangeJob?.cancel()
+        }
+    }
     LaunchedEffect(nowPlayingHomeLayoutHintDismissed) {
         if (nowPlayingHomeLayoutHintDismissed) {
             homeLayoutHintDismissedInSession = true
@@ -894,6 +906,7 @@ internal fun NowPlayingScreen(
     ) {
         { mode: NowPlayingHomeLayoutMode ->
             if (mode != nowPlayingHomeLayoutMode) {
+                homeLayoutChangeJob?.cancel()
                 if (!nowPlayingHomeLayoutHintDismissed && !homeLayoutHintDismissedInSession) {
                     homeLayoutHintScope.launch {
                         delay(NowPlayingHomeLayoutAnimationDurationMillis.toLong())
@@ -901,7 +914,13 @@ internal fun NowPlayingScreen(
                     }
                 }
                 haptic.performHapticFeedback(HapticFeedbackType.LongPress)
-                onNowPlayingHomeLayoutModeChange(mode)
+                homeLayoutChangeJob = homeLayoutHintScope.launch {
+                    homeLayoutLyricsVisible = false
+                    delay(NowPlayingHomeLyricsFadeOutDurationMillis.toLong())
+                    onNowPlayingHomeLayoutModeChange(mode)
+                    delay(NowPlayingHomeLayoutAnimationDurationMillis.toLong())
+                    homeLayoutLyricsVisible = true
+                }
             }
         }
     }
@@ -1379,7 +1398,8 @@ internal fun NowPlayingScreen(
                                             onOpenLyrics = showLyricsSurface,
                                             colors = lyricColors,
                                             modifier = Modifier.fillMaxSize(),
-                                            isLandscape = true
+                                            isLandscape = true,
+                                            contentKey = item?.mediaId
                                         )
                                     }
                                 }
@@ -1605,7 +1625,8 @@ internal fun NowPlayingScreen(
                                             onOpenLyrics = showLyricsSurface,
                                             colors = lyricColors,
                                             modifier = Modifier.fillMaxSize(),
-                                            isLandscape = true
+                                            isLandscape = true,
+                                            contentKey = item?.mediaId
                                         )
                                     }
                                 }
@@ -1670,8 +1691,8 @@ internal fun NowPlayingScreen(
             val portraitScreenHeight = configuration.screenHeightDp.dp
             val homeBezier = remember { CubicBezierEasing(0.20f, 0f, 0f, 1f) }
             val homeLayoutDurationMillis = NowPlayingHomeLayoutAnimationDurationMillis
-            val homeFadeInDurationMillis = 240
-            val homeFadeOutDurationMillis = 160
+            val homeFadeInDurationMillis = NowPlayingHomeLyricsFadeInDurationMillis
+            val homeFadeOutDurationMillis = NowPlayingHomeLyricsFadeOutDurationMillis
             val expandedHomeLyricsSettings = remember(lyricsPageSettings) {
                 lyricsPageSettings.copy(displayAreaMode = 0)
             }
@@ -1713,22 +1734,8 @@ internal fun NowPlayingScreen(
                     widthClass = widthClass
                 )
             }
-            val lyricsTopPadding by homeLayoutTransition.animateDp(
-                transitionSpec = {
-                    tween(durationMillis = homeLayoutDurationMillis, easing = homeBezier)
-                },
-                label = "nowPlayingHomeLyricsTopPadding"
-            ) { expanded ->
-                if (expanded) 14.dp else 6.dp
-            }
-            val lyricsHorizontalPadding by homeLayoutTransition.animateDp(
-                transitionSpec = {
-                    tween(durationMillis = homeLayoutDurationMillis, easing = homeBezier)
-                },
-                label = "nowPlayingHomeLyricsHorizontalPadding"
-            ) { expanded ->
-                if (expanded) 0.dp else portraitContentHorizontalPadding
-            }
+            val expandedLyricsTopPadding = 14.dp
+            val classicLyricsTopPadding = 6.dp
             val homeCoverAspectRatio by homeLayoutTransition.animateFloat(
                 transitionSpec = {
                     tween(durationMillis = homeLayoutDurationMillis, easing = homeBezier)
@@ -1777,30 +1784,35 @@ internal fun NowPlayingScreen(
             ) { expanded ->
                 if (expanded) 1f else 0f
             }
-            val expandedLyricsAlpha by homeLayoutTransition.animateFloat(
-                transitionSpec = {
-                    if (targetState) {
-                        tween(durationMillis = homeFadeInDurationMillis, easing = LinearOutSlowInEasing)
-                    } else {
-                        tween(durationMillis = homeFadeOutDurationMillis, easing = FastOutLinearInEasing)
-                    }
-                },
+            val homeLayoutSettled = homeLayoutTransition.currentState == homeLayoutTransition.targetState
+            LaunchedEffect(expandedHomeLayout) {
+                if (!homeLayoutSettled) {
+                    homeLayoutLyricsVisible = false
+                }
+            }
+            LaunchedEffect(homeLayoutSettled) {
+                if (homeLayoutSettled) {
+                    homeLayoutLyricsVisible = true
+                }
+            }
+            val expandedLyricsActive = expandedHomeLayout && homeLayoutSettled && homeLayoutLyricsVisible
+            val classicLyricsActive = !expandedHomeLayout && homeLayoutSettled && homeLayoutLyricsVisible
+            val expandedLyricsAlpha by animateFloatAsState(
+                targetValue = if (expandedLyricsActive) 1f else 0f,
+                animationSpec = tween(
+                    durationMillis = if (expandedLyricsActive) homeFadeInDurationMillis else homeFadeOutDurationMillis,
+                    easing = if (expandedLyricsActive) LinearOutSlowInEasing else FastOutLinearInEasing
+                ),
                 label = "nowPlayingHomeExpandedLyricsAlpha"
-            ) { expanded ->
-                if (expanded) 1f else 0f
-            }
-            val classicLyricsAlpha by homeLayoutTransition.animateFloat(
-                transitionSpec = {
-                    if (targetState) {
-                        tween(durationMillis = homeFadeOutDurationMillis, easing = FastOutLinearInEasing)
-                    } else {
-                        tween(durationMillis = homeFadeInDurationMillis, easing = LinearOutSlowInEasing)
-                    }
-                },
+            )
+            val classicLyricsAlpha by animateFloatAsState(
+                targetValue = if (classicLyricsActive) 1f else 0f,
+                animationSpec = tween(
+                    durationMillis = if (classicLyricsActive) homeFadeInDurationMillis else homeFadeOutDurationMillis,
+                    easing = if (classicLyricsActive) LinearOutSlowInEasing else FastOutLinearInEasing
+                ),
                 label = "nowPlayingHomeClassicLyricsAlpha"
-            ) { expanded ->
-                if (expanded) 0f else 1f
-            }
+            )
             val lyricsExpandedInteractionEnabled = expandedLyricsAlpha > 0.5f
             val lyricsClassicInteractionEnabled = classicLyricsAlpha > 0.5f
             // --- 垂直布局 (手机 或 平板竖屏) ---
@@ -1954,58 +1966,63 @@ internal fun NowPlayingScreen(
                                 Box(
                                     modifier = portraitContentWidthModifier
                                         .weight(1f)
-                                        .padding(horizontal = lyricsHorizontalPadding)
                                         .then(lyricsMotion),
                                     contentAlignment = Alignment.TopCenter
                                 ) {
-                                    Box(
-                                        modifier = Modifier
-                                            .fillMaxSize()
-                                            .padding(top = lyricsTopPadding)
-                                            .graphicsLayer { alpha = expandedLyricsAlpha }
-                                    ) {
-                                        PlaybackProgressContent(viewModel, isVideo) { progress ->
-                                            NowPlayingLyricsSurface(
-                                                isLandscape = false,
-                                                playbackPositionMs = progress.positionMs,
-                                                lyrics = lyricsState.lyrics,
-                                                lyricColors = lyricColors,
-                                                accentColor = accentColor,
-                                                onAccentColor = onAccentColor,
-                                                lyricsPageSettings = expandedHomeLyricsSettings,
-                                                onSeekTo = { viewModel.seekTo(it) },
-                                                onTimelinePlay = { targetMs ->
-                                                    viewModel.seekTo(targetMs)
-                                                    viewModel.play()
-                                                },
-                                                onAddLyrics = openManualLyricsAction,
-                                                interactionEnabled = lyricsExpandedInteractionEnabled,
-                                                stableFocusAnchor = true,
-                                                expandedHomeVisualEffects = true,
-                                                lyricItemOuterHorizontalPadding = 6.dp,
-                                                lyricItemInnerHorizontalPadding = 8.dp,
-                                                modifier = Modifier.fillMaxSize()
-                                            )
+                                    if (expandedLyricsActive || expandedLyricsAlpha > 0.001f) {
+                                        Box(
+                                            modifier = Modifier
+                                                .fillMaxSize()
+                                                .padding(top = expandedLyricsTopPadding)
+                                                .graphicsLayer { alpha = expandedLyricsAlpha }
+                                        ) {
+                                            PlaybackProgressContent(viewModel, isVideo) { progress ->
+                                                NowPlayingLyricsSurface(
+                                                    isLandscape = false,
+                                                    playbackPositionMs = progress.positionMs,
+                                                    lyrics = lyricsState.lyrics,
+                                                    lyricColors = lyricColors,
+                                                    accentColor = accentColor,
+                                                    onAccentColor = onAccentColor,
+                                                    lyricsPageSettings = expandedHomeLyricsSettings,
+                                                    onSeekTo = { viewModel.seekTo(it) },
+                                                    onTimelinePlay = { targetMs ->
+                                                        viewModel.seekTo(targetMs)
+                                                        viewModel.play()
+                                                    },
+                                                    onAddLyrics = openManualLyricsAction,
+                                                    interactionEnabled = lyricsExpandedInteractionEnabled,
+                                                    stableFocusAnchor = true,
+                                                    expandedHomeVisualEffects = true,
+                                                    lyricItemOuterHorizontalPadding = 6.dp,
+                                                    lyricItemInnerHorizontalPadding = 8.dp,
+                                                    contentKey = item?.mediaId,
+                                                    modifier = Modifier.fillMaxSize()
+                                                )
+                                            }
                                         }
                                     }
-                                    Box(
-                                        modifier = Modifier
-                                            .fillMaxWidth()
-                                            .height(58.dp)
-                                            .align(Alignment.TopCenter)
-                                            .offset(y = lyricsTopPadding)
-                                            .graphicsLayer { alpha = classicLyricsAlpha },
-                                        contentAlignment = Alignment.Center
-                                    ) {
-                                        PlaybackProgressContent(viewModel, isVideo) { progress ->
-                                            SingleLineLyrics(
-                                                lyrics = lyricsState.lyrics,
-                                                currentPosition = progress.positionMs,
-                                                onOpenLyrics = showLyricsSurface,
-                                                colors = lyricColors,
-                                                interactionEnabled = lyricsClassicInteractionEnabled,
-                                                modifier = Modifier.fillMaxWidth()
-                                            )
+                                    if (classicLyricsActive || classicLyricsAlpha > 0.001f) {
+                                        Box(
+                                            modifier = Modifier
+                                                .fillMaxWidth()
+                                                .height(58.dp)
+                                                .align(Alignment.TopCenter)
+                                                .padding(horizontal = portraitContentHorizontalPadding)
+                                                .padding(top = classicLyricsTopPadding)
+                                                .graphicsLayer { alpha = classicLyricsAlpha },
+                                            contentAlignment = Alignment.Center
+                                        ) {
+                                            PlaybackProgressContent(viewModel, isVideo) { progress ->
+                                                SingleLineLyrics(
+                                                    lyrics = lyricsState.lyrics,
+                                                    currentPosition = progress.positionMs,
+                                                    onOpenLyrics = showLyricsSurface,
+                                                    colors = lyricColors,
+                                                    interactionEnabled = lyricsClassicInteractionEnabled,
+                                                    modifier = Modifier.fillMaxWidth()
+                                                )
+                                            }
                                         }
                                     }
                                 }
@@ -2109,6 +2126,7 @@ internal fun NowPlayingScreen(
                             viewModel.play()
                         },
                         onAddLyrics = openManualLyricsAction,
+                        contentKey = item?.mediaId,
                         modifier = Modifier
                             .fillMaxSize()
                             .then(routeTransition.nowPlayingMotionModifier(currentMotionLayout, NowPlayingMotionSlot.COVER))

--- a/app/src/main/java/com/asmr/player/ui/player/NowPlayingScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/player/NowPlayingScreen.kt
@@ -1961,7 +1961,7 @@ internal fun NowPlayingScreen(
                                     Box(
                                         modifier = Modifier
                                             .fillMaxSize()
-                                            .offset(y = lyricsTopPadding)
+                                            .padding(top = lyricsTopPadding)
                                             .graphicsLayer { alpha = expandedLyricsAlpha }
                                     ) {
                                         PlaybackProgressContent(viewModel, isVideo) { progress ->
@@ -1981,6 +1981,7 @@ internal fun NowPlayingScreen(
                                                 onAddLyrics = openManualLyricsAction,
                                                 interactionEnabled = lyricsExpandedInteractionEnabled,
                                                 stableFocusAnchor = true,
+                                                expandedHomeVisualEffects = true,
                                                 lyricItemOuterHorizontalPadding = 6.dp,
                                                 lyricItemInnerHorizontalPadding = 8.dp,
                                                 modifier = Modifier.fillMaxSize()

--- a/app/src/main/java/com/asmr/player/ui/player/nowplaying/NowPlayingSurfaceComponents.kt
+++ b/app/src/main/java/com/asmr/player/ui/player/nowplaying/NowPlayingSurfaceComponents.kt
@@ -209,9 +209,20 @@ internal fun NowPlayingLyricsSurface(
     lyricItemOuterHorizontalPadding: Dp = if (isLandscape) 10.dp else 14.dp,
     lyricItemInnerHorizontalPadding: Dp = if (isLandscape) 8.dp else 10.dp,
     contentKey: String? = null,
+    contentVisible: Boolean = true,
     modifier: Modifier = Modifier
 ) {
-    Box(modifier = modifier) {
+    val surfaceAlpha by animateFloatAsState(
+        targetValue = if (contentVisible) 1f else 0f,
+        animationSpec = tween(durationMillis = if (contentVisible) 220 else 120),
+        label = "nowPlayingLyricsSurfaceAlpha"
+    )
+    val effectiveInteractionEnabled = interactionEnabled && contentVisible
+    Box(
+        modifier = modifier.graphicsLayer {
+            alpha = surfaceAlpha
+        }
+    ) {
         if (lyrics.isEmpty()) {
             Column(
                 modifier = Modifier
@@ -229,6 +240,7 @@ internal fun NowPlayingLyricsSurface(
                     Spacer(modifier = Modifier.height(14.dp))
                     Button(
                         onClick = onAddLyrics,
+                        enabled = effectiveInteractionEnabled,
                         colors = ButtonDefaults.buttonColors(
                             containerColor = accentColor,
                             contentColor = onAccentColor
@@ -249,12 +261,13 @@ internal fun NowPlayingLyricsSurface(
                 modifier = Modifier.fillMaxSize(),
                 isLandscape = isLandscape,
                 settings = lyricsPageSettings,
-                interactionEnabled = interactionEnabled,
+                interactionEnabled = effectiveInteractionEnabled,
                 stableFocusAnchor = stableFocusAnchor,
                 expandedHomeVisualEffects = expandedHomeVisualEffects,
                 itemOuterHorizontalPadding = lyricItemOuterHorizontalPadding,
                 itemInnerHorizontalPadding = lyricItemInnerHorizontalPadding,
-                contentKey = contentKey
+                contentKey = contentKey,
+                contentVisible = contentVisible
             )
         }
     }

--- a/app/src/main/java/com/asmr/player/ui/player/nowplaying/NowPlayingSurfaceComponents.kt
+++ b/app/src/main/java/com/asmr/player/ui/player/nowplaying/NowPlayingSurfaceComponents.kt
@@ -208,6 +208,7 @@ internal fun NowPlayingLyricsSurface(
     expandedHomeVisualEffects: Boolean = false,
     lyricItemOuterHorizontalPadding: Dp = if (isLandscape) 10.dp else 14.dp,
     lyricItemInnerHorizontalPadding: Dp = if (isLandscape) 8.dp else 10.dp,
+    contentKey: String? = null,
     modifier: Modifier = Modifier
 ) {
     Box(modifier = modifier) {
@@ -252,7 +253,8 @@ internal fun NowPlayingLyricsSurface(
                 stableFocusAnchor = stableFocusAnchor,
                 expandedHomeVisualEffects = expandedHomeVisualEffects,
                 itemOuterHorizontalPadding = lyricItemOuterHorizontalPadding,
-                itemInnerHorizontalPadding = lyricItemInnerHorizontalPadding
+                itemInnerHorizontalPadding = lyricItemInnerHorizontalPadding,
+                contentKey = contentKey
             )
         }
     }

--- a/app/src/main/java/com/asmr/player/ui/player/nowplaying/NowPlayingSurfaceComponents.kt
+++ b/app/src/main/java/com/asmr/player/ui/player/nowplaying/NowPlayingSurfaceComponents.kt
@@ -205,6 +205,7 @@ internal fun NowPlayingLyricsSurface(
     onAddLyrics: (() -> Unit)? = null,
     interactionEnabled: Boolean = true,
     stableFocusAnchor: Boolean = false,
+    expandedHomeVisualEffects: Boolean = false,
     lyricItemOuterHorizontalPadding: Dp = if (isLandscape) 10.dp else 14.dp,
     lyricItemInnerHorizontalPadding: Dp = if (isLandscape) 8.dp else 10.dp,
     modifier: Modifier = Modifier
@@ -249,6 +250,7 @@ internal fun NowPlayingLyricsSurface(
                 settings = lyricsPageSettings,
                 interactionEnabled = interactionEnabled,
                 stableFocusAnchor = stableFocusAnchor,
+                expandedHomeVisualEffects = expandedHomeVisualEffects,
                 itemOuterHorizontalPadding = lyricItemOuterHorizontalPadding,
                 itemInnerHorizontalPadding = lyricItemInnerHorizontalPadding
             )

--- a/app/src/main/java/com/asmr/player/ui/search/SearchScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/search/SearchScreen.kt
@@ -132,7 +132,11 @@ import com.asmr.player.ui.common.withAddedBottomPadding
 import com.asmr.player.ui.library.AlbumGridItem
 import com.asmr.player.ui.library.AlbumGridItemSpacing
 import com.asmr.player.ui.library.AlbumItem
+import com.asmr.player.ui.library.AlbumMetaActionDialog
 import com.asmr.player.ui.library.rememberAlbumMetaCopyAction
+import com.asmr.player.ui.groups.AlbumGroupsViewModel
+import com.asmr.player.ui.playlists.PlaylistsViewModel
+import com.asmr.player.ui.settings.SettingsViewModel
 import com.asmr.player.ui.sidepanel.LandscapeRightPanelHost
 import com.asmr.player.ui.sidepanel.RecentAlbumsPanel
 import com.asmr.player.ui.theme.AsmrTheme
@@ -325,6 +329,10 @@ fun SearchScreen(
     val gridState = rememberSaveable(resultScrollKey, saver = LazyStaggeredGridState.Saver) { LazyStaggeredGridState() }
     val colorScheme = AsmrTheme.colorScheme
     val copyMeta = rememberAlbumMetaCopyAction(viewModel.messageManager)
+    val playlistsViewModel: PlaylistsViewModel = hiltViewModel()
+    val albumGroupsViewModel: AlbumGroupsViewModel = hiltViewModel()
+    val settingsViewModel: SettingsViewModel = hiltViewModel()
+    val searchBlockedKeywords by settingsViewModel.searchBlockedKeywords.collectAsState()
     val scope = rememberCoroutineScope()
     val keyboardController = LocalSoftwareKeyboardController.current
     val isCompact = windowSizeClass.widthSizeClass == WindowWidthSizeClass.Compact
@@ -335,6 +343,24 @@ fun SearchScreen(
     var keywordSyncedFromState by rememberSaveable { mutableStateOf(false) }
     var optionsSyncedFromState by rememberSaveable { mutableStateOf(false) }
     var lastHandledSubmittedSearchSignal by rememberSaveable { mutableStateOf(0L) }
+    var metaActionKeyword by rememberSaveable { mutableStateOf<String?>(null) }
+
+    fun openMetaActions(value: String) {
+        val normalized = value.trim()
+        if (normalized.isNotBlank()) metaActionKeyword = normalized
+    }
+
+    fun addMetaBlockedKeyword(value: String) {
+        val normalized = value.trim()
+        if (normalized.isBlank()) return
+        val exists = searchBlockedKeywords.any { it.equals(normalized, ignoreCase = true) }
+        settingsViewModel.addSearchBlockedKeyword(normalized)
+        if (exists) {
+            viewModel.messageManager.showInfo("屏蔽词已存在：$normalized")
+        } else {
+            viewModel.messageManager.showSuccess("已添加屏蔽词：$normalized")
+        }
+    }
 
     LaunchedEffect(Unit) {
         viewModel.bootstrap(
@@ -429,6 +455,30 @@ fun SearchScreen(
         keyboardController?.hide()
         val accepted = viewModel.search("")
         if (!accepted) return
+        scrollResultsToTop()
+        chromeState.expand()
+    }
+
+    fun searchMetaKeyword(value: String) {
+        if (searchSubmitLocked) {
+            viewModel.messageManager.showInfo("搜索处理中，请稍后再试")
+            return
+        }
+        val normalized = value.trim()
+        if (normalized.isBlank()) return
+        keyboardController?.hide()
+        val accepted = viewModel.search(
+            keyword = normalized,
+            order = selectedOrder,
+            collectedSort = selectedCollectedSort,
+            purchasedOnly = purchasedOnly,
+            presaleOnly = presaleOnly,
+            chineseTranslatedOnly = chineseTranslatedOnly,
+            collectedOnly = collectedOnly,
+            locale = selectedLocale
+        )
+        if (!accepted) return
+        keyword = normalized
         scrollResultsToTop()
         chromeState.expand()
     }
@@ -951,8 +1001,11 @@ fun SearchScreen(
                                                 coverReloadKey = state.resultRevision,
                                                 onRjClick = { copyMeta("RJ", it) },
                                                 onCircleClick = { copyMeta("社团", it) },
+                                                onCircleLongClick = ::openMetaActions,
                                                 onCvClick = { copyMeta("CV", it) },
+                                                onCvLongClick = ::openMetaActions,
                                                 onTagClick = { copyMeta("标签", it) },
+                                                onTagLongClick = ::openMetaActions,
                                             )
                                         }
                                     }
@@ -1014,8 +1067,11 @@ fun SearchScreen(
                                                 coverReloadKey = state.resultRevision,
                                                 onRjClick = { copyMeta("RJ", it) },
                                                 onCircleClick = { copyMeta("社团", it) },
+                                                onCircleLongClick = ::openMetaActions,
                                                 onCvClick = { copyMeta("CV", it) },
+                                                onCvLongClick = ::openMetaActions,
                                                 onTagClick = { copyMeta("标签", it) },
+                                                onTagLongClick = ::openMetaActions,
                                             )
                                         }
                                     }
@@ -1182,6 +1238,17 @@ fun SearchScreen(
                 }
             }
         }
+    }
+
+    metaActionKeyword?.let { targetKeyword ->
+        AlbumMetaActionDialog(
+            keyword = targetKeyword,
+            onDismissRequest = { metaActionKeyword = null },
+            onSearch = ::searchMetaKeyword,
+            onCreatePlaylist = playlistsViewModel::createPlaylist,
+            onCreateGroup = albumGroupsViewModel::createGroup,
+            onAddBlockedKeyword = ::addMetaBlockedKeyword,
+        )
     }
 }
 

--- a/app/src/test/java/com/asmr/player/ui/player/LyricsPageLayoutTest.kt
+++ b/app/src/test/java/com/asmr/player/ui/player/LyricsPageLayoutTest.kt
@@ -131,6 +131,13 @@ class LyricsPageLayoutTest {
     }
 
     @Test
+    fun lyricDisplayActiveIndex_fallsBackToFirstLineBeforePlaybackStarts() {
+        assertEquals(0, lyricDisplayActiveIndex(activeIndex = -1, totalCount = 4))
+        assertEquals(3, lyricDisplayActiveIndex(activeIndex = 7, totalCount = 4))
+        assertEquals(-1, lyricDisplayActiveIndex(activeIndex = -1, totalCount = 0))
+    }
+
+    @Test
     fun centeredLyricIndexForTimeline_picksNearestVisibleItemCenter() {
         val frames = listOf(
             LyricVisibleItemFrame(index = 0, offsetPx = -20, sizePx = 60),

--- a/app/src/test/java/com/asmr/player/ui/player/LyricsPageLayoutTest.kt
+++ b/app/src/test/java/com/asmr/player/ui/player/LyricsPageLayoutTest.kt
@@ -2,6 +2,7 @@ package com.asmr.player.ui.player
 
 import androidx.compose.ui.text.style.TextAlign
 import com.asmr.player.data.settings.LyricsPageSettings
+import com.asmr.player.util.SubtitleEntry
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -112,6 +113,21 @@ class LyricsPageLayoutTest {
         assertTrue(farBelow.blurDp > below.blurDp)
         assertTrue(above.dispersionOffsetYDp < 0f)
         assertTrue(below.dispersionOffsetYDp > 0f)
+    }
+
+    @Test
+    fun lyricContentKey_changesWhenAudioLyricsChange() {
+        val first = listOf(
+            SubtitleEntry(startMs = 0L, endMs = 1000L, text = "第一首"),
+            SubtitleEntry(startMs = 1200L, endMs = 2000L, text = "尾句")
+        )
+        val second = listOf(
+            SubtitleEntry(startMs = 0L, endMs = 1000L, text = "第二首"),
+            SubtitleEntry(startMs = 1200L, endMs = 2000L, text = "尾句")
+        )
+
+        assertTrue(lyricContentKey(first) != lyricContentKey(second))
+        assertTrue(lyricContentKey(first, contentKey = "track-a") != lyricContentKey(first, contentKey = "track-b"))
     }
 
     @Test

--- a/app/src/test/java/com/asmr/player/ui/player/LyricsPageLayoutTest.kt
+++ b/app/src/test/java/com/asmr/player/ui/player/LyricsPageLayoutTest.kt
@@ -3,6 +3,7 @@ package com.asmr.player.ui.player
 import androidx.compose.ui.text.style.TextAlign
 import com.asmr.player.data.settings.LyricsPageSettings
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class LyricsPageLayoutTest {
@@ -93,6 +94,24 @@ class LyricsPageLayoutTest {
         assertEquals(TextAlign.Center, lyricTextAlign(1))
         assertEquals(TextAlign.End, lyricTextAlign(2))
         assertEquals(TextAlign.Center, lyricTextAlign(999))
+    }
+
+    @Test
+    fun lyricFocusVisualEffect_disabledOrActiveLineHasNoEffect() {
+        assertEquals(0f, lyricFocusVisualEffectForLine(index = 2, activeIndex = 2, enabled = true).blurDp, 0.001f)
+        assertEquals(0f, lyricFocusVisualEffectForLine(index = 1, activeIndex = 2, enabled = false).blurDp, 0.001f)
+    }
+
+    @Test
+    fun lyricFocusVisualEffect_addsDirectionalDispersionAwayFromCenter() {
+        val above = lyricFocusVisualEffectForLine(index = 3, activeIndex = 5, enabled = true)
+        val below = lyricFocusVisualEffectForLine(index = 7, activeIndex = 5, enabled = true)
+        val farBelow = lyricFocusVisualEffectForLine(index = 9, activeIndex = 5, enabled = true)
+
+        assertTrue(above.blurDp > 0f)
+        assertTrue(farBelow.blurDp > below.blurDp)
+        assertTrue(above.dispersionOffsetYDp < 0f)
+        assertTrue(below.dispersionOffsetYDp > 0f)
     }
 
     @Test

--- a/app/src/test/java/com/asmr/player/ui/player/NowPlayingHomeLayoutCoverTest.kt
+++ b/app/src/test/java/com/asmr/player/ui/player/NowPlayingHomeLayoutCoverTest.kt
@@ -22,13 +22,27 @@ class NowPlayingHomeLayoutCoverTest {
     @Test
     fun classicCoverKeepsComfortableWidthOnWidePortrait() {
         assertEquals(
-            400.dp,
+            360.dp,
             nowPlayingHomeCoverWidth(
                 expanded = false,
                 availableWidth = 720.dp,
                 widthClass = WindowWidthSizeClass.Medium,
                 contentHorizontalPadding = 24.dp
             )
+        )
+    }
+
+    @Test
+    fun compactClassicCoverUsesReducedPaddedWidth() {
+        assertEquals(
+            287.04f,
+            nowPlayingHomeCoverWidth(
+                expanded = false,
+                availableWidth = 360.dp,
+                widthClass = WindowWidthSizeClass.Compact,
+                contentHorizontalPadding = 24.dp
+            ).value,
+            0.001f
         )
     }
 


### PR DESCRIPTION
## Summary
- 为社团、tag、cv 增加长按操作弹窗，支持关键词快捷搜索、创建列表/分组、加入屏蔽词
- 优化封面展开模式歌词边缘模糊过渡，并增加中心歌词上下行的模糊色散效果
- 缩小经典圆角封面尺寸，优化封面排布切换时歌词淡入淡出与初始定位
- 优化切换音频时歌词加载、定位和淡入淡出，减少全量滚动和闪烁

## Verification
- .\gradlew-local.bat :app:testReleaseUnitTest --tests com.asmr.player.ui.player.NowPlayingHomeLayoutCoverTest --tests com.asmr.player.ui.player.LyricsPageLayoutTest
- .\gradlew-local.bat :app:compileReleaseKotlin
- .\gradlew-local.bat :app:installRelease