### PR TITLE
修复二级页面 Header 与专辑详情样式适配

### DIFF
--- a/app/src/main/java/com/asmr/player/main/MainContainer.kt
+++ b/app/src/main/java/com/asmr/player/main/MainContainer.kt
@@ -405,8 +405,8 @@ private fun SecondaryPageBackground(
     Box(
         modifier = modifier
             .fillMaxSize()
-            .background(pageBackgroundColor)
             .padding(top = topPadding)
+            .background(pageBackgroundColor)
     ) {
         content()
     }

--- a/app/src/main/java/com/asmr/player/ui/library/AlbumMetaChips.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/AlbumMetaChips.kt
@@ -9,12 +9,10 @@ import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.FlowRow
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -32,6 +30,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.platform.LocalClipboardManager
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -52,7 +51,6 @@ import com.asmr.player.util.MessageManager
 private val AlbumMetaPillShape = RoundedCornerShape(999.dp)
 private val AlbumMetaTagShape = RoundedCornerShape(7.dp)
 private val AlbumMetaDenseTagShape = RoundedCornerShape(6.dp)
-private val AlbumHeaderMetaLabelWidth = 58.dp
 private const val AlbumHeaderMetaCollapsedLines = 2
 
 private data class AlbumMetaPalette(
@@ -433,22 +431,21 @@ private fun AlbumHeaderMetaFlow(
     modifier: Modifier = Modifier,
     itemContent: @Composable (Int) -> Unit,
 ) {
+    val labelGap = with(LocalDensity.current) {
+        minOf(horizontalSpacing, MaterialTheme.typography.labelSmall.fontSize.toDp() / 2f)
+    }
     Row(
         modifier = modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(labelGap),
         verticalAlignment = Alignment.Top,
     ) {
-        Box(
-            modifier = Modifier.width(AlbumHeaderMetaLabelWidth),
-            contentAlignment = Alignment.TopStart,
-        ) {
-            AlbumMetaBadge(
-                text = label,
-                tone = labelTone,
-                shape = AlbumMetaTagShape,
-                textWeight = FontWeight.SemiBold,
-                leadingIcon = labelIcon,
-            )
-        }
+        AlbumMetaBadge(
+            text = label,
+            tone = labelTone,
+            shape = AlbumMetaTagShape,
+            textWeight = FontWeight.SemiBold,
+            leadingIcon = labelIcon,
+        )
         AlbumMetaMeasuredFlow(
             modifier = Modifier.weight(1f),
             itemCount = itemCount,

--- a/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailDlsiteTabs.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailDlsiteTabs.kt
@@ -846,6 +846,11 @@ internal fun AlbumDlsiteInfoBreadcrumbTabV2(
     loadRemoteFileSize: suspend (String) -> Long?
 ) {
     val scope = rememberCoroutineScope()
+    val colorScheme = AsmrTheme.colorScheme
+    val sectionActionIconColors = IconButtonDefaults.iconButtonColors(
+        contentColor = colorScheme.textPrimary,
+        disabledContentColor = colorScheme.textTertiary.copy(alpha = 0.7f)
+    )
     val videoTracks = remember(trialTracks) { trialTracks.filter { isVideoPreviewUrl(it.path) } }
     val audioTracks = remember(trialTracks) { trialTracks.filterNot { isVideoPreviewUrl(it.path) } }
     var currentPath by rememberSaveable(treeStateKey) { mutableStateOf(initialCurrentPath.trim().trim('/')) }
@@ -979,7 +984,11 @@ internal fun AlbumDlsiteInfoBreadcrumbTabV2(
                     animateIntro = animateIntro
                 ),
                 actions = {
-                    IconButton(onClick = onRefreshAsmrOne, enabled = !isLoadingAsmrOne) {
+                    IconButton(
+                        onClick = onRefreshAsmrOne,
+                        enabled = !isLoadingAsmrOne,
+                        colors = sectionActionIconColors
+                    ) {
                         Icon(Icons.Rounded.Refresh, contentDescription = "刷新")
                     }
                 }
@@ -1134,10 +1143,18 @@ internal fun AlbumDlsiteInfoBreadcrumbTabV2(
                     animateIntro = animateIntro
                 ),
                 actions = {
-                    IconButton(onClick = onRefreshTrial, enabled = !isLoading && !isLoadingTrial) {
+                    IconButton(
+                        onClick = onRefreshTrial,
+                        enabled = !isLoading && !isLoadingTrial,
+                        colors = sectionActionIconColors
+                    ) {
                         Icon(Icons.Rounded.Refresh, contentDescription = "刷新")
                     }
-                    IconButton(onClick = onDownloadTrial, enabled = trialDownloadEnabled) {
+                    IconButton(
+                        onClick = onDownloadTrial,
+                        enabled = trialDownloadEnabled,
+                        colors = sectionActionIconColors
+                    ) {
                         Icon(Icons.Rounded.Download, contentDescription = "下载")
                     }
                 }

--- a/app/src/test/java/com/asmr/player/ui/library/AlbumMetaChipsTest.kt
+++ b/app/src/test/java/com/asmr/player/ui/library/AlbumMetaChipsTest.kt
@@ -1,0 +1,47 @@
+package com.asmr.player.ui.library
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.semantics.SemanticsActions
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performSemanticsAction
+import androidx.compose.ui.text.TextLayoutResult
+import androidx.compose.ui.unit.Density
+import com.asmr.player.ui.theme.AsmrPlayerTheme
+import org.junit.Assert.assertFalse
+import org.junit.Rule
+import org.junit.Test
+
+class AlbumMetaChipsTest {
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    @Test
+    fun headerLabels_doNotEllipsizeWithLargeFontScale() {
+        composeRule.setContent {
+            CompositionLocalProvider(LocalDensity provides Density(density = 1f, fontScale = 1.5f)) {
+                AsmrPlayerTheme {
+                    Column(modifier = Modifier.fillMaxWidth()) {
+                        AlbumHeaderCvFlow(cvText = "声优甲")
+                        AlbumHeaderTagsFlow(tags = listOf("治愈"))
+                    }
+                }
+            }
+        }
+
+        assertTextDoesNotOverflow("声优")
+        assertTextDoesNotOverflow("标签")
+    }
+
+    private fun assertTextDoesNotOverflow(text: String) {
+        val textLayoutResults = mutableListOf<TextLayoutResult>()
+        composeRule.onNodeWithText(text).performSemanticsAction(SemanticsActions.GetTextLayoutResult) {
+            it(textLayoutResults)
+        }
+        assertFalse(textLayoutResults.single().hasVisualOverflow)
+    }
+}


### PR DESCRIPTION
## 变更

- 恢复非沉浸式二级页面 Header 的标题和返回按钮显示
- 修复专辑详情“声优/标签”胶囊在部分机型或字体缩放下省略、间距异常的问题
- 让 ONE、试听/试看区域操作按钮跟随应用主题，在深色模式下显示浅色图标
- 增加专辑元数据标签在大字体缩放下的回归测试

## 验证

- `./gradlew-local.bat :app:installRelease` 构建并安装成功
- 已在连接设备上确认声优/标签无省略、间距正常
- 已在深色模式下确认 ONE 刷新图标使用浅色主题色

## 说明

- 本地单元测试执行器受系统 `CLASSPATH` 中含空格的 Java 路径影响未能启动；测试源码编译通过，Release 构建与安装通过