### PR TITLE
perf: 优化音频播放时列表滚动性能

### DIFF
--- a/app/src/main/java/com/asmr/player/cache/LazyListPreloader.kt
+++ b/app/src/main/java/com/asmr/player/cache/LazyListPreloader.kt
@@ -15,11 +15,9 @@ import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.distinctUntilChanged
 
 private const val MaxRememberedPreloadKeys = 96
-private const val ScrollingLeadViewportMultiplier = 1
 private const val IdleLeadViewportMultiplier = 3
-private const val ScrollingPreloadDelayMs = 24L
 private const val IdlePreloadDelayMs = 160L
-private const val ScrollingPreloadParallelism = 1
+private const val IdlePreloadParallelism = 1
 
 private data class LazyListPreloadSnapshot(
     val firstVisibleIndex: Int,
@@ -39,13 +37,12 @@ fun LazyListPreloader(
     models: List<Any>,
     enabled: Boolean = true,
     preloadNext: Int = 24,
-    preloadNextWhileScrolling: Int = 8,
     preloadSize: IntSize? = null,
     cacheManagerProvider: () -> ImageCacheManager,
 ) {
     val manager = remember { cacheManagerProvider() }
     val preloadedModels = remember { LinkedHashSet<Any>() }
-    LaunchedEffect(state, models, enabled, preloadNext, preloadNextWhileScrolling, preloadSize) {
+    LaunchedEffect(state, models, enabled, preloadNext, preloadSize) {
         preloadedModels.clear()
         if (!enabled) return@LaunchedEffect
         snapshotFlow {
@@ -63,7 +60,6 @@ fun LazyListPreloader(
                 preloadedModels = preloadedModels,
                 itemCount = models.size,
                 preloadNext = preloadNext,
-                preloadNextWhileScrolling = preloadNextWhileScrolling,
                 preloadSize = preloadSize,
                 modelAt = models::get,
             )
@@ -76,7 +72,6 @@ fun LazyListPreloader(
     itemCount: Int,
     enabled: Boolean = true,
     preloadNext: Int = 24,
-    preloadNextWhileScrolling: Int = 8,
     preloadSize: IntSize? = null,
     cacheManagerProvider: () -> ImageCacheManager,
     modelAt: (Int) -> Any?,
@@ -84,7 +79,7 @@ fun LazyListPreloader(
     val manager = remember { cacheManagerProvider() }
     val preloadedModels = remember { LinkedHashSet<Any>() }
     val latestModelAt = rememberUpdatedState(modelAt)
-    LaunchedEffect(state, itemCount, enabled, preloadNext, preloadNextWhileScrolling, preloadSize) {
+    LaunchedEffect(state, itemCount, enabled, preloadNext, preloadSize) {
         preloadedModels.clear()
         if (!enabled) return@LaunchedEffect
         snapshotFlow {
@@ -102,7 +97,6 @@ fun LazyListPreloader(
                 preloadedModels = preloadedModels,
                 itemCount = itemCount,
                 preloadNext = preloadNext,
-                preloadNextWhileScrolling = preloadNextWhileScrolling,
                 preloadSize = preloadSize,
                 modelAt = { index -> latestModelAt.value(index) },
             )
@@ -115,7 +109,6 @@ fun LazyStaggeredGridPreloader(
     itemCount: Int,
     enabled: Boolean = true,
     preloadNext: Int = 24,
-    preloadNextWhileScrolling: Int = 8,
     preloadSize: IntSize? = null,
     cacheManagerProvider: () -> ImageCacheManager,
     modelAt: (Int) -> Any?,
@@ -123,7 +116,7 @@ fun LazyStaggeredGridPreloader(
     val manager = remember { cacheManagerProvider() }
     val preloadedModels = remember { LinkedHashSet<Any>() }
     val latestModelAt = rememberUpdatedState(modelAt)
-    LaunchedEffect(state, itemCount, enabled, preloadNext, preloadNextWhileScrolling, preloadSize) {
+    LaunchedEffect(state, itemCount, enabled, preloadNext, preloadSize) {
         preloadedModels.clear()
         if (!enabled) return@LaunchedEffect
         snapshotFlow {
@@ -141,7 +134,6 @@ fun LazyStaggeredGridPreloader(
                 preloadedModels = preloadedModels,
                 itemCount = itemCount,
                 preloadNext = preloadNext,
-                preloadNextWhileScrolling = preloadNextWhileScrolling,
                 preloadSize = preloadSize,
                 modelAt = { index -> latestModelAt.value(index) },
             )
@@ -153,7 +145,6 @@ private suspend fun Flow<LazyListPreloadSnapshot>.collectImagePreloads(
     preloadedModels: LinkedHashSet<Any>,
     itemCount: Int,
     preloadNext: Int,
-    preloadNextWhileScrolling: Int,
     preloadSize: IntSize?,
     modelAt: (Int) -> Any?,
 ) {
@@ -175,12 +166,11 @@ private suspend fun Flow<LazyListPreloadSnapshot>.collectImagePreloads(
             visibleItemCount = snapshot.visibleItemCount,
             itemCount = itemCount,
             preloadNext = preloadNext,
-            preloadNextWhileScrolling = preloadNextWhileScrolling,
             isScrolling = snapshot.isScrolling,
             direction = direction,
         ) ?: return@collectLatest
 
-        delay(if (snapshot.isScrolling) ScrollingPreloadDelayMs else IdlePreloadDelayMs)
+        delay(IdlePreloadDelayMs)
         val toPreload = range.mapNotNull { index ->
             modelAt(index)?.takeUnless { model -> model in preloadedModels }
         }
@@ -191,7 +181,7 @@ private suspend fun Flow<LazyListPreloadSnapshot>.collectImagePreloads(
                 scope = this,
                 models = toPreload,
                 size = preloadSize,
-                maxConcurrency = if (snapshot.isScrolling) ScrollingPreloadParallelism else null,
+                maxConcurrency = IdlePreloadParallelism,
             ).join()
         }
         preloadedModels.addAll(toPreload)
@@ -228,16 +218,13 @@ internal fun resolveLazyListPreloadRange(
     visibleItemCount: Int,
     itemCount: Int,
     preloadNext: Int,
-    preloadNextWhileScrolling: Int,
     isScrolling: Boolean,
     direction: LazyListPreloadDirection,
 ): IntRange? {
-    if (firstVisibleIndex < 0 || lastVisibleIndex < 0 || itemCount <= 0) return null
+    if (isScrolling || firstVisibleIndex < 0 || lastVisibleIndex < 0 || itemCount <= 0) return null
     val leadCount = resolveLazyListPreloadLeadCount(
         visibleItemCount = visibleItemCount,
         preloadNext = preloadNext,
-        preloadNextWhileScrolling = preloadNextWhileScrolling,
-        isScrolling = isScrolling,
     )
     val range = when (direction) {
         LazyListPreloadDirection.Forward -> {
@@ -256,13 +243,9 @@ internal fun resolveLazyListPreloadRange(
 internal fun resolveLazyListPreloadLeadCount(
     visibleItemCount: Int,
     preloadNext: Int,
-    preloadNextWhileScrolling: Int,
-    isScrolling: Boolean,
 ): Int {
-    val viewportLead = visibleItemCount.coerceAtLeast(1) *
-        if (isScrolling) ScrollingLeadViewportMultiplier else IdleLeadViewportMultiplier
-    val baseLead = if (isScrolling) preloadNextWhileScrolling else preloadNext
-    return maxOf(baseLead, viewportLead)
+    val viewportLead = visibleItemCount.coerceAtLeast(1) * IdleLeadViewportMultiplier
+    return maxOf(preloadNext, viewportLead)
 }
 
 private fun <T> LinkedHashSet<T>.trimOldest(maxSize: Int) {

--- a/app/src/main/java/com/asmr/player/playback/StereoFftAnalyzer.kt
+++ b/app/src/main/java/com/asmr/player/playback/StereoFftAnalyzer.kt
@@ -99,6 +99,11 @@ class StereoFftAnalyzer(
         var lastSeq = 0L
         var idleFrames = 0
         while (scope.isActive) {
+            if (!StereoSpectrumBus.captureActive) {
+                idleFrames = 0
+                delay(SpectrumAnalyzerInactivePollMillis)
+                continue
+            }
             val sr = sampleRate
             val framesDelay = ((visualDelayMs.toLong() * sr.toLong()) / 1000L).toInt()
             val slotsDelay = ((framesDelay + pcmBuffer.frameSize / 2) / pcmBuffer.frameSize).coerceIn(0, pcmBuffer.slotCount - 1)
@@ -109,7 +114,7 @@ class StereoFftAnalyzer(
                     publishDecay()
                     idleFrames = 0
                 }
-                delay(16)
+                delay(SpectrumAnalyzerFrameIntervalMillis)
                 continue
             }
             idleFrames = 0
@@ -119,6 +124,7 @@ class StereoFftAnalyzer(
             computeBins(leftIn, spectrumStore.leftWriteBuffer(writeIndex), smoothLeft, isLeft = true)
             computeBins(rightIn, spectrumStore.rightWriteBuffer(writeIndex), smoothRight, isLeft = false)
             spectrumStore.publish(writeIndex)
+            delay(SpectrumAnalyzerFrameIntervalMillis)
         }
     }
 
@@ -296,3 +302,6 @@ class StereoFftAnalyzer(
         }
     }
 }
+
+internal const val SpectrumAnalyzerFrameIntervalMillis = 16L
+internal const val SpectrumAnalyzerInactivePollMillis = 96L

--- a/app/src/main/java/com/asmr/player/ui/common/CollapsibleHeader.kt
+++ b/app/src/main/java/com/asmr/player/ui/common/CollapsibleHeader.kt
@@ -1,24 +1,21 @@
 package com.asmr.player.ui.common
 
 import androidx.compose.animation.core.Animatable
-import androidx.compose.animation.core.AnimationVector1D
 import androidx.compose.animation.core.FastOutSlowInEasing
 import androidx.compose.animation.core.tween
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
-import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.listSaver
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
-import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
 import androidx.compose.ui.input.nestedscroll.NestedScrollSource
 import androidx.compose.ui.unit.Velocity
-import kotlinx.coroutines.flow.collectLatest
+
+private const val CollapsibleHeaderSettleDurationMillis = 220
 
 internal const val COLLAPSIBLE_HEADER_STATE_EXPANDED = "expanded"
 internal const val COLLAPSIBLE_HEADER_STATE_PARTIAL = "partial"
@@ -57,11 +54,7 @@ class CollapsibleHeaderState internal constructor(
         override suspend fun onPostFling(consumed: Velocity, available: Velocity): Velocity {
             if (descendantScrollBlocked) return Velocity.Zero
             if (heightPx <= 0f) return Velocity.Zero
-            if (offsetPx > -heightPx * 0.5f) {
-                expand()
-            } else {
-                collapse()
-            }
+            settleAfterFling()
             return Velocity.Zero
         }
     }
@@ -93,6 +86,23 @@ class CollapsibleHeaderState internal constructor(
         offsetPx = -heightPx
     }
 
+    private suspend fun settleAfterFling() {
+        val targetOffsetPx = collapsibleHeaderSettleTargetOffset(
+            heightPx = heightPx,
+            offsetPx = offsetPx,
+        )
+        if (targetOffsetPx == offsetPx) return
+        Animatable(offsetPx).animateTo(
+            targetValue = targetOffsetPx,
+            animationSpec = tween(
+                durationMillis = CollapsibleHeaderSettleDurationMillis,
+                easing = FastOutSlowInEasing,
+            ),
+        ) {
+            offsetPx = value.coerceIn(-heightPx, 0f)
+        }
+    }
+
     companion object {
         val Saver = listSaver<CollapsibleHeaderState, Float>(
             save = { listOf(it.heightPx, it.offsetPx) },
@@ -110,21 +120,10 @@ class CollapsibleHeaderState internal constructor(
 fun rememberCollapsibleHeaderState(): CollapsibleHeaderState =
     rememberSaveable(saver = CollapsibleHeaderState.Saver) { CollapsibleHeaderState() }
 
-@Composable
-internal fun rememberAnimatedCollapsibleHeaderOffset(
-    state: CollapsibleHeaderState
-): Animatable<Float, AnimationVector1D> {
-    val animatedOffset = remember(state) { Animatable(state.offsetPx) }
-    LaunchedEffect(state) {
-        snapshotFlow { state.offsetPx }
-            .collectLatest { targetOffset ->
-                animatedOffset.animateTo(
-                    targetValue = targetOffset,
-                    animationSpec = tween(durationMillis = 220, easing = FastOutSlowInEasing)
-                )
-            }
-    }
-    return animatedOffset
+internal fun collapsibleHeaderSettleTargetOffset(heightPx: Float, offsetPx: Float): Float {
+    if (heightPx <= 0f) return 0f
+    val clampedOffsetPx = offsetPx.coerceIn(-heightPx, 0f)
+    return if (clampedOffsetPx > -heightPx * 0.5f) 0f else -heightPx
 }
 
 internal fun collapsibleHeaderUiState(collapseFraction: Float): String = when {

--- a/app/src/main/java/com/asmr/player/ui/common/LazyListCompositionPrefetch.kt
+++ b/app/src/main/java/com/asmr/player/ui/common/LazyListCompositionPrefetch.kt
@@ -1,0 +1,118 @@
+package com.asmr.player.ui.common
+
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.lazy.LazyListLayoutInfo
+import androidx.compose.foundation.lazy.LazyListPrefetchScope
+import androidx.compose.foundation.lazy.LazyListPrefetchStrategy
+import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.foundation.lazy.layout.LazyLayoutPrefetchState
+import androidx.compose.foundation.lazy.layout.NestedPrefetchScope
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.Saver
+import androidx.compose.runtime.saveable.rememberSaveable
+
+private const val DefaultForwardCompositionPrefetchCount = 4
+private const val DefaultBackwardCompositionPrefetchCount = 1
+
+@OptIn(ExperimentalFoundationApi::class)
+private class EaraLazyListPrefetchStrategy(
+    private val forwardItemCount: Int,
+    private val backwardItemCount: Int,
+) : LazyListPrefetchStrategy {
+    private val handles = mutableMapOf<Int, LazyLayoutPrefetchState.PrefetchHandle>()
+
+    override fun LazyListPrefetchScope.onScroll(delta: Float, layoutInfo: LazyListLayoutInfo) {
+        updatePrefetches(layoutInfo)
+    }
+
+    override fun LazyListPrefetchScope.onVisibleItemsUpdated(layoutInfo: LazyListLayoutInfo) {
+        updatePrefetches(layoutInfo)
+    }
+
+    override fun NestedPrefetchScope.onNestedPrefetch(firstVisibleItemIndex: Int) = Unit
+
+    private fun LazyListPrefetchScope.updatePrefetches(layoutInfo: LazyListLayoutInfo) {
+        val visibleItems = layoutInfo.visibleItemsInfo
+        if (visibleItems.isEmpty()) return
+        val targetIndices = resolveCompositionPrefetchIndices(
+            firstVisibleIndex = visibleItems.first().index,
+            lastVisibleIndex = visibleItems.last().index,
+            totalItemCount = layoutInfo.totalItemsCount,
+            forwardItemCount = forwardItemCount,
+            backwardItemCount = backwardItemCount,
+        ).toSet()
+
+        val iterator = handles.iterator()
+        while (iterator.hasNext()) {
+            val entry = iterator.next()
+            if (entry.key !in targetIndices) {
+                entry.value.cancel()
+                iterator.remove()
+            }
+        }
+        targetIndices.forEach { index ->
+            if (index !in handles) {
+                handles[index] = schedulePrefetch(index)
+            }
+        }
+    }
+}
+
+@Composable
+@OptIn(ExperimentalFoundationApi::class)
+fun rememberSaveablePrefetchedLazyListState(
+    stateKey: Any?,
+    initialFirstVisibleItemIndex: Int = 0,
+    initialFirstVisibleItemScrollOffset: Int = 0,
+): LazyListState {
+    val prefetchStrategy = remember(stateKey) {
+        EaraLazyListPrefetchStrategy(
+            forwardItemCount = DefaultForwardCompositionPrefetchCount,
+            backwardItemCount = DefaultBackwardCompositionPrefetchCount,
+        )
+    }
+    val saver = remember(prefetchStrategy) {
+        Saver<LazyListState, List<Int>>(
+            save = { state ->
+                listOf(state.firstVisibleItemIndex, state.firstVisibleItemScrollOffset)
+            },
+            restore = { restored ->
+                LazyListState(
+                    firstVisibleItemIndex = restored.getOrElse(0) { 0 },
+                    firstVisibleItemScrollOffset = restored.getOrElse(1) { 0 },
+                    prefetchStrategy = prefetchStrategy,
+                )
+            },
+        )
+    }
+    return rememberSaveable(stateKey, saver = saver) {
+        LazyListState(
+            firstVisibleItemIndex = initialFirstVisibleItemIndex,
+            firstVisibleItemScrollOffset = initialFirstVisibleItemScrollOffset,
+            prefetchStrategy = prefetchStrategy,
+        )
+    }
+}
+
+internal fun resolveCompositionPrefetchIndices(
+    firstVisibleIndex: Int,
+    lastVisibleIndex: Int,
+    totalItemCount: Int,
+    forwardItemCount: Int,
+    backwardItemCount: Int,
+): IntArray {
+    if (totalItemCount <= 0 || firstVisibleIndex > lastVisibleIndex) return IntArray(0)
+    val result = ArrayList<Int>(
+        forwardItemCount.coerceAtLeast(0) + backwardItemCount.coerceAtLeast(0)
+    )
+    for (offset in 1..forwardItemCount.coerceAtLeast(0)) {
+        val index = lastVisibleIndex + offset
+        if (index < totalItemCount) result += index
+    }
+    for (offset in 1..backwardItemCount.coerceAtLeast(0)) {
+        val index = firstVisibleIndex - offset
+        if (index >= 0) result += index
+    }
+    return result.toIntArray()
+}

--- a/app/src/main/java/com/asmr/player/ui/common/LazyListCompositionPrefetch.kt
+++ b/app/src/main/java/com/asmr/player/ui/common/LazyListCompositionPrefetch.kt
@@ -35,9 +35,11 @@ private class EaraLazyListPrefetchStrategy(
     private fun LazyListPrefetchScope.updatePrefetches(layoutInfo: LazyListLayoutInfo) {
         val visibleItems = layoutInfo.visibleItemsInfo
         if (visibleItems.isEmpty()) return
+        val firstVisibleIndex = visibleItems.first().index
+        val lastVisibleIndex = visibleItems.last().index
         val targetIndices = resolveCompositionPrefetchIndices(
-            firstVisibleIndex = visibleItems.first().index,
-            lastVisibleIndex = visibleItems.last().index,
+            firstVisibleIndex = firstVisibleIndex,
+            lastVisibleIndex = lastVisibleIndex,
             totalItemCount = layoutInfo.totalItemsCount,
             forwardItemCount = forwardItemCount,
             backwardItemCount = backwardItemCount,
@@ -65,11 +67,17 @@ fun rememberSaveablePrefetchedLazyListState(
     stateKey: Any?,
     initialFirstVisibleItemIndex: Int = 0,
     initialFirstVisibleItemScrollOffset: Int = 0,
+    forwardCompositionPrefetchCount: Int = DefaultForwardCompositionPrefetchCount,
+    backwardCompositionPrefetchCount: Int = DefaultBackwardCompositionPrefetchCount,
 ): LazyListState {
-    val prefetchStrategy = remember(stateKey) {
+    val prefetchStrategy = remember(
+        stateKey,
+        forwardCompositionPrefetchCount,
+        backwardCompositionPrefetchCount,
+    ) {
         EaraLazyListPrefetchStrategy(
-            forwardItemCount = DefaultForwardCompositionPrefetchCount,
-            backwardItemCount = DefaultBackwardCompositionPrefetchCount,
+            forwardItemCount = forwardCompositionPrefetchCount.coerceAtLeast(0),
+            backwardItemCount = backwardCompositionPrefetchCount.coerceAtLeast(0),
         )
     }
     val saver = remember(prefetchStrategy) {

--- a/app/src/main/java/com/asmr/player/ui/common/LightweightVerticalOverscroll.kt
+++ b/app/src/main/java/com/asmr/player/ui/common/LightweightVerticalOverscroll.kt
@@ -1,0 +1,172 @@
+package com.asmr.player.ui.common
+
+import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.animate
+import androidx.compose.animation.core.spring
+import androidx.compose.foundation.gestures.awaitEachGesture
+import androidx.compose.foundation.gestures.awaitFirstDown
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.draw.drawWithContent
+import androidx.compose.ui.graphics.drawscope.clipRect
+import androidx.compose.ui.graphics.drawscope.withTransform
+import androidx.compose.ui.input.pointer.PointerEventPass
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.dp
+import kotlin.math.abs
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.launch
+
+private const val StretchDragResistance = 0.22f
+private const val StretchScaleFraction = 0.028f
+private const val StretchTranslationFraction = 0.14f
+
+@Composable
+fun Modifier.lightweightVerticalStretchOverscroll(
+    isAtStart: () -> Boolean,
+    isAtEnd: () -> Boolean,
+): Modifier {
+    val density = LocalDensity.current
+    val coroutineScope = rememberCoroutineScope()
+    val latestIsAtStart by rememberUpdatedState(isAtStart)
+    val latestIsAtEnd by rememberUpdatedState(isAtEnd)
+    val maxDistancePx = with(density) { 72.dp.toPx() }
+    val state = remember(coroutineScope, maxDistancePx) {
+        LightweightVerticalOverscrollState(
+            coroutineScope = coroutineScope,
+            maxDistancePx = maxDistancePx,
+        )
+    }
+
+    DisposableEffect(state) {
+        onDispose(state::dispose)
+    }
+
+    return pointerInput(state) {
+        awaitEachGesture {
+            val down = awaitFirstDown(
+                requireUnconsumed = false,
+                pass = PointerEventPass.Initial,
+            )
+            var trackedPointerId = down.id
+            var previousPosition = down.position
+            var dragFromDown = Offset.Zero
+            var verticalGesture: Boolean? = null
+            state.interruptSettle()
+
+            do {
+                val event = awaitPointerEvent(PointerEventPass.Initial)
+                val change = event.changes.firstOrNull { it.id == trackedPointerId }
+                    ?: event.changes.firstOrNull()
+                if (change != null) {
+                    trackedPointerId = change.id
+                    val positionDelta = change.position - previousPosition
+                    previousPosition = change.position
+                    if (verticalGesture == null) {
+                        dragFromDown += positionDelta
+                        if (dragFromDown.getDistance() > viewConfiguration.touchSlop) {
+                            verticalGesture = abs(dragFromDown.y) > abs(dragFromDown.x)
+                        }
+                    }
+                    if (verticalGesture == true) {
+                        state.dragBy(
+                            deltaY = positionDelta.y,
+                            isAtStart = latestIsAtStart(),
+                            isAtEnd = latestIsAtEnd(),
+                        )
+                    }
+                }
+            } while (event.changes.any { it.pressed })
+
+            state.settle()
+        }
+    }.drawWithContent {
+        val distancePx = state.distancePx
+        if (abs(distancePx) < 0.5f) {
+            drawContent()
+            return@drawWithContent
+        }
+
+        val progress = (abs(distancePx) / state.maxDistancePx).coerceIn(0f, 1f)
+        val pivotY = if (distancePx > 0f) 0f else size.height
+        clipRect {
+            withTransform({
+                translate(top = distancePx * StretchTranslationFraction)
+                scale(
+                    scaleX = 1f,
+                    scaleY = 1f + progress * StretchScaleFraction,
+                    pivot = Offset(size.width / 2f, pivotY),
+                )
+            }) {
+                this@drawWithContent.drawContent()
+            }
+        }
+    }
+}
+
+private class LightweightVerticalOverscrollState(
+    private val coroutineScope: CoroutineScope,
+    val maxDistancePx: Float,
+) {
+    var distancePx by mutableFloatStateOf(0f)
+        private set
+
+    private var settleJob: Job? = null
+
+    fun interruptSettle() {
+        settleJob?.cancel()
+    }
+
+    fun dragBy(deltaY: Float, isAtStart: Boolean, isAtEnd: Boolean) {
+        if (deltaY == 0f) return
+        interruptSettle()
+
+        distancePx = when {
+            distancePx > 0f && deltaY < 0f -> (distancePx + deltaY).coerceAtLeast(0f)
+            distancePx < 0f && deltaY > 0f -> (distancePx + deltaY).coerceAtMost(0f)
+            isAtStart && deltaY > 0f -> resistedDistance(distancePx, deltaY)
+            isAtEnd && deltaY < 0f -> resistedDistance(distancePx, deltaY)
+            else -> 0f
+        }
+    }
+
+    fun settle() {
+        settleJob?.cancel()
+        if (distancePx == 0f) return
+
+        settleJob = coroutineScope.launch {
+            animate(
+                initialValue = distancePx,
+                targetValue = 0f,
+                animationSpec = spring(
+                    dampingRatio = Spring.DampingRatioNoBouncy,
+                    stiffness = Spring.StiffnessMediumLow,
+                ),
+            ) { value, _ ->
+                distancePx = value
+            }
+            distancePx = 0f
+        }
+    }
+
+    fun dispose() {
+        settleJob?.cancel()
+    }
+
+    private fun resistedDistance(currentDistance: Float, deltaY: Float): Float {
+        val remainingFraction =
+            (1f - abs(currentDistance) / maxDistancePx).coerceIn(0.08f, 1f)
+        return (currentDistance + deltaY * StretchDragResistance * remainingFraction)
+            .coerceIn(-maxDistancePx, maxDistancePx)
+    }
+}

--- a/app/src/main/java/com/asmr/player/ui/hotlistening/HotListeningScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/hotlistening/HotListeningScreen.kt
@@ -1,5 +1,7 @@
 package com.asmr.player.ui.hotlistening
 
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.LocalOverscrollConfiguration
 import androidx.compose.foundation.MutatePriority
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -36,6 +38,7 @@ import androidx.compose.material3.TextButton
 import androidx.compose.material3.windowsizeclass.WindowSizeClass
 import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
@@ -46,6 +49,7 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.compositeOver
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
@@ -64,6 +68,7 @@ import com.asmr.player.ui.common.LocalBottomOverlayPadding
 import com.asmr.player.ui.common.albumCoverImageModel
 import com.asmr.player.ui.common.albumStableKey
 import com.asmr.player.ui.common.interruptScrollableFlingOnPointerDown
+import com.asmr.player.ui.common.lightweightVerticalStretchOverscroll
 import com.asmr.player.ui.common.rememberCalmScrollableFlingBehavior
 import com.asmr.player.ui.common.rememberSaveablePrefetchedLazyListState
 import com.asmr.player.ui.common.shouldFadeInCover
@@ -88,7 +93,7 @@ private fun hotListeningItemKey(section: String, album: Album): String {
     return "hot-listening:$section:${albumStableKey(album)}"
 }
 
-@OptIn(ExperimentalMaterial3Api::class)
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalFoundationApi::class)
 @Composable
 fun HotListeningScreen(
     windowSizeClass: WindowSizeClass,
@@ -117,7 +122,11 @@ fun HotListeningScreen(
     val contentScrollKey = remember(selectedPeriod, selectedSortMode, scrollResetNonce) {
         "hot-listening:$selectedPeriod:${selectedSortMode.name}:$scrollResetNonce"
     }
-    val listState = rememberSaveablePrefetchedLazyListState(stateKey = contentScrollKey)
+    val listState = rememberSaveablePrefetchedLazyListState(
+        stateKey = contentScrollKey,
+        forwardCompositionPrefetchCount = 2,
+        backwardCompositionPrefetchCount = 2,
+    )
     val gridState = rememberSaveable(contentScrollKey, saver = LazyStaggeredGridState.Saver) {
         LazyStaggeredGridState()
     }
@@ -290,43 +299,27 @@ fun HotListeningScreen(
                             state.entries.getOrNull(idx)?.album?.let { albumCoverImageModel(it) }
                         }
                     )
-                    LazyColumn(
-                        state = listState,
-                        modifier = Modifier
-                            .fillMaxSize()
-                            .thinScrollbar(listState),
-                        flingBehavior = rememberCalmScrollableFlingBehavior(),
-                        contentPadding = PaddingValues(bottom = 8.dp)
-                            .withAddedBottomPadding(LocalBottomOverlayPadding.current)
-                    ) {
-                        lazyItemsIndexed(
-                            items = state.entries,
-                            key = { _, entry -> hotListeningItemKey("visible", entry.album) },
-                            contentType = { _, _ -> "album" }
-                        ) { _, entry ->
-                            HotListeningListItem(
-                                entry = entry,
-                                onAlbumClick = onAlbumClick,
-                                copyMeta = copyMeta,
-                                onMetaLongClick = ::openMetaActions,
-                                coverFadeIn = listCoverFadeIn
-                            )
-                        }
-                        if (state.blockedEntries.isNotEmpty()) {
-                            item(
-                                key = "blocked-footer",
-                                contentType = "blockedFooter"
-                            ) {
-                                BlockedHotListeningFooter(
-                                    blockedCount = state.blockedEntries.size,
-                                    expanded = showBlockedEntries,
-                                    onToggle = { showBlockedEntries = !showBlockedEntries }
+                    CompositionLocalProvider(LocalOverscrollConfiguration provides null) {
+                        Box(
+                            modifier = Modifier
+                                .fillMaxSize()
+                                .lightweightVerticalStretchOverscroll(
+                                    isAtStart = { !listState.canScrollBackward },
+                                    isAtEnd = { !listState.canScrollForward },
                                 )
-                            }
-                            if (showBlockedEntries) {
+                        ) {
+                            LazyColumn(
+                                state = listState,
+                                modifier = Modifier
+                                    .fillMaxSize()
+                                    .thinScrollbar(listState),
+                                flingBehavior = rememberCalmScrollableFlingBehavior(),
+                                contentPadding = PaddingValues(bottom = 8.dp)
+                                    .withAddedBottomPadding(LocalBottomOverlayPadding.current)
+                            ) {
                                 lazyItemsIndexed(
-                                    items = state.blockedEntries,
-                                    key = { _, entry -> hotListeningItemKey("blocked", entry.album) },
+                                    items = state.entries,
+                                    key = { _, entry -> hotListeningItemKey("visible", entry.album) },
                                     contentType = { _, _ -> "album" }
                                 ) { _, entry ->
                                     HotListeningListItem(
@@ -336,6 +329,35 @@ fun HotListeningScreen(
                                         onMetaLongClick = ::openMetaActions,
                                         coverFadeIn = listCoverFadeIn
                                     )
+                                }
+                                if (state.blockedEntries.isNotEmpty()) {
+                                    item(
+                                        key = "blocked-footer",
+                                        contentType = "blockedFooter"
+                                    ) {
+                                        BlockedHotListeningFooter(
+                                            blockedCount = state.blockedEntries.size,
+                                            expanded = showBlockedEntries,
+                                            onToggle = { showBlockedEntries = !showBlockedEntries }
+                                        )
+                                    }
+                                    if (showBlockedEntries) {
+                                        lazyItemsIndexed(
+                                            items = state.blockedEntries,
+                                            key = { _, entry ->
+                                                hotListeningItemKey("blocked", entry.album)
+                                            },
+                                            contentType = { _, _ -> "album" }
+                                        ) { _, entry ->
+                                            HotListeningListItem(
+                                                entry = entry,
+                                                onAlbumClick = onAlbumClick,
+                                                copyMeta = copyMeta,
+                                                onMetaLongClick = ::openMetaActions,
+                                                coverFadeIn = listCoverFadeIn
+                                            )
+                                        }
+                                    }
                                 }
                             }
                         }
@@ -362,61 +384,75 @@ fun HotListeningScreen(
                             state.entries.getOrNull(idx)?.album?.let { albumCoverImageModel(it) }
                         }
                     )
-                    LazyVerticalStaggeredGrid(
-                        columns = StaggeredGridCells.Adaptive(adaptiveCellSize),
-                        state = gridState,
-                        modifier = Modifier
-                            .fillMaxSize()
-                            .thinScrollbar(gridState),
-                        flingBehavior = rememberCalmScrollableFlingBehavior(),
-                        contentPadding = PaddingValues(
-                            start = 8.dp,
-                            end = 8.dp,
-                            bottom = 16.dp
-                        ).withAddedBottomPadding(LocalBottomOverlayPadding.current),
-                        horizontalArrangement = Arrangement.spacedBy(AlbumGridItemSpacing),
-                        verticalItemSpacing = AlbumGridItemSpacing
-                    ) {
-                        items(
-                            state.entries.size,
-                            key = { index -> hotListeningItemKey("visible", state.entries[index].album) },
-                            contentType = { "albumGrid" }
-                        ) { index ->
-                            HotListeningGridItem(
-                                entry = state.entries[index],
-                                onAlbumClick = onAlbumClick,
-                                copyMeta = copyMeta,
-                                onMetaLongClick = ::openMetaActions,
-                                coverFadeIn = gridCoverFadeIn
-                            )
-                        }
-                        if (state.blockedEntries.isNotEmpty()) {
-                            item(
-                                key = "blocked-footer",
-                                contentType = "blockedFooter",
-                                span = StaggeredGridItemSpan.FullLine
-                            ) {
-                                BlockedHotListeningFooter(
-                                    blockedCount = state.blockedEntries.size,
-                                    expanded = showBlockedEntries,
-                                    onToggle = { showBlockedEntries = !showBlockedEntries }
+                    CompositionLocalProvider(LocalOverscrollConfiguration provides null) {
+                        Box(
+                            modifier = Modifier
+                                .fillMaxSize()
+                                .lightweightVerticalStretchOverscroll(
+                                    isAtStart = { !gridState.canScrollBackward },
+                                    isAtEnd = { !gridState.canScrollForward },
                                 )
-                            }
-                            if (showBlockedEntries) {
+                        ) {
+                            LazyVerticalStaggeredGrid(
+                                columns = StaggeredGridCells.Adaptive(adaptiveCellSize),
+                                state = gridState,
+                                modifier = Modifier
+                                    .fillMaxSize()
+                                    .thinScrollbar(gridState),
+                                flingBehavior = rememberCalmScrollableFlingBehavior(),
+                                contentPadding = PaddingValues(
+                                    start = 8.dp,
+                                    end = 8.dp,
+                                    bottom = 16.dp
+                                ).withAddedBottomPadding(LocalBottomOverlayPadding.current),
+                                horizontalArrangement = Arrangement.spacedBy(AlbumGridItemSpacing),
+                                verticalItemSpacing = AlbumGridItemSpacing
+                            ) {
                                 items(
-                                    state.blockedEntries.size,
-                                    key = { index ->
-                                        hotListeningItemKey("blocked", state.blockedEntries[index].album)
-                                    },
+                                    state.entries.size,
+                                    key = { index -> hotListeningItemKey("visible", state.entries[index].album) },
                                     contentType = { "albumGrid" }
                                 ) { index ->
                                     HotListeningGridItem(
-                                        entry = state.blockedEntries[index],
+                                        entry = state.entries[index],
                                         onAlbumClick = onAlbumClick,
                                         copyMeta = copyMeta,
                                         onMetaLongClick = ::openMetaActions,
                                         coverFadeIn = gridCoverFadeIn
                                     )
+                                }
+                                if (state.blockedEntries.isNotEmpty()) {
+                                    item(
+                                        key = "blocked-footer",
+                                        contentType = "blockedFooter",
+                                        span = StaggeredGridItemSpan.FullLine
+                                    ) {
+                                        BlockedHotListeningFooter(
+                                            blockedCount = state.blockedEntries.size,
+                                            expanded = showBlockedEntries,
+                                            onToggle = { showBlockedEntries = !showBlockedEntries }
+                                        )
+                                    }
+                                    if (showBlockedEntries) {
+                                        items(
+                                            state.blockedEntries.size,
+                                            key = { index ->
+                                                hotListeningItemKey(
+                                                    "blocked",
+                                                    state.blockedEntries[index].album
+                                                )
+                                            },
+                                            contentType = { "albumGrid" }
+                                        ) { index ->
+                                            HotListeningGridItem(
+                                                entry = state.blockedEntries[index],
+                                                onAlbumClick = onAlbumClick,
+                                                copyMeta = copyMeta,
+                                                onMetaLongClick = ::openMetaActions,
+                                                coverFadeIn = gridCoverFadeIn
+                                            )
+                                        }
+                                    }
                                 }
                             }
                         }
@@ -447,7 +483,11 @@ private fun HotListeningListItem(
     coverFadeIn: Boolean = true
 ) {
     val album = entry.album
+    val colorScheme = AsmrTheme.colorScheme
     val coverBadge = remember(entry) { entry.toCoverBadge() }
+    val containerColor = remember(colorScheme.surface, colorScheme.background) {
+        colorScheme.surface.copy(alpha = 0.5f).compositeOver(colorScheme.background)
+    }
     AlbumItem(
         album = album,
         onClick = { onAlbumClick(album) },
@@ -455,6 +495,7 @@ private fun HotListeningListItem(
         coverBadge = coverBadge,
         animateOnlineDetails = false,
         coverFadeIn = coverFadeIn,
+        containerColor = containerColor,
         onRjClick = { copyMeta("RJ", it) },
         onCircleClick = { copyMeta("社团", it) },
         onCircleLongClick = onMetaLongClick,
@@ -474,7 +515,11 @@ private fun HotListeningGridItem(
     coverFadeIn: Boolean = true
 ) {
     val album = entry.album
+    val colorScheme = AsmrTheme.colorScheme
     val coverBadge = remember(entry) { entry.toCoverBadge() }
+    val containerColor = remember(colorScheme.surface, colorScheme.background) {
+        colorScheme.surface.copy(alpha = 0.3f).compositeOver(colorScheme.background)
+    }
     AlbumGridItem(
         album = album,
         onClick = { onAlbumClick(album) },
@@ -482,6 +527,7 @@ private fun HotListeningGridItem(
         coverBadge = coverBadge,
         animateOnlineDetails = false,
         coverFadeIn = coverFadeIn,
+        containerColor = containerColor,
         onRjClick = { copyMeta("RJ", it) },
         onCircleClick = { copyMeta("社团", it) },
         onCircleLongClick = onMetaLongClick,
@@ -533,8 +579,8 @@ private fun HotListeningEntry.toCoverBadge(): AlbumCoverBadge {
     return AlbumCoverBadge(
         icon = icon,
         text = metricLabel,
-        showContainer = false,
-        bottomScrim = true,
+        showContainer = true,
+        bottomScrim = false,
         compactOffset = true
     )
 }

--- a/app/src/main/java/com/asmr/player/ui/hotlistening/HotListeningScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/hotlistening/HotListeningScreen.kt
@@ -65,6 +65,7 @@ import com.asmr.player.ui.common.albumCoverImageModel
 import com.asmr.player.ui.common.albumStableKey
 import com.asmr.player.ui.common.interruptScrollableFlingOnPointerDown
 import com.asmr.player.ui.common.rememberCalmScrollableFlingBehavior
+import com.asmr.player.ui.common.rememberSaveablePrefetchedLazyListState
 import com.asmr.player.ui.common.shouldFadeInCover
 import com.asmr.player.ui.common.thinScrollbar
 import com.asmr.player.ui.common.withAddedBottomPadding
@@ -116,9 +117,7 @@ fun HotListeningScreen(
     val contentScrollKey = remember(selectedPeriod, selectedSortMode, scrollResetNonce) {
         "hot-listening:$selectedPeriod:${selectedSortMode.name}:$scrollResetNonce"
     }
-    val listState = rememberSaveable(contentScrollKey, saver = LazyListState.Saver) {
-        LazyListState(0, 0)
-    }
+    val listState = rememberSaveablePrefetchedLazyListState(stateKey = contentScrollKey)
     val gridState = rememberSaveable(contentScrollKey, saver = LazyStaggeredGridState.Saver) {
         LazyStaggeredGridState()
     }
@@ -285,7 +284,6 @@ fun HotListeningScreen(
                         itemCount = state.entries.size,
                         enabled = isActive,
                         preloadNext = 24,
-                        preloadNextWhileScrolling = 8,
                         preloadSize = preloadSize,
                         cacheManagerProvider = { cacheManager },
                         modelAt = { idx ->
@@ -358,7 +356,6 @@ fun HotListeningScreen(
                         itemCount = state.entries.size,
                         enabled = isActive,
                         preloadNext = 24,
-                        preloadNextWhileScrolling = 8,
                         preloadSize = gridPreloadSize,
                         cacheManagerProvider = { cacheManager },
                         modelAt = { idx ->

--- a/app/src/main/java/com/asmr/player/ui/library/AlbumItem.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/AlbumItem.kt
@@ -126,6 +126,7 @@ fun AlbumItem(
     coverFadeIn: Boolean = true,
     coverReloadKey: Any? = null,
     coverRetainPainterDuringReload: Boolean = false,
+    containerColor: Color? = null,
 ) {
     val colorScheme = AsmrTheme.colorScheme
     val shape = remember { RoundedCornerShape(AlbumListItemCornerRadius) }
@@ -155,7 +156,7 @@ fun AlbumItem(
             .padding(horizontal = AlbumItemHorizontalPadding, vertical = AlbumItemVerticalPadding)
             .testTag(ALBUM_ITEM_CARD_TAG)
             .clip(shape)
-            .background(colorScheme.surface.copy(alpha = 0.5f))
+            .background(containerColor ?: colorScheme.surface.copy(alpha = 0.5f))
             .combinedClickable(
                 onClick = onClick,
                 onLongClick = onLongClick
@@ -401,6 +402,7 @@ fun AlbumGridItem(
     coverFadeIn: Boolean = true,
     coverReloadKey: Any? = null,
     coverRetainPainterDuringReload: Boolean = false,
+    containerColor: Color? = null,
 ) {
     val colorScheme = AsmrTheme.colorScheme
     val shape = remember { RoundedCornerShape(AlbumGridItemCornerRadius) }
@@ -418,7 +420,7 @@ fun AlbumGridItem(
     Column(
         modifier = modifier
             .clip(shape)
-            .background(colorScheme.surface.copy(alpha = 0.3f))
+            .background(containerColor ?: colorScheme.surface.copy(alpha = 0.3f))
             .combinedClickable(
                 onClick = onClick,
                 onLongClick = onLongClick

--- a/app/src/main/java/com/asmr/player/ui/library/LibraryScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/LibraryScreen.kt
@@ -4,6 +4,7 @@ import android.content.Intent
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.LocalOverscrollConfiguration
 import androidx.compose.foundation.MutatePriority
 import androidx.compose.foundation.gestures.stopScroll
 import androidx.compose.foundation.layout.BoxWithConstraints
@@ -63,6 +64,7 @@ import com.asmr.player.ui.common.FlatDialogAction
 import com.asmr.player.ui.common.FlatDialogActionTone
 import com.asmr.player.ui.common.StableWindowInsets
 import com.asmr.player.ui.common.interruptScrollableFlingOnPointerDown
+import com.asmr.player.ui.common.lightweightVerticalStretchOverscroll
 import com.asmr.player.ui.common.rememberAudioMeta
 import com.asmr.player.ui.common.rememberAudioMetaText
 import com.asmr.player.ui.common.rememberCalmScrollableFlingBehavior
@@ -91,6 +93,7 @@ import androidx.compose.material3.windowsizeclass.WindowSizeClass
 import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
@@ -532,11 +535,12 @@ fun LibraryScreen(
                             }
                         } else {
                             // Main content area
-                            Box(
-                                modifier = Modifier
-                                    .fillMaxSize()
-                                    .interruptScrollableFlingOnPointerDown { stopActiveScroll() }
-                            ) {
+                            CompositionLocalProvider(LocalOverscrollConfiguration provides null) {
+                                Box(
+                                    modifier = Modifier
+                                        .fillMaxSize()
+                                        .interruptScrollableFlingOnPointerDown { stopActiveScroll() }
+                                ) {
                                 val isTrackListLoading = isTrackList &&
                                     (pagedTrackAlbumHeaders.loadState.refresh is LoadState.Loading) &&
                                     pagedTrackAlbumHeaders.itemCount == 0
@@ -603,6 +607,10 @@ fun LibraryScreen(
                                         state = listState,
                                         modifier = Modifier
                                             .fillMaxSize()
+                                            .lightweightVerticalStretchOverscroll(
+                                                isAtStart = { !listState.canScrollBackward },
+                                                isAtEnd = { !listState.canScrollForward },
+                                            )
                                             .clearFocusOnTapOutside()
                                             .nestedScroll(chromeState.nestedScrollConnection)
                                             .thinScrollbar(listState),
@@ -811,6 +819,10 @@ fun LibraryScreen(
                                         state = gridState,
                                         modifier = Modifier
                                             .fillMaxSize()
+                                            .lightweightVerticalStretchOverscroll(
+                                                isAtStart = { !gridState.canScrollBackward },
+                                                isAtEnd = { !gridState.canScrollForward },
+                                            )
                                             .clearFocusOnTapOutside()
                                             .nestedScroll(chromeState.nestedScrollConnection)
                                             .thinScrollbar(gridState),
@@ -876,6 +888,10 @@ fun LibraryScreen(
                                         state = listState,
                                         modifier = Modifier
                                             .fillMaxSize()
+                                            .lightweightVerticalStretchOverscroll(
+                                                isAtStart = { !listState.canScrollBackward },
+                                                isAtEnd = { !listState.canScrollForward },
+                                            )
                                             .clearFocusOnTapOutside()
                                             .nestedScroll(chromeState.nestedScrollConnection)
                                             .thinScrollbar(listState),
@@ -938,6 +954,7 @@ fun LibraryScreen(
                                     chromeState = chromeState,
                                     onMeasured = { chromeState.updateHeight(it.height.toFloat()) }
                                 )
+                            }
                             }
                         }
                     }

--- a/app/src/main/java/com/asmr/player/ui/library/LibraryScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/LibraryScreen.kt
@@ -177,7 +177,7 @@ import com.asmr.player.ui.common.collapsibleHeaderUiState
 import com.asmr.player.ui.common.albumCoverImageModel
 import com.asmr.player.ui.common.shouldFadeInCover
 import com.asmr.player.ui.common.rememberCollapsibleHeaderState
-import com.asmr.player.ui.common.rememberAnimatedCollapsibleHeaderOffset
+import com.asmr.player.ui.common.rememberSaveablePrefetchedLazyListState
 import com.asmr.player.ui.common.thinScrollbar
 import com.asmr.player.ui.common.collectAsStateWhileActive
 import com.asmr.player.playback.MediaItemFactory
@@ -306,7 +306,7 @@ fun LibraryScreen(
         if (newText != searchText) searchText = newText
     }
 
-    val listState = rememberSaveable(saver = LazyListState.Saver) { LazyListState(0, 0) }
+    val listState = rememberSaveablePrefetchedLazyListState(stateKey = "library")
     val gridState = rememberSaveable(saver = androidx.compose.foundation.lazy.staggeredgrid.LazyStaggeredGridState.Saver) {
         androidx.compose.foundation.lazy.staggeredgrid.LazyStaggeredGridState()
     }
@@ -800,7 +800,6 @@ fun LibraryScreen(
                                         itemCount = pagedAlbums.itemCount,
                                         enabled = isActive,
                                         preloadNext = 24,
-                                        preloadNextWhileScrolling = 8,
                                         preloadSize = gridPreloadSize,
                                         cacheManagerProvider = { cacheManager },
                                         modelAt = { idx ->
@@ -867,7 +866,6 @@ fun LibraryScreen(
                                         itemCount = pagedAlbums.itemCount,
                                         enabled = isActive,
                                         preloadNext = 24,
-                                        preloadNextWhileScrolling = 8,
                                         preloadSize = preloadSize,
                                         cacheManagerProvider = { cacheManager },
                                         modelAt = { idx ->
@@ -1148,7 +1146,6 @@ internal fun LibraryChrome(
 ) {
     val colorScheme = AsmrTheme.colorScheme
     val collapseOvershootPx = with(LocalDensity.current) { LibraryChromeCollapseOvershoot.toPx() }
-    val animatedChromeOffsetPx = rememberAnimatedCollapsibleHeaderOffset(chromeState)
     val collapseStateDescription by remember(chromeState) {
         derivedStateOf { collapsibleHeaderUiState(chromeState.collapseFraction) }
     }
@@ -1166,7 +1163,7 @@ internal fun LibraryChrome(
             .onSizeChanged(onMeasured)
             .graphicsLayer {
                 val collapseFraction = chromeState.collapseFraction.coerceIn(0f, 1f)
-                translationY = animatedChromeOffsetPx.value - (collapseFraction * collapseOvershootPx)
+                translationY = chromeState.offsetPx - (collapseFraction * collapseOvershootPx)
                 alpha = 1f - (collapseFraction * 0.1f)
             }
             .semantics { stateDescription = collapseStateDescription }

--- a/app/src/main/java/com/asmr/player/ui/search/SearchScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/search/SearchScreen.kt
@@ -127,7 +127,7 @@ import com.asmr.player.ui.common.collapsibleHeaderUiState
 import com.asmr.player.ui.common.consumeTapThrough
 import com.asmr.player.ui.common.rememberCalmScrollableFlingBehavior
 import com.asmr.player.ui.common.rememberCollapsibleHeaderState
-import com.asmr.player.ui.common.rememberAnimatedCollapsibleHeaderOffset
+import com.asmr.player.ui.common.rememberSaveablePrefetchedLazyListState
 import com.asmr.player.ui.common.shouldFadeInCover
 import com.asmr.player.ui.common.thinScrollbar
 import com.asmr.player.ui.common.withAddedBottomPadding
@@ -329,7 +329,7 @@ fun SearchScreen(
     )
     val success = uiState as? SearchUiState.Success
     val resultScrollKey = searchResultScrollKey(success)
-    val listState = rememberSaveable(resultScrollKey, saver = LazyListState.Saver) { LazyListState(0, 0) }
+    val listState = rememberSaveablePrefetchedLazyListState(stateKey = resultScrollKey)
     val gridState = rememberSaveable(resultScrollKey, saver = LazyStaggeredGridState.Saver) { LazyStaggeredGridState() }
     val colorScheme = AsmrTheme.colorScheme
     val copyMeta = rememberAlbumMetaCopyAction(viewModel.messageManager)
@@ -968,7 +968,6 @@ fun SearchScreen(
                                         itemCount = state.results.size,
                                         enabled = isActive,
                                         preloadNext = 24,
-                                        preloadNextWhileScrolling = 8,
                                         preloadSize = preloadSize,
                                         cacheManagerProvider = { cacheManager },
                                         modelAt = { idx ->
@@ -1027,7 +1026,6 @@ fun SearchScreen(
                                         itemCount = state.results.size,
                                         enabled = isActive,
                                         preloadNext = 24,
-                                        preloadNextWhileScrolling = 8,
                                         preloadSize = gridPreloadSize,
                                         cacheManagerProvider = { cacheManager },
                                         modelAt = { idx ->
@@ -1366,7 +1364,6 @@ internal fun SearchChrome(
     onPrev: () -> Unit,
     onNext: () -> Unit
 ) {
-    val animatedOffsetPx = rememberAnimatedCollapsibleHeaderOffset(chromeState)
     val collapseStateDescription by remember(chromeState) {
         derivedStateOf { collapsibleHeaderUiState(chromeState.collapseFraction) }
     }
@@ -1375,7 +1372,7 @@ internal fun SearchChrome(
             .onSizeChanged(onMeasured)
             // Use layout offset instead of a graphics layer so Android text selection
             // toolbars anchor to the real on-screen position of the editable field.
-            .offset { IntOffset(x = 0, y = animatedOffsetPx.value.roundToInt()) }
+            .offset { IntOffset(x = 0, y = chromeState.offsetPx.roundToInt()) }
             .semantics { stateDescription = collapseStateDescription }
             .testTag(chromeTestTag)
     ) {

--- a/app/src/main/java/com/asmr/player/ui/search/SearchScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/search/SearchScreen.kt
@@ -7,6 +7,7 @@ import androidx.compose.animation.core.snap
 import androidx.compose.animation.core.spring
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.LocalOverscrollConfiguration
 import androidx.compose.foundation.MutatePriority
 import androidx.compose.foundation.gestures.awaitFirstDown
 import androidx.compose.foundation.background
@@ -67,6 +68,7 @@ import androidx.compose.material3.pulltorefresh.rememberPullToRefreshState
 import androidx.compose.material3.windowsizeclass.WindowSizeClass
 import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
@@ -804,10 +806,11 @@ fun SearchScreen(
                     modifier = searchContentModifier
                         .interruptScrollableFlingOnPointerDown { stopActiveScroll() }
                 ) {
-                    Box(
-                        modifier = Modifier
-                            .fillMaxSize()
-                            .pointerInput(resultScrollKey, viewMode) {
+                    CompositionLocalProvider(LocalOverscrollConfiguration provides null) {
+                        Box(
+                            modifier = Modifier
+                                .fillMaxSize()
+                                .pointerInput(resultScrollKey, viewMode) {
                                 awaitEachGesture {
                                     val down = awaitFirstDown(requireUnconsumed = false, pass = PointerEventPass.Initial)
                                     var trackedPointerId = down.id
@@ -894,8 +897,8 @@ fun SearchScreen(
                                     Modifier
                                 }
                             )
-                            .clipToBounds()
-                    ) {
+                                .clipToBounds()
+                        ) {
                         if (pullRefreshHintVisible) {
                             SearchPullActionHint(
                                 progress = pullRefreshProgress,
@@ -1139,6 +1142,7 @@ fun SearchScreen(
                                     activeText = "正在翻页"
                                 )
                             }
+                        }
                         }
                     }
 

--- a/app/src/test/java/com/asmr/player/cache/LazyListPreloaderTest.kt
+++ b/app/src/test/java/com/asmr/player/cache/LazyListPreloaderTest.kt
@@ -6,36 +6,19 @@ import org.junit.Test
 
 class LazyListPreloaderTest {
     @Test
-    fun preloadLeadCount_keepsScrollingWindowBoundedToOneViewport() {
-        assertEquals(
-            8,
-            resolveLazyListPreloadLeadCount(
-                visibleItemCount = 6,
-                preloadNext = 24,
-                preloadNextWhileScrolling = 8,
-                isScrolling = true,
-            )
-        )
-        assertEquals(
-            12,
-            resolveLazyListPreloadLeadCount(
-                visibleItemCount = 12,
-                preloadNext = 24,
-                preloadNextWhileScrolling = 8,
-                isScrolling = true,
-            )
-        )
-    }
-
-    @Test
     fun preloadLeadCount_keepsIdleWindowWider() {
         assertEquals(
             24,
             resolveLazyListPreloadLeadCount(
                 visibleItemCount = 6,
                 preloadNext = 24,
-                preloadNextWhileScrolling = 8,
-                isScrolling = false,
+            )
+        )
+        assertEquals(
+            36,
+            resolveLazyListPreloadLeadCount(
+                visibleItemCount = 12,
+                preloadNext = 24,
             )
         )
     }
@@ -43,15 +26,14 @@ class LazyListPreloaderTest {
     @Test
     fun preloadRange_prefetchesAfterLastVisibleItemWhenScrollingForward() {
         assertEquals(
-            5..12,
+            5..28,
             resolveLazyListPreloadRange(
                 firstVisibleIndex = 0,
                 lastVisibleIndex = 4,
                 visibleItemCount = 5,
                 itemCount = 30,
                 preloadNext = 24,
-                preloadNextWhileScrolling = 8,
-                isScrolling = true,
+                isScrolling = false,
                 direction = LazyListPreloadDirection.Forward,
             )
         )
@@ -60,15 +42,14 @@ class LazyListPreloaderTest {
     @Test
     fun preloadRange_prefetchesBeforeFirstVisibleItemWhenScrollingBackward() {
         assertEquals(
-            2..9,
+            0..9,
             resolveLazyListPreloadRange(
                 firstVisibleIndex = 10,
                 lastVisibleIndex = 15,
                 visibleItemCount = 6,
                 itemCount = 30,
                 preloadNext = 24,
-                preloadNextWhileScrolling = 8,
-                isScrolling = true,
+                isScrolling = false,
                 direction = LazyListPreloadDirection.Backward,
             )
         )
@@ -84,7 +65,6 @@ class LazyListPreloaderTest {
                 visibleItemCount = 5,
                 itemCount = 10,
                 preloadNext = 24,
-                preloadNextWhileScrolling = 8,
                 isScrolling = false,
                 direction = LazyListPreloadDirection.Forward,
             )
@@ -96,9 +76,23 @@ class LazyListPreloaderTest {
                 visibleItemCount = 5,
                 itemCount = 10,
                 preloadNext = 24,
-                preloadNextWhileScrolling = 8,
-                isScrolling = true,
+                isScrolling = false,
                 direction = LazyListPreloadDirection.Backward,
+            )
+        )
+    }
+
+    @Test
+    fun preloadRange_pausesWhileListIsScrolling() {
+        assertNull(
+            resolveLazyListPreloadRange(
+                firstVisibleIndex = 4,
+                lastVisibleIndex = 9,
+                visibleItemCount = 6,
+                itemCount = 30,
+                preloadNext = 24,
+                isScrolling = true,
+                direction = LazyListPreloadDirection.Forward,
             )
         )
     }

--- a/app/src/test/java/com/asmr/player/ui/common/CollapsibleHeaderStateTest.kt
+++ b/app/src/test/java/com/asmr/player/ui/common/CollapsibleHeaderStateTest.kt
@@ -21,4 +21,12 @@ class CollapsibleHeaderStateTest {
         assertEquals(0f, state.offsetPx)
         assertEquals(COLLAPSIBLE_HEADER_STATE_EXPANDED, collapsibleHeaderUiState(state.collapseFraction))
     }
+
+    @Test
+    fun settleTarget_usesHalfHeightThreshold() {
+        assertEquals(0f, collapsibleHeaderSettleTargetOffset(heightPx = 120f, offsetPx = -59f))
+        assertEquals(-120f, collapsibleHeaderSettleTargetOffset(heightPx = 120f, offsetPx = -60f))
+        assertEquals(-120f, collapsibleHeaderSettleTargetOffset(heightPx = 120f, offsetPx = -200f))
+        assertEquals(0f, collapsibleHeaderSettleTargetOffset(heightPx = 0f, offsetPx = -30f))
+    }
 }

--- a/app/src/test/java/com/asmr/player/ui/common/LazyListCompositionPrefetchTest.kt
+++ b/app/src/test/java/com/asmr/player/ui/common/LazyListCompositionPrefetchTest.kt
@@ -1,0 +1,31 @@
+package com.asmr.player.ui.common
+
+import org.junit.Assert.assertArrayEquals
+import org.junit.Test
+
+class LazyListCompositionPrefetchTest {
+
+    @Test
+    fun prefetchIndices_includeForwardAndBackwardItemsWithinBounds() {
+        assertArrayEquals(
+            intArrayOf(10, 11, 12, 13, 4),
+            resolveCompositionPrefetchIndices(
+                firstVisibleIndex = 5,
+                lastVisibleIndex = 9,
+                totalItemCount = 20,
+                forwardItemCount = 4,
+                backwardItemCount = 1,
+            ),
+        )
+        assertArrayEquals(
+            intArrayOf(3, 4),
+            resolveCompositionPrefetchIndices(
+                firstVisibleIndex = 0,
+                lastVisibleIndex = 2,
+                totalItemCount = 5,
+                forwardItemCount = 4,
+                backwardItemCount = 1,
+            ),
+        )
+    }
+}

--- a/app/src/test/java/com/asmr/player/ui/common/LazyListCompositionPrefetchTest.kt
+++ b/app/src/test/java/com/asmr/player/ui/common/LazyListCompositionPrefetchTest.kt
@@ -28,4 +28,18 @@ class LazyListCompositionPrefetchTest {
             ),
         )
     }
+
+    @Test
+    fun prefetchIndices_supportsSmallSymmetricWindow() {
+        assertArrayEquals(
+            intArrayOf(17, 18, 9, 8),
+            resolveCompositionPrefetchIndices(
+                firstVisibleIndex = 10,
+                lastVisibleIndex = 16,
+                totalItemCount = 30,
+                forwardItemCount = 2,
+                backwardItemCount = 2,
+            ),
+        )
+    }
 }


### PR DESCRIPTION
## 变更内容
- 优化播放音频时列表双向惯性滚动的预取策略，减少向上滚动后半段的组合抖动
- 降低热门收听卡片的混合与绘制开销
- 将热门收听、本地库的系统过滚替换为仅作用于可见列表的轻量绘制反馈
- 在线搜索关闭系统过滚，保留下拉刷新与上拉翻页反馈，避免效果叠加

## 验证
- `./gradlew-local.bat :app:installRelease` 通过并成功安装到 Android 16 真机
- 120 Hz、音频播放中，热门收听 8 组交替滚动的长帧间隔由系统过滚方案的 23 次降至 3 次；7/8 组 cadence P99 为 8.33–8.42 ms
- `git diff --check` 通过，变更文件均为 UTF-8 无 BOM