### PR TITLE
fix: cache and stabilize search recommendations

### DIFF
--- a/app/src/main/java/com/asmr/player/ui/search/SearchAssistScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/search/SearchAssistScreen.kt
@@ -85,11 +85,24 @@ internal const val SEARCH_ASSIST_HISTORY_CLEAR_TAG = "search_assist_history_clea
 internal const val SEARCH_ASSIST_RECOMMENDATION_CARD_TAG = "search_assist_recommendation_card"
 internal const val SEARCH_ASSIST_RECOMMENDATION_REFRESH_TAG = "search_assist_recommendation_refresh"
 internal const val SEARCH_ASSIST_CHROME_TAG = "search_assist_chrome"
+internal const val SEARCH_ASSIST_HOT_CVS_SECTION_TAG = "search_assist_hot_cvs_section"
+internal const val SEARCH_ASSIST_HOT_TAGS_SECTION_TAG = "search_assist_hot_tags_section"
+internal const val SEARCH_ASSIST_RECOMMENDATION_SECTION_TAG = "search_assist_recommendation_section"
 private const val SearchAssistCollapsedRows = 2
+private const val SearchAssistRecommendationColumns = 2
+private const val SearchAssistRecommendationRows =
+    (SEARCH_ASSIST_RECOMMENDATION_DISPLAY_LIMIT + SearchAssistRecommendationColumns - 1) /
+        SearchAssistRecommendationColumns
 private val SearchAssistChromeContentGap = 8.dp
-private val SearchAssistSkeletonChipHeight = 30.dp
-private val SearchAssistSkeletonWorkHeightCompact = 76.dp
-private val SearchAssistSkeletonWorkHeightExpanded = 84.dp
+private val SearchAssistSectionHeaderHeight = 32.dp
+private val SearchAssistChipHeight = 30.dp
+private val SearchAssistChipVerticalSpacing = 6.dp
+private val SearchAssistCollapsedChipFlowHeight =
+    SearchAssistChipHeight * SearchAssistCollapsedRows +
+        SearchAssistChipVerticalSpacing * (SearchAssistCollapsedRows - 1)
+private val SearchAssistWorkHeightCompact = 76.dp
+private val SearchAssistWorkHeightExpanded = 84.dp
+private val SearchAssistWorkRowSpacing = 8.dp
 
 @Composable
 fun SearchAssistScreen(
@@ -320,10 +333,16 @@ internal fun SearchAssistContent(
 
             if (uiState.isLoadingSuggestions) {
                 item(contentType = "hotCvsLoading") {
-                    SearchAssistTermSectionSkeleton(title = "热门声优")
+                    SearchAssistTermSectionSkeleton(
+                        title = "热门声优",
+                        modifier = Modifier.testTag(SEARCH_ASSIST_HOT_CVS_SECTION_TAG)
+                    )
                 }
                 item(contentType = "hotTagsLoading") {
-                    SearchAssistTermSectionSkeleton(title = "热门标签")
+                    SearchAssistTermSectionSkeleton(
+                        title = "热门标签",
+                        modifier = Modifier.testTag(SEARCH_ASSIST_HOT_TAGS_SECTION_TAG)
+                    )
                 }
             } else {
                 if (uiState.suggestions.hotCvs.isNotEmpty()) {
@@ -333,7 +352,8 @@ internal fun SearchAssistContent(
                             terms = uiState.suggestions.hotCvs,
                             expanded = hotCvsExpanded,
                             onExpandedChange = { hotCvsExpanded = it },
-                            onTermClick = { submit(it) }
+                            onTermClick = { submit(it) },
+                            modifier = Modifier.testTag(SEARCH_ASSIST_HOT_CVS_SECTION_TAG)
                         )
                     }
                 }
@@ -344,7 +364,8 @@ internal fun SearchAssistContent(
                             terms = uiState.suggestions.hotTags,
                             expanded = hotTagsExpanded,
                             onExpandedChange = { hotTagsExpanded = it },
-                            onTermClick = { submit(it) }
+                            onTermClick = { submit(it) },
+                            modifier = Modifier.testTag(SEARCH_ASSIST_HOT_TAGS_SECTION_TAG)
                         )
                     }
                 }
@@ -354,19 +375,24 @@ internal fun SearchAssistContent(
                 item(contentType = "recommendationsLoading") {
                     SearchAssistWorkSectionSkeleton(
                         title = "猜你喜欢",
-                        compact = isCompact
+                        compact = isCompact,
+                        modifier = Modifier.testTag(SEARCH_ASSIST_RECOMMENDATION_SECTION_TAG)
                     )
                 }
             } else if (uiState.suggestions.recommendations.isNotEmpty()) {
                 item(contentType = "recommendations") {
                     SearchAssistSection(
                         title = "猜你喜欢",
+                        modifier = Modifier.testTag(SEARCH_ASSIST_RECOMMENDATION_SECTION_TAG),
                         trailing = {
                             TextButton(
                                 onClick = onRefreshRecommendations,
                                 enabled = !uiState.isLoadingRecommendations &&
                                     uiState.hasMoreRecommendations,
-                                modifier = Modifier.testTag(SEARCH_ASSIST_RECOMMENDATION_REFRESH_TAG)
+                                modifier = Modifier
+                                    .height(SearchAssistSectionHeaderHeight)
+                                    .testTag(SEARCH_ASSIST_RECOMMENDATION_REFRESH_TAG),
+                                contentPadding = PaddingValues(horizontal = 8.dp, vertical = 0.dp)
                             ) {
                                 Icon(
                                     imageVector = Icons.Rounded.Refresh,
@@ -383,12 +409,16 @@ internal fun SearchAssistContent(
                             }
                         }
                     ) {
-                        val rows = uiState.suggestions.recommendations.chunked(2)
-                        Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                        val rows = uiState.suggestions.recommendations
+                            .chunked(SearchAssistRecommendationColumns)
+                        Column(
+                            modifier = Modifier.height(searchAssistRecommendationGridHeight(isCompact)),
+                            verticalArrangement = Arrangement.spacedBy(SearchAssistWorkRowSpacing)
+                        ) {
                             rows.forEach { row ->
                                 Row(
                                     modifier = Modifier.fillMaxWidth(),
-                                    horizontalArrangement = Arrangement.spacedBy(8.dp)
+                                    horizontalArrangement = Arrangement.spacedBy(SearchAssistWorkRowSpacing)
                                 ) {
                                     row.forEach { recommendation ->
                                         SearchAssistRecommendationCard(
@@ -467,9 +497,15 @@ internal fun SearchAssistContent(
 }
 
 @Composable
-private fun SearchAssistTermSectionSkeleton(title: String) {
-    SearchAssistSection(title = title) {
-        SearchAssistChipFlow(expanded = false) {
+private fun SearchAssistTermSectionSkeleton(
+    title: String,
+    modifier: Modifier = Modifier
+) {
+    SearchAssistSection(title = title, modifier = modifier) {
+        SearchAssistChipFlow(
+            expanded = false,
+            reserveCollapsedHeight = true
+        ) {
             listOf(0.26f, 0.22f, 0.30f, 0.18f, 0.24f, 0.28f).forEach { widthFraction ->
                 SearchAssistTextChipSkeleton(widthFraction = widthFraction)
             }
@@ -480,14 +516,18 @@ private fun SearchAssistTermSectionSkeleton(title: String) {
 @Composable
 private fun SearchAssistWorkSectionSkeleton(
     title: String,
-    compact: Boolean
+    compact: Boolean,
+    modifier: Modifier = Modifier
 ) {
-    SearchAssistSection(title = title) {
-        Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
-            repeat(2) {
+    SearchAssistSection(title = title, modifier = modifier) {
+        Column(
+            modifier = Modifier.height(searchAssistRecommendationGridHeight(compact)),
+            verticalArrangement = Arrangement.spacedBy(SearchAssistWorkRowSpacing)
+        ) {
+            repeat(SearchAssistRecommendationRows) {
                 Row(
                     modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.spacedBy(8.dp)
+                    horizontalArrangement = Arrangement.spacedBy(SearchAssistWorkRowSpacing)
                 ) {
                     SearchAssistWorkChipSkeleton(
                         compact = compact,
@@ -506,17 +546,20 @@ private fun SearchAssistWorkSectionSkeleton(
 @Composable
 private fun SearchAssistSection(
     title: String,
+    modifier: Modifier = Modifier,
     trailing: @Composable (() -> Unit)? = null,
     content: @Composable () -> Unit
 ) {
     Column(
-        modifier = Modifier
+        modifier = modifier
             .fillMaxWidth()
             .padding(horizontal = 12.dp),
         verticalArrangement = Arrangement.spacedBy(6.dp)
     ) {
         Row(
-            modifier = Modifier.fillMaxWidth(),
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(SearchAssistSectionHeaderHeight),
             verticalAlignment = Alignment.CenterVertically
         ) {
             Text(
@@ -545,10 +588,12 @@ private fun SearchAssistTermSection(
     terms: List<SearchSuggestionTerm>,
     expanded: Boolean,
     onExpandedChange: (Boolean) -> Unit,
-    onTermClick: (String) -> Unit
+    onTermClick: (String) -> Unit,
+    modifier: Modifier = Modifier
 ) {
     SearchAssistSection(
         title = title,
+        modifier = modifier,
         trailing = {
             ExpandCollapseIconButton(
                 expanded = expanded,
@@ -572,7 +617,7 @@ private fun SearchAssistTextChipSkeleton(
     AsmrShimmerPlaceholder(
         modifier = Modifier
             .fillMaxWidth(widthFraction)
-            .height(SearchAssistSkeletonChipHeight)
+            .height(SearchAssistChipHeight)
             .clip(shape),
         cornerRadius = 7
     )
@@ -598,11 +643,12 @@ private fun SearchAssistTextChip(
     Row(
         modifier = Modifier
             .widthIn(max = 220.dp)
+            .height(SearchAssistChipHeight)
             .clip(shape)
             .background(containerColor)
             .border(1.dp, borderColor, shape)
             .clickable(onClick = onClick)
-            .padding(horizontal = 9.dp, vertical = 5.dp),
+            .padding(horizontal = 9.dp),
         verticalAlignment = Alignment.CenterVertically
     ) {
         Text(
@@ -621,11 +667,7 @@ private fun SearchAssistWorkChipSkeleton(
     modifier: Modifier = Modifier
 ) {
     val shape = RoundedCornerShape(8.dp)
-    val cardHeight = if (compact) {
-        SearchAssistSkeletonWorkHeightCompact
-    } else {
-        SearchAssistSkeletonWorkHeightExpanded
-    }
+    val cardHeight = searchAssistRecommendationCardHeight(compact)
     Row(
         modifier = modifier
             .height(cardHeight)
@@ -685,7 +727,10 @@ private fun SearchAssistTermChips(
     expanded: Boolean,
     onTermClick: (String) -> Unit
 ) {
-    SearchAssistChipFlow(expanded = expanded) {
+    SearchAssistChipFlow(
+        expanded = expanded,
+        reserveCollapsedHeight = true
+    ) {
         terms.forEach { term ->
             SearchAssistTextChip(
                 text = term.value,
@@ -699,14 +744,20 @@ private fun SearchAssistTermChips(
 private fun SearchAssistChipFlow(
     expanded: Boolean,
     modifier: Modifier = Modifier,
+    reserveCollapsedHeight: Boolean = false,
     content: @Composable () -> Unit
 ) {
+    val layoutModifier = if (!expanded && reserveCollapsedHeight) {
+        modifier.height(SearchAssistCollapsedChipFlowHeight)
+    } else {
+        modifier
+    }
     Layout(
         content = content,
-        modifier = modifier.fillMaxWidth()
+        modifier = layoutModifier.fillMaxWidth()
     ) { measurables, constraints ->
         val horizontalSpacingPx = 8.dp.roundToPx()
-        val verticalSpacingPx = 6.dp.roundToPx()
+        val verticalSpacingPx = SearchAssistChipVerticalSpacing.roundToPx()
         val maxWidth = constraints.maxWidth
         val placements = mutableListOf<SearchAssistChipPlacement>()
         var x = 0
@@ -817,7 +868,7 @@ private fun SearchAssistRecommendationCard(
 
     Row(
         modifier = modifier
-            .height(if (compact) 76.dp else 84.dp)
+            .height(searchAssistRecommendationCardHeight(compact))
             .clip(shape)
             .background(containerColor)
             .border(
@@ -837,7 +888,7 @@ private fun SearchAssistRecommendationCard(
             loading = NoImageLoadingIndicator,
             modifier = Modifier
                 .aspectRatio(1f)
-                .height(if (compact) 76.dp else 84.dp)
+                .height(searchAssistRecommendationCardHeight(compact))
                 .clip(RoundedCornerShape(topStart = 8.dp, bottomStart = 8.dp))
         )
         Column(
@@ -865,6 +916,13 @@ private fun SearchAssistRecommendationCard(
         }
     }
 }
+
+private fun searchAssistRecommendationCardHeight(compact: Boolean) =
+    if (compact) SearchAssistWorkHeightCompact else SearchAssistWorkHeightExpanded
+
+private fun searchAssistRecommendationGridHeight(compact: Boolean) =
+    searchAssistRecommendationCardHeight(compact) * SearchAssistRecommendationRows +
+        SearchAssistWorkRowSpacing * (SearchAssistRecommendationRows - 1)
 
 @Composable
 private fun AssistMutedText(text: String) {

--- a/app/src/main/java/com/asmr/player/ui/search/SearchAssistViewModel.kt
+++ b/app/src/main/java/com/asmr/player/ui/search/SearchAssistViewModel.kt
@@ -30,6 +30,7 @@ internal const val SEARCH_ASSIST_RESULT_CHINESE_TRANSLATED_ONLY_KEY = "searchChi
 internal const val SEARCH_ASSIST_RESULT_COLLECTED_ONLY_KEY = "searchCollectedOnly"
 internal const val SEARCH_ASSIST_RESULT_COLLECTED_SORT_KEY = "searchCollectedSortName"
 internal const val SEARCH_ASSIST_RESULT_LOCALE_KEY = "searchLocale"
+internal const val SEARCH_ASSIST_RECOMMENDATION_DISPLAY_LIMIT = 10
 
 data class SearchAssistSearchRequest(
     val keyword: String = "",
@@ -208,7 +209,7 @@ class SearchAssistViewModel @Inject constructor(
         val recommendations = items
             .map { item -> item.toSearchAssistRecommendation() }
             .filter { recommendation -> recommendation.album.rjCode.isNotBlank() }
-            .take(RECOMMENDATION_DISPLAY_LIMIT)
+            .take(SEARCH_ASSIST_RECOMMENDATION_DISPLAY_LIMIT)
         _uiState.update {
             it.copy(
                 isLoadingRecommendations = false,
@@ -241,19 +242,18 @@ class SearchAssistViewModel @Inject constructor(
             asmrOneAvailabilityApi.getRecommendations(
                 seedRjs = listenedRjs.take(MAX_RECOMMENDATION_SEEDS),
                 excludeRjs = listenedRjs,
-                limit = RECOMMENDATION_DISPLAY_LIMIT
+                limit = SEARCH_ASSIST_RECOMMENDATION_DISPLAY_LIMIT
             )
         } else {
             asmrOneAvailabilityApi.continueRecommendations(
                 cursor = recommendationCursor,
-                limit = RECOMMENDATION_DISPLAY_LIMIT
+                limit = SEARCH_ASSIST_RECOMMENDATION_DISPLAY_LIMIT
             )
         }
 
     private companion object {
         const val MAX_RECOMMENDATION_SEEDS = 20
         const val MAX_RECOMMENDATION_EXCLUDES = 200
-        const val RECOMMENDATION_DISPLAY_LIMIT = 10
     }
 }
 

--- a/app/src/main/java/com/asmr/player/ui/search/SearchAssistViewModel.kt
+++ b/app/src/main/java/com/asmr/player/ui/search/SearchAssistViewModel.kt
@@ -62,7 +62,8 @@ class SearchAssistViewModel @Inject constructor(
     private val searchCacheStore: SearchCacheStore,
     private val hotListeningApi: HotListeningApi,
     private val asmrOneAvailabilityApi: AsmrOneAvailabilityApi,
-    private val listeningRecordRepository: ListeningRecordRepository
+    private val listeningRecordRepository: ListeningRecordRepository,
+    private val recommendationSessionCache: SearchRecommendationSessionCache
 ) : ViewModel() {
     private val _uiState = MutableStateFlow(SearchAssistUiState())
     val uiState: StateFlow<SearchAssistUiState> = _uiState.asStateFlow()
@@ -176,6 +177,13 @@ class SearchAssistViewModel @Inject constructor(
             }
             return
         }
+        recommendationSessionCache.read(
+            seedRjs = listenedRjs.take(MAX_RECOMMENDATION_SEEDS),
+            excludeRjs = listenedRjs
+        )?.let { cachedResponse ->
+            applyRecommendationResponse(cachedResponse)
+            return
+        }
         loadRecommendationBatch()
     }
 
@@ -186,6 +194,15 @@ class SearchAssistViewModel @Inject constructor(
             _uiState.update { it.copy(isLoadingRecommendations = false) }
             return
         }
+        recommendationSessionCache.write(
+            seedRjs = listenedRjs.take(MAX_RECOMMENDATION_SEEDS),
+            excludeRjs = listenedRjs,
+            response = response
+        )
+        applyRecommendationResponse(response)
+    }
+
+    private fun applyRecommendationResponse(response: AsmrOneRecommendationResponse) {
         val items = response.items.orEmpty()
         recommendationCursor = response.recommendationContinuationCursor()
         val recommendations = items

--- a/app/src/main/java/com/asmr/player/ui/search/SearchRecommendationSessionCache.kt
+++ b/app/src/main/java/com/asmr/player/ui/search/SearchRecommendationSessionCache.kt
@@ -1,0 +1,80 @@
+package com.asmr.player.ui.search
+
+import com.asmr.player.data.remote.api.AsmrOneRecommendationResponse
+import com.asmr.player.data.remote.api.normalizeRecommendationRjs
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class SearchRecommendationSessionCache @Inject constructor() {
+    private val lock = Any()
+    private var cachedSession: CachedRecommendationSession? = null
+
+    internal fun read(
+        seedRjs: List<String>,
+        excludeRjs: List<String>,
+        nowElapsedMs: Long = monotonicNowMs()
+    ): AsmrOneRecommendationResponse? = synchronized(lock) {
+        val cached = cachedSession ?: return@synchronized null
+        val elapsedMs = nowElapsedMs - cached.savedAtElapsedMs
+        if (
+            cached.key != recommendationSessionKey(seedRjs, excludeRjs) ||
+            elapsedMs < 0L ||
+            elapsedMs >= RECOMMENDATION_SESSION_CACHE_TTL_MS
+        ) {
+            if (elapsedMs < 0L || elapsedMs >= RECOMMENDATION_SESSION_CACHE_TTL_MS) {
+                cachedSession = null
+            }
+            return@synchronized null
+        }
+        cached.response.snapshot()
+    }
+
+    internal fun write(
+        seedRjs: List<String>,
+        excludeRjs: List<String>,
+        response: AsmrOneRecommendationResponse,
+        nowElapsedMs: Long = monotonicNowMs()
+    ) {
+        val key = recommendationSessionKey(seedRjs, excludeRjs)
+        if (key.seedRjs.isEmpty()) return
+        synchronized(lock) {
+            cachedSession = CachedRecommendationSession(
+                key = key,
+                response = response.snapshot(),
+                savedAtElapsedMs = nowElapsedMs
+            )
+        }
+    }
+}
+
+private data class RecommendationSessionKey(
+    val seedRjs: List<String>,
+    val excludeRjs: List<String>
+)
+
+private data class CachedRecommendationSession(
+    val key: RecommendationSessionKey,
+    val response: AsmrOneRecommendationResponse,
+    val savedAtElapsedMs: Long
+)
+
+private fun recommendationSessionKey(
+    seedRjs: List<String>,
+    excludeRjs: List<String>
+): RecommendationSessionKey = RecommendationSessionKey(
+    seedRjs = normalizeRecommendationRjs(seedRjs, MAX_RECOMMENDATION_CACHE_SEEDS),
+    excludeRjs = normalizeRecommendationRjs(excludeRjs, MAX_RECOMMENDATION_CACHE_EXCLUDES)
+)
+
+private fun AsmrOneRecommendationResponse.snapshot(): AsmrOneRecommendationResponse = copy(
+    items = items?.toList(),
+    matchedSeedRjs = matchedSeedRjs?.toList(),
+    unmatchedSeedRjs = unmatchedSeedRjs?.toList()
+)
+
+private fun monotonicNowMs(): Long = System.nanoTime() / 1_000_000L
+
+private const val MAX_RECOMMENDATION_CACHE_SEEDS = 20
+private const val MAX_RECOMMENDATION_CACHE_EXCLUDES = 200
+internal const val RECOMMENDATION_SESSION_CACHE_TTL_MS = 30 * 60 * 1_000L

--- a/app/src/test/java/com/asmr/player/ui/search/SearchAssistScreenTest.kt
+++ b/app/src/test/java/com/asmr/player/ui/search/SearchAssistScreenTest.kt
@@ -1,5 +1,6 @@
 package com.asmr.player.ui.search
 
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.semantics.SemanticsProperties
 import androidx.compose.ui.test.SemanticsMatcher
 import androidx.compose.ui.test.assert
@@ -337,4 +338,71 @@ class SearchAssistScreenTest {
         composeRule.onNodeWithText("推荐作品").assertExists()
         composeRule.onAllNodesWithText("RJ333333").assertCountEquals(0)
     }
+
+    @Test
+    fun loadingAndLoadedSuggestionSectionsKeepTheSameHeight() {
+        val uiState = mutableStateOf(SearchAssistUiState())
+        val hotCvs = (1..8).map { index ->
+            SearchSuggestionTerm(value = "热门声优 $index", count = 10 - index, rank = index)
+        }
+        val hotTags = (1..8).map { index ->
+            SearchSuggestionTerm(value = "热门标签 $index", count = 10 - index, rank = index)
+        }
+        val recommendations = (1..SEARCH_ASSIST_RECOMMENDATION_DISPLAY_LIMIT).map { index ->
+            SearchAssistRecommendation(
+                album = Album(
+                    title = "推荐作品 $index",
+                    path = "",
+                    workId = "RJ${index.toString().padStart(6, '0')}",
+                    rjCode = "RJ${index.toString().padStart(6, '0')}",
+                    cv = "声优 $index"
+                )
+            )
+        }
+
+        composeRule.setContent {
+            AsmrPlayerTheme {
+                SearchAssistContent(
+                    windowSizeClass = testWindowSizeClass(),
+                    initialRequest = SearchAssistSearchRequest(),
+                    uiState = uiState.value,
+                    onSubmitSearch = {},
+                    onClearHistory = {},
+                    onRefreshRecommendations = {}
+                )
+            }
+        }
+
+        val sectionTags = listOf(
+            SEARCH_ASSIST_HOT_CVS_SECTION_TAG,
+            SEARCH_ASSIST_HOT_TAGS_SECTION_TAG,
+            SEARCH_ASSIST_RECOMMENDATION_SECTION_TAG
+        )
+        val loadingHeights = sectionTags.associateWith(::sectionHeight)
+
+        composeRule.runOnIdle {
+            uiState.value = SearchAssistUiState(
+                suggestions = SearchSuggestionsUiData(
+                    hotCvs = hotCvs,
+                    hotTags = hotTags,
+                    recommendations = recommendations
+                ),
+                isLoadingSuggestions = false,
+                isLoadingRecommendations = false,
+                hasMoreRecommendations = true
+            )
+        }
+
+        sectionTags.forEach { tag ->
+            assertEquals(
+                "Section $tag changed height after loading",
+                loadingHeights.getValue(tag),
+                sectionHeight(tag),
+                0.5f
+            )
+        }
+    }
+
+    private fun sectionHeight(tag: String): Float =
+        composeRule.onAllNodesWithTag(tag).fetchSemanticsNodes().single().boundsInRoot.height
 }

--- a/app/src/test/java/com/asmr/player/ui/search/SearchRecommendationSessionCacheTest.kt
+++ b/app/src/test/java/com/asmr/player/ui/search/SearchRecommendationSessionCacheTest.kt
@@ -1,0 +1,105 @@
+package com.asmr.player.ui.search
+
+import com.asmr.player.data.remote.api.AsmrOneRecommendationItem
+import com.asmr.player.data.remote.api.AsmrOneRecommendationResponse
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class SearchRecommendationSessionCacheTest {
+    private val seedRjs = listOf("RJ123456")
+    private val excludeRjs = listOf("RJ123456", "RJ654321")
+
+    @Test
+    fun sameNormalizedInputsRestoreCachedRecommendationSession() {
+        val cache = SearchRecommendationSessionCache()
+        val response = recommendationResponse("RJ777777", "next-cursor")
+
+        cache.write(
+            seedRjs = listOf(" rj123456 "),
+            excludeRjs = listOf("rj123456", "RJ654321"),
+            response = response,
+            nowElapsedMs = 100L
+        )
+
+        assertEquals(
+            response,
+            cache.read(seedRjs, excludeRjs, nowElapsedMs = 200L)
+        )
+    }
+
+    @Test
+    fun changedSeedsOrExcludesDoNotReuseCachedSession() {
+        val cache = SearchRecommendationSessionCache()
+        cache.write(
+            seedRjs = seedRjs,
+            excludeRjs = excludeRjs,
+            response = recommendationResponse("RJ777777", "next-cursor"),
+            nowElapsedMs = 100L
+        )
+
+        assertNull(
+            cache.read(
+                seedRjs = listOf("RJ999999"),
+                excludeRjs = excludeRjs,
+                nowElapsedMs = 200L
+            )
+        )
+        assertNull(
+            cache.read(
+                seedRjs = seedRjs,
+                excludeRjs = excludeRjs + "RJ888888",
+                nowElapsedMs = 200L
+            )
+        )
+    }
+
+    @Test
+    fun latestRecommendationPageReplacesEarlierPage() {
+        val cache = SearchRecommendationSessionCache()
+        cache.write(
+            seedRjs = seedRjs,
+            excludeRjs = excludeRjs,
+            response = recommendationResponse("RJ777777", "next-cursor"),
+            nowElapsedMs = 100L
+        )
+        val latest = recommendationResponse("RJ888888", "next-cursor")
+
+        cache.write(
+            seedRjs = seedRjs,
+            excludeRjs = excludeRjs,
+            response = latest,
+            nowElapsedMs = 200L
+        )
+
+        assertEquals(latest, cache.read(seedRjs, excludeRjs, nowElapsedMs = 300L))
+    }
+
+    @Test
+    fun expiredSessionIsNotRestored() {
+        val cache = SearchRecommendationSessionCache()
+        cache.write(
+            seedRjs = seedRjs,
+            excludeRjs = excludeRjs,
+            response = recommendationResponse("RJ777777", "next-cursor"),
+            nowElapsedMs = 100L
+        )
+
+        assertNull(
+            cache.read(
+                seedRjs = seedRjs,
+                excludeRjs = excludeRjs,
+                nowElapsedMs = 100L + RECOMMENDATION_SESSION_CACHE_TTL_MS
+            )
+        )
+    }
+
+    private fun recommendationResponse(
+        rj: String,
+        cursor: String
+    ): AsmrOneRecommendationResponse = AsmrOneRecommendationResponse(
+        items = listOf(AsmrOneRecommendationItem(rj = rj)),
+        nextCursor = cursor,
+        hasMore = cursor.isNotBlank()
+    )
+}


### PR DESCRIPTION
Summary: cache recommendation pages and cursors for unchanged normalized seeds/excludes; 
restore the latest recommendation batch when reopening search assist; align skeleton and loaded section dimensions to remove layout shifts.
 Validation: recommendation cache release unit tests passed; loading-vs-loaded Compose height test passed; 