### PR TITLE
perf: 优化在线专辑详情与长列表性能

### DIFF
--- a/app/src/main/java/com/asmr/player/cache/CacheKeyFactory.kt
+++ b/app/src/main/java/com/asmr/player/cache/CacheKeyFactory.kt
@@ -5,8 +5,18 @@ import android.content.res.Configuration
 import androidx.compose.ui.unit.IntSize
 import coil.request.ImageRequest
 import java.security.MessageDigest
+import java.util.LinkedHashMap
 
 object CacheKeyFactory {
+    private const val MaxRememberedHashes = 2048
+    private val hashCacheLock = Any()
+    private val hashCache = object : LinkedHashMap<String, String>(256, 0.75f, true) {
+        override fun removeEldestEntry(eldest: MutableMap.MutableEntry<String, String>?): Boolean {
+            return size > MaxRememberedHashes
+        }
+    }
+    private val md5Digest = ThreadLocal.withInitial { MessageDigest.getInstance("MD5") }
+
     fun createKey(
         context: Context,
         model: Any,
@@ -17,7 +27,7 @@ object CacheKeyFactory {
         val w = size?.width ?: -1
         val h = size?.height ?: -1
         val dark = isDarkMode(context)
-        return md5("$version|$dark|$w|$h|$data")
+        return cachedMd5("$version|$dark|$w|$h|$data")
     }
 
     /**
@@ -31,7 +41,7 @@ object CacheKeyFactory {
     ): String {
         val data = normalizeModel(model)
         val dark = isDarkMode(context)
-        return md5("$version|$dark|$data")
+        return cachedMd5("$version|$dark|$data")
     }
 
     private fun normalizeModel(model: Any): String {
@@ -55,10 +65,24 @@ object CacheKeyFactory {
         return uiMode == Configuration.UI_MODE_NIGHT_YES
     }
 
-    private fun md5(input: String): String {
-        val digest = MessageDigest.getInstance("MD5").digest(input.toByteArray(Charsets.UTF_8))
-        return buildString(digest.size * 2) {
-            for (b in digest) append(((b.toInt() and 0xFF) + 0x100).toString(16).substring(1))
+    private fun cachedMd5(input: String): String {
+        synchronized(hashCacheLock) {
+            hashCache[input]?.let { return it }
+        }
+        val digest = checkNotNull(md5Digest.get())
+        digest.reset()
+        val bytes = digest.digest(input.toByteArray(Charsets.UTF_8))
+        val chars = CharArray(bytes.size * 2)
+        for (index in bytes.indices) {
+            val value = bytes[index].toInt() and 0xFF
+            chars[index * 2] = HexDigits[value ushr 4]
+            chars[index * 2 + 1] = HexDigits[value and 0x0F]
+        }
+        val hash = String(chars)
+        return synchronized(hashCacheLock) {
+            hashCache[input] ?: hash.also { hashCache[input] = it }
         }
     }
+
+    private const val HexDigits = "0123456789abcdef"
 }

--- a/app/src/main/java/com/asmr/player/cache/LazyListPreloader.kt
+++ b/app/src/main/java/com/asmr/player/cache/LazyListPreloader.kt
@@ -37,6 +37,7 @@ internal enum class LazyListPreloadDirection {
 fun LazyListPreloader(
     state: LazyListState,
     models: List<Any>,
+    enabled: Boolean = true,
     preloadNext: Int = 24,
     preloadNextWhileScrolling: Int = 8,
     preloadSize: IntSize? = null,
@@ -44,8 +45,9 @@ fun LazyListPreloader(
 ) {
     val manager = remember { cacheManagerProvider() }
     val preloadedModels = remember { LinkedHashSet<Any>() }
-    LaunchedEffect(state, models, preloadNext, preloadNextWhileScrolling, preloadSize) {
+    LaunchedEffect(state, models, enabled, preloadNext, preloadNextWhileScrolling, preloadSize) {
         preloadedModels.clear()
+        if (!enabled) return@LaunchedEffect
         snapshotFlow {
             val visibleItems = state.layoutInfo.visibleItemsInfo
             LazyListPreloadSnapshot(
@@ -72,6 +74,7 @@ fun LazyListPreloader(
 fun LazyListPreloader(
     state: LazyListState,
     itemCount: Int,
+    enabled: Boolean = true,
     preloadNext: Int = 24,
     preloadNextWhileScrolling: Int = 8,
     preloadSize: IntSize? = null,
@@ -81,13 +84,14 @@ fun LazyListPreloader(
     val manager = remember { cacheManagerProvider() }
     val preloadedModels = remember { LinkedHashSet<Any>() }
     val latestModelAt = rememberUpdatedState(modelAt)
-    LaunchedEffect(state, itemCount, preloadNext, preloadNextWhileScrolling, preloadSize) {
+    LaunchedEffect(state, itemCount, enabled, preloadNext, preloadNextWhileScrolling, preloadSize) {
         preloadedModels.clear()
+        if (!enabled) return@LaunchedEffect
         snapshotFlow {
             val visibleItems = state.layoutInfo.visibleItemsInfo
             LazyListPreloadSnapshot(
-                firstVisibleIndex = visibleItems.minOfOrNull { it.index } ?: -1,
-                lastVisibleIndex = visibleItems.maxOfOrNull { it.index } ?: -1,
+                firstVisibleIndex = visibleItems.firstOrNull()?.index ?: -1,
+                lastVisibleIndex = visibleItems.lastOrNull()?.index ?: -1,
                 visibleItemCount = visibleItems.size,
                 isScrolling = state.isScrollInProgress,
             )
@@ -109,6 +113,7 @@ fun LazyListPreloader(
 fun LazyStaggeredGridPreloader(
     state: LazyStaggeredGridState,
     itemCount: Int,
+    enabled: Boolean = true,
     preloadNext: Int = 24,
     preloadNextWhileScrolling: Int = 8,
     preloadSize: IntSize? = null,
@@ -118,8 +123,9 @@ fun LazyStaggeredGridPreloader(
     val manager = remember { cacheManagerProvider() }
     val preloadedModels = remember { LinkedHashSet<Any>() }
     val latestModelAt = rememberUpdatedState(modelAt)
-    LaunchedEffect(state, itemCount, preloadNext, preloadNextWhileScrolling, preloadSize) {
+    LaunchedEffect(state, itemCount, enabled, preloadNext, preloadNextWhileScrolling, preloadSize) {
         preloadedModels.clear()
+        if (!enabled) return@LaunchedEffect
         snapshotFlow {
             val visibleItems = state.layoutInfo.visibleItemsInfo
             LazyListPreloadSnapshot(

--- a/app/src/main/java/com/asmr/player/main/MainContainer.kt
+++ b/app/src/main/java/com/asmr/player/main/MainContainer.kt
@@ -516,6 +516,7 @@ fun MainContainer(
     val navController = rememberNavController()
     val navigator = remember(navController) { AppNavigator(navController) }
     val navBackStackEntry by navController.currentBackStackEntryAsState()
+    val visibleNavEntries by navController.visibleEntries.collectAsState()
     val currentRoute = navBackStackEntry?.destination?.route
     val hasPreviousBackStackEntry = navController.previousBackStackEntry != null
     val currentPlaylistSystemType = navBackStackEntry?.arguments?.getString("type")
@@ -1329,6 +1330,17 @@ fun MainContainer(
         val currentScreenIsPrimary = currentPrimaryRoute != null
         val showBackButton = !currentScreenIsPrimary
         val showPrimaryBrand = currentScreenIsPrimary
+        val albumDetailExitTransitionActive = !isAlbumDetailRoute && visibleNavEntries.any { entry ->
+            entry.destination.route?.startsWith("album_detail") == true
+        }
+        val sharedTopBarAlpha by animateFloatAsState(
+            targetValue = if (albumDetailExitTransitionActive) 0f else 1f,
+            animationSpec = tween(
+                durationMillis = if (albumDetailExitTransitionActive) 0 else 160,
+                easing = LinearOutSlowInEasing
+            ),
+            label = "sharedTopBarAlbumDetailExitAlpha"
+        )
         val useLargeBottomChrome = windowSizeClass.widthSizeClass != WindowWidthSizeClass.Compact && !isPhone
         val navigationBarBottomPadding = StableWindowInsets.navigationBars
             .only(WindowInsetsSides.Bottom)
@@ -1352,7 +1364,12 @@ fun MainContainer(
                         containerColor = Color.Transparent,
                         contentColor = colorScheme.onBackground,
                         topBar = {
-                            EaraTopBarContainer(overlay = isAlbumDetailRoute) {
+                            EaraTopBarContainer(
+                                overlay = isAlbumDetailRoute || albumDetailExitTransitionActive,
+                                modifier = Modifier.graphicsLayer {
+                                    alpha = if (albumDetailExitTransitionActive) 0f else sharedTopBarAlpha
+                                }
+                            ) {
                                 Column {
                                     val topBarHeight = if (isAlbumDetailRoute) 56.dp else 48.dp
                                     Spacer(modifier = Modifier.windowInsetsTopHeight(StableWindowInsets.statusBars))

--- a/app/src/main/java/com/asmr/player/ui/common/AlbumCoverHelpers.kt
+++ b/app/src/main/java/com/asmr/player/ui/common/AlbumCoverHelpers.kt
@@ -3,7 +3,16 @@ package com.asmr.player.ui.common
 import com.asmr.player.cache.CacheImageModel
 import com.asmr.player.domain.model.Album
 import com.asmr.player.util.DlsiteAntiHotlink
+import java.util.LinkedHashMap
 import kotlin.math.absoluteValue
+
+private const val MaxRememberedAlbumCoverModels = 512
+private val albumCoverModelCacheLock = Any()
+private val albumCoverModelCache = object : LinkedHashMap<String, Any>(128, 0.75f, true) {
+    override fun removeEldestEntry(eldest: MutableMap.MutableEntry<String, Any>?): Boolean {
+        return size > MaxRememberedAlbumCoverModels
+    }
+}
 
 fun albumStableKey(album: Album): String {
     val id = album.rjCode.ifBlank { album.workId }.trim()
@@ -34,12 +43,22 @@ fun albumCoverImageModel(
         coverPath = coverPath,
         coverUrl = coverUrl
     ) ?: return null
+    synchronized(albumCoverModelCacheLock) {
+        albumCoverModelCache[data]?.let { return it }
+    }
     val headers = if (data.startsWith("http", ignoreCase = true)) {
         DlsiteAntiHotlink.headersForImageUrl(data)
     } else {
         emptyMap()
     }
-    return if (headers.isEmpty()) data else CacheImageModel(data = data, headers = headers, keyTag = "dlsite")
+    val model: Any = if (headers.isEmpty()) {
+        data
+    } else {
+        CacheImageModel(data = data, headers = headers, keyTag = "dlsite")
+    }
+    return synchronized(albumCoverModelCacheLock) {
+        albumCoverModelCache[data] ?: model.also { albumCoverModelCache[data] = it }
+    }
 }
 
 private fun albumCoverData(

--- a/app/src/main/java/com/asmr/player/ui/common/AsmrAsyncImage.kt
+++ b/app/src/main/java/com/asmr/player/ui/common/AsmrAsyncImage.kt
@@ -55,6 +55,7 @@ fun AsmrAsyncImage(
     fadeIn: Boolean = true,
     fadeInMillis: Int = 500,
     peekAnySizeForInitial: Boolean = false,
+    requestSize: IntSize? = null,
     // 按原尺寸加载（size=null）：缓存 key 与显示尺寸无关，让列表与详情大图共用同一缓存条目，
     // 详情页进入即内存命中、不再二次网络请求、不再低分辨率占位闪烁。显示时由 ContentScale 缩放。
     loadAtOriginalSize: Boolean = false,
@@ -85,19 +86,24 @@ fun AsmrAsyncImage(
     val crossfade = remember(normalizedModel, reloadKey) { Animatable(if (seededPainter != null) 1f else 0f) }
     val crossfadeRunning = remember(normalizedModel, reloadKey) { mutableStateOf(false) }
     val latestFadeIn by rememberUpdatedState(fadeIn)
-    val containerModifier = modifier.onSizeChanged { sz ->
-        if (sz.width > 0 && sz.height > 0) measuredSize.value = IntSize(sz.width, sz.height)
+    val containerModifier = if (requestSize == null) {
+        modifier.onSizeChanged { sz ->
+            if (sz.width > 0 && sz.height > 0) measuredSize.value = IntSize(sz.width, sz.height)
+        }
+    } else {
+        modifier
     }
     val contentModifier = Modifier.fillMaxSize()
 
-    val loadSizeKey = if (loadAtOriginalSize) Unit else measuredSize.value
+    val resolvedSize = requestSize ?: measuredSize.value
+    val loadSizeKey: Any? = if (loadAtOriginalSize) Unit else resolvedSize
     LaunchedEffect(normalizedModel, loadSizeKey, reloadKey) {
-        val initialSize = measuredSize.value
+        val initialSize = requestSize ?: measuredSize.value
         if (!loadAtOriginalSize && initialSize == null) return@LaunchedEffect
         if (!loadAtOriginalSize && loadWhenSizeStableForMillis > 0L) {
             delay(loadWhenSizeStableForMillis)
         }
-        val sz = measuredSize.value ?: initialSize ?: IntSize.Zero
+        val sz = requestSize ?: measuredSize.value ?: initialSize ?: IntSize.Zero
         suspend fun finishWithExistingPainter() {
             state.value = AsmrAsyncImageState.Success
             crossfadeRunning.value = false
@@ -117,7 +123,7 @@ fun AsmrAsyncImage(
             crossfadeRunning.value = false
             val hasExistingPainter = painter.value != null
             val shouldRetainPainter = (retainPainterDuringReload || loadAtOriginalSize || seededPlaceholder.value) && hasExistingPainter
-            val requestSize = if (loadAtOriginalSize) null else sz
+            val imageRequestSize = if (loadAtOriginalSize) null else sz
             if (!shouldRetainPainter) {
                 state.value = AsmrAsyncImageState.Loading
                 painter.value = null
@@ -129,7 +135,7 @@ fun AsmrAsyncImage(
             val img = withTimeoutOrNull(15_000) {
                 manager.loadImage(
                     model = normalizedModel,
-                    size = requestSize,
+                    size = imageRequestSize,
                     cachePolicy = CachePolicy.DEFAULT
                 )
             } ?: throw IllegalStateException("Image load timeout")

--- a/app/src/main/java/com/asmr/player/ui/common/EaraTopBar.kt
+++ b/app/src/main/java/com/asmr/player/ui/common/EaraTopBar.kt
@@ -37,7 +37,7 @@ internal fun EaraTopBarContainer(
     val colorScheme = AsmrTheme.colorScheme
     val pageBackground = resolveMainPageBackgroundColor(colorScheme)
     val tonalTop = colorScheme.primarySoft
-        .copy(alpha = if (colorScheme.isDark) 0.44f else 0.28f)
+        .copy(alpha = if (colorScheme.isDark) 0.44f else 0.38f)
         .compositeOver(pageBackground)
 
     Box(

--- a/app/src/main/java/com/asmr/player/ui/hotlistening/HotListeningScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/hotlistening/HotListeningScreen.kt
@@ -122,7 +122,9 @@ fun HotListeningScreen(
         LazyStaggeredGridState()
     }
 
-    val periods = listOf("day" to "过去一天", "week" to "过去一周", "month" to "过去一月")
+    val periods = remember {
+        listOf("day" to "过去一天", "week" to "过去一周", "month" to "过去一月")
+    }
 
     fun stopActiveScroll() {
         scope.launch(start = CoroutineStart.UNDISPATCHED) {
@@ -280,6 +282,7 @@ fun HotListeningScreen(
                     LazyListPreloader(
                         state = listState,
                         itemCount = state.entries.size,
+                        enabled = isActive,
                         preloadNext = 24,
                         preloadNextWhileScrolling = 8,
                         preloadSize = preloadSize,
@@ -352,6 +355,7 @@ fun HotListeningScreen(
                     LazyStaggeredGridPreloader(
                         state = gridState,
                         itemCount = state.entries.size,
+                        enabled = isActive,
                         preloadNext = 24,
                         preloadNextWhileScrolling = 8,
                         preloadSize = gridPreloadSize,

--- a/app/src/main/java/com/asmr/player/ui/library/AlbumDetailScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/AlbumDetailScreen.kt
@@ -10,6 +10,7 @@ import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.animateContentSize
 import androidx.compose.animation.core.Spring
 import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.animate
 import androidx.compose.animation.core.FastOutLinearInEasing
 import androidx.compose.animation.core.FastOutSlowInEasing
 import androidx.compose.animation.core.animateFloatAsState
@@ -121,6 +122,7 @@ import androidx.compose.material.icons.automirrored.rounded.PlaylistPlay
 import androidx.compose.material.icons.automirrored.rounded.QueueMusic
 import java.io.File
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.flow.distinctUntilChanged
@@ -141,9 +143,7 @@ import com.asmr.player.ui.common.AsmrImageLoadingPlaceholder
 import com.asmr.player.ui.common.EaraLogoLoadingIndicator
 import com.asmr.player.ui.common.ImagePreviewDialog
 import com.asmr.player.ui.common.ImagePreviewRequest
-import com.asmr.player.ui.common.collapsibleHeaderUiState
 import com.asmr.player.ui.common.consumeTapThrough
-import com.asmr.player.ui.common.rememberCollapsibleHeaderState
 import com.asmr.player.ui.groups.AlbumGroupsViewModel
 import com.asmr.player.ui.groups.AlbumGroupPickerScreen
 import com.asmr.player.ui.playlists.PlaylistPickerScreen
@@ -187,8 +187,12 @@ internal data class PreparedMediaPlayback(
 private val AlbumDetailHeroContentGap = 8.dp
 private val AlbumDetailHeroTransitionHeight = 96.dp
 private val AlbumDetailHeroBlurRampHeight = 188.dp
+private val AlbumDetailHeroBlurRadius = 32.dp
 private val AlbumDetailScrolledContentFadeSpan = 10.dp
 private const val AlbumDetailInitialIntroDurationMs = 1200L
+private const val AlbumDetailHeroIntroDurationMs = 520
+private const val AlbumDetailHeroIntroStartScale = 1.025f
+private const val AlbumDetailHeroBlurRadiusMaxPx = 96f
 private const val AlbumDetailHeroOvershootResistance = 0.30f
 private const val AlbumDetailHeroOvershootReleaseMultiplier = 0.72f
 private const val AlbumDetailHeroExpandOvershootScale = 0.16f
@@ -222,7 +226,7 @@ private val AlbumHeaderExpandTweenSpec = tween<IntSize>(
     easing = FastOutLinearInEasing
 )
 
-private val AlbumHeaderActionMorphSpec = tween<Float>(
+private val AlbumHeaderActionColorTweenSpec = tween<Float>(
     durationMillis = 280,
     easing = FastOutSlowInEasing
 )
@@ -231,6 +235,17 @@ private val DlsiteSectionResizeTweenSpec = tween<IntSize>(
     durationMillis = 280,
     easing = FastOutSlowInEasing
 )
+
+private class AlbumDetailHeroMotionState {
+    var collapsePx by mutableFloatStateOf(0f)
+    var visualOvershootPx by mutableFloatStateOf(0f)
+    var visualOvershootJob: Job? = null
+
+    fun cancelVisualOvershootAnimation() {
+        visualOvershootJob?.cancel()
+        visualOvershootJob = null
+    }
+}
 
 internal fun dlsiteSectionRevealModifier(
     modifier: Modifier = Modifier,
@@ -420,10 +435,6 @@ fun AlbumDetailScreen(
                     var localPreviewFile by remember { mutableStateOf<LocalTreeUiEntry.File?>(null) }
                     var onlinePreviewFile by remember { mutableStateOf<AsmrTreeUiEntry.File?>(null) }
                     var imagePreviewRequest by remember { mutableStateOf<ImagePreviewRequest?>(null) }
-                    // tab 标签栏已移除，但各二级页面组件仍需要一个折叠头状态用于嵌套滚动协调。
-                    // 由于不再渲染 chrome，其 heightPx 始终为 0，相关调用均为安全空操作。
-                    val tabChromeState = rememberCollapsibleHeaderState()
-
                     BoxWithConstraints(modifier = Modifier.fillMaxSize()) {
                         val pageContainerColor = dynamicPageContainerColor(colorScheme)
                         val heroHeightLimit = if (isCompact) {
@@ -451,38 +462,44 @@ fun AlbumDetailScreen(
                         val heroCollapseMaxPx = with(heroDensity) { (heroHeight * 0.5f).toPx() }
                         val heroVisualOvershootMaxPx = with(heroDensity) { (heroHeight * 0.10f).toPx() }
                         val contentViewportTopPx = with(heroDensity) { contentViewportTop.toPx() }
-                        val heroCollapseAnim = remember { Animatable(0f) }
-                        val heroVisualOvershootAnim = remember { Animatable(0f) }
-                        val heroCollapsePx = heroCollapseAnim.value.coerceIn(0f, heroCollapseMaxPx)
-                        val heroVisualOvershootPx = heroVisualOvershootAnim.value
+                        val heroMotion = remember(screenKey) { AlbumDetailHeroMotionState() }
                         val scope = rememberCoroutineScope()
                         LaunchedEffect(heroCollapseMaxPx, heroVisualOvershootMaxPx) {
-                            heroCollapseAnim.snapTo(
-                                heroCollapseAnim.value.coerceIn(0f, heroCollapseMaxPx)
-                            )
-                            heroVisualOvershootAnim.snapTo(
-                                heroVisualOvershootAnim.value.coerceIn(
-                                    -heroVisualOvershootMaxPx,
-                                    0f
-                                )
+                            heroMotion.collapsePx = heroMotion.collapsePx.coerceIn(0f, heroCollapseMaxPx)
+                            heroMotion.visualOvershootPx = heroMotion.visualOvershootPx.coerceIn(
+                                -heroVisualOvershootMaxPx,
+                                0f
                             )
                         }
-                        val heroNestedScroll = remember(heroCollapseMaxPx, heroVisualOvershootMaxPx, scope) {
+                        DisposableEffect(heroMotion) {
+                            onDispose { heroMotion.cancelVisualOvershootAnimation() }
+                        }
+                        val heroNestedScroll = remember(
+                            heroCollapseMaxPx,
+                            heroVisualOvershootMaxPx,
+                            heroMotion,
+                            scope
+                        ) {
                             object : NestedScrollConnection {
                                 private fun settleVisualOvershoot(initialVelocity: Float = 0f): Boolean {
-                                    if (abs(heroVisualOvershootAnim.value) < 0.5f) return false
-                                    scope.launch {
-                                        heroVisualOvershootAnim.animateTo(
-                                            0f,
-                                            animationSpec = AlbumDetailHeroBounceBackSpec,
-                                            initialVelocity = initialVelocity
-                                        )
+                                    val start = heroMotion.visualOvershootPx
+                                    if (abs(start) < 0.5f) return false
+                                    heroMotion.cancelVisualOvershootAnimation()
+                                    heroMotion.visualOvershootJob = scope.launch {
+                                        animate(
+                                            initialValue = start,
+                                            targetValue = 0f,
+                                            initialVelocity = initialVelocity,
+                                            animationSpec = AlbumDetailHeroBounceBackSpec
+                                        ) { value, _ ->
+                                            heroMotion.visualOvershootPx = value
+                                        }
                                     }
                                     return true
                                 }
 
                                 private fun dragOvershootDelta(delta: Float): Float {
-                                    val progress = (-heroVisualOvershootAnim.value / heroVisualOvershootMaxPx)
+                                    val progress = (-heroMotion.visualOvershootPx / heroVisualOvershootMaxPx)
                                         .coerceIn(0f, 1f)
                                     val resistance = AlbumDetailHeroOvershootResistance * (1f - progress * progress * 0.62f)
                                     return delta * resistance
@@ -490,19 +507,16 @@ fun AlbumDetailScreen(
 
                                 private fun applyCollapseDelta(delta: Float): Float {
                                     if (delta == 0f) return 0f
-                                    scope.launch { heroCollapseAnim.stop() }
-                                    scope.launch { heroVisualOvershootAnim.stop() }
-                                    val current = heroCollapseAnim.value.coerceIn(0f, heroCollapseMaxPx)
+                                    heroMotion.cancelVisualOvershootAnimation()
+                                    val current = heroMotion.collapsePx.coerceIn(0f, heroCollapseMaxPx)
                                     var remaining = delta
                                     var consumed = 0f
 
-                                    if (remaining > 0f && heroVisualOvershootAnim.value < 0f) {
+                                    if (remaining > 0f && heroMotion.visualOvershootPx < 0f) {
                                         val visualRelease = (remaining * AlbumDetailHeroOvershootReleaseMultiplier)
-                                            .coerceAtMost(-heroVisualOvershootAnim.value)
+                                            .coerceAtMost(-heroMotion.visualOvershootPx)
                                         if (visualRelease > 0f) {
-                                            scope.launch {
-                                                heroVisualOvershootAnim.snapTo(heroVisualOvershootAnim.value + visualRelease)
-                                            }
+                                            heroMotion.visualOvershootPx += visualRelease
                                             remaining -= visualRelease / AlbumDetailHeroOvershootReleaseMultiplier
                                             consumed += visualRelease / AlbumDetailHeroOvershootReleaseMultiplier
                                         }
@@ -512,7 +526,7 @@ fun AlbumDetailScreen(
                                         val collapseTarget = (current + remaining).coerceIn(0f, heroCollapseMaxPx)
                                         val collapseApplied = collapseTarget - current
                                         if (collapseApplied != 0f) {
-                                            scope.launch { heroCollapseAnim.snapTo(collapseTarget) }
+                                            heroMotion.collapsePx = collapseTarget
                                             remaining -= collapseApplied
                                             consumed += collapseApplied
                                         }
@@ -520,9 +534,9 @@ fun AlbumDetailScreen(
 
                                     if (remaining < 0f) {
                                         val visualDelta = dragOvershootDelta(remaining)
-                                        val visualTarget = (heroVisualOvershootAnim.value + visualDelta)
+                                        val visualTarget = (heroMotion.visualOvershootPx + visualDelta)
                                             .coerceIn(-heroVisualOvershootMaxPx, 0f)
-                                        scope.launch { heroVisualOvershootAnim.snapTo(visualTarget) }
+                                        heroMotion.visualOvershootPx = visualTarget
                                         consumed += remaining
                                     }
 
@@ -545,24 +559,26 @@ fun AlbumDetailScreen(
                                 private fun absorbFlingOvershoot(velocityY: Float): Boolean {
                                     val target = flingOvershootTarget(velocityY)
                                     if (target >= -0.5f) return settleVisualOvershoot()
-                                    scope.launch {
-                                        heroVisualOvershootAnim.stop()
-                                        if (target < heroVisualOvershootAnim.value) {
-                                            heroVisualOvershootAnim.animateTo(
-                                                target,
+                                    heroMotion.cancelVisualOvershootAnimation()
+                                    heroMotion.visualOvershootJob = scope.launch {
+                                        if (target < heroMotion.visualOvershootPx) {
+                                            animate(
+                                                initialValue = heroMotion.visualOvershootPx,
+                                                targetValue = target,
                                                 animationSpec = tween(
                                                     durationMillis = AlbumDetailHeroFlingApproachMillis,
                                                     easing = FastOutSlowInEasing
                                                 )
-                                            )
+                                            ) { value, _ -> heroMotion.visualOvershootPx = value }
                                         }
-                                        heroVisualOvershootAnim.animateTo(
-                                            0f,
+                                        animate(
+                                            initialValue = heroMotion.visualOvershootPx,
+                                            targetValue = 0f,
                                             animationSpec = tween(
                                                 durationMillis = AlbumDetailHeroFlingSettleMillis,
                                                 easing = FastOutSlowInEasing
                                             )
-                                        )
+                                        ) { value, _ -> heroMotion.visualOvershootPx = value }
                                     }
                                     return true
                                 }
@@ -571,8 +587,8 @@ fun AlbumDetailScreen(
                                     val dy = available.y
                                     // 向上浏览（手指上滑，dy<0）：先把滚动用于折叠 hero，再交给列表。
                                     if (dy < 0f && (
-                                            heroCollapseAnim.value < heroCollapseMaxPx ||
-                                                heroVisualOvershootAnim.value < 0f
+                                            heroMotion.collapsePx < heroCollapseMaxPx ||
+                                                heroMotion.visualOvershootPx < 0f
                                             )
                                     ) {
                                         val applied = applyCollapseDelta(-dy)
@@ -590,8 +606,8 @@ fun AlbumDetailScreen(
                                     val dy = available.y
                                     // 列表已到顶仍有下滑剩余（dy>0）：把剩余滚动用于展开 hero。
                                     if (dy > 0f && (
-                                            heroCollapseAnim.value > 0f ||
-                                                heroVisualOvershootAnim.value > -heroVisualOvershootMaxPx
+                                            heroMotion.collapsePx > 0f ||
+                                                heroMotion.visualOvershootPx > -heroVisualOvershootMaxPx
                                             )
                                     ) {
                                         val applied = applyCollapseDelta(-dy)
@@ -607,7 +623,7 @@ fun AlbumDetailScreen(
                                 }
 
                                 override suspend fun onPostFling(consumed: Velocity, available: Velocity): Velocity {
-                                    if (available.y > 0f && heroCollapseAnim.value <= 0.5f) {
+                                    if (available.y > 0f && heroMotion.collapsePx <= 0.5f) {
                                         absorbFlingOvershoot(available.y)
                                     } else {
                                         settleVisualOvershoot()
@@ -667,7 +683,7 @@ fun AlbumDetailScreen(
                                 dlsiteEditions = headerDlsiteEditions,
                                 dlsiteSelectedLang = model.dlsiteSelectedLang,
                                 onDlsiteLangSelected = { viewModel.selectDlsiteLanguage(it) },
-                                canSaveOnline = canUseAsmrOneTreeActions,
+                                showSaveAction = tab == 1,
                                 onDownloadClick = {
                                     downloadSource = if (tab == 2) {
                                         OnlineDownloadSource.DlsitePlay
@@ -676,7 +692,7 @@ fun AlbumDetailScreen(
                                     }
                                     showAsmrDownloadDialog = true
                                 },
-                                showDlsitePlayLossless = tab == 2 && resolvedInitialTarget,
+                                showDlsitePlayLossless = tab == 2,
                                 onLosslessDownloadClick = {
                                     viewModel.downloadDlsitePlayLosslessArchive()
                                 },
@@ -725,9 +741,9 @@ fun AlbumDetailScreen(
                                 showCoverLoadingState = showHeroCoverLoadingState,
                                 messageManager = viewModel.messageManager,
                                 onMetaLongClick = ::openMetaActions,
-                                collapsePx = { heroCollapsePx },
+                                collapsePx = { heroMotion.collapsePx },
                                 collapseMaxPx = heroCollapseMaxPx,
-                                visualOvershootPx = { heroVisualOvershootPx },
+                                visualOvershootPx = { heroMotion.visualOvershootPx },
                                 visualOvershootMaxPx = heroVisualOvershootMaxPx,
                                 modifier = Modifier.align(Alignment.TopCenter)
                             )
@@ -763,13 +779,18 @@ fun AlbumDetailScreen(
                                     .fillMaxWidth()
                                     .height(contentViewportHeight + heroHeight * 0.5f)
                                     .offset {
-                                        IntOffset(0, (contentViewportTopPx - heroCollapsePx).roundToInt())
+                                        IntOffset(
+                                            0,
+                                            (contentViewportTopPx - heroMotion.collapsePx).roundToInt()
+                                        )
                                     }
                                     .nestedScroll(heroNestedScroll)
                                     .clipToBounds()
+                                    .background(pageContainerColor)
                                     .albumDetailScrolledContentFade(
                                         fadeStartY = contentFadeStartY,
-                                        fadeEndY = contentFadeEndY
+                                        fadeEndY = contentFadeEndY,
+                                        fadeColor = pageContainerColor
                                     )
                             ) {
                                 when (selectedTab) {
@@ -796,7 +817,6 @@ fun AlbumDetailScreen(
                                                     viewModel.persistListScrollPosition("scroll:$localTreeStateKey", index, offset)
                                                 },
                                                 topContentPadding = 0.dp,
-                                                chromeState = tabChromeState,
                                                 album = local,
                                                 header = { headerContent(0) },
                                                 onPlayMediaItems = onPlayMediaItems,
@@ -890,7 +910,6 @@ fun AlbumDetailScreen(
                                         treeStateKey = asmrOneTreeStateKey,
                                         initialCurrentPath = viewModel.getTreeCurrentPath(asmrOneTreeStateKey),
                                         topContentPadding = 0.dp,
-                                        chromeState = tabChromeState,
                                         animateIntro = shouldPlayInitialAnimations,
                                         onPersistCurrentPath = { path ->
                                             viewModel.persistTreeCurrentPath(asmrOneTreeStateKey, path)
@@ -930,7 +949,6 @@ fun AlbumDetailScreen(
                                         treeStateKey = "tree:dlsitePlay:${model.baseRjCode.ifBlank { model.rjCode }.trim().uppercase()}",
                                         initialCurrentPath = viewModel.getTreeCurrentPath("tree:dlsitePlay:${model.baseRjCode.ifBlank { model.rjCode }.trim().uppercase()}"),
                                         topContentPadding = 0.dp,
-                                        chromeState = tabChromeState,
                                         animateIntro = shouldPlayInitialAnimations,
                                         onPersistCurrentPath = { path ->
                                             val rj = model.baseRjCode.ifBlank { model.rjCode }.trim().uppercase()
@@ -1146,43 +1164,64 @@ private fun AlbumDetailHeroBackground(
     val imageModel = rememberAlbumCoverImageModel(coverSource)
     val density = LocalDensity.current
     val fullHeightPx = with(density) { height.toPx() }
-    val visualOvershootScale = run {
-        val max = visualOvershootMaxPx.coerceAtLeast(1f)
-        val expandProgress = (-visualOvershootPx() / max).coerceIn(0f, 1f)
-        1f + expandProgress * AlbumDetailHeroExpandOvershootScale
+    val heroIntroProgress = remember(introSessionKey) {
+        Animatable(if (animateIntro) 0f else 1f)
     }
-    val blurModifier = remember {
+    LaunchedEffect(introSessionKey, animateIntro) {
+        if (!animateIntro) {
+            heroIntroProgress.snapTo(1f)
+            return@LaunchedEffect
+        }
+        heroIntroProgress.snapTo(0f)
+        withFrameNanos { }
+        heroIntroProgress.animateTo(
+            targetValue = 1f,
+            animationSpec = tween(
+                durationMillis = AlbumDetailHeroIntroDurationMs,
+                easing = FastOutSlowInEasing
+            )
+        )
+    }
+    val blurRadiusPx = with(density) {
+        AlbumDetailHeroBlurRadius.toPx().coerceAtMost(AlbumDetailHeroBlurRadiusMaxPx)
+    }
+    val blurModifier = remember(blurRadiusPx) {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
             Modifier.graphicsLayer {
-                val blurPx = 84.dp.toPx()
                 renderEffect = RenderEffect
-                    .createBlurEffect(blurPx, blurPx, Shader.TileMode.CLAMP)
+                    .createBlurEffect(blurRadiusPx, blurRadiusPx, Shader.TileMode.CLAMP)
                     .asComposeRenderEffect()
             }
         } else {
-            Modifier.blur(64.dp)
+            Modifier.blur(AlbumDetailHeroBlurRadius)
         }
     }
 
-    // 真实“折叠”而非整体缩放：只压缩 hero 的布局高度（宽度保持满宽 -> 不会出现左右空白）。
-    // 封面填充折叠后的盒子高度（fillMaxSize + Crop）：盒子变矮时 Crop 的缩放因子随之减小，
-    // 宽方向原本被裁掉的左右两侧逐渐显露出来（封面通常较宽，折叠即“横向缩小”露出更多画面）。
-    // 折叠过程中保留当前位图、稳定后再按新尺寸重载，避免逐帧重复解码与闪烁。
-    // 标题/元信息底部对齐，会随折叠后的底边上移但尺寸保持不变。
+    // hero 的可见高度跟随手势变化，但内部始终按完整高度测量。这样封面、毛玻璃和文字不必逐帧
+    // 重测；底部元素只通过图层位移跟随折叠，模糊缓存也能在滚动期间持续复用。
     Box(
         modifier = modifier
             .fillMaxWidth()
+            .clipToBounds()
             .layout { measurable, constraints ->
+                val measuredFullHeight = fullHeightPx
+                    .roundToInt()
+                    .coerceAtLeast(1)
+                    .coerceIn(constraints.minHeight, constraints.maxHeight)
                 val collapse = collapsePx().coerceIn(0f, collapseMaxPx)
-                val targetHeight = (fullHeightPx - collapse).coerceAtLeast(1f).roundToInt()
+                val targetHeight = (measuredFullHeight - collapse)
+                    .coerceAtLeast(1f)
+                    .roundToInt()
                 val placeable = measurable.measure(
-                    constraints.copy(minHeight = targetHeight, maxHeight = targetHeight)
+                    constraints.copy(
+                        minHeight = measuredFullHeight,
+                        maxHeight = measuredFullHeight
+                    )
                 )
                 layout(placeable.width, targetHeight) {
                     placeable.place(0, 0)
                 }
             }
-            .clipToBounds()
     ) {
         Box(
             modifier = Modifier
@@ -1200,34 +1239,19 @@ private fun AlbumDetailHeroBackground(
             modifier = Modifier
                 .fillMaxSize()
                 .graphicsLayer {
-                    compositingStrategy = CompositingStrategy.Offscreen
-                    scaleX = visualOvershootScale
-                    scaleY = visualOvershootScale
+                    val intro = heroIntroProgress.value.coerceIn(0f, 1f)
+                    val introScale = AlbumDetailHeroIntroStartScale -
+                        (AlbumDetailHeroIntroStartScale - 1f) * intro
+                    val overshootProgress = (
+                        -visualOvershootPx() / visualOvershootMaxPx.coerceAtLeast(1f)
+                        ).coerceIn(0f, 1f)
+                    val scale = introScale * (
+                        1f + overshootProgress * AlbumDetailHeroExpandOvershootScale
+                        )
+                    alpha = intro
+                    scaleX = scale
+                    scaleY = scale
                     transformOrigin = TransformOrigin(0.5f, 0f)
-                }
-                .drawWithCache {
-                    val fadeHeightPx = AlbumDetailHeroBlurRampHeight.toPx()
-                        .coerceAtMost(size.height * 0.52f)
-                    val fadeStartY = (size.height - fadeHeightPx).coerceAtLeast(0f)
-                    val stops = (0..5).map { i ->
-                        val t = i / 5f
-                        val eased = t * t * (3f - 2f * t)
-                        val alpha = 1f - eased * 0.38f
-                        t to Color.White.copy(alpha = alpha)
-                    }.toTypedArray()
-                    val mask = Brush.verticalGradient(
-                        colorStops = arrayOf(
-                            0f to Color.White,
-                            *stops,
-                            1f to Color.Transparent
-                        ),
-                        startY = fadeStartY,
-                        endY = size.height
-                    )
-                    onDrawWithContent {
-                        drawContent()
-                        drawRect(brush = mask, blendMode = BlendMode.DstIn)
-                    }
                 },
             placeholder = { m -> DiscPlaceholder(modifier = m, cornerRadius = 0) },
             loading = { m -> AsmrImageLoadingPlaceholder(modifier = m, cornerRadius = 0, indicatorSize = 36.dp) },
@@ -1253,8 +1277,19 @@ private fun AlbumDetailHeroBackground(
                 .then(blurModifier)
                 .graphicsLayer {
                     compositingStrategy = CompositingStrategy.Offscreen
-                    scaleX = visualOvershootScale
-                    scaleY = visualOvershootScale
+                    val intro = heroIntroProgress.value.coerceIn(0f, 1f)
+                    val introScale = AlbumDetailHeroIntroStartScale -
+                        (AlbumDetailHeroIntroStartScale - 1f) * intro
+                    val overshootProgress = (
+                        -visualOvershootPx() / visualOvershootMaxPx.coerceAtLeast(1f)
+                        ).coerceIn(0f, 1f)
+                    val scale = introScale * (
+                        1f + overshootProgress * AlbumDetailHeroExpandOvershootScale
+                        )
+                    alpha = intro
+                    translationY = -collapsePx().coerceIn(0f, collapseMaxPx)
+                    scaleX = scale
+                    scaleY = scale
                     transformOrigin = TransformOrigin(0.5f, 0f)
                 }
                 .drawWithCache {
@@ -1288,6 +1323,9 @@ private fun AlbumDetailHeroBackground(
         Box(
             modifier = Modifier
                 .fillMaxSize()
+                .graphicsLayer {
+                    alpha = heroIntroProgress.value.coerceIn(0f, 1f)
+                }
                 .background(
                     Brush.verticalGradient(
                         colorStops = arrayOf(
@@ -1304,6 +1342,9 @@ private fun AlbumDetailHeroBackground(
                 .align(Alignment.BottomCenter)
                 .fillMaxWidth()
                 .height(AlbumDetailHeroTransitionHeight * 1.7f)
+                .graphicsLayer {
+                    translationY = -collapsePx().coerceIn(0f, collapseMaxPx)
+                }
                 .background(
                     Brush.verticalGradient(
                         colorStops = arrayOf(
@@ -1324,7 +1365,11 @@ private fun AlbumDetailHeroBackground(
             listenTogetherRjListenerCount = listenTogetherRjListenerCount,
             messageManager = messageManager,
             onMetaLongClick = onMetaLongClick,
-            modifier = Modifier.align(Alignment.BottomStart)
+            modifier = Modifier
+                .align(Alignment.BottomStart)
+                .graphicsLayer {
+                    translationY = -collapsePx().coerceIn(0f, collapseMaxPx)
+                }
         )
     }
 }
@@ -1517,40 +1562,40 @@ private fun rememberAlbumCoverImageModel(data: String): Any {
 
 private fun Modifier.albumDetailScrolledContentFade(
     fadeStartY: Dp,
-    fadeEndY: Dp
+    fadeEndY: Dp,
+    fadeColor: Color
 ): Modifier {
-    return this
-        .graphicsLayer {
-            compositingStrategy = CompositingStrategy.Offscreen
-        }
-        .drawWithContent {
-            drawContent()
+    return drawWithCache {
             val fadeStartPx = fadeStartY.toPx().coerceAtLeast(0f)
             val fadeEndPx = fadeEndY.toPx().coerceAtLeast(fadeStartPx + 1f)
             val rampStart = (fadeStartPx / fadeEndPx).coerceIn(0f, 1f)
             val rampSpan = (1f - rampStart).coerceAtLeast(0.0001f)
-            // 用 smoothstep 缓动的多段渐变替代线性裁切，使内容向上滚入 hero 区域时
-            // 平滑自然地溶解消失，而不是生硬地一刀切。
             fun stopAt(t: Float): Pair<Float, Color> {
                 val eased = t * t * (3f - 2f * t)
-                return (rampStart + rampSpan * t) to Color.White.copy(alpha = eased)
+                return (rampStart + rampSpan * t) to fadeColor.copy(alpha = 1f - eased)
             }
-            drawRect(
-                brush = Brush.verticalGradient(
-                    colorStops = arrayOf(
-                        0f to Color.Transparent,
-                        rampStart to Color.Transparent,
-                        stopAt(0.2f),
-                        stopAt(0.4f),
-                        stopAt(0.6f),
-                        stopAt(0.8f),
-                        1f to Color.White
-                    ),
-                    startY = 0f,
-                    endY = fadeEndPx
+            val fadeBrush = Brush.verticalGradient(
+                colorStops = arrayOf(
+                    0f to fadeColor,
+                    rampStart to fadeColor,
+                    stopAt(0.2f),
+                    stopAt(0.4f),
+                    stopAt(0.6f),
+                    stopAt(0.8f),
+                    1f to Color.Transparent
                 ),
-                blendMode = BlendMode.DstIn
+                startY = 0f,
+                endY = fadeEndPx
             )
+            // 页面背景是纯色，用缓存的覆盖渐变即可得到同样的溶解效果；不再为整块长列表
+            // 建立离屏缓冲区，也不在每个滚动帧重新创建 Brush 和色标数组。
+            onDrawWithContent {
+                drawContent()
+                drawRect(
+                    brush = fadeBrush,
+                    size = androidx.compose.ui.geometry.Size(size.width, fadeEndPx)
+                )
+            }
         }
 }
 
@@ -1563,7 +1608,7 @@ private fun AlbumHeader(
     dlsiteEditions: List<DlsiteLanguageEdition>,
     dlsiteSelectedLang: String,
     onDlsiteLangSelected: (String) -> Unit,
-    canSaveOnline: Boolean,
+    showSaveAction: Boolean,
     onDownloadClick: () -> Unit,
     showDlsitePlayLossless: Boolean,
     onLosslessDownloadClick: () -> Unit,
@@ -1731,7 +1776,7 @@ private fun AlbumHeader(
                             ) {
                                 val groupState = when {
                                     showDlsitePlayLossless -> AlbumHeaderButtonGroupState.Lossless
-                                    canSaveOnline -> AlbumHeaderButtonGroupState.Save
+                                    showSaveAction -> AlbumHeaderButtonGroupState.Save
                                     else -> AlbumHeaderButtonGroupState.DownloadOnly
                                 }
                                 AlbumHeaderDownloadAction(
@@ -1982,35 +2027,27 @@ private fun AlbumHeaderDownloadAction(
 ) {
     val colorScheme = AsmrTheme.colorScheme
     val hasSecondaryAction = groupState != AlbumHeaderButtonGroupState.DownloadOnly
-    var displayedSecondaryState by remember { mutableStateOf(groupState) }
-    LaunchedEffect(groupState) {
-        if (groupState != AlbumHeaderButtonGroupState.DownloadOnly) {
-            displayedSecondaryState = groupState
-        }
+    val secondaryActionEnabled = when (groupState) {
+        AlbumHeaderButtonGroupState.Save -> saveEnabled
+        AlbumHeaderButtonGroupState.Lossless -> losslessDownloadEnabled
+        AlbumHeaderButtonGroupState.DownloadOnly -> false
     }
-    val morphProgress by animateFloatAsState(
-        targetValue = if (hasSecondaryAction) 1f else 0f,
-        animationSpec = AlbumHeaderActionMorphSpec,
-        label = "albumHeaderDownloadActionMorph",
-        finishedListener = { value ->
-            if (value == 0f && groupState == AlbumHeaderButtonGroupState.DownloadOnly) {
-                displayedSecondaryState = AlbumHeaderButtonGroupState.DownloadOnly
-            }
-        }
-    )
-    val enabledProgress by animateFloatAsState(
+    val downloadColorProgress by animateFloatAsState(
         targetValue = if (downloadEnabled) 1f else 0f,
-        animationSpec = AlbumHeaderActionMorphSpec,
-        label = "albumHeaderDownloadActionEnabled"
+        animationSpec = AlbumHeaderActionColorTweenSpec,
+        label = "albumHeaderDownloadColor"
+    )
+    val secondaryColorProgress by animateFloatAsState(
+        targetValue = if (secondaryActionEnabled) 1f else 0f,
+        animationSpec = AlbumHeaderActionColorTweenSpec,
+        label = "albumHeaderSecondaryActionColor"
     )
     val radius = 10.dp
-    val secondaryContentAlpha = ((morphProgress - 0.22f) / 0.78f).coerceIn(0f, 1f)
-    val mainEndRadius = radius * (1f - morphProgress)
     val mainShape = RoundedCornerShape(
         topStart = radius,
         bottomStart = radius,
-        topEnd = mainEndRadius,
-        bottomEnd = mainEndRadius
+        topEnd = if (hasSecondaryAction) 0.dp else radius,
+        bottomEnd = if (hasSecondaryAction) 0.dp else radius
     )
     val secondaryShape = RoundedCornerShape(
         topStart = 0.dp,
@@ -2022,12 +2059,20 @@ private fun AlbumHeaderDownloadAction(
         alpha = if (colorScheme.isDark) 0.54f else 0.74f
     )
     val disabledContent = colorScheme.textTertiary.copy(alpha = if (colorScheme.isDark) 0.72f else 0.86f)
-    val primaryContainer = lerp(disabledContainer, colorScheme.primary, enabledProgress)
-    val primaryContent = lerp(disabledContent, colorScheme.onPrimary, enabledProgress)
-    val secondaryContainer = colorScheme.primary.copy(
+    val primaryContainer = lerp(disabledContainer, colorScheme.primary, downloadColorProgress)
+    val primaryContent = lerp(disabledContent, colorScheme.onPrimary, downloadColorProgress)
+    val secondaryDisabledContainer = colorScheme.surfaceVariant.copy(
+        alpha = if (colorScheme.isDark) 0.42f else 0.62f
+    )
+    val secondaryActiveContainer = colorScheme.primary.copy(
         alpha = if (colorScheme.isDark) 0.22f else 0.14f
     )
-    val activeSecondaryState = if (hasSecondaryAction) groupState else displayedSecondaryState
+    val secondaryContainer = lerp(
+        secondaryDisabledContainer,
+        secondaryActiveContainer,
+        secondaryColorProgress
+    )
+    val secondaryContent = lerp(disabledContent, colorScheme.primary, secondaryColorProgress)
 
     Row(
         modifier = modifier,
@@ -2052,54 +2097,51 @@ private fun AlbumHeaderDownloadAction(
             Spacer(modifier = Modifier.width(iconGap))
             Text("下载", style = MaterialTheme.typography.labelMedium, maxLines = 1)
         }
-        Box(
-            modifier = Modifier
-                .fillMaxHeight()
-                .weight(morphProgress.coerceAtLeast(0.001f))
-                .graphicsLayer { alpha = morphProgress }
-        ) {
-            when (activeSecondaryState) {
-                AlbumHeaderButtonGroupState.Save -> Button(
-                    onClick = onSaveClick,
-                    enabled = saveEnabled && secondaryContentAlpha > 0.92f,
-                    modifier = Modifier
-                        .fillMaxSize()
-                        .graphicsLayer { alpha = secondaryContentAlpha },
-                    shape = secondaryShape,
-                    contentPadding = PaddingValues(horizontal = horizontalPadding, vertical = 0.dp),
-                    colors = ButtonDefaults.buttonColors(
-                        containerColor = secondaryContainer,
-                        contentColor = colorScheme.primary,
-                        disabledContainerColor = secondaryContainer,
-                        disabledContentColor = colorScheme.primary.copy(alpha = 0.72f)
-                    )
-                ) {
-                    Icon(Icons.Rounded.Bookmark, contentDescription = null, modifier = Modifier.size(iconSize))
-                    Spacer(modifier = Modifier.width(iconGap))
-                    Text("保存", style = MaterialTheme.typography.labelMedium, maxLines = 1)
-                }
+        if (hasSecondaryAction) {
+            Box(
+                modifier = Modifier
+                    .fillMaxHeight()
+                    .weight(1f)
+            ) {
+                when (groupState) {
+                    AlbumHeaderButtonGroupState.Save -> Button(
+                        onClick = onSaveClick,
+                        enabled = saveEnabled,
+                        modifier = Modifier.fillMaxSize(),
+                        shape = secondaryShape,
+                        contentPadding = PaddingValues(horizontal = horizontalPadding, vertical = 0.dp),
+                        colors = ButtonDefaults.buttonColors(
+                            containerColor = secondaryContainer,
+                            contentColor = secondaryContent,
+                            disabledContainerColor = secondaryContainer,
+                            disabledContentColor = secondaryContent
+                        )
+                    ) {
+                        Icon(Icons.Rounded.Bookmark, contentDescription = null, modifier = Modifier.size(iconSize))
+                        Spacer(modifier = Modifier.width(iconGap))
+                        Text("保存", style = MaterialTheme.typography.labelMedium, maxLines = 1)
+                    }
 
-                AlbumHeaderButtonGroupState.Lossless -> Button(
-                    onClick = onLosslessDownloadClick,
-                    enabled = losslessDownloadEnabled && secondaryContentAlpha > 0.92f,
-                    modifier = Modifier
-                        .fillMaxSize()
-                        .graphicsLayer { alpha = secondaryContentAlpha },
-                    shape = secondaryShape,
-                    contentPadding = PaddingValues(horizontal = horizontalPadding, vertical = 0.dp),
-                    colors = ButtonDefaults.buttonColors(
-                        containerColor = secondaryContainer,
-                        contentColor = colorScheme.primary,
-                        disabledContainerColor = secondaryContainer,
-                        disabledContentColor = colorScheme.primary.copy(alpha = 0.72f)
-                    )
-                ) {
-                    Icon(Icons.Rounded.LibraryMusic, contentDescription = null, modifier = Modifier.size(iconSize))
-                    Spacer(modifier = Modifier.width(iconGap))
-                    Text("无损下载", style = MaterialTheme.typography.labelMedium, maxLines = 1)
-                }
+                    AlbumHeaderButtonGroupState.Lossless -> Button(
+                        onClick = onLosslessDownloadClick,
+                        enabled = losslessDownloadEnabled,
+                        modifier = Modifier.fillMaxSize(),
+                        shape = secondaryShape,
+                        contentPadding = PaddingValues(horizontal = horizontalPadding, vertical = 0.dp),
+                        colors = ButtonDefaults.buttonColors(
+                            containerColor = secondaryContainer,
+                            contentColor = secondaryContent,
+                            disabledContainerColor = secondaryContainer,
+                            disabledContentColor = secondaryContent
+                        )
+                    ) {
+                        Icon(Icons.Rounded.LibraryMusic, contentDescription = null, modifier = Modifier.size(iconSize))
+                        Spacer(modifier = Modifier.width(iconGap))
+                        Text("无损下载", style = MaterialTheme.typography.labelMedium, maxLines = 1)
+                    }
 
-                AlbumHeaderButtonGroupState.DownloadOnly -> Unit
+                    AlbumHeaderButtonGroupState.DownloadOnly -> Unit
+                }
             }
         }
     }
@@ -2139,7 +2181,7 @@ private fun AlbumHeaderInfoReveal(
         delay(AlbumDetailRevealSettleMs)
         hasPlayed = true
     }
-    val alpha by animateFloatAsState(
+    val alpha = animateFloatAsState(
         targetValue = if (visible) 1f else 0f,
         animationSpec = AlbumHeaderEnterTweenSpec,
         label = "albumHeaderInfoAlpha"
@@ -2149,7 +2191,7 @@ private fun AlbumHeaderInfoReveal(
         // 避免先超过最终位置再回到目标位置。
         Box(
             modifier = Modifier.graphicsLayer {
-                this.alpha = alpha
+                this.alpha = alpha.value
             }
         ) {
             content()
@@ -2168,15 +2210,7 @@ private fun AlbumHeaderInfoReveal(
             animationSpec = tween(durationMillis = 160, easing = FastOutLinearInEasing),
             shrinkTowards = Alignment.Top
         )
-    ) {
-        Box(
-            modifier = Modifier.graphicsLayer {
-                this.alpha = alpha
-            }
-        ) {
-            content()
-        }
-    }
+    ) { content() }
 }
 
 @OptIn(ExperimentalLayoutApi::class)

--- a/app/src/main/java/com/asmr/player/ui/library/AlbumItem.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/AlbumItem.kt
@@ -46,7 +46,9 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.layout.Layout
+import androidx.compose.ui.layout.Placeable
 import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
@@ -74,6 +76,22 @@ private val AlbumItemCoverContentSpacing = 8.dp
 private val AlbumGridInfoHorizontalPadding = 6.dp
 private val AlbumGridInfoVerticalPadding = 8.dp
 private val AlbumDetailSkeletonHeight = 18.dp
+private val AlbumListBadgeScrim = Brush.verticalGradient(
+    colors = listOf(
+        Color.Transparent,
+        Color.Black.copy(alpha = 0.18f),
+        Color.Black.copy(alpha = 0.42f),
+        Color.Black.copy(alpha = 0.68f)
+    )
+)
+private val AlbumGridBadgeScrim = Brush.verticalGradient(
+    colors = listOf(
+        Color.Transparent,
+        Color.Black.copy(alpha = 0.18f),
+        Color.Black.copy(alpha = 0.44f),
+        Color.Black.copy(alpha = 0.70f)
+    )
+)
 private val AlbumOnlineDetailResizeSpring = spring<IntSize>(
     dampingRatio = Spring.DampingRatioNoBouncy,
     stiffness = Spring.StiffnessMediumLow
@@ -125,6 +143,11 @@ fun AlbumItem(
     val screenWidthDp = LocalConfiguration.current.screenWidthDp
     val listItemHeight = (screenWidthDp.dp * 0.24f).coerceIn(112.dp, 140.dp)
     val coverSize = listItemHeight
+    val density = LocalDensity.current
+    val coverRequestSize = remember(coverSize, density) {
+        val sizePx = with(density) { coverSize.roundToPx() }
+        IntSize(sizePx, sizePx)
+    }
 
     Box(
         modifier = modifier
@@ -160,6 +183,7 @@ fun AlbumItem(
                         reloadKey = coverReloadKey,
                         retainPainterDuringReload = coverRetainPainterDuringReload,
                         peekAnySizeForInitial = true,
+                        requestSize = coverRequestSize,
                         loading = NoImageLoadingIndicator,
                         modifier = Modifier.fillMaxSize().clip(coverShape),
                     )
@@ -169,16 +193,7 @@ fun AlbumItem(
                                 .align(Alignment.BottomCenter)
                                 .fillMaxWidth()
                                 .fillMaxHeight(0.34f)
-                                .background(
-                                    Brush.verticalGradient(
-                                        colors = listOf(
-                                            Color.Transparent,
-                                            Color.Black.copy(alpha = 0.18f),
-                                            Color.Black.copy(alpha = 0.42f),
-                                            Color.Black.copy(alpha = 0.68f)
-                                        )
-                                    )
-                                )
+                                .background(AlbumListBadgeScrim)
                         )
                     }
                     coverBadge?.let { badge ->
@@ -322,17 +337,23 @@ internal fun BalancedColumn(
     content: @Composable () -> Unit,
 ) {
     Layout(content = content, modifier = modifier) { measurables, constraints ->
-        val placeables = measurables.map { measurable ->
-            measurable.measure(constraints.copy(minHeight = 0))
+        val childConstraints = constraints.copy(minHeight = 0)
+        val placeables = ArrayList<Placeable>(measurables.size)
+        var childrenHeight = 0
+        var widestChild = 0
+        for (index in measurables.indices) {
+            val placeable = measurables[index].measure(childConstraints)
+            placeables.add(placeable)
+            childrenHeight += placeable.height
+            if (placeable.width > widestChild) widestChild = placeable.width
         }
 
         val layoutWidth = if (constraints.maxWidth != Constraints.Infinity) {
             constraints.maxWidth
         } else {
-            maxOf(constraints.minWidth, placeables.maxOfOrNull { it.width } ?: 0)
+            maxOf(constraints.minWidth, widestChild)
         }
 
-        val childrenHeight = placeables.sumOf { it.height }
         val layoutHeight = if (constraints.maxHeight != Constraints.Infinity) {
             maxOf(constraints.minHeight, constraints.maxHeight, childrenHeight)
         } else {
@@ -342,13 +363,16 @@ internal fun BalancedColumn(
         val remaining = (layoutHeight - childrenHeight).coerceAtLeast(0)
         val gapCount = placeables.size + 1
         val idealGap = if (gapCount > 0) remaining / gapCount else 0
-        val gap = idealGap.coerceIn(minGap.roundToPx(), maxGap.roundToPx())
+        val minGapPx = minGap.roundToPx()
+        val maxGapPx = maxGap.roundToPx()
+        val gap = idealGap.coerceIn(minGapPx, maxGapPx)
         val used = gap * gapCount
         val extra = remaining - used
 
         layout(layoutWidth, layoutHeight) {
             var y = (extra / 2) + gap
-            placeables.forEach { placeable ->
+            for (index in placeables.indices) {
+                val placeable = placeables[index]
                 placeable.placeRelative(0, y)
                 y += placeable.height + gap
             }
@@ -419,16 +443,7 @@ fun AlbumGridItem(
                         .align(Alignment.BottomCenter)
                         .fillMaxWidth()
                         .fillMaxHeight(0.36f)
-                        .background(
-                            Brush.verticalGradient(
-                                colors = listOf(
-                                    Color.Transparent,
-                                    Color.Black.copy(alpha = 0.18f),
-                                    Color.Black.copy(alpha = 0.44f),
-                                    Color.Black.copy(alpha = 0.70f)
-                                )
-                            )
-                        )
+                        .background(AlbumGridBadgeScrim)
                 )
             }
             

--- a/app/src/main/java/com/asmr/player/ui/library/LibraryScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/LibraryScreen.kt
@@ -794,6 +794,7 @@ fun LibraryScreen(
                                     LazyStaggeredGridPreloader(
                                         state = gridState,
                                         itemCount = pagedAlbums.itemCount,
+                                        enabled = isActive,
                                         preloadNext = 24,
                                         preloadNextWhileScrolling = 8,
                                         preloadSize = gridPreloadSize,
@@ -860,6 +861,7 @@ fun LibraryScreen(
                                     LazyListPreloader(
                                         state = listState,
                                         itemCount = pagedAlbums.itemCount,
+                                        enabled = isActive,
                                         preloadNext = 24,
                                         preloadNextWhileScrolling = 8,
                                         preloadSize = preloadSize,

--- a/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailDlsiteTabs.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailDlsiteTabs.kt
@@ -1,4 +1,4 @@
-﻿package com.asmr.player.ui.library
+package com.asmr.player.ui.library
 
 import android.content.Intent
 import android.net.Uri
@@ -8,7 +8,6 @@ import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.SizeTransform
-import androidx.compose.animation.animateContentSize
 import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.FastOutSlowInEasing
 import androidx.compose.animation.core.animateFloatAsState
@@ -28,7 +27,6 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.ExperimentalFoundationApi
-import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.foundation.layout.*
@@ -119,7 +117,6 @@ import androidx.compose.material.icons.automirrored.rounded.QueueMusic
 import java.io.File
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
-import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.launch
 
 import androidx.compose.ui.draw.clip
@@ -140,8 +137,6 @@ import com.asmr.player.ui.common.EaraLogoLoadingIndicator
 import com.asmr.player.ui.common.ImagePreviewItem
 import com.asmr.player.ui.common.ImagePreviewPreparedItem
 import com.asmr.player.ui.common.ImagePreviewRequest
-import com.asmr.player.ui.common.collapsibleHeaderUiState
-import com.asmr.player.ui.common.rememberCollapsibleHeaderState
 import com.asmr.player.ui.common.rememberCalmScrollableFlingBehavior
 import com.asmr.player.ui.playlists.PlaylistPickerScreen
 import com.asmr.player.ui.theme.AsmrTheme
@@ -708,10 +703,7 @@ private fun LazyItemScope.dlsiteAnimatedSectionModifier(
     animateIntro: Boolean = true
 ): Modifier {
     if (!animateIntro) return modifier
-    return dlsiteSectionRevealModifier(
-        modifier = modifier.animateItemPlacement(animationSpec = DlsiteSectionPlacementTweenSpec),
-        enabled = true
-    )
+    return modifier.animateItemPlacement(animationSpec = DlsiteSectionPlacementTweenSpec)
 }
 
 @Composable
@@ -764,9 +756,7 @@ private fun DirectoryTreeAnimatedContent(
 ) {
     AnimatedContent(
         targetState = targetState,
-        modifier = modifier.animateContentSize(
-            animationSpec = tween(durationMillis = 260, easing = FastOutSlowInEasing)
-        ),
+        modifier = modifier,
         transitionSpec = {
             (
                 fadeIn(animationSpec = tween(durationMillis = 180, delayMillis = 60)) +
@@ -847,7 +837,6 @@ internal fun AlbumDlsiteInfoBreadcrumbTabV2(
     treeStateKey: String,
     initialCurrentPath: String,
     topContentPadding: Dp,
-    chromeState: com.asmr.player.ui.common.CollapsibleHeaderState,
     animateIntro: Boolean,
     onPersistCurrentPath: (String) -> Unit,
     initialScroll: Pair<Int, Int>,
@@ -883,20 +872,11 @@ internal fun AlbumDlsiteInfoBreadcrumbTabV2(
     val listState = rememberSaveable("scroll:$treeStateKey", saver = LazyListState.Saver) {
         LazyListState(initialScroll.first, initialScroll.second)
     }
-    LaunchedEffect(listState, treeStateKey) {
-        snapshotFlow { listState.firstVisibleItemIndex to listState.firstVisibleItemScrollOffset }
-            .distinctUntilChanged()
-            .collect { (idx, off) -> onPersistScroll(idx, off) }
-    }
-    LaunchedEffect(listState, treeStateKey) {
-        snapshotFlow {
-            listState.firstVisibleItemIndex == 0 && listState.firstVisibleItemScrollOffset == 0
-        }
-            .distinctUntilChanged()
-            .collect { atTop ->
-                if (atTop) chromeState.expand()
-            }
-    }
+    PersistAlbumDetailListScroll(
+        listState = listState,
+        stateKey = treeStateKey,
+        onPersistScroll = onPersistScroll
+    )
     LaunchedEffect(currentPath, treeStateKey) {
         onPersistCurrentPath(currentPath)
     }
@@ -912,7 +892,6 @@ internal fun AlbumDlsiteInfoBreadcrumbTabV2(
     LazyColumn(
         modifier = Modifier
             .fillMaxSize()
-            .nestedScroll(chromeState.nestedScrollConnection)
             .thinScrollbar(listState),
         state = listState,
         flingBehavior = rememberCalmScrollableFlingBehavior(),
@@ -1042,7 +1021,6 @@ internal fun AlbumDlsiteInfoBreadcrumbTabV2(
                                     onOpenBatchPlaylistPicker = onOpenBatchPlaylistPicker,
                                     onAddMediaItemsToQueue = onAddMediaItemsToQueue,
                                     animateIntro = false,
-                                    parentChromeState = chromeState,
                                     folderKeyPrefix = "asmr-folder",
                                     fileKeyPrefix = "asmr-file",
                                     fileContent = { file, selectionMode, selected, enterSelectionMode, onSelectedChange ->
@@ -1277,7 +1255,6 @@ internal fun AlbumDlsitePlayBreadcrumbTabV2(
     treeStateKey: String,
     initialCurrentPath: String,
     topContentPadding: Dp,
-    chromeState: com.asmr.player.ui.common.CollapsibleHeaderState,
     animateIntro: Boolean,
     onPersistCurrentPath: (String) -> Unit,
     initialScroll: Pair<Int, Int>,
@@ -1325,23 +1302,12 @@ internal fun AlbumDlsitePlayBreadcrumbTabV2(
     val listState = rememberSaveable("scroll:$treeStateKey", saver = LazyListState.Saver) {
         LazyListState(restoredIndex, initialScroll.second)
     }
-    LaunchedEffect(listState, treeStateKey) {
-        snapshotFlow { listState.firstVisibleItemIndex to listState.firstVisibleItemScrollOffset }
-            .distinctUntilChanged()
-            .collect { (idx, off) ->
-                val persistedIndex = (idx - headerItemCount).coerceAtLeast(0)
-                onPersistScroll(persistedIndex, off)
-            }
-    }
-    LaunchedEffect(listState, treeStateKey) {
-        snapshotFlow {
-            listState.firstVisibleItemIndex == 0 && listState.firstVisibleItemScrollOffset == 0
-        }
-            .distinctUntilChanged()
-            .collect { atTop ->
-                if (atTop) chromeState.expand()
-            }
-    }
+    PersistAlbumDetailListScroll(
+        listState = listState,
+        stateKey = treeStateKey,
+        indexOffset = headerItemCount,
+        onPersistScroll = onPersistScroll
+    )
 
     val rj = rjCode.trim().uppercase()
     var currentPath by rememberSaveable(treeStateKey) { mutableStateOf(initialCurrentPath.trim().trim('/')) }
@@ -1379,7 +1345,6 @@ internal fun AlbumDlsitePlayBreadcrumbTabV2(
     LazyColumn(
         modifier = Modifier
             .fillMaxSize()
-            .nestedScroll(chromeState.nestedScrollConnection)
             .thinScrollbar(listState),
         state = listState,
         flingBehavior = rememberCalmScrollableFlingBehavior(),
@@ -1456,7 +1421,6 @@ internal fun AlbumDlsitePlayBreadcrumbTabV2(
                                 onOpenBatchPlaylistPicker = onOpenBatchPlaylistPicker,
                                 onAddMediaItemsToQueue = onAddMediaItemsToQueue,
                                 animateIntro = animateIntro,
-                                parentChromeState = chromeState,
                                 folderKeyPrefix = "dlplay-folder",
                                 fileKeyPrefix = "dlplay-file",
                                 fileContent = { file, selectionMode, selected, enterSelectionMode, onSelectedChange ->

--- a/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailLocalTab.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailLocalTab.kt
@@ -1,4 +1,4 @@
-﻿package com.asmr.player.ui.library
+package com.asmr.player.ui.library
 
 import android.content.Intent
 import android.net.Uri
@@ -7,7 +7,6 @@ import androidx.activity.compose.BackHandler
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.animation.AnimatedContent
-import androidx.compose.animation.animateContentSize
 import androidx.compose.animation.core.Spring
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.animateDpAsState
@@ -23,7 +22,6 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.ExperimentalFoundationApi
-import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.foundation.layout.*
@@ -109,7 +107,6 @@ import androidx.compose.material.icons.automirrored.rounded.QueueMusic
 import java.io.File
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
-import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.launch
 
 import androidx.compose.ui.draw.clip
@@ -125,8 +122,6 @@ import com.asmr.player.ui.common.CvChipsFlow
 import com.asmr.player.ui.common.EaraLogoLoadingIndicator
 import com.asmr.player.ui.common.ImagePreviewItem
 import com.asmr.player.ui.common.ImagePreviewRequest
-import com.asmr.player.ui.common.collapsibleHeaderUiState
-import com.asmr.player.ui.common.rememberCollapsibleHeaderState
 import com.asmr.player.ui.common.rememberCalmScrollableFlingBehavior
 import com.asmr.player.ui.playlists.PlaylistPickerScreen
 import com.asmr.player.ui.theme.AsmrTheme
@@ -147,7 +142,6 @@ internal fun AlbumLocalBreadcrumbTabV2(
     initialScroll: Pair<Int, Int>,
     onPersistScroll: (Int, Int) -> Unit,
     topContentPadding: Dp,
-    chromeState: com.asmr.player.ui.common.CollapsibleHeaderState,
     animateIntro: Boolean,
     album: Album,
     header: @Composable () -> Unit,
@@ -177,20 +171,11 @@ internal fun AlbumLocalBreadcrumbTabV2(
     val listState = rememberSaveable("scroll:$stateKey", saver = LazyListState.Saver) {
         LazyListState(initialScroll.first, initialScroll.second)
     }
-    LaunchedEffect(listState, stateKey) {
-        snapshotFlow { listState.firstVisibleItemIndex to listState.firstVisibleItemScrollOffset }
-            .distinctUntilChanged()
-            .collect { (idx, off) -> onPersistScroll(idx, off) }
-    }
-    LaunchedEffect(listState, stateKey) {
-        snapshotFlow {
-            listState.firstVisibleItemIndex == 0 && listState.firstVisibleItemScrollOffset == 0
-        }
-            .distinctUntilChanged()
-            .collect { atTop ->
-                if (atTop) chromeState.expand()
-            }
-    }
+    PersistAlbumDetailListScroll(
+        listState = listState,
+        stateKey = stateKey,
+        onPersistScroll = onPersistScroll
+    )
     LaunchedEffect(currentPath, stateKey) {
         onPersistCurrentPath(currentPath)
     }
@@ -235,7 +220,6 @@ internal fun AlbumLocalBreadcrumbTabV2(
     LazyColumn(
         modifier = Modifier
             .fillMaxSize()
-            .nestedScroll(chromeState.nestedScrollConnection)
             .thinScrollbar(listState),
         state = listState,
         flingBehavior = rememberCalmScrollableFlingBehavior(),
@@ -268,7 +252,6 @@ internal fun AlbumLocalBreadcrumbTabV2(
                     onOpenBatchPlaylistPicker = onOpenBatchPlaylistPicker,
                     onAddMediaItemsToQueue = onAddMediaItemsToQueue,
                     animateIntro = animateIntro,
-                    parentChromeState = chromeState,
                     preferredPath = preferredCurrentPath,
                     onTogglePreferredPath = { enabled ->
                         onTogglePreferredCurrentPath(currentPath, enabled)

--- a/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailScrollPersistence.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailScrollPersistence.kt
@@ -1,0 +1,42 @@
+package com.asmr.player.ui.library
+
+import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.snapshotFlow
+import kotlinx.coroutines.flow.distinctUntilChanged
+
+/**
+ * 只在滚动结束或页面离开时保存位置，避免滚动过程中逐像素分配对象并写入 ViewModel。
+ */
+@Composable
+internal fun PersistAlbumDetailListScroll(
+    listState: LazyListState,
+    stateKey: String,
+    indexOffset: Int = 0,
+    onPersistScroll: (Int, Int) -> Unit
+) {
+    val latestPersistScroll by rememberUpdatedState(onPersistScroll)
+
+    fun persistCurrentPosition() {
+        latestPersistScroll(
+            (listState.firstVisibleItemIndex - indexOffset).coerceAtLeast(0),
+            listState.firstVisibleItemScrollOffset.coerceAtLeast(0)
+        )
+    }
+
+    LaunchedEffect(listState, stateKey, indexOffset) {
+        snapshotFlow { listState.isScrollInProgress }
+            .distinctUntilChanged()
+            .collect { isScrolling ->
+                if (!isScrolling) persistCurrentPosition()
+            }
+    }
+
+    DisposableEffect(listState, stateKey, indexOffset) {
+        onDispose { persistCurrentPosition() }
+    }
+}

--- a/app/src/main/java/com/asmr/player/ui/search/SearchScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/search/SearchScreen.kt
@@ -962,6 +962,7 @@ fun SearchScreen(
                                     LazyListPreloader(
                                         state = listState,
                                         itemCount = state.results.size,
+                                        enabled = isActive,
                                         preloadNext = 24,
                                         preloadNextWhileScrolling = 8,
                                         preloadSize = preloadSize,
@@ -1020,6 +1021,7 @@ fun SearchScreen(
                                     LazyStaggeredGridPreloader(
                                         state = gridState,
                                         itemCount = state.results.size,
+                                        enabled = isActive,
                                         preloadNext = 24,
                                         preloadNextWhileScrolling = 8,
                                         preloadSize = gridPreloadSize,


### PR DESCRIPTION
## 变更内容

- 深度优化在线专辑详情页进入动画、滚动性能与顶层 Header 过渡
- 修复详情内容背景、Hero 边界和下载/保存按钮动画回归
- 降低在线搜索、热门收听和收藏长列表的组合、测量与图片预取开销
- 保留现有动画、视觉效果和交互行为

## 性能验证

- 当前设备 120 Hz，热门收听三轮 P50 均为 8 ms，新口径掉帧为 1/0/0 帧
- 当前设备 120 Hz，在线搜索三轮 P50 均为 8 ms，新口径掉帧均为 0 帧
- Perfetto 中热门收听预取测量耗时约下降 71%，在线搜索约下降 52%

## 验证

- :app:compileReleaseKotlin 通过
- :app:installRelease 通过并已在连接设备验证
- 单元测试源码编译通过；本机 Gradle Test Executor 因 Windows Java 路径拆分问题未能启动测试进程