### PR TITLE
fix: improve audio playback recovery

### DIFF
--- a/app/src/main/java/com/asmr/player/playback/FadingPlayer.kt
+++ b/app/src/main/java/com/asmr/player/playback/FadingPlayer.kt
@@ -50,6 +50,13 @@ class FadingPlayer(
         pendingSwitchFadeIn = false
         volumeFader.cancel()
         volume = 0f
+        if (
+            delegate.playbackState == Player.STATE_IDLE &&
+            delegate.playerError != null &&
+            delegate.mediaItemCount > 0
+        ) {
+            delegate.prepare()
+        }
         delegate.play()
         volumeFader.fadeTo(this, 1f, playFadeDurationMs)
     }

--- a/app/src/main/java/com/asmr/player/playback/PlaybackRecoveryPolicy.kt
+++ b/app/src/main/java/com/asmr/player/playback/PlaybackRecoveryPolicy.kt
@@ -1,0 +1,72 @@
+package com.asmr.player.playback
+
+import androidx.media3.common.PlaybackException
+
+internal data class PlaybackRecoveryAttempt(
+    val number: Int,
+    val delayMs: Long
+)
+
+internal class PlaybackRecoveryPolicy(
+    private val maxAttempts: Int = 4,
+    private val initialDelayMs: Long = 1_000L,
+    private val maxDelayMs: Long = 8_000L
+) {
+    private var currentMediaKey: String? = null
+    private var attemptCount: Int = 0
+
+    init {
+        require(maxAttempts > 0)
+        require(initialDelayMs >= 0L)
+        require(maxDelayMs >= initialDelayMs)
+    }
+
+    fun nextAttempt(mediaKey: String): PlaybackRecoveryAttempt? {
+        if (currentMediaKey != mediaKey) {
+            currentMediaKey = mediaKey
+            attemptCount = 0
+        }
+        if (attemptCount >= maxAttempts) return null
+
+        val attempt = attemptCount + 1
+        val multiplier = 1L shl attemptCount.coerceAtMost(30)
+        val delayMs = (initialDelayMs * multiplier).coerceAtMost(maxDelayMs)
+        attemptCount = attempt
+        return PlaybackRecoveryAttempt(number = attempt, delayMs = delayMs)
+    }
+
+    fun reset() {
+        currentMediaKey = null
+        attemptCount = 0
+    }
+}
+
+internal fun isRecoverableRemotePlaybackFailure(
+    uriText: String,
+    errorCode: Int,
+    httpStatusCode: Int? = null
+): Boolean {
+    val normalizedUri = uriText.trim()
+    if (
+        !normalizedUri.startsWith("http://", ignoreCase = true) &&
+        !normalizedUri.startsWith("https://", ignoreCase = true)
+    ) {
+        return false
+    }
+
+    return when (errorCode) {
+        PlaybackException.ERROR_CODE_TIMEOUT,
+        PlaybackException.ERROR_CODE_IO_UNSPECIFIED,
+        PlaybackException.ERROR_CODE_IO_NETWORK_CONNECTION_FAILED,
+        PlaybackException.ERROR_CODE_IO_NETWORK_CONNECTION_TIMEOUT -> true
+
+        PlaybackException.ERROR_CODE_IO_BAD_HTTP_STATUS -> {
+            httpStatusCode == null ||
+                httpStatusCode == 408 ||
+                httpStatusCode == 429 ||
+                httpStatusCode in 500..599
+        }
+
+        else -> false
+    }
+}

--- a/app/src/main/java/com/asmr/player/service/PlaybackService.kt
+++ b/app/src/main/java/com/asmr/player/service/PlaybackService.kt
@@ -21,13 +21,16 @@ import androidx.core.app.TaskStackBuilder
 import androidx.media3.common.AudioAttributes
 import androidx.media3.common.C
 import androidx.media3.common.MediaItem
+import androidx.media3.common.PlaybackException
 import androidx.media3.common.Player
 import androidx.media3.common.util.UnstableApi
 import androidx.media3.exoplayer.ExoPlayer
+import androidx.media3.exoplayer.upstream.DefaultLoadErrorHandlingPolicy
 import androidx.media3.exoplayer.source.DefaultMediaSourceFactory
 import androidx.media3.datasource.DefaultDataSource
 import androidx.media3.datasource.DefaultHttpDataSource
 import androidx.media3.datasource.FileDataSource
+import androidx.media3.datasource.HttpDataSource
 import androidx.media3.datasource.ResolvingDataSource
 import androidx.media3.session.MediaSession
 import androidx.media3.session.MediaSessionService
@@ -56,6 +59,7 @@ import com.asmr.player.playback.AppVolume
 import com.asmr.player.playback.AppVolumeBoostController
 import com.asmr.player.playback.GraphicEqualizerAudioProcessor
 import com.asmr.player.playback.PlaybackMediaCache
+import com.asmr.player.playback.PlaybackRecoveryPolicy
 import com.asmr.player.playback.RoutingPlaybackDataSource
 import com.asmr.player.playback.SceneEffectAudioProcessor
 import com.asmr.player.playback.StereoFftAnalyzer
@@ -65,6 +69,7 @@ import com.asmr.player.playback.StereoSpectrumBus
 import com.asmr.player.playback.StereoSpectrumTapAudioProcessor
 import com.asmr.player.playback.VolumeThresholdAudioProcessor
 import com.asmr.player.playback.VolumeFader
+import com.asmr.player.playback.isRecoverableRemotePlaybackFailure
 import com.asmr.player.util.EmbeddedMediaExtractor
 import com.asmr.player.util.SubtitleEntry
 import com.asmr.player.util.SubtitleIndexFinder
@@ -143,12 +148,15 @@ class PlaybackService : MediaSessionService() {
 
     private val audioFocusChangeListener = AudioManager.OnAudioFocusChangeListener { focusChange ->
         when (focusChange) {
-            AudioManager.AUDIOFOCUS_GAIN -> hasAudioFocus = true
-            AudioManager.AUDIOFOCUS_LOSS,
+            AudioManager.AUDIOFOCUS_GAIN -> handleAudioFocusGain()
+            AudioManager.AUDIOFOCUS_LOSS -> {
+                hasAudioFocus = false
+                handleAudioFocusLoss(resumeWhenFocusReturns = false)
+            }
             AudioManager.AUDIOFOCUS_LOSS_TRANSIENT,
             AudioManager.AUDIOFOCUS_LOSS_TRANSIENT_CAN_DUCK -> {
                 hasAudioFocus = false
-                handleAudioFocusLoss()
+                handleAudioFocusLoss(resumeWhenFocusReturns = true)
             }
         }
     }
@@ -211,6 +219,8 @@ class PlaybackService : MediaSessionService() {
     private var lastMarkedElapsedMs: Long = 0L
 
     private var statsJob: Job? = null
+    private var playbackRecoveryJob: Job? = null
+    private val playbackRecoveryPolicy = PlaybackRecoveryPolicy()
     private var currentTrackListenedMs: Long = 0L
     private var isCurrentTrackCounted: Boolean = false
     private var currentMediaId: String? = null
@@ -247,6 +257,8 @@ class PlaybackService : MediaSessionService() {
         val httpFactory = DefaultHttpDataSource.Factory()
             .setUserAgent(DLSITE_UA)
             .setAllowCrossProtocolRedirects(true)
+            .setConnectTimeoutMs(NETWORK_CONNECT_TIMEOUT_MS)
+            .setReadTimeoutMs(NETWORK_READ_TIMEOUT_MS)
         
         val transferListener = object : TransferListener {
             override fun onTransferInitializing(source: DataSource, dataSpec: DataSpec, isNetwork: Boolean) {}
@@ -301,6 +313,10 @@ class PlaybackService : MediaSessionService() {
             upstreamFactory = upstreamDataSourceFactory,
             cachedFactory = cacheDataSourceFactory
         )
+        val mediaSourceFactory = DefaultMediaSourceFactory(dataSourceFactory)
+            .setLoadErrorHandlingPolicy(
+                DefaultLoadErrorHandlingPolicy(NETWORK_MINIMUM_LOADABLE_RETRY_COUNT)
+            )
 
         exoPlayer = ExoPlayer.Builder(this)
             .setRenderersFactory(
@@ -316,7 +332,7 @@ class PlaybackService : MediaSessionService() {
                     spectrumTapAudioProcessor
                 )
             )
-            .setMediaSourceFactory(DefaultMediaSourceFactory(dataSourceFactory))
+            .setMediaSourceFactory(mediaSourceFactory)
             .setAudioAttributes(
                 AudioAttributes.Builder()
                     .setContentType(C.AUDIO_CONTENT_TYPE_MUSIC)
@@ -360,7 +376,12 @@ class PlaybackService : MediaSessionService() {
                 if (isPlaying) {
                     markCurrentAlbumPlayed()
                 } else {
-                    abandonPlaybackAudioFocus()
+                    if (
+                        !autoPausedByAudioFocusLoss &&
+                        (!exoPlayer.playWhenReady || exoPlayer.playbackState == Player.STATE_ENDED)
+                    ) {
+                        abandonPlaybackAudioFocus()
+                    }
                     serviceScope.launch { persistCurrentTrackProgressIfNeeded(force = true) }
                     serviceScope.launch { listeningRecordRepository.flush() }
                 }
@@ -368,6 +389,7 @@ class PlaybackService : MediaSessionService() {
             }
 
             override fun onMediaItemTransition(mediaItem: androidx.media3.common.MediaItem?, reason: Int) {
+                cancelPlaybackRecovery(resetPolicy = true)
                 serviceScope.launch { updateArtworkForCurrentMedia() }
                 serviceScope.launch { loadLyricsForCurrentMedia() }
                 applyVideoSurfaceVisibility()
@@ -381,6 +403,26 @@ class PlaybackService : MediaSessionService() {
                 currentTrackListenedMs = 0L
                 isCurrentTrackCounted = false
                 lastProgressPersistElapsedMs = 0L
+            }
+
+            override fun onPlaybackStateChanged(playbackState: Int) {
+                when (playbackState) {
+                    Player.STATE_READY -> cancelPlaybackRecovery(resetPolicy = true)
+                    Player.STATE_ENDED -> abandonPlaybackAudioFocus()
+                }
+            }
+
+            override fun onPlayWhenReadyChanged(playWhenReady: Boolean, reason: Int) {
+                if (!playWhenReady) {
+                    cancelPlaybackRecovery(resetPolicy = true)
+                    if (!autoPausedByAudioFocusLoss) {
+                        abandonPlaybackAudioFocus()
+                    }
+                }
+            }
+
+            override fun onPlayerError(error: PlaybackException) {
+                schedulePlaybackRecovery(error)
             }
 
             override fun onEvents(player: Player, events: Player.Events) {
@@ -450,8 +492,12 @@ class PlaybackService : MediaSessionService() {
             settingsRepository.pauseOnOtherAudio.collectLatest { enabled ->
                 pauseOnOtherAudioEnabled = enabled
                 if (!enabled) {
+                    val shouldResume = autoPausedByAudioFocusLoss
                     autoPausedByAudioFocusLoss = false
                     abandonPlaybackAudioFocus()
+                    if (shouldResume) {
+                        runCatching { sessionPlayer.play() }
+                    }
                 } else if (exoPlayer.isPlaying && !hasAudioFocus) {
                     requestPlaybackAudioFocus()
                 }
@@ -690,14 +736,99 @@ class PlaybackService : MediaSessionService() {
         return hasAudioFocus
     }
 
-    private fun handleAudioFocusLoss() {
+    private fun handleAudioFocusGain() {
+        hasAudioFocus = true
+        if (!autoPausedByAudioFocusLoss) return
+        autoPausedByAudioFocusLoss = false
         if (!pauseOnOtherAudioEnabled) return
-        if (!exoPlayer.isPlaying) return
-        autoPausedByAudioFocusLoss = true
+        if (exoPlayer.mediaItemCount == 0 || exoPlayer.playbackState == Player.STATE_ENDED) return
+
+        Log.d("PlaybackService", "Resume after transient audio focus loss")
+        serviceScope.launch(Dispatchers.Main.immediate) {
+            runCatching { sessionPlayer.play() }
+                .onFailure { Log.w("PlaybackService", "Failed to resume after audio focus gain", it) }
+        }
+    }
+
+    private fun handleAudioFocusLoss(resumeWhenFocusReturns: Boolean) {
+        if (!pauseOnOtherAudioEnabled) return
+        if (!exoPlayer.playWhenReady) return
+        autoPausedByAudioFocusLoss = resumeWhenFocusReturns
         Log.d("PlaybackService", "Auto pause due to audio focus loss")
         serviceScope.launch(Dispatchers.Main.immediate) {
             sessionPlayer.pause()
         }
+    }
+
+    private fun schedulePlaybackRecovery(error: PlaybackException) {
+        val item = exoPlayer.currentMediaItem ?: return
+        if (!exoPlayer.playWhenReady) return
+
+        val mediaItemIndex = exoPlayer.currentMediaItemIndex
+        val uri = item.localConfiguration?.uri?.toString().orEmpty()
+        if (
+            !isRecoverableRemotePlaybackFailure(
+                uriText = uri,
+                errorCode = error.errorCode,
+                httpStatusCode = error.findHttpStatusCode()
+            )
+        ) {
+            return
+        }
+
+        val mediaKey = "$mediaItemIndex:${item.mediaId}:$uri"
+        val attempt = playbackRecoveryPolicy.nextAttempt(mediaKey)
+        if (attempt == null) {
+            Log.e(
+                "PlaybackService",
+                "Playback recovery exhausted for mediaId=${item.mediaId} error=${error.errorCodeName}"
+            )
+            return
+        }
+
+        playbackRecoveryJob?.cancel()
+        playbackRecoveryJob = serviceScope.launch(Dispatchers.Main.immediate) {
+            Log.w(
+                "PlaybackService",
+                "Scheduling playback recovery attempt=${attempt.number} delayMs=${attempt.delayMs} " +
+                    "mediaId=${item.mediaId} error=${error.errorCodeName}"
+            )
+            delay(attempt.delayMs)
+            if (!exoPlayer.playWhenReady) return@launch
+            val currentItem = exoPlayer.currentMediaItem ?: return@launch
+            val currentUri = currentItem.localConfiguration?.uri?.toString().orEmpty()
+            if (
+                exoPlayer.currentMediaItemIndex != mediaItemIndex ||
+                currentItem.mediaId != item.mediaId ||
+                currentUri != uri
+            ) {
+                return@launch
+            }
+            if (exoPlayer.playerError !== error || exoPlayer.playbackState != Player.STATE_IDLE) return@launch
+
+            val resumePositionMs = exoPlayer.currentPosition.coerceAtLeast(0L)
+            exoPlayer.seekTo(resumePositionMs)
+            exoPlayer.prepare()
+        }
+    }
+
+    private fun cancelPlaybackRecovery(resetPolicy: Boolean) {
+        playbackRecoveryJob?.cancel()
+        playbackRecoveryJob = null
+        if (resetPolicy) {
+            playbackRecoveryPolicy.reset()
+        }
+    }
+
+    private fun PlaybackException.findHttpStatusCode(): Int? {
+        var current: Throwable? = this
+        while (current != null) {
+            if (current is HttpDataSource.InvalidResponseCodeException) {
+                return current.responseCode
+            }
+            current = current.cause
+        }
+        return null
     }
 
     private fun abandonPlaybackAudioFocus() {
@@ -1162,6 +1293,7 @@ class PlaybackService : MediaSessionService() {
     override fun onDestroy() {
         overlay?.hide()
         statsJob?.cancel()
+        cancelPlaybackRecovery(resetPolicy = true)
         effectApplyJob?.cancel()
         sleepTimerJob?.cancel()
         unregisterPlaybackRouteListeners()
@@ -1192,5 +1324,8 @@ class PlaybackService : MediaSessionService() {
         private const val MEDIA_NOTIFICATION_CONTROLLER_HINT =
             "androidx.media3.session.MediaNotificationManager"
         private const val OUTPUT_EVENT_DEBOUNCE_MS = 1200L
+        private const val NETWORK_CONNECT_TIMEOUT_MS = 15_000
+        private const val NETWORK_READ_TIMEOUT_MS = 30_000
+        private const val NETWORK_MINIMUM_LOADABLE_RETRY_COUNT = 6
     }
 }

--- a/app/src/test/java/com/asmr/player/playback/PlaybackRecoveryPolicyTest.kt
+++ b/app/src/test/java/com/asmr/player/playback/PlaybackRecoveryPolicyTest.kt
@@ -1,0 +1,102 @@
+package com.asmr.player.playback
+
+import androidx.media3.common.PlaybackException
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class PlaybackRecoveryPolicyTest {
+
+    @Test
+    fun retriesUseBoundedExponentialBackoff() {
+        val policy = PlaybackRecoveryPolicy(
+            maxAttempts = 4,
+            initialDelayMs = 1_000L,
+            maxDelayMs = 5_000L
+        )
+
+        assertEquals(PlaybackRecoveryAttempt(1, 1_000L), policy.nextAttempt("track"))
+        assertEquals(PlaybackRecoveryAttempt(2, 2_000L), policy.nextAttempt("track"))
+        assertEquals(PlaybackRecoveryAttempt(3, 4_000L), policy.nextAttempt("track"))
+        assertEquals(PlaybackRecoveryAttempt(4, 5_000L), policy.nextAttempt("track"))
+        assertNull(policy.nextAttempt("track"))
+    }
+
+    @Test
+    fun changingMediaResetsRetryBudget() {
+        val policy = PlaybackRecoveryPolicy(maxAttempts = 1)
+
+        assertEquals(1, policy.nextAttempt("first")?.number)
+        assertNull(policy.nextAttempt("first"))
+        assertEquals(1, policy.nextAttempt("second")?.number)
+    }
+
+    @Test
+    fun resetRestoresRetryBudget() {
+        val policy = PlaybackRecoveryPolicy(maxAttempts = 1)
+
+        assertEquals(1, policy.nextAttempt("track")?.number)
+        policy.reset()
+
+        assertEquals(1, policy.nextAttempt("track")?.number)
+    }
+
+    @Test
+    fun remoteNetworkFailuresAreRecoverable() {
+        assertTrue(
+            isRecoverableRemotePlaybackFailure(
+                uriText = "https://example.com/audio.flac",
+                errorCode = PlaybackException.ERROR_CODE_IO_NETWORK_CONNECTION_FAILED
+            )
+        )
+        assertTrue(
+            isRecoverableRemotePlaybackFailure(
+                uriText = "http://example.com/audio.wav",
+                errorCode = PlaybackException.ERROR_CODE_IO_NETWORK_CONNECTION_TIMEOUT
+            )
+        )
+    }
+
+    @Test
+    fun onlyTransientHttpStatusesAreRecoverable() {
+        assertTrue(
+            isRecoverableRemotePlaybackFailure(
+                uriText = "https://example.com/audio.mp3",
+                errorCode = PlaybackException.ERROR_CODE_IO_BAD_HTTP_STATUS,
+                httpStatusCode = 503
+            )
+        )
+        assertTrue(
+            isRecoverableRemotePlaybackFailure(
+                uriText = "https://example.com/audio.mp3",
+                errorCode = PlaybackException.ERROR_CODE_IO_BAD_HTTP_STATUS,
+                httpStatusCode = 429
+            )
+        )
+        assertFalse(
+            isRecoverableRemotePlaybackFailure(
+                uriText = "https://example.com/missing.mp3",
+                errorCode = PlaybackException.ERROR_CODE_IO_BAD_HTTP_STATUS,
+                httpStatusCode = 404
+            )
+        )
+    }
+
+    @Test
+    fun localAndUnsupportedFailuresAreNotRetried() {
+        assertFalse(
+            isRecoverableRemotePlaybackFailure(
+                uriText = "file:///storage/emulated/0/audio.mp3",
+                errorCode = PlaybackException.ERROR_CODE_IO_NETWORK_CONNECTION_FAILED
+            )
+        )
+        assertFalse(
+            isRecoverableRemotePlaybackFailure(
+                uriText = "https://example.com/audio.mp3",
+                errorCode = PlaybackException.ERROR_CODE_DECODING_FAILED
+            )
+        )
+    }
+}


### PR DESCRIPTION
增强网络播放容错：延长网络超时、增加 Media3 加载重试，并在终止性网络错误后进行有限退避恢复；修复短暂音频焦点丢失后无法续播；允许用户从播放器错误态主动重新准备。验证：PlaybackRecoveryPolicyTest 通过，assembleRelease 与 Release lint 通过，已在连接设备完成 installRelease 覆盖安装。