### PR TITLE
fix: 修复已收录作品目录语言错误

### DIFF
--- a/app/src/main/java/com/asmr/player/data/remote/api/Asmr100Api.kt
+++ b/app/src/main/java/com/asmr/player/data/remote/api/Asmr100Api.kt
@@ -28,6 +28,7 @@ interface Asmr100Api {
     @GET("tracks/{workId}")
     suspend fun getTracks(
         @Path("workId") workId: String,
+        @Query("v") version: Int = 2,
         @Header(NetworkHeaders.HEADER_SILENT_IO_ERROR) silentIoError: String? = null
     ): List<AsmrOneTrackNodeResponse>
 

--- a/app/src/main/java/com/asmr/player/data/remote/api/Asmr200Api.kt
+++ b/app/src/main/java/com/asmr/player/data/remote/api/Asmr200Api.kt
@@ -29,6 +29,7 @@ interface Asmr200Api {
     @GET("tracks/{workId}")
     suspend fun getTracks(
         @Path("workId") workId: String,
+        @Query("v") version: Int = 2,
         @Header(NetworkHeaders.HEADER_SILENT_IO_ERROR) silentIoError: String? = null
     ): List<AsmrOneTrackNodeResponse>
 

--- a/app/src/main/java/com/asmr/player/data/remote/api/Asmr300Api.kt
+++ b/app/src/main/java/com/asmr/player/data/remote/api/Asmr300Api.kt
@@ -28,6 +28,7 @@ interface Asmr300Api {
     @GET("tracks/{workId}")
     suspend fun getTracks(
         @Path("workId") workId: String,
+        @Query("v") version: Int = 2,
         @Header(NetworkHeaders.HEADER_SILENT_IO_ERROR) silentIoError: String? = null
     ): List<AsmrOneTrackNodeResponse>
 

--- a/app/src/main/java/com/asmr/player/data/remote/api/AsmrOneApi.kt
+++ b/app/src/main/java/com/asmr/player/data/remote/api/AsmrOneApi.kt
@@ -26,6 +26,7 @@ interface AsmrOneApi {
     @GET("tracks/{workId}")
     suspend fun getTracks(
         @Path("workId") workId: String,
+        @Query("v") version: Int = 2,
         @Header(NetworkHeaders.HEADER_SILENT_IO_ERROR) silentIoError: String? = null
     ): List<AsmrOneTrackNodeResponse>
 

--- a/app/src/main/java/com/asmr/player/ui/library/AlbumDetailViewModel.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/AlbumDetailViewModel.kt
@@ -1584,10 +1584,17 @@ class AlbumDetailViewModel @Inject constructor(
                     ?.uppercase()
                     .orEmpty()
                 val originalRj = jpnWorkno.ifBlank { latestBase.ifBlank { keyRj } }
-                val backendRjs = listOf(keyRj, originalRj, latest.dlsiteWorkno, latestBase)
-                    .map { it.trim().uppercase() }
-                    .filter { RJ_CODE_REGEX.matches(it) }
-                    .distinct()
+                val preferInitialCollectedRj = latest.displayAlbum.hasAsmrOne &&
+                    !latest.isDlsiteLanguageUserSelected &&
+                    RJ_CODE_REGEX.matches(latestBase)
+                val backendRjs = asmrOneTrackRjCandidates(
+                    baseRj = latestBase,
+                    currentRj = keyRj,
+                    dlsiteWorkno = latest.dlsiteWorkno,
+                    originalRj = originalRj,
+                    selectedLang = selectedLang,
+                    preferInitialCollectedRj = preferInitialCollectedRj
+                )
                 fun finishWithResolvedAsmrOneTree(
                     workId: String?,
                     site: Int?,
@@ -1632,6 +1639,22 @@ class AlbumDetailViewModel @Inject constructor(
                         site = null,
                         tree = backendFallback.third
                     )
+                }
+
+                if (preferInitialCollectedRj) {
+                    val preferredInitial = resolveAsmrOneWork(latestBase)
+                    if (preferredInitial != null) {
+                        val (preferredWorkId, preferredSite) = preferredInitial
+                        val preferredTree = getAsmrOneTracksCached(preferredSite, preferredWorkId)
+                        if (preferredTree.isNotEmpty()) {
+                            finishWithResolvedAsmrOneTree(
+                                workId = preferredWorkId,
+                                site = preferredSite,
+                                tree = preferredTree
+                            )
+                            return@launch
+                        }
+                    }
                 }
 
                 val collected = isAsmrOneCollected(originalRj, timeoutMs = 1_200L)
@@ -1697,30 +1720,21 @@ class AlbumDetailViewModel @Inject constructor(
                     if (site != null) asmrOneCrawler.getDetailsFromSite(site, originalWorkId) else asmrOneCrawler.getDetails(originalWorkId)
                 }.getOrNull()
 
-                val otherId = if (selectedLang == "JPN") {
-                    null
-                } else {
-                    val other = originalDetails?.other_language_editions_in_db.orEmpty()
-                    other.firstOrNull { it.source_id.orEmpty().trim().equals(keyRj, ignoreCase = true) }?.id
-                        ?: when (selectedLang) {
-                            "CHI_HANS" -> other.firstOrNull { it.lang.orEmpty().contains("简体") }?.id
-                            "CHI_HANT" -> other.firstOrNull { it.lang.orEmpty().contains("繁體") }?.id
-                            "KO_KR" -> other.firstOrNull { it.lang.orEmpty().contains("韩") || it.lang.orEmpty().contains("韓") }?.id
-                            else -> null
-                        }
-                }
-
-                val finalWorkId = otherId?.toString()?.trim().orEmpty().ifBlank { originalWorkId }
-                val tree = getAsmrOneTracksCached(site, finalWorkId).ifEmpty {
-                    if (finalWorkId != originalWorkId) getAsmrOneTracksCached(site, originalWorkId) else emptyList()
-                }
-                val workId = finalWorkId
+                val workId = resolveAsmrOneTrackWorkId(
+                    resolvedWorkId = originalWorkId,
+                    resolvedDetails = originalDetails,
+                    selectedLang = selectedLang,
+                    selectedRjs = backendRjs
+                )
+                val tree = workId
+                    ?.let { getAsmrOneTracksCached(site, it) }
+                    .orEmpty()
                 if (token != asmrOneLoadToken) {
                     asmrOneAttemptedRj.remove(keyRj)
                     finishAsmrOneLoad(keyRj, resolved = false)
                     return@launch
                 }
-                if (workId.isBlank()) {
+                if (workId.isNullOrBlank()) {
                     if (loadBackendFallbackAndFinishIfFound()) return@launch
                     asmrOneAttemptedRj.remove(keyRj)
                     finishAsmrOneLoad(keyRj, resolved = true)
@@ -1841,32 +1855,6 @@ class AlbumDetailViewModel @Inject constructor(
                 )
             }
         }
-    }
-
-    private suspend fun fetchAsmrOneWithFallback(
-        primaryRj: String,
-        fallbackRj: String
-    ): Triple<String?, Int?, List<AsmrOneTrackNodeResponse>> {
-        suspend fun pickExact(workNo: String): Triple<String?, Int?, List<AsmrOneTrackNodeResponse>> {
-            val normalized = workNo.trim().uppercase()
-            if (normalized.isBlank()) return Triple(null, null, emptyList())
-            val resolved = resolveAsmrOneWork(normalized) ?: return Triple(null, null, emptyList())
-            val (workId, site) = resolved
-            val tree = getAsmrOneTracksCached(site, workId)
-            return Triple(workId, site, tree)
-        }
-
-        val primary = pickExact(primaryRj)
-        if (primary.first != null) return primary
-
-        val normalizedFallback = fallbackRj.trim()
-        val normalizedPrimary = primaryRj.trim()
-        if (normalizedFallback.isNotBlank() && !normalizedFallback.equals(normalizedPrimary, ignoreCase = true)) {
-            val fallback = pickExact(normalizedFallback)
-            if (fallback.first != null) return fallback
-        }
-
-        return Triple(null, null, emptyList())
     }
 
     private fun albumFromInitialHint(rj: String, hint: AlbumCoverHint?): Album {

--- a/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailViewModelSupport.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailViewModelSupport.kt
@@ -18,6 +18,7 @@ import com.asmr.player.data.local.db.entities.TagEntity
 import com.asmr.player.data.local.db.entities.TagSource
 import com.asmr.player.data.local.db.entities.TrackTagEntity
 import com.asmr.player.data.remote.api.AsmrOneTrackNodeResponse
+import com.asmr.player.data.remote.api.WorkDetailsResponse
 import com.asmr.player.data.remote.crawler.AsmrOneCrawler
 import com.asmr.player.data.remote.dlsite.DlsiteCloudSyncCandidate
 import com.asmr.player.data.remote.dlsite.DlsiteCloudSyncResolveResult
@@ -357,6 +358,85 @@ internal fun resolveInitialDlsiteLoadTarget(
         workno = selectedWorkno
     )
 }
+
+internal fun asmrOneTrackRjCandidates(
+    baseRj: String,
+    currentRj: String,
+    dlsiteWorkno: String,
+    originalRj: String,
+    selectedLang: String,
+    preferInitialCollectedRj: Boolean
+): List<String> {
+    val normalizedLang = selectedLang.trim().uppercase().ifBlank { "JPN" }
+    return buildList {
+        if (preferInitialCollectedRj) add(baseRj)
+        add(currentRj)
+        add(dlsiteWorkno)
+        if (normalizedLang == "JPN") {
+            add(originalRj)
+            add(baseRj)
+        }
+    }
+        .map { it.trim().uppercase() }
+        .filter { ALBUM_DETAIL_RJ_CODE_REGEX.matches(it) }
+        .distinct()
+}
+
+internal fun resolveAsmrOneTrackWorkId(
+    resolvedWorkId: String,
+    resolvedDetails: WorkDetailsResponse?,
+    selectedLang: String,
+    selectedRjs: List<String>
+): String? {
+    val normalizedWorkId = resolvedWorkId.trim().ifBlank { return null }
+    val normalizedLang = selectedLang.trim().uppercase().ifBlank { "JPN" }
+    if (normalizedLang == "JPN") return normalizedWorkId
+
+    val exactRjs = selectedRjs
+        .map { it.trim().uppercase() }
+        .filter { ALBUM_DETAIL_RJ_CODE_REGEX.matches(it) }
+        .toSet()
+    val details = resolvedDetails ?: return null
+    val resolvedSourceRj = details.source_id.trim().uppercase()
+    if (resolvedSourceRj in exactRjs) return normalizedWorkId
+
+    val otherEditions = details.other_language_editions_in_db.orEmpty()
+    val exactEdition = otherEditions.firstOrNull { edition ->
+        edition.source_id.orEmpty().trim().uppercase() in exactRjs
+    }
+    val languageEdition = exactEdition ?: otherEditions.firstOrNull { edition ->
+        asmrOneEditionMatchesLanguage(edition.lang.orEmpty(), normalizedLang)
+    }
+    return languageEdition?.id?.takeIf { it > 0 }?.toString()
+}
+
+private fun asmrOneEditionMatchesLanguage(languageLabel: String, selectedLang: String): Boolean {
+    val normalizedLabel = languageLabel.trim().uppercase()
+    return when (selectedLang) {
+        "CHI_HANS" -> normalizedLabel.contains("CHI_HANS") ||
+            normalizedLabel.contains("简体") ||
+            normalizedLabel.contains("簡体") ||
+            normalizedLabel.contains("简中") ||
+            normalizedLabel.contains("簡中")
+
+        "CHI_HANT" -> normalizedLabel.contains("CHI_HANT") ||
+            normalizedLabel.contains("繁体") ||
+            normalizedLabel.contains("繁體") ||
+            normalizedLabel.contains("繁中")
+
+        "KO_KR" -> normalizedLabel.contains("KO_KR") ||
+            normalizedLabel.contains("韩") ||
+            normalizedLabel.contains("韓")
+
+        "ENG" -> normalizedLabel.contains("ENG") ||
+            normalizedLabel.contains("英语") ||
+            normalizedLabel.contains("英語")
+
+        else -> normalizedLabel == selectedLang
+    }
+}
+
+private val ALBUM_DETAIL_RJ_CODE_REGEX = Regex("""RJ\d{6,}""")
 
 internal data class AsmrOneLeafDownload(
     val url: String,

--- a/app/src/test/java/com/asmr/player/ui/library/AlbumDetailAsmrOneLanguageTargetTest.kt
+++ b/app/src/test/java/com/asmr/player/ui/library/AlbumDetailAsmrOneLanguageTargetTest.kt
@@ -1,0 +1,106 @@
+package com.asmr.player.ui.library
+
+import com.asmr.player.data.remote.api.AsmrOneOtherLanguageEditionInDb
+import com.asmr.player.data.remote.api.WorkDetailsResponse
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class AlbumDetailAsmrOneLanguageTargetTest {
+
+    @Test
+    fun collectedSearchResult_prefersExactCollectedRjBeforeDlsiteEditionRj() {
+        val candidates = asmrOneTrackRjCandidates(
+            baseRj = "RJ01612762",
+            currentRj = "RJ01598807",
+            dlsiteWorkno = "RJ01598807",
+            originalRj = "RJ01579177",
+            selectedLang = "CHI_HANT",
+            preferInitialCollectedRj = true
+        )
+
+        assertEquals(listOf("RJ01612762", "RJ01598807"), candidates)
+    }
+
+    @Test
+    fun nonJapaneseSelection_doesNotIncludeJapaneseFallbackCandidate() {
+        val candidates = asmrOneTrackRjCandidates(
+            baseRj = "RJ01583802",
+            currentRj = "RJ01593950",
+            dlsiteWorkno = "RJ01593950",
+            originalRj = "RJ01583802",
+            selectedLang = "CHI_HANS",
+            preferInitialCollectedRj = false
+        )
+
+        assertEquals(listOf("RJ01593950"), candidates)
+    }
+
+    @Test
+    fun translatedWorkId_matchesExactCollectedRjFromOriginalDetails() {
+        val details = workDetails(
+            id = 1_579_177,
+            sourceId = "RJ01579177",
+            otherEditions = listOf(
+                AsmrOneOtherLanguageEditionInDb(
+                    id = 1_612_762,
+                    lang = "繁體中文",
+                    source_id = "RJ01612762"
+                )
+            )
+        )
+
+        val workId = resolveAsmrOneTrackWorkId(
+            resolvedWorkId = "1579177",
+            resolvedDetails = details,
+            selectedLang = "CHI_HANT",
+            selectedRjs = listOf("RJ01612762", "RJ01598807")
+        )
+
+        assertEquals("1612762", workId)
+    }
+
+    @Test
+    fun nonJapaneseSelection_neverFallsBackToOriginalWorkIdWhenEditionIsUnknown() {
+        val workId = resolveAsmrOneTrackWorkId(
+            resolvedWorkId = "1583802",
+            resolvedDetails = null,
+            selectedLang = "CHI_HANS",
+            selectedRjs = listOf("RJ01593951", "RJ01593950")
+        )
+
+        assertNull(workId)
+    }
+
+    @Test
+    fun japaneseSelection_usesResolvedOriginalWorkId() {
+        val workId = resolveAsmrOneTrackWorkId(
+            resolvedWorkId = "1583802",
+            resolvedDetails = null,
+            selectedLang = "JPN",
+            selectedRjs = listOf("RJ01583802")
+        )
+
+        assertEquals("1583802", workId)
+    }
+
+    private fun workDetails(
+        id: Int,
+        sourceId: String,
+        otherEditions: List<AsmrOneOtherLanguageEditionInDb>
+    ): WorkDetailsResponse {
+        return WorkDetailsResponse(
+            id = id,
+            source_id = sourceId,
+            title = "",
+            circle = null,
+            vas = null,
+            tags = null,
+            duration = 0,
+            mainCoverUrl = "",
+            dl_count = 0,
+            price = 0,
+            other_language_editions_in_db = otherEditions
+        )
+    }
+}


### PR DESCRIPTION
## 问题
“已收录”搜索结果中的简体/繁体中文作品进入详情页后，可能因为 DLSite 语言版 RJ 替换和日文原版回退而显示日文目录。

## 修复
- 已收录结果优先使用点击时携带的精确 RJ 加载 asmr.one 目录
- 非日文语言不再静默回退到日文原版目录
- 加强关联语言版本的 source_id 与语言标签匹配
- tracks 接口统一携带 v=2
- 补充场景的目标选择回归测试

## 验证
- 相关 release 单测通过
- .\gradlew-local.bat :app:installRelease 成功
- release APK 已成功安装