### PR TITLE
perf: 优化长列表滚动性能

### DIFF
--- a/app/src/main/java/com/asmr/player/cache/ImageCacheManager.kt
+++ b/app/src/main/java/com/asmr/player/cache/ImageCacheManager.kt
@@ -270,7 +270,7 @@ class ImageCacheManager(
         models.forEach { m ->
             scope.launch {
                 preloadSemaphore.withPermit {
-                    runCatching { loadImage(model = m, size = size, cachePolicy = CachePolicy.CACHE_WARMUP) }
+                    preloadModel(model = m, size = size)
                 }
             }
         }
@@ -280,23 +280,37 @@ class ImageCacheManager(
         return preload(scope, models, size = null)
     }
 
-    fun preload(scope: CoroutineScope, models: List<Any>, size: IntSize?): Job {
+    fun preload(
+        scope: CoroutineScope,
+        models: List<Any>,
+        size: IntSize?,
+        maxConcurrency: Int? = null,
+    ): Job {
         return scope.launch(Dispatchers.IO) {
+            val requestSemaphore = Semaphore(
+                permits = (maxConcurrency ?: models.size).coerceAtLeast(1)
+            )
             coroutineScope {
                 models.forEach { model ->
                     launch {
-                        preloadSemaphore.withPermit {
-                            runCatching {
-                                loadImage(
-                                    model = model,
-                                    size = size,
-                                    cachePolicy = CachePolicy.CACHE_WARMUP
-                                )
+                        requestSemaphore.withPermit {
+                            preloadSemaphore.withPermit {
+                                preloadModel(model = model, size = size)
                             }
                         }
                     }
                 }
             }
+        }
+    }
+
+    private suspend fun preloadModel(model: Any, size: IntSize?) {
+        try {
+            loadImage(model = model, size = size, cachePolicy = CachePolicy.CACHE_WARMUP)
+        } catch (error: CancellationException) {
+            throw error
+        } catch (_: Throwable) {
+            // 预取失败不影响可见图片按正常路径重试。
         }
     }
 

--- a/app/src/main/java/com/asmr/player/cache/LazyListPreloader.kt
+++ b/app/src/main/java/com/asmr/player/cache/LazyListPreloader.kt
@@ -10,28 +10,37 @@ import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.unit.IntSize
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.distinctUntilChanged
 
 private const val MaxRememberedPreloadKeys = 96
-private const val ScrollingLeadViewportMultiplier = 2
+private const val ScrollingLeadViewportMultiplier = 1
 private const val IdleLeadViewportMultiplier = 3
+private const val ScrollingPreloadDelayMs = 24L
 private const val IdlePreloadDelayMs = 160L
+private const val ScrollingPreloadParallelism = 1
 
 private data class LazyListPreloadSnapshot(
+    val firstVisibleIndex: Int,
     val lastVisibleIndex: Int,
     val visibleItemCount: Int,
-    val isScrolling: Boolean
+    val isScrolling: Boolean,
 )
+
+internal enum class LazyListPreloadDirection {
+    Forward,
+    Backward,
+}
 
 @Composable
 fun LazyListPreloader(
     state: LazyListState,
     models: List<Any>,
     preloadNext: Int = 24,
-    preloadNextWhileScrolling: Int = 16,
+    preloadNextWhileScrolling: Int = 8,
     preloadSize: IntSize? = null,
-    cacheManagerProvider: () -> ImageCacheManager
+    cacheManagerProvider: () -> ImageCacheManager,
 ) {
     val manager = remember { cacheManagerProvider() }
     val preloadedModels = remember { LinkedHashSet<Any>() }
@@ -40,33 +49,22 @@ fun LazyListPreloader(
         snapshotFlow {
             val visibleItems = state.layoutInfo.visibleItemsInfo
             LazyListPreloadSnapshot(
+                firstVisibleIndex = visibleItems.minOfOrNull { it.index } ?: -1,
                 lastVisibleIndex = visibleItems.maxOfOrNull { it.index } ?: -1,
                 visibleItemCount = visibleItems.size,
-                isScrolling = state.isScrollInProgress
+                isScrolling = state.isScrollInProgress,
             )
         }
             .distinctUntilChanged()
-            .collectLatest { snapshot ->
-                val range = resolveLazyListPreloadRequest(
-                    lastVisibleIndex = snapshot.lastVisibleIndex,
-                    visibleItemCount = snapshot.visibleItemCount,
-                    itemCount = models.size,
-                    preloadNext = preloadNext,
-                    preloadNextWhileScrolling = preloadNextWhileScrolling,
-                    isScrolling = snapshot.isScrolling
-                ) ?: return@collectLatest
-                delay(IdlePreloadDelayMs)
-                val toPreload = range.mapNotNull { index ->
-                    models[index].takeUnless { model -> model in preloadedModels }
-                }
-                if (toPreload.isNotEmpty()) {
-                    coroutineScope {
-                        manager.preload(this, toPreload, preloadSize).join()
-                    }
-                    preloadedModels.addAll(toPreload)
-                    preloadedModels.trimOldest(maxSize = MaxRememberedPreloadKeys)
-                }
-            }
+            .collectImagePreloads(
+                manager = manager,
+                preloadedModels = preloadedModels,
+                itemCount = models.size,
+                preloadNext = preloadNext,
+                preloadNextWhileScrolling = preloadNextWhileScrolling,
+                preloadSize = preloadSize,
+                modelAt = models::get,
+            )
     }
 }
 
@@ -75,10 +73,10 @@ fun LazyListPreloader(
     state: LazyListState,
     itemCount: Int,
     preloadNext: Int = 24,
-    preloadNextWhileScrolling: Int = 16,
+    preloadNextWhileScrolling: Int = 8,
     preloadSize: IntSize? = null,
     cacheManagerProvider: () -> ImageCacheManager,
-    modelAt: (Int) -> Any?
+    modelAt: (Int) -> Any?,
 ) {
     val manager = remember { cacheManagerProvider() }
     val preloadedModels = remember { LinkedHashSet<Any>() }
@@ -88,33 +86,22 @@ fun LazyListPreloader(
         snapshotFlow {
             val visibleItems = state.layoutInfo.visibleItemsInfo
             LazyListPreloadSnapshot(
+                firstVisibleIndex = visibleItems.minOfOrNull { it.index } ?: -1,
                 lastVisibleIndex = visibleItems.maxOfOrNull { it.index } ?: -1,
                 visibleItemCount = visibleItems.size,
-                isScrolling = state.isScrollInProgress
+                isScrolling = state.isScrollInProgress,
             )
         }
             .distinctUntilChanged()
-            .collectLatest { snapshot ->
-                val range = resolveLazyListPreloadRequest(
-                    lastVisibleIndex = snapshot.lastVisibleIndex,
-                    visibleItemCount = snapshot.visibleItemCount,
-                    itemCount = itemCount,
-                    preloadNext = preloadNext,
-                    preloadNextWhileScrolling = preloadNextWhileScrolling,
-                    isScrolling = snapshot.isScrolling
-                ) ?: return@collectLatest
-                delay(IdlePreloadDelayMs)
-                val toPreload = range.mapNotNull { index ->
-                    latestModelAt.value(index)?.takeUnless { model -> model in preloadedModels }
-                }
-                if (toPreload.isNotEmpty()) {
-                    coroutineScope {
-                        manager.preload(this, toPreload, preloadSize).join()
-                    }
-                    preloadedModels.addAll(toPreload)
-                    preloadedModels.trimOldest(maxSize = MaxRememberedPreloadKeys)
-                }
-            }
+            .collectImagePreloads(
+                manager = manager,
+                preloadedModels = preloadedModels,
+                itemCount = itemCount,
+                preloadNext = preloadNext,
+                preloadNextWhileScrolling = preloadNextWhileScrolling,
+                preloadSize = preloadSize,
+                modelAt = { index -> latestModelAt.value(index) },
+            )
     }
 }
 
@@ -123,10 +110,10 @@ fun LazyStaggeredGridPreloader(
     state: LazyStaggeredGridState,
     itemCount: Int,
     preloadNext: Int = 24,
-    preloadNextWhileScrolling: Int = 16,
+    preloadNextWhileScrolling: Int = 8,
     preloadSize: IntSize? = null,
     cacheManagerProvider: () -> ImageCacheManager,
-    modelAt: (Int) -> Any?
+    modelAt: (Int) -> Any?,
 ) {
     val manager = remember { cacheManagerProvider() }
     val preloadedModels = remember { LinkedHashSet<Any>() }
@@ -136,81 +123,135 @@ fun LazyStaggeredGridPreloader(
         snapshotFlow {
             val visibleItems = state.layoutInfo.visibleItemsInfo
             LazyListPreloadSnapshot(
+                firstVisibleIndex = visibleItems.minOfOrNull { it.index } ?: -1,
                 lastVisibleIndex = visibleItems.maxOfOrNull { it.index } ?: -1,
                 visibleItemCount = visibleItems.size,
-                isScrolling = state.isScrollInProgress
+                isScrolling = state.isScrollInProgress,
             )
         }
             .distinctUntilChanged()
-            .collectLatest { snapshot ->
-                val range = resolveLazyListPreloadRequest(
-                    lastVisibleIndex = snapshot.lastVisibleIndex,
-                    visibleItemCount = snapshot.visibleItemCount,
-                    itemCount = itemCount,
-                    preloadNext = preloadNext,
-                    preloadNextWhileScrolling = preloadNextWhileScrolling,
-                    isScrolling = snapshot.isScrolling
-                ) ?: return@collectLatest
-                delay(IdlePreloadDelayMs)
-                val toPreload = range.mapNotNull { index ->
-                    latestModelAt.value(index)?.takeUnless { model -> model in preloadedModels }
-                }
-                if (toPreload.isNotEmpty()) {
-                    coroutineScope {
-                        manager.preload(this, toPreload, preloadSize).join()
-                    }
-                    preloadedModels.addAll(toPreload)
-                    preloadedModels.trimOldest(maxSize = MaxRememberedPreloadKeys)
-                }
-            }
+            .collectImagePreloads(
+                manager = manager,
+                preloadedModels = preloadedModels,
+                itemCount = itemCount,
+                preloadNext = preloadNext,
+                preloadNextWhileScrolling = preloadNextWhileScrolling,
+                preloadSize = preloadSize,
+                modelAt = { index -> latestModelAt.value(index) },
+            )
+    }
+}
+
+private suspend fun Flow<LazyListPreloadSnapshot>.collectImagePreloads(
+    manager: ImageCacheManager,
+    preloadedModels: LinkedHashSet<Any>,
+    itemCount: Int,
+    preloadNext: Int,
+    preloadNextWhileScrolling: Int,
+    preloadSize: IntSize?,
+    modelAt: (Int) -> Any?,
+) {
+    var previousSnapshot: LazyListPreloadSnapshot? = null
+    var direction = LazyListPreloadDirection.Forward
+    collectLatest { snapshot ->
+        direction = resolveLazyListPreloadDirection(
+            previousFirstVisibleIndex = previousSnapshot?.firstVisibleIndex,
+            previousLastVisibleIndex = previousSnapshot?.lastVisibleIndex,
+            firstVisibleIndex = snapshot.firstVisibleIndex,
+            lastVisibleIndex = snapshot.lastVisibleIndex,
+            previousDirection = direction,
+        )
+        previousSnapshot = snapshot
+
+        val range = resolveLazyListPreloadRange(
+            firstVisibleIndex = snapshot.firstVisibleIndex,
+            lastVisibleIndex = snapshot.lastVisibleIndex,
+            visibleItemCount = snapshot.visibleItemCount,
+            itemCount = itemCount,
+            preloadNext = preloadNext,
+            preloadNextWhileScrolling = preloadNextWhileScrolling,
+            isScrolling = snapshot.isScrolling,
+            direction = direction,
+        ) ?: return@collectLatest
+
+        delay(if (snapshot.isScrolling) ScrollingPreloadDelayMs else IdlePreloadDelayMs)
+        val toPreload = range.mapNotNull { index ->
+            modelAt(index)?.takeUnless { model -> model in preloadedModels }
+        }
+        if (toPreload.isEmpty()) return@collectLatest
+
+        coroutineScope {
+            manager.preload(
+                scope = this,
+                models = toPreload,
+                size = preloadSize,
+                maxConcurrency = if (snapshot.isScrolling) ScrollingPreloadParallelism else null,
+            ).join()
+        }
+        preloadedModels.addAll(toPreload)
+        preloadedModels.trimOldest(maxSize = MaxRememberedPreloadKeys)
+    }
+}
+
+internal fun resolveLazyListPreloadDirection(
+    previousFirstVisibleIndex: Int?,
+    previousLastVisibleIndex: Int?,
+    firstVisibleIndex: Int,
+    lastVisibleIndex: Int,
+    previousDirection: LazyListPreloadDirection = LazyListPreloadDirection.Forward,
+): LazyListPreloadDirection {
+    if (
+        previousFirstVisibleIndex == null || previousLastVisibleIndex == null ||
+        previousFirstVisibleIndex < 0 || previousLastVisibleIndex < 0 ||
+        firstVisibleIndex < 0 || lastVisibleIndex < 0
+    ) {
+        return previousDirection
+    }
+    return when {
+        firstVisibleIndex > previousFirstVisibleIndex -> LazyListPreloadDirection.Forward
+        firstVisibleIndex < previousFirstVisibleIndex -> LazyListPreloadDirection.Backward
+        lastVisibleIndex > previousLastVisibleIndex -> LazyListPreloadDirection.Forward
+        lastVisibleIndex < previousLastVisibleIndex -> LazyListPreloadDirection.Backward
+        else -> previousDirection
     }
 }
 
 internal fun resolveLazyListPreloadRange(
+    firstVisibleIndex: Int,
     lastVisibleIndex: Int,
     visibleItemCount: Int,
     itemCount: Int,
     preloadNext: Int,
     preloadNextWhileScrolling: Int,
-    isScrolling: Boolean
+    isScrolling: Boolean,
+    direction: LazyListPreloadDirection,
 ): IntRange? {
+    if (firstVisibleIndex < 0 || lastVisibleIndex < 0 || itemCount <= 0) return null
     val leadCount = resolveLazyListPreloadLeadCount(
         visibleItemCount = visibleItemCount,
         preloadNext = preloadNext,
         preloadNextWhileScrolling = preloadNextWhileScrolling,
-        isScrolling = isScrolling
+        isScrolling = isScrolling,
     )
-    val start = (lastVisibleIndex + 1).coerceAtLeast(0)
-    val end = (start + leadCount).coerceAtMost(itemCount)
-    return if (start >= end) null else start until end
-}
+    val range = when (direction) {
+        LazyListPreloadDirection.Forward -> {
+            val start = (lastVisibleIndex + 1).coerceIn(0, itemCount)
+            start until (start + leadCount).coerceAtMost(itemCount)
+        }
 
-internal fun resolveLazyListPreloadRequest(
-    lastVisibleIndex: Int,
-    visibleItemCount: Int,
-    itemCount: Int,
-    preloadNext: Int,
-    preloadNextWhileScrolling: Int,
-    isScrolling: Boolean
-): IntRange? {
-    if (!shouldRunLazyListPreload(isScrolling)) return null
-    return resolveLazyListPreloadRange(
-        lastVisibleIndex = lastVisibleIndex,
-        visibleItemCount = visibleItemCount,
-        itemCount = itemCount,
-        preloadNext = preloadNext,
-        preloadNextWhileScrolling = preloadNextWhileScrolling,
-        isScrolling = false
-    )
+        LazyListPreloadDirection.Backward -> {
+            val end = firstVisibleIndex.coerceIn(0, itemCount)
+            (end - leadCount).coerceAtLeast(0) until end
+        }
+    }
+    return range.takeUnless { it.isEmpty() }
 }
-
-internal fun shouldRunLazyListPreload(isScrolling: Boolean): Boolean = !isScrolling
 
 internal fun resolveLazyListPreloadLeadCount(
     visibleItemCount: Int,
     preloadNext: Int,
     preloadNextWhileScrolling: Int,
-    isScrolling: Boolean
+    isScrolling: Boolean,
 ): Int {
     val viewportLead = visibleItemCount.coerceAtLeast(1) *
         if (isScrolling) ScrollingLeadViewportMultiplier else IdleLeadViewportMultiplier

--- a/app/src/main/java/com/asmr/player/ui/hotlistening/HotListeningScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/hotlistening/HotListeningScreen.kt
@@ -281,7 +281,7 @@ fun HotListeningScreen(
                         state = listState,
                         itemCount = state.entries.size,
                         preloadNext = 24,
-                        preloadNextWhileScrolling = 16,
+                        preloadNextWhileScrolling = 8,
                         preloadSize = preloadSize,
                         cacheManagerProvider = { cacheManager },
                         modelAt = { idx ->
@@ -353,7 +353,7 @@ fun HotListeningScreen(
                         state = gridState,
                         itemCount = state.entries.size,
                         preloadNext = 24,
-                        preloadNextWhileScrolling = 16,
+                        preloadNextWhileScrolling = 8,
                         preloadSize = gridPreloadSize,
                         cacheManagerProvider = { cacheManager },
                         modelAt = { idx ->
@@ -445,11 +445,13 @@ private fun HotListeningListItem(
     coverFadeIn: Boolean = true
 ) {
     val album = entry.album
+    val coverBadge = remember(entry) { entry.toCoverBadge() }
     AlbumItem(
         album = album,
         onClick = { onAlbumClick(album) },
         coverRetainPainterDuringReload = true,
-        coverBadge = entry.toCoverBadge(),
+        coverBadge = coverBadge,
+        animateOnlineDetails = false,
         coverFadeIn = coverFadeIn,
         onRjClick = { copyMeta("RJ", it) },
         onCircleClick = { copyMeta("社团", it) },
@@ -470,11 +472,13 @@ private fun HotListeningGridItem(
     coverFadeIn: Boolean = true
 ) {
     val album = entry.album
+    val coverBadge = remember(entry) { entry.toCoverBadge() }
     AlbumGridItem(
         album = album,
         onClick = { onAlbumClick(album) },
         coverRetainPainterDuringReload = true,
-        coverBadge = entry.toCoverBadge(),
+        coverBadge = coverBadge,
+        animateOnlineDetails = false,
         coverFadeIn = coverFadeIn,
         onRjClick = { copyMeta("RJ", it) },
         onCircleClick = { copyMeta("社团", it) },

--- a/app/src/main/java/com/asmr/player/ui/library/AlbumItem.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/AlbumItem.kt
@@ -104,6 +104,7 @@ fun AlbumItem(
     coverBadge: AlbumCoverBadge? = null,
     onlineDetailLoading: Boolean = false,
     onlineCvLoading: Boolean = onlineDetailLoading,
+    animateOnlineDetails: Boolean = true,
     coverFadeIn: Boolean = true,
     coverReloadKey: Any? = null,
     coverRetainPainterDuringReload: Boolean = false,
@@ -222,6 +223,9 @@ fun AlbumItem(
                         }
                     }
                 }
+                val tagsStateContent = remember(album.tags) {
+                    album.tags.joinToString(separator = "\n")
+                }
 
                 BalancedColumn(
                     modifier = Modifier
@@ -251,7 +255,8 @@ fun AlbumItem(
 
                     AlbumOnlineDetailAnimatedLine(
                         content = if (onlineCvLoading) "" else album.cv,
-                        loading = onlineCvLoading
+                        loading = onlineCvLoading,
+                        animated = animateOnlineDetails,
                     ) {
                         AlbumCvChipsSingleLine(
                             cvText = album.cv,
@@ -262,8 +267,9 @@ fun AlbumItem(
                         )
                     }
                     AlbumOnlineDetailAnimatedLine(
-                        content = album.tags.joinToString(separator = "\n"),
+                        content = tagsStateContent,
                         loading = onlineDetailLoading,
+                        animated = animateOnlineDetails,
                         loadingContent = {
                             AlbumDetailSkeletonLine(widthFraction = 0.86f)
                         }
@@ -282,6 +288,7 @@ fun AlbumItem(
                     AlbumOnlineDetailAnimatedLine(
                         content = statsText,
                         loading = onlineDetailLoading && !album.hasRatingInfo(),
+                        animated = animateOnlineDetails,
                         modifier = Modifier.testTag(ALBUM_ITEM_STATS_TAG)
                     ) {
                         Text(
@@ -366,6 +373,7 @@ fun AlbumGridItem(
     coverBadge: AlbumCoverBadge? = null,
     onlineDetailLoading: Boolean = false,
     onlineCvLoading: Boolean = onlineDetailLoading,
+    animateOnlineDetails: Boolean = true,
     coverFadeIn: Boolean = true,
     coverReloadKey: Any? = null,
     coverRetainPainterDuringReload: Boolean = false,
@@ -448,6 +456,7 @@ fun AlbumGridItem(
 
             AlbumOnlineDetailAnimatedOverlay(
                 visible = album.releaseDate.isNotBlank(),
+                animated = animateOnlineDetails,
                 modifier = Modifier
                     .align(Alignment.BottomEnd)
                     .padding(8.dp)
@@ -506,6 +515,7 @@ fun AlbumGridItem(
             AlbumOnlineDetailAnimatedLine(
                 content = if (onlineCvLoading) "" else album.cv,
                 loading = onlineCvLoading,
+                animated = animateOnlineDetails,
                 loadingContent = {
                     AlbumDetailSkeletonLine(widthFraction = 0.72f)
                 }
@@ -532,10 +542,14 @@ fun AlbumGridItem(
                     }
                 }
             }
+            val tagsStateContent = remember(album.tags) {
+                album.tags.joinToString(separator = "\n")
+            }
 
             AlbumOnlineDetailAnimatedLine(
-                content = album.tags.joinToString(separator = "\n"),
+                content = tagsStateContent,
                 loading = onlineDetailLoading,
+                animated = animateOnlineDetails,
                 loadingContent = {
                     AlbumDetailSkeletonLine(widthFraction = 0.92f)
                 }
@@ -551,7 +565,8 @@ fun AlbumGridItem(
 
             AlbumOnlineDetailAnimatedLine(
                 content = statsText,
-                loading = onlineDetailLoading && !album.hasRatingInfo()
+                loading = onlineDetailLoading && !album.hasRatingInfo(),
+                animated = animateOnlineDetails,
             ) {
                 Text(
                     text = statsText,
@@ -569,12 +584,24 @@ fun AlbumGridItem(
 private fun AlbumOnlineDetailAnimatedLine(
     content: String,
     loading: Boolean,
+    animated: Boolean,
     modifier: Modifier = Modifier,
     loadingContent: @Composable () -> Unit = {
         AlbumDetailSkeletonLine(widthFraction = 0.62f)
     },
     contentBlock: @Composable () -> Unit,
 ) {
+    if (!animated) {
+        when {
+            content.isNotBlank() -> Box(modifier = modifier.fillMaxWidth()) {
+                contentBlock()
+            }
+            loading -> Box(modifier = modifier.fillMaxWidth()) {
+                loadingContent()
+            }
+        }
+        return
+    }
     val stateKey = onlineDetailLineStateKey(content = content, loading = loading)
     var keepMounted by remember { mutableStateOf(stateKey != "empty") }
     LaunchedEffect(stateKey) {
@@ -612,9 +639,18 @@ private fun onlineDetailLineStateKey(
 @Composable
 private fun AlbumOnlineDetailAnimatedOverlay(
     visible: Boolean,
+    animated: Boolean,
     modifier: Modifier = Modifier,
     content: @Composable () -> Unit,
 ) {
+    if (!animated) {
+        if (visible) {
+            Box(modifier = modifier) {
+                content()
+            }
+        }
+        return
+    }
     AnimatedContent(
         targetState = visible,
         modifier = modifier,

--- a/app/src/main/java/com/asmr/player/ui/library/LibraryScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/LibraryScreen.kt
@@ -795,7 +795,7 @@ fun LibraryScreen(
                                         state = gridState,
                                         itemCount = pagedAlbums.itemCount,
                                         preloadNext = 24,
-                                        preloadNextWhileScrolling = 16,
+                                        preloadNextWhileScrolling = 8,
                                         preloadSize = gridPreloadSize,
                                         cacheManagerProvider = { cacheManager },
                                         modelAt = { idx ->
@@ -861,7 +861,7 @@ fun LibraryScreen(
                                         state = listState,
                                         itemCount = pagedAlbums.itemCount,
                                         preloadNext = 24,
-                                        preloadNextWhileScrolling = 16,
+                                        preloadNextWhileScrolling = 8,
                                         preloadSize = preloadSize,
                                         cacheManagerProvider = { cacheManager },
                                         modelAt = { idx ->

--- a/app/src/main/java/com/asmr/player/ui/player/MiniPlayer.kt
+++ b/app/src/main/java/com/asmr/player/ui/player/MiniPlayer.kt
@@ -122,7 +122,7 @@ fun MiniPlayer(
             .map { it.isPlaying }
             .distinctUntilChanged()
     }.collectAsState(initial = false)
-    val progressState by remember(viewModel, displayMode) {
+    val progressState = remember(viewModel, displayMode) {
         if (displayMode == MiniPlayerDisplayMode.Expanded) {
             viewModel.playback
                 .map { MiniPlayerProgress(it.positionMs, it.durationMs) }
@@ -164,8 +164,6 @@ fun MiniPlayer(
             optimisticIsPlaying = null
         }
     }
-
-    val progress = progressState.fraction
 
     AnimatedContent(
         targetState = displayMode,
@@ -328,7 +326,7 @@ fun MiniPlayer(
                             }
 
                             LinearProgressIndicator(
-                                progress = { progress },
+                                progress = { progressState.value.fraction },
                                 modifier = Modifier
                                     .fillMaxWidth()
                                     .height((if (largeLayout) 3.dp else 2.dp) * resolvedCompactScale),

--- a/app/src/main/java/com/asmr/player/ui/search/SearchScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/search/SearchScreen.kt
@@ -963,7 +963,7 @@ fun SearchScreen(
                                         state = listState,
                                         itemCount = state.results.size,
                                         preloadNext = 24,
-                                        preloadNextWhileScrolling = 16,
+                                        preloadNextWhileScrolling = 8,
                                         preloadSize = preloadSize,
                                         cacheManagerProvider = { cacheManager },
                                         modelAt = { idx ->
@@ -1021,7 +1021,7 @@ fun SearchScreen(
                                         state = gridState,
                                         itemCount = state.results.size,
                                         preloadNext = 24,
-                                        preloadNextWhileScrolling = 16,
+                                        preloadNextWhileScrolling = 8,
                                         preloadSize = gridPreloadSize,
                                         cacheManagerProvider = { cacheManager },
                                         modelAt = { idx ->

--- a/app/src/test/java/com/asmr/player/cache/LazyListPreloaderTest.kt
+++ b/app/src/test/java/com/asmr/player/cache/LazyListPreloaderTest.kt
@@ -6,115 +6,145 @@ import org.junit.Test
 
 class LazyListPreloaderTest {
     @Test
-    fun preloadLeadCount_expandsWithVisibleItemsWhileScrolling() {
+    fun preloadLeadCount_keepsScrollingWindowBoundedToOneViewport() {
         assertEquals(
-            16,
+            8,
             resolveLazyListPreloadLeadCount(
                 visibleItemCount = 6,
                 preloadNext = 24,
-                preloadNextWhileScrolling = 16,
-                isScrolling = true
+                preloadNextWhileScrolling = 8,
+                isScrolling = true,
+            )
+        )
+        assertEquals(
+            12,
+            resolveLazyListPreloadLeadCount(
+                visibleItemCount = 12,
+                preloadNext = 24,
+                preloadNextWhileScrolling = 8,
+                isScrolling = true,
             )
         )
     }
 
     @Test
-    fun preloadLeadCount_keepsIdleWindowWiderThanScrollingWindow() {
+    fun preloadLeadCount_keepsIdleWindowWider() {
         assertEquals(
             24,
             resolveLazyListPreloadLeadCount(
                 visibleItemCount = 6,
                 preloadNext = 24,
-                preloadNextWhileScrolling = 16,
-                isScrolling = false
+                preloadNextWhileScrolling = 8,
+                isScrolling = false,
             )
         )
     }
 
     @Test
-    fun preloadLeadCount_usesConfiguredMinimumForTinyViewports() {
+    fun preloadRange_prefetchesAfterLastVisibleItemWhenScrollingForward() {
         assertEquals(
-            16,
-            resolveLazyListPreloadLeadCount(
-                visibleItemCount = 1,
-                preloadNext = 24,
-                preloadNextWhileScrolling = 16,
-                isScrolling = true
-            )
-        )
-        assertEquals(
-            24,
-            resolveLazyListPreloadLeadCount(
-                visibleItemCount = 1,
-                preloadNext = 24,
-                preloadNextWhileScrolling = 16,
-                isScrolling = false
-            )
-        )
-    }
-
-    @Test
-    fun preloadRange_startsAfterLastVisibleItemAndClipsAtEnd() {
-        assertEquals(
-            5..20,
+            5..12,
             resolveLazyListPreloadRange(
+                firstVisibleIndex = 0,
                 lastVisibleIndex = 4,
+                visibleItemCount = 5,
+                itemCount = 30,
+                preloadNext = 24,
+                preloadNextWhileScrolling = 8,
+                isScrolling = true,
+                direction = LazyListPreloadDirection.Forward,
+            )
+        )
+    }
+
+    @Test
+    fun preloadRange_prefetchesBeforeFirstVisibleItemWhenScrollingBackward() {
+        assertEquals(
+            2..9,
+            resolveLazyListPreloadRange(
+                firstVisibleIndex = 10,
+                lastVisibleIndex = 15,
                 visibleItemCount = 6,
                 itemCount = 30,
                 preloadNext = 24,
-                preloadNextWhileScrolling = 16,
-                isScrolling = true
+                preloadNextWhileScrolling = 8,
+                isScrolling = true,
+                direction = LazyListPreloadDirection.Backward,
             )
         )
+    }
+
+    @Test
+    fun preloadRange_clipsAtDatasetEdges() {
         assertEquals(
             8..9,
             resolveLazyListPreloadRange(
+                firstVisibleIndex = 3,
                 lastVisibleIndex = 7,
-                visibleItemCount = 6,
+                visibleItemCount = 5,
                 itemCount = 10,
                 preloadNext = 24,
-                preloadNextWhileScrolling = 16,
-                isScrolling = false
+                preloadNextWhileScrolling = 8,
+                isScrolling = false,
+                direction = LazyListPreloadDirection.Forward,
             )
         )
-    }
-
-    @Test
-    fun preloadRange_returnsNullWhenThereAreNoAheadItems() {
         assertNull(
             resolveLazyListPreloadRange(
-                lastVisibleIndex = 9,
-                visibleItemCount = 6,
+                firstVisibleIndex = 0,
+                lastVisibleIndex = 4,
+                visibleItemCount = 5,
                 itemCount = 10,
                 preloadNext = 24,
-                preloadNextWhileScrolling = 16,
-                isScrolling = true
+                preloadNextWhileScrolling = 8,
+                isScrolling = true,
+                direction = LazyListPreloadDirection.Backward,
             )
         )
     }
 
     @Test
-    fun preloadRequest_pausesWhileListIsScrolling() {
-        assertNull(
-            resolveLazyListPreloadRequest(
-                lastVisibleIndex = 4,
-                visibleItemCount = 6,
-                itemCount = 30,
-                preloadNext = 24,
-                preloadNextWhileScrolling = 16,
-                isScrolling = true
+    fun preloadDirection_followsVisibleWindowMovement() {
+        assertEquals(
+            LazyListPreloadDirection.Forward,
+            resolveLazyListPreloadDirection(
+                previousFirstVisibleIndex = 4,
+                previousLastVisibleIndex = 9,
+                firstVisibleIndex = 5,
+                lastVisibleIndex = 10,
             )
         )
-
         assertEquals(
-            5..28,
-            resolveLazyListPreloadRequest(
-                lastVisibleIndex = 4,
-                visibleItemCount = 6,
-                itemCount = 30,
-                preloadNext = 24,
-                preloadNextWhileScrolling = 16,
-                isScrolling = false
+            LazyListPreloadDirection.Backward,
+            resolveLazyListPreloadDirection(
+                previousFirstVisibleIndex = 5,
+                previousLastVisibleIndex = 10,
+                firstVisibleIndex = 4,
+                lastVisibleIndex = 9,
+            )
+        )
+    }
+
+    @Test
+    fun preloadDirection_usesTrailingEdgeAndRetainsLastDirectionWhenStable() {
+        assertEquals(
+            LazyListPreloadDirection.Backward,
+            resolveLazyListPreloadDirection(
+                previousFirstVisibleIndex = 5,
+                previousLastVisibleIndex = 10,
+                firstVisibleIndex = 5,
+                lastVisibleIndex = 9,
+                previousDirection = LazyListPreloadDirection.Forward,
+            )
+        )
+        assertEquals(
+            LazyListPreloadDirection.Backward,
+            resolveLazyListPreloadDirection(
+                previousFirstVisibleIndex = 5,
+                previousLastVisibleIndex = 10,
+                firstVisibleIndex = 5,
+                lastVisibleIndex = 10,
+                previousDirection = LazyListPreloadDirection.Backward,
             )
         )
     }


### PR DESCRIPTION
## 改动概述
- 快速滚动时按方向执行有界图片预取，并将滚动期预取限制为单并发
- 将迷你播放器进度状态读取收窄到进度条绘制阶段
- 避免热门收听静态卡片挂载不会触发的在线详情动画容器
- 补充预取方向、窗口和边界单元测试

## 实机结果
- 设备：Android 16
- 热门收听后台播放稳态超过 16.67ms 的帧：约 11.3% 降至约 6.3%
- 在线搜索最终稳态：暂停约 7.2%，后台播放约 5.2%
- 保留在线搜索详情过渡、封面淡入、导航及播放器动画

## 验证
- 通过 .\gradlew-local.bat :app:installRelease，Release 已安装到连接设备
- Release Kotlin/Java、DEX、资源处理与安装均成功
- 定向单测源码编译成功；本机 Gradle Test Executor 因 JDK 路径拆分导致 ClassNotFoundException，测试进程未能启动