### PR TITLE
feat: 接入猜你喜欢推荐

### DIFF
--- a/app/src/main/java/com/asmr/player/data/local/db/dao/ListeningSessionDao.kt
+++ b/app/src/main/java/com/asmr/player/data/local/db/dao/ListeningSessionDao.kt
@@ -53,6 +53,14 @@ interface ListeningSessionDao {
     @Query("SELECT * FROM listening_sessions WHERE listeningDate = :date ORDER BY startAtMs DESC")
     suspend fun getSessionsForDate(date: String): List<ListeningSessionEntity>
 
+    @Query(
+        "SELECT UPPER(TRIM(rjCode)) FROM listening_sessions " +
+            "WHERE TRIM(rjCode) != '' " +
+            "GROUP BY UPPER(TRIM(rjCode)) " +
+            "ORDER BY MAX(lastActiveAtMs) DESC LIMIT :limit"
+    )
+    suspend fun getRecentDistinctRjs(limit: Int): List<String>
+
     // ---- 年度报告数据基础：聚合查询 ----
 
     /** 区间内不同作品数量（按 rjCode 去重，忽略空 rjCode）。 */

--- a/app/src/main/java/com/asmr/player/data/remote/api/AsmrOneAvailabilityApi.kt
+++ b/app/src/main/java/com/asmr/player/data/remote/api/AsmrOneAvailabilityApi.kt
@@ -69,6 +69,29 @@ data class AsmrOneCollectedSearchItem(
     val rateAverage2dp: Double? = null
 )
 
+data class AsmrOneRecommendationRequest(
+    val seedRjs: List<String>,
+    val excludeRjs: List<String>,
+    val limit: Int
+)
+
+data class AsmrOneRecommendationResponse(
+    val items: List<AsmrOneRecommendationItem>? = emptyList(),
+    val matchedSeedRjs: List<String>? = emptyList(),
+    val unmatchedSeedRjs: List<String>? = emptyList(),
+    val limit: Int = 0,
+    val serverTimeEpochMs: Long = 0L
+)
+
+data class AsmrOneRecommendationItem(
+    val rj: String = "",
+    val title: String = "",
+    val cvs: List<String>? = emptyList(),
+    val matchedRjs: List<String>? = emptyList(),
+    val originalWorkno: String = "",
+    val mainCoverUrl: String = ""
+)
+
 data class AsmrOneBackendTrackTreeResponse(
     val rj: String = "",
     val workId: Int = 0,
@@ -99,6 +122,9 @@ class AsmrOneAvailabilityApi @Inject constructor(
     private val userAgent = buildUserAgent()
     private val requestClient by lazy { okHttpClient.withSearchTimeouts() }
     private val trackTreeClient by lazy { okHttpClient.withBackendTrackTreeTimeouts() }
+
+    val isBackendConfigured: Boolean
+        get() = backendBaseUrl.isNotBlank()
 
     suspend fun check(rjs: List<String>): Map<String, Boolean> {
         val normalized = rjs
@@ -176,6 +202,41 @@ class AsmrOneAvailabilityApi @Inject constructor(
         }
     }
 
+    suspend fun getRecommendations(
+        seedRjs: List<String>,
+        excludeRjs: List<String>,
+        limit: Int
+    ): AsmrOneRecommendationResponse {
+        if (!isBackendConfigured) throw IOException("asmr.one backend is not configured")
+        val normalizedSeeds = normalizeRecommendationRjs(seedRjs, MAX_RECOMMENDATION_SEEDS)
+        if (normalizedSeeds.isEmpty()) return AsmrOneRecommendationResponse()
+        val requestBody = AsmrOneRecommendationRequest(
+            seedRjs = normalizedSeeds,
+            excludeRjs = normalizeRecommendationRjs(excludeRjs, MAX_RECOMMENDATION_EXCLUDES),
+            limit = limit.coerceIn(1, MAX_RECOMMENDATION_LIMIT)
+        )
+        return withContext(Dispatchers.IO) {
+            val request = Request.Builder()
+                .url(resolveUrl("api/asmr-one/recommendations"))
+                .header("User-Agent", userAgent)
+                .header("X-Listen-Together-App", appHeaderValue)
+                .header("X-Listen-Together-Client-Session-Id", clientSessionId)
+                .header("X-Listen-Together-Device-Fingerprint", deviceFingerprint)
+                .header(NetworkHeaders.HEADER_SILENT_IO_ERROR, NetworkHeaders.SILENT_IO_ERROR_ON)
+                .post(gson.toJson(requestBody).toRequestBody(JSON_MEDIA_TYPE))
+                .build()
+            requestClient.newCall(request).awaitResponse().use { response ->
+                if (!response.isSuccessful) {
+                    throw IOException("asmr.one recommendations failed: HTTP ${response.code}")
+                }
+                val raw = response.body?.string().orEmpty()
+                if (raw.isBlank()) return@withContext AsmrOneRecommendationResponse()
+                gson.fromJson(raw, AsmrOneRecommendationResponse::class.java)
+                    ?: AsmrOneRecommendationResponse()
+            }
+        }
+    }
+
     suspend fun getTrackTreeByRj(rj: String): AsmrOneBackendTrackTreeResponse {
         if (backendBaseUrl.isBlank()) throw IOException("asmr.one backend is not configured")
         val normalizedRj = rj.trim().uppercase()
@@ -248,8 +309,21 @@ class AsmrOneAvailabilityApi @Inject constructor(
         private val JSON_MEDIA_TYPE = "application/json; charset=utf-8".toMediaType()
         private val RJ_CODE_REGEX = Regex("""RJ\d{6,}""")
         private const val MAX_RJS = 100
+        private const val MAX_RECOMMENDATION_SEEDS = 20
+        private const val MAX_RECOMMENDATION_EXCLUDES = 200
+        private const val MAX_RECOMMENDATION_LIMIT = 50
     }
 }
+
+internal fun normalizeRecommendationRjs(values: List<String>, limit: Int): List<String> =
+    values.asSequence()
+        .map { it.trim().uppercase() }
+        .filter { RECOMMENDATION_RJ_CODE_REGEX.matches(it) }
+        .distinct()
+        .take(limit.coerceAtLeast(0))
+        .toList()
+
+private val RECOMMENDATION_RJ_CODE_REGEX = Regex("""RJ\d{6,}""")
 
 private fun AsmrOneAvailabilityItem.matchedRequestRjs(requested: Set<String>): List<String> {
     if (requested.isEmpty()) return emptyList()

--- a/app/src/main/java/com/asmr/player/data/repository/ListeningRecordRepository.kt
+++ b/app/src/main/java/com/asmr/player/data/repository/ListeningRecordRepository.kt
@@ -181,6 +181,15 @@ class ListeningRecordRepository @Inject constructor(
     fun observeSessionsForDate(date: String): Flow<List<ListeningSessionEntity>> =
         sessionDao.observeSessionsForDate(date)
 
+    suspend fun recentRjs(limit: Int): List<String> =
+        if (limit <= 0) {
+            emptyList()
+        } else {
+            withContext(Dispatchers.IO) {
+                sessionDao.getRecentDistinctRjs(limit.coerceAtMost(MAX_RECENT_RJS))
+            }
+        }
+
     suspend fun distinctWorkCount(startDate: String, endDate: String): Int =
         withContext(Dispatchers.IO) { sessionDao.distinctWorkCount(startDate, endDate) }
 
@@ -221,5 +230,6 @@ class ListeningRecordRepository @Inject constructor(
         private const val SESSION_GAP_MS = 30L * 60L * 1000L
         /** 写回数据库的节流间隔（5 秒）。 */
         private const val PERSIST_INTERVAL_MS = 5_000L
+        private const val MAX_RECENT_RJS = 200
     }
 }

--- a/app/src/main/java/com/asmr/player/hotlistening/HotListeningApi.kt
+++ b/app/src/main/java/com/asmr/player/hotlistening/HotListeningApi.kt
@@ -68,7 +68,6 @@ data class SearchSuggestionTerm(
 data class SearchSuggestionsResponse(
     val hotCvs: List<SearchSuggestionTerm> = emptyList(),
     val hotTags: List<SearchSuggestionTerm> = emptyList(),
-    val hotWorks: List<HotListeningItem> = emptyList(),
     val serverTimeEpochMs: Long = 0L
 )
 

--- a/app/src/main/java/com/asmr/player/main/MainContainer.kt
+++ b/app/src/main/java/com/asmr/player/main/MainContainer.kt
@@ -2022,11 +2022,7 @@ fun MainContainer(
                         SearchAssistScreen(
                             windowSizeClass = windowSizeClass,
                             initialRequest = searchAssistInitialRequest,
-                            onSubmitSearch = ::submitSearchAssistRequest,
-                            onOpenFullRanking = {
-                                navController.popBackStack(Routes.Search, false)
-                                openPrimaryRoute(Routes.HotListening)
-                            }
+                            onSubmitSearch = ::submitSearchAssistRequest
                         )
                     }
                 }
@@ -2052,11 +2048,7 @@ fun MainContainer(
                         SearchAssistScreen(
                             windowSizeClass = windowSizeClass,
                             initialRequest = initialRequest,
-                            onSubmitSearch = ::submitSearchAssistRequest,
-                            onOpenFullRanking = {
-                                navController.popBackStack(Routes.Search, false)
-                                openPrimaryRoute(Routes.HotListening)
-                            }
+                            onSubmitSearch = ::submitSearchAssistRequest
                         )
                     }
                 }

--- a/app/src/main/java/com/asmr/player/ui/search/SearchAssistScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/search/SearchAssistScreen.kt
@@ -24,7 +24,7 @@ import androidx.compose.material.icons.automirrored.rounded.KeyboardArrowRight
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.Delete
 import androidx.compose.material.icons.rounded.KeyboardArrowDown
-import androidx.compose.material.icons.rounded.Leaderboard
+import androidx.compose.material.icons.rounded.Refresh
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
@@ -82,8 +82,8 @@ internal const val SEARCH_ASSIST_INPUT_TAG = "search_assist_input"
 internal const val SEARCH_ASSIST_SUBMIT_TAG = "search_assist_submit"
 internal const val SEARCH_ASSIST_CLEAR_TAG = "search_assist_clear"
 internal const val SEARCH_ASSIST_HISTORY_CLEAR_TAG = "search_assist_history_clear"
-internal const val SEARCH_ASSIST_HOT_WORK_CARD_TAG = "search_assist_hot_work_card"
-internal const val SEARCH_ASSIST_FULL_RANKING_TAG = "search_assist_full_ranking"
+internal const val SEARCH_ASSIST_RECOMMENDATION_CARD_TAG = "search_assist_recommendation_card"
+internal const val SEARCH_ASSIST_RECOMMENDATION_REFRESH_TAG = "search_assist_recommendation_refresh"
 internal const val SEARCH_ASSIST_CHROME_TAG = "search_assist_chrome"
 private const val SearchAssistCollapsedRows = 2
 private val SearchAssistChromeContentGap = 8.dp
@@ -96,7 +96,6 @@ fun SearchAssistScreen(
     windowSizeClass: WindowSizeClass,
     initialRequest: SearchAssistSearchRequest,
     onSubmitSearch: (SearchAssistSearchRequest) -> Unit,
-    onOpenFullRanking: () -> Unit,
     viewModel: SearchAssistViewModel = hiltViewModel()
 ) {
     val uiState by viewModel.uiState.collectAsState()
@@ -112,7 +111,7 @@ fun SearchAssistScreen(
             uiState = uiState,
             onSubmitSearch = { request -> viewModel.submitSearch(request, onSubmitSearch) },
             onClearHistory = viewModel::clearHistory,
-            onOpenFullRanking = onOpenFullRanking
+            onRefreshRecommendations = viewModel::refreshRecommendations
         )
     }
 }
@@ -124,7 +123,7 @@ internal fun SearchAssistContent(
     uiState: SearchAssistUiState,
     onSubmitSearch: (SearchAssistSearchRequest) -> Unit,
     onClearHistory: () -> Unit,
-    onOpenFullRanking: () -> Unit
+    onRefreshRecommendations: () -> Unit
 ) {
     val keyboardController = LocalSoftwareKeyboardController.current
     val inputFocusRequester = remember { FocusRequester() }
@@ -326,68 +325,72 @@ internal fun SearchAssistContent(
                 item(contentType = "hotTagsLoading") {
                     SearchAssistTermSectionSkeleton(title = "热门标签")
                 }
-                item(contentType = "hotWorksLoading") {
+            } else {
+                if (uiState.suggestions.hotCvs.isNotEmpty()) {
+                    item(contentType = "hotCvs") {
+                        SearchAssistTermSection(
+                            title = "热门声优",
+                            terms = uiState.suggestions.hotCvs,
+                            expanded = hotCvsExpanded,
+                            onExpandedChange = { hotCvsExpanded = it },
+                            onTermClick = { submit(it) }
+                        )
+                    }
+                }
+                if (uiState.suggestions.hotTags.isNotEmpty()) {
+                    item(contentType = "hotTags") {
+                        SearchAssistTermSection(
+                            title = "热门标签",
+                            terms = uiState.suggestions.hotTags,
+                            expanded = hotTagsExpanded,
+                            onExpandedChange = { hotTagsExpanded = it },
+                            onTermClick = { submit(it) }
+                        )
+                    }
+                }
+            }
+
+            if (uiState.isLoadingRecommendations && uiState.suggestions.recommendations.isEmpty()) {
+                item(contentType = "recommendationsLoading") {
                     SearchAssistWorkSectionSkeleton(
-                        title = "热门作品",
+                        title = "猜你喜欢",
                         compact = isCompact
                     )
                 }
-            } else if (uiState.suggestions.hotCvs.isNotEmpty()) {
-                item(contentType = "hotCvs") {
-                    SearchAssistTermSection(
-                        title = "热门声优",
-                        terms = uiState.suggestions.hotCvs,
-                        expanded = hotCvsExpanded,
-                        onExpandedChange = { hotCvsExpanded = it },
-                        onTermClick = { submit(it) }
-                    )
-                }
-            }
-
-            if (uiState.suggestions.hotTags.isNotEmpty()) {
-                item(contentType = "hotTags") {
-                    SearchAssistTermSection(
-                        title = "热门标签",
-                        terms = uiState.suggestions.hotTags,
-                        expanded = hotTagsExpanded,
-                        onExpandedChange = { hotTagsExpanded = it },
-                        onTermClick = { submit(it) }
-                    )
-                }
-            }
-
-            if (uiState.suggestions.hotWorks.isNotEmpty()) {
-                item(contentType = "hotWorks") {
+            } else if (uiState.suggestions.recommendations.isNotEmpty()) {
+                item(contentType = "recommendations") {
                     SearchAssistSection(
-                        title = "热门作品",
+                        title = "猜你喜欢",
                         trailing = {
                             TextButton(
-                                onClick = onOpenFullRanking,
-                                modifier = Modifier.testTag(SEARCH_ASSIST_FULL_RANKING_TAG)
+                                onClick = onRefreshRecommendations,
+                                enabled = !uiState.isLoadingRecommendations,
+                                modifier = Modifier.testTag(SEARCH_ASSIST_RECOMMENDATION_REFRESH_TAG)
                             ) {
                                 Icon(
-                                    imageVector = Icons.Rounded.Leaderboard,
+                                    imageVector = Icons.Rounded.Refresh,
                                     contentDescription = null,
                                     modifier = Modifier.size(16.dp)
                                 )
-                                Text("查看完整榜单")
+                                Text(if (uiState.isLoadingRecommendations) "推荐中" else "换一批")
                             }
                         }
                     ) {
-                        val rows = uiState.suggestions.hotWorks.chunked(2)
+                        val rows = uiState.suggestions.recommendations.chunked(2)
                         Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
                             rows.forEach { row ->
                                 Row(
                                     modifier = Modifier.fillMaxWidth(),
                                     horizontalArrangement = Arrangement.spacedBy(8.dp)
                                 ) {
-                                    row.forEach { work ->
-                                        SearchAssistWorkChip(
-                                            work = work,
+                                    row.forEach { recommendation ->
+                                        SearchAssistRecommendationCard(
+                                            recommendation = recommendation,
                                             modifier = Modifier.weight(1f),
                                             compact = isCompact,
                                             onClick = {
-                                                val rj = work.album.rjCode.ifBlank { work.album.workId }
+                                                val album = recommendation.album
+                                                val rj = album.rjCode.ifBlank { album.workId }
                                                 submit(rj)
                                             }
                                         )
@@ -780,14 +783,14 @@ private fun HeaderIconButton(
 }
 
 @Composable
-private fun SearchAssistWorkChip(
-    work: SearchAssistHotWork,
+private fun SearchAssistRecommendationCard(
+    recommendation: SearchAssistRecommendation,
     compact: Boolean,
     onClick: () -> Unit,
     modifier: Modifier = Modifier
 ) {
     val colorScheme = AsmrTheme.colorScheme
-    val album = work.album
+    val album = recommendation.album
     val shape = RoundedCornerShape(8.dp)
     val coverData = album.coverThumbPath.takeIf { it.isNotBlank() && it.contains("_v2") }
         .orEmpty()
@@ -803,10 +806,7 @@ private fun SearchAssistWorkChip(
     }
     val containerColor = colorScheme.surface.copy(alpha = if (colorScheme.isDark) 0.72f else 0.82f)
         .compositeOver(colorScheme.background)
-    val meta = listOf(album.cv, album.circle)
-        .map { it.trim() }
-        .firstOrNull { it.isNotBlank() }
-        .orEmpty()
+    val cv = album.cv.trim()
 
     Row(
         modifier = modifier
@@ -819,7 +819,7 @@ private fun SearchAssistWorkChip(
                 shape = shape
             )
             .clickable(onClick = onClick)
-            .testTag(SEARCH_ASSIST_HOT_WORK_CARD_TAG),
+            .testTag(SEARCH_ASSIST_RECOMMENDATION_CARD_TAG),
         verticalAlignment = Alignment.CenterVertically
     ) {
         AsmrAsyncImage(
@@ -840,15 +840,15 @@ private fun SearchAssistWorkChip(
             verticalArrangement = Arrangement.spacedBy(4.dp)
         ) {
             Text(
-                text = album.title.ifBlank { "热门作品" },
+                text = album.title.ifBlank { "推荐作品" },
                 style = MaterialTheme.typography.labelMedium,
                 color = colorScheme.textPrimary,
                 maxLines = 2,
                 overflow = TextOverflow.Ellipsis
             )
-            if (meta.isNotBlank()) {
+            if (cv.isNotBlank()) {
                 Text(
-                    text = meta,
+                    text = cv,
                     style = MaterialTheme.typography.labelSmall,
                     color = colorScheme.textSecondary,
                     maxLines = 1,

--- a/app/src/main/java/com/asmr/player/ui/search/SearchAssistViewModel.kt
+++ b/app/src/main/java/com/asmr/player/ui/search/SearchAssistViewModel.kt
@@ -3,11 +3,16 @@ package com.asmr.player.ui.search
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.asmr.player.data.local.datastore.SearchCacheStore
+import com.asmr.player.data.remote.api.AsmrOneAvailabilityApi
+import com.asmr.player.data.remote.api.AsmrOneRecommendationItem
+import com.asmr.player.data.remote.api.AsmrOneRecommendationResponse
+import com.asmr.player.data.remote.api.normalizeRecommendationRjs
+import com.asmr.player.data.repository.ListeningRecordRepository
 import com.asmr.player.domain.model.Album
 import com.asmr.player.hotlistening.HotListeningApi
-import com.asmr.player.hotlistening.HotListeningItem
 import com.asmr.player.hotlistening.SearchSuggestionTerm
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -54,20 +59,23 @@ data class SearchAssistSearchRequest(
 @HiltViewModel
 class SearchAssistViewModel @Inject constructor(
     private val searchCacheStore: SearchCacheStore,
-    private val hotListeningApi: HotListeningApi
+    private val hotListeningApi: HotListeningApi,
+    private val asmrOneAvailabilityApi: AsmrOneAvailabilityApi,
+    private val listeningRecordRepository: ListeningRecordRepository
 ) : ViewModel() {
     private val _uiState = MutableStateFlow(SearchAssistUiState())
     val uiState: StateFlow<SearchAssistUiState> = _uiState.asStateFlow()
+    private var listenedRjs: List<String> = emptyList()
+    private val recommendationSeenRjs = linkedSetOf<String>()
 
     init {
         refresh()
     }
 
     fun refresh() {
-        viewModelScope.launch {
-            loadHistory()
-            loadSuggestions()
-        }
+        viewModelScope.launch { loadHistory() }
+        viewModelScope.launch { loadSuggestionTerms() }
+        viewModelScope.launch { loadRecommendations() }
     }
 
     fun submitSearch(request: SearchAssistSearchRequest, onSubmitted: (SearchAssistSearchRequest) -> Unit) {
@@ -94,10 +102,13 @@ class SearchAssistViewModel @Inject constructor(
         _uiState.update { it.copy(history = history) }
     }
 
-    private suspend fun loadSuggestions() {
+    private suspend fun loadSuggestionTerms() {
         if (!hotListeningApi.isBackendConfigured) {
             _uiState.update {
-                it.copy(isLoadingSuggestions = false, suggestions = SearchSuggestionsUiData())
+                it.copy(
+                    isLoadingSuggestions = false,
+                    suggestions = it.suggestions.copy(hotCvs = emptyList(), hotTags = emptyList())
+                )
             }
             return
         }
@@ -111,44 +122,181 @@ class SearchAssistViewModel @Inject constructor(
                         .filter { term -> term.value.isNotBlank() },
                     hotTags = suggestions?.hotTags.orEmpty()
                         .filter { term -> term.value.isNotBlank() },
-                    hotWorks = suggestions?.hotWorks.orEmpty()
-                        .filter { item -> item.rj.isNotBlank() || item.title.isNotBlank() }
-                        .take(10)
-                        .map { item -> item.toHotWork() }
+                    recommendations = it.suggestions.recommendations
                 )
             )
         }
+    }
+
+    fun refreshRecommendations() {
+        if (_uiState.value.isLoadingRecommendations || listenedRjs.isEmpty()) return
+        _uiState.update { it.copy(isLoadingRecommendations = true) }
+        viewModelScope.launch {
+            loadRecommendationBatch(retryWithoutSeenWhenEmpty = true)
+        }
+    }
+
+    private suspend fun loadRecommendations() {
+        if (!asmrOneAvailabilityApi.isBackendConfigured) {
+            _uiState.update {
+                it.copy(
+                    isLoadingRecommendations = false,
+                    suggestions = it.suggestions.copy(recommendations = emptyList())
+                )
+            }
+            return
+        }
+        _uiState.update { it.copy(isLoadingRecommendations = true) }
+        listenedRjs = normalizeRecommendationRjs(
+            values = try {
+                listeningRecordRepository.recentRjs(MAX_RECOMMENDATION_EXCLUDES)
+            } catch (error: CancellationException) {
+                throw error
+            } catch (_: Throwable) {
+                emptyList()
+            },
+            limit = MAX_RECOMMENDATION_EXCLUDES
+        )
+        recommendationSeenRjs.clear()
+        if (listenedRjs.isEmpty()) {
+            _uiState.update {
+                it.copy(
+                    isLoadingRecommendations = false,
+                    suggestions = it.suggestions.copy(recommendations = emptyList())
+                )
+            }
+            return
+        }
+        loadRecommendationBatch(retryWithoutSeenWhenEmpty = false)
+    }
+
+    private suspend fun loadRecommendationBatch(retryWithoutSeenWhenEmpty: Boolean) {
+        _uiState.update { it.copy(isLoadingRecommendations = true) }
+        val exclusionPlan = planRecommendationExclusions(
+            listenedRjs = listenedRjs,
+            recommendationSeenRjs = recommendationSeenRjs.toList(),
+            maxExcludes = MAX_RECOMMENDATION_EXCLUDES
+        )
+        if (exclusionPlan.resetRecommendationSeen) {
+            recommendationSeenRjs.clear()
+        }
+        var response = requestRecommendations(exclusionPlan.excludeRjs)
+        if (
+            retryWithoutSeenWhenEmpty &&
+            response != null &&
+            response.items.orEmpty().isEmpty() &&
+            recommendationSeenRjs.isNotEmpty()
+        ) {
+            recommendationSeenRjs.clear()
+            response = requestRecommendations(listenedRjs)
+        }
+        if (response == null) {
+            _uiState.update { it.copy(isLoadingRecommendations = false) }
+            return
+        }
+        val items = response.items.orEmpty()
+        items.flatMapTo(recommendationSeenRjs) { item -> item.recommendationExclusionRjs() }
+        val recommendations = items
+            .map { item -> item.toSearchAssistRecommendation() }
+            .filter { recommendation -> recommendation.album.rjCode.isNotBlank() }
+            .take(RECOMMENDATION_DISPLAY_LIMIT)
+        _uiState.update {
+            it.copy(
+                isLoadingRecommendations = false,
+                suggestions = it.suggestions.copy(recommendations = recommendations)
+            )
+        }
+    }
+
+    private suspend fun requestRecommendations(excludeRjs: List<String>): AsmrOneRecommendationResponse? =
+        try {
+            asmrOneAvailabilityApi.getRecommendations(
+                seedRjs = listenedRjs.take(MAX_RECOMMENDATION_SEEDS),
+                excludeRjs = excludeRjs,
+                limit = RECOMMENDATION_DISPLAY_LIMIT
+            )
+        } catch (error: CancellationException) {
+            throw error
+        } catch (_: Throwable) {
+            null
+        }
+
+    private companion object {
+        const val MAX_RECOMMENDATION_SEEDS = 20
+        const val MAX_RECOMMENDATION_EXCLUDES = 200
+        const val RECOMMENDATION_DISPLAY_LIMIT = 20
     }
 }
 
 data class SearchAssistUiState(
     val history: List<String> = emptyList(),
     val suggestions: SearchSuggestionsUiData = SearchSuggestionsUiData(),
-    val isLoadingSuggestions: Boolean = true
+    val isLoadingSuggestions: Boolean = true,
+    val isLoadingRecommendations: Boolean = true
 )
 
 data class SearchSuggestionsUiData(
     val hotCvs: List<SearchSuggestionTerm> = emptyList(),
     val hotTags: List<SearchSuggestionTerm> = emptyList(),
-    val hotWorks: List<SearchAssistHotWork> = emptyList()
+    val recommendations: List<SearchAssistRecommendation> = emptyList()
 )
 
-data class SearchAssistHotWork(
-    val album: Album
-)
+data class SearchAssistRecommendation(val album: Album)
 
-internal fun HotListeningItem.toHotWork(): SearchAssistHotWork {
-    val normalizedRj = rj.trim().uppercase()
-    return SearchAssistHotWork(
+internal fun AsmrOneRecommendationItem.toSearchAssistRecommendation(): SearchAssistRecommendation {
+    val normalizedRj = buildList {
+        add(rj)
+        add(originalWorkno)
+        addAll(matchedRjs.orEmpty())
+    }
+        .asSequence()
+        .map { it.trim().uppercase() }
+        .firstOrNull { RECOMMENDATION_RJ_REGEX.matches(it) }
+        .orEmpty()
+    return SearchAssistRecommendation(
         album = Album(
-            title = title.trim().ifBlank { "热门作品" },
+            title = title.trim(),
             path = "",
             workId = normalizedRj,
             rjCode = normalizedRj,
-            circle = circle.trim(),
-            cv = cv.trim(),
-            tags = tagList,
-            coverUrl = coverUrl.trim()
+            cv = cvs.orEmpty()
+                .map { it.trim() }
+                .filter { it.isNotBlank() }
+                .joinToString(" / "),
+            coverUrl = mainCoverUrl.trim()
         )
     )
 }
+
+internal data class RecommendationExclusionPlan(
+    val excludeRjs: List<String>,
+    val resetRecommendationSeen: Boolean
+)
+
+internal fun planRecommendationExclusions(
+    listenedRjs: List<String>,
+    recommendationSeenRjs: List<String>,
+    maxExcludes: Int
+): RecommendationExclusionPlan {
+    val normalizedListened = normalizeRecommendationRjs(listenedRjs, maxExcludes)
+    val listenedSet = normalizedListened.toSet()
+    val normalizedSeen = normalizeRecommendationRjs(recommendationSeenRjs, Int.MAX_VALUE)
+        .filterNot(listenedSet::contains)
+    val shouldResetSeen = normalizedListened.size + normalizedSeen.size > maxExcludes
+    return RecommendationExclusionPlan(
+        excludeRjs = if (shouldResetSeen) normalizedListened else normalizedListened + normalizedSeen,
+        resetRecommendationSeen = shouldResetSeen
+    )
+}
+
+internal fun AsmrOneRecommendationItem.recommendationExclusionRjs(): List<String> =
+    normalizeRecommendationRjs(
+        values = buildList {
+            add(rj)
+            add(originalWorkno)
+            addAll(matchedRjs.orEmpty())
+        },
+        limit = Int.MAX_VALUE
+    )
+
+private val RECOMMENDATION_RJ_REGEX = Regex("""RJ\d{6,}""")

--- a/app/src/test/java/com/asmr/player/data/remote/api/AsmrOneRecommendationSupportTest.kt
+++ b/app/src/test/java/com/asmr/player/data/remote/api/AsmrOneRecommendationSupportTest.kt
@@ -1,0 +1,28 @@
+package com.asmr.player.data.remote.api
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class AsmrOneRecommendationSupportTest {
+    @Test
+    fun normalizeRecommendationRjsKeepsRecentValidUniqueValuesWithinLimit() {
+        val result = normalizeRecommendationRjs(
+            values = listOf(
+                " rj123456 ",
+                "RJ123456",
+                "not-an-rj",
+                "RJ654321",
+                "RJ12345",
+                "rj7777777"
+            ),
+            limit = 2
+        )
+
+        assertEquals(listOf("RJ123456", "RJ654321"), result)
+    }
+
+    @Test
+    fun normalizeRecommendationRjsReturnsEmptyForNonPositiveLimit() {
+        assertEquals(emptyList<String>(), normalizeRecommendationRjs(listOf("RJ123456"), 0))
+    }
+}

--- a/app/src/test/java/com/asmr/player/ui/search/SearchAssistRecommendationSupportTest.kt
+++ b/app/src/test/java/com/asmr/player/ui/search/SearchAssistRecommendationSupportTest.kt
@@ -1,0 +1,70 @@
+package com.asmr.player.ui.search
+
+import com.asmr.player.data.remote.api.AsmrOneRecommendationItem
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class SearchAssistRecommendationSupportTest {
+    @Test
+    fun recommendationMapsTitleCvAndCover() {
+        val recommendation = AsmrOneRecommendationItem(
+            rj = "rj123456",
+            title = "安眠作品",
+            cvs = listOf("声优 A", "", "声优 B"),
+            mainCoverUrl = "https://example.com/cover.jpg"
+        ).toSearchAssistRecommendation()
+
+        assertEquals("RJ123456", recommendation.album.rjCode)
+        assertEquals("安眠作品", recommendation.album.title)
+        assertEquals("声优 A / 声优 B", recommendation.album.cv)
+        assertEquals("https://example.com/cover.jpg", recommendation.album.coverUrl)
+    }
+
+    @Test
+    fun recommendationFallsBackToMatchedRj() {
+        val recommendation = AsmrOneRecommendationItem(
+            rj = "",
+            matchedRjs = listOf("invalid", "RJ765432")
+        ).toSearchAssistRecommendation()
+
+        assertEquals("RJ765432", recommendation.album.rjCode)
+    }
+
+    @Test
+    fun recommendationExclusionsContainEveryMatchedLanguageEdition() {
+        val exclusions = AsmrOneRecommendationItem(
+            rj = "RJ123456",
+            originalWorkno = "RJ654321",
+            matchedRjs = listOf("RJ123456", "RJ777777", "rj888888")
+        ).recommendationExclusionRjs()
+
+        assertEquals(
+            listOf("RJ123456", "RJ654321", "RJ777777", "RJ888888"),
+            exclusions
+        )
+    }
+
+    @Test
+    fun exclusionPlanKeepsExactLimitAndResetsOnlyAfterOverflow() {
+        val listened = (100000 until 100190).map { "RJ$it" }
+        val seenAtLimit = (200000 until 200010).map { "RJ$it" }
+
+        val exactLimitPlan = planRecommendationExclusions(
+            listenedRjs = listened,
+            recommendationSeenRjs = seenAtLimit,
+            maxExcludes = 200
+        )
+        assertFalse(exactLimitPlan.resetRecommendationSeen)
+        assertEquals(200, exactLimitPlan.excludeRjs.size)
+
+        val overflowPlan = planRecommendationExclusions(
+            listenedRjs = listened,
+            recommendationSeenRjs = seenAtLimit + "RJ200010",
+            maxExcludes = 200
+        )
+        assertTrue(overflowPlan.resetRecommendationSeen)
+        assertEquals(listened, overflowPlan.excludeRjs)
+    }
+}

--- a/app/src/test/java/com/asmr/player/ui/search/SearchAssistScreenTest.kt
+++ b/app/src/test/java/com/asmr/player/ui/search/SearchAssistScreenTest.kt
@@ -12,6 +12,7 @@ import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performImeAction
+import androidx.compose.ui.test.performScrollTo
 import androidx.compose.ui.test.performTextInput
 import androidx.compose.ui.test.performTouchInput
 import androidx.compose.ui.text.TextRange
@@ -42,7 +43,7 @@ class SearchAssistScreenTest {
                     uiState = SearchAssistUiState(),
                     onSubmitSearch = {},
                     onClearHistory = {},
-                    onOpenFullRanking = {}
+                    onRefreshRecommendations = {}
                 )
             }
         }
@@ -66,7 +67,7 @@ class SearchAssistScreenTest {
                     uiState = SearchAssistUiState(),
                     onSubmitSearch = {},
                     onClearHistory = {},
-                    onOpenFullRanking = {}
+                    onRefreshRecommendations = {}
                 )
             }
         }
@@ -93,7 +94,7 @@ class SearchAssistScreenTest {
                     uiState = SearchAssistUiState(),
                     onSubmitSearch = { submitted += it },
                     onClearHistory = {},
-                    onOpenFullRanking = {}
+                    onRefreshRecommendations = {}
                 )
             }
         }
@@ -121,11 +122,12 @@ class SearchAssistScreenTest {
                         suggestions = SearchSuggestionsUiData(
                             hotCvs = listOf(SearchSuggestionTerm(value = "CV A", count = 12, rank = 1)),
                             hotTags = listOf(SearchSuggestionTerm(value = "耳语", count = 8, rank = 1))
-                        )
+                        ),
+                        isLoadingSuggestions = false
                     ),
                     onSubmitSearch = { submitted += it },
                     onClearHistory = {},
-                    onOpenFullRanking = {}
+                    onRefreshRecommendations = {}
                 )
             }
         }
@@ -153,11 +155,12 @@ class SearchAssistScreenTest {
                     uiState = SearchAssistUiState(
                         suggestions = SearchSuggestionsUiData(
                             hotCvs = listOf(SearchSuggestionTerm(value = "CV A", count = 12, rank = 1))
-                        )
+                        ),
+                        isLoadingSuggestions = false
                     ),
                     onSubmitSearch = { submitted += it },
                     onClearHistory = {},
-                    onOpenFullRanking = {}
+                    onRefreshRecommendations = {}
                 )
             }
         }
@@ -181,11 +184,12 @@ class SearchAssistScreenTest {
                     uiState = SearchAssistUiState(
                         suggestions = SearchSuggestionsUiData(
                             hotCvs = listOf(SearchSuggestionTerm(value = "CV A", count = 12, rank = 1))
-                        )
+                        ),
+                        isLoadingSuggestions = false
                     ),
                     onSubmitSearch = { submitted += it },
                     onClearHistory = {},
-                    onOpenFullRanking = {}
+                    onRefreshRecommendations = {}
                 )
             }
         }
@@ -213,7 +217,7 @@ class SearchAssistScreenTest {
                     uiState = SearchAssistUiState(),
                     onSubmitSearch = { submitted += it },
                     onClearHistory = {},
-                    onOpenFullRanking = {}
+                    onRefreshRecommendations = {}
                 )
             }
         }
@@ -231,9 +235,9 @@ class SearchAssistScreenTest {
     }
 
     @Test
-    fun clearHistoryHotWorkAndFullRankingUseSeparateCallbacks() {
+    fun clearHistoryRecommendationCardAndRefreshUseSeparateCallbacks() {
         var clearHistoryCount = 0
-        var fullRankingCount = 0
+        var refreshRecommendationsCount = 0
         val submitted = mutableListOf<SearchAssistSearchRequest>()
         val firstAlbum = Album(
             title = "Rain Work",
@@ -260,15 +264,16 @@ class SearchAssistScreenTest {
                     uiState = SearchAssistUiState(
                         history = listOf("雨声"),
                         suggestions = SearchSuggestionsUiData(
-                            hotWorks = listOf(
-                                SearchAssistHotWork(album = firstAlbum),
-                                SearchAssistHotWork(album = secondAlbum)
+                            recommendations = listOf(
+                                SearchAssistRecommendation(album = firstAlbum),
+                                SearchAssistRecommendation(album = secondAlbum)
                             )
-                        )
+                        ),
+                        isLoadingRecommendations = false
                     ),
                     onSubmitSearch = { submitted += it },
                     onClearHistory = { clearHistoryCount += 1 },
-                    onOpenFullRanking = { fullRankingCount += 1 }
+                    onRefreshRecommendations = { refreshRecommendationsCount += 1 }
                 )
             }
         }
@@ -279,20 +284,27 @@ class SearchAssistScreenTest {
             assertEquals(0, clearHistoryCount)
         }
         composeRule.onNodeWithText("清空").performClick()
-        composeRule.onNodeWithTag(SEARCH_ASSIST_FULL_RANKING_TAG).performClick()
-        composeRule.onAllNodesWithTag(SEARCH_ASSIST_HOT_WORK_CARD_TAG).assertCountEquals(2)
+        composeRule.onNodeWithText("猜你喜欢").assertExists()
+        composeRule.onNodeWithText("CV A").assertExists()
+        composeRule.onAllNodesWithText("Circle A").assertCountEquals(0)
+        composeRule.onAllNodesWithTag(SEARCH_ASSIST_RECOMMENDATION_CARD_TAG).assertCountEquals(2)
         composeRule.onAllNodesWithText("RJ111111").assertCountEquals(0)
-        composeRule.onAllNodesWithTag(SEARCH_ASSIST_HOT_WORK_CARD_TAG)[0].performClick()
+        composeRule.onAllNodesWithTag(SEARCH_ASSIST_RECOMMENDATION_CARD_TAG)[0]
+            .performScrollTo()
+            .performClick()
+        composeRule.onNodeWithTag(SEARCH_ASSIST_RECOMMENDATION_REFRESH_TAG)
+            .performScrollTo()
+            .performClick()
 
         composeRule.runOnIdle {
             assertEquals(1, clearHistoryCount)
-            assertEquals(1, fullRankingCount)
+            assertEquals(1, refreshRecommendationsCount)
             assertEquals(listOf("RJ111111"), submitted.map { it.keyword })
         }
     }
 
     @Test
-    fun hotWorkWithoutTitleUsesGenericLabelInsteadOfRj() {
+    fun recommendationWithoutTitleUsesGenericLabelInsteadOfRj() {
         composeRule.setContent {
             AsmrPlayerTheme {
                 SearchAssistContent(
@@ -300,8 +312,8 @@ class SearchAssistScreenTest {
                     initialRequest = SearchAssistSearchRequest(),
                     uiState = SearchAssistUiState(
                         suggestions = SearchSuggestionsUiData(
-                            hotWorks = listOf(
-                                SearchAssistHotWork(
+                            recommendations = listOf(
+                                SearchAssistRecommendation(
                                     album = Album(
                                         title = "",
                                         path = "",
@@ -311,16 +323,17 @@ class SearchAssistScreenTest {
                                     )
                                 )
                             )
-                        )
+                        ),
+                        isLoadingRecommendations = false
                     ),
                     onSubmitSearch = {},
                     onClearHistory = {},
-                    onOpenFullRanking = {}
+                    onRefreshRecommendations = {}
                 )
             }
         }
 
-        composeRule.onNodeWithText("热门作品").assertExists()
+        composeRule.onNodeWithText("推荐作品").assertExists()
         composeRule.onAllNodesWithText("RJ333333").assertCountEquals(0)
     }
 }


### PR DESCRIPTION
## 变更内容
- 接入 EaraServer POST /api/asmr-one/recommendations
- 使用本地最近收听 RJ 生成种子与长期排除列表
- 将二级搜索页“热门作品”替换为“猜你喜欢”，卡片展示标题与 CV
- 增加“换一批”，将已展示作品及全部 matchedRjs 加入会话级排除集合
- 在排除项超过 200 或候选耗尽时重置会话排除集合
- 移除旧热门榜单入口与废弃热门作品数据链路

## 验证
- 推荐接口线上请求返回 HTTP 200
- release 推荐逻辑单元测试通过
- 相关 Compose 交互测试通过
- ./gradlew-local.bat :app:installRelease 成功安装到连接设备