### PR TITLE
fix: preload all primary navigation pages

### DIFF
--- a/app/src/main/java/com/asmr/player/main/MainNavigationSupport.kt
+++ b/app/src/main/java/com/asmr/player/main/MainNavigationSupport.kt
@@ -276,7 +276,7 @@ internal fun shouldClearPendingPrimaryNavigationRoute(
 }
 
 internal fun resolvePrimaryPagerBeyondBoundsPageCount(pageCount: Int): Int {
-    return (pageCount - 1).coerceIn(0, 1)
+    return (pageCount - 1).coerceAtLeast(0)
 }
 
 internal fun resolveCurrentPrimaryDestinationRoute(

--- a/app/src/test/java/com/asmr/player/MainNavigationSupportTest.kt
+++ b/app/src/test/java/com/asmr/player/MainNavigationSupportTest.kt
@@ -108,11 +108,11 @@ class MainNavigationSupportTest {
     }
 
     @Test
-    fun resolvePrimaryPagerBeyondBoundsPageCount_keepsOnlyAdjacentPageReady() {
+    fun resolvePrimaryPagerBeyondBoundsPageCount_keepsAllPrimaryPagesComposed() {
         assertEquals(0, resolvePrimaryPagerBeyondBoundsPageCount(0))
         assertEquals(0, resolvePrimaryPagerBeyondBoundsPageCount(1))
         assertEquals(1, resolvePrimaryPagerBeyondBoundsPageCount(2))
-        assertEquals(1, resolvePrimaryPagerBeyondBoundsPageCount(8))
+        assertEquals(7, resolvePrimaryPagerBeyondBoundsPageCount(8))
     }
 
     @Test


### PR DESCRIPTION
## Summary
- restore the primary pager cache size to include every bottom navigation page
- keep all primary destinations composed for smoother multi-page navigation
- update the navigation cache unit test for the eight-page configuration

## Validation
- `.\gradlew-local.bat :app:testReleaseUnitTest --tests com.asmr.player.MainNavigationSupportTest.resolvePrimaryPagerBeyondBoundsPageCount_keepsAllPrimaryPagesComposed`
- `.\gradlew-local.bat :app:installRelease` (installed successfully on the connected device)

## Test note
- Running the complete `MainNavigationSupportTest` class still reports two unrelated existing failures in the theme media source tests at lines 213 and 233.