### PR TITLE
fix: optimize album detail online directory loading

### DIFF
--- a/app/src/main/java/com/asmr/player/data/remote/OnlineDirectoryRequestTimeouts.kt
+++ b/app/src/main/java/com/asmr/player/data/remote/OnlineDirectoryRequestTimeouts.kt
@@ -1,0 +1,14 @@
+package com.asmr.player.data.remote
+
+import okhttp3.OkHttpClient
+import java.util.concurrent.TimeUnit
+
+internal const val ONLINE_DIRECTORY_REQUEST_TIMEOUT_MS = 2_500L
+
+internal fun OkHttpClient.withOnlineDirectoryRequestTimeouts(): OkHttpClient =
+    newBuilder()
+        .callTimeout(ONLINE_DIRECTORY_REQUEST_TIMEOUT_MS, TimeUnit.MILLISECONDS)
+        .connectTimeout(ONLINE_DIRECTORY_REQUEST_TIMEOUT_MS, TimeUnit.MILLISECONDS)
+        .readTimeout(ONLINE_DIRECTORY_REQUEST_TIMEOUT_MS, TimeUnit.MILLISECONDS)
+        .writeTimeout(ONLINE_DIRECTORY_REQUEST_TIMEOUT_MS, TimeUnit.MILLISECONDS)
+        .build()

--- a/app/src/main/java/com/asmr/player/data/remote/api/AsmrOneAvailabilityApi.kt
+++ b/app/src/main/java/com/asmr/player/data/remote/api/AsmrOneAvailabilityApi.kt
@@ -4,6 +4,7 @@ import android.os.Build
 import com.asmr.player.BuildConfig
 import com.asmr.player.data.remote.NetworkHeaders
 import com.asmr.player.data.remote.awaitResponse
+import com.asmr.player.data.remote.withOnlineDirectoryRequestTimeouts
 import com.asmr.player.data.remote.withSearchTimeouts
 import com.asmr.player.listentogether.XxHash64
 import com.google.gson.Gson
@@ -17,7 +18,6 @@ import okhttp3.Request
 import okhttp3.RequestBody.Companion.toRequestBody
 import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 import java.io.IOException
-import java.util.concurrent.TimeUnit
 import java.util.UUID
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -127,7 +127,7 @@ class AsmrOneAvailabilityApi @Inject constructor(
     private val deviceFingerprint = buildDeviceFingerprint()
     private val userAgent = buildUserAgent()
     private val requestClient by lazy { okHttpClient.withSearchTimeouts() }
-    private val trackTreeClient by lazy { okHttpClient.withBackendTrackTreeTimeouts() }
+    private val trackTreeClient by lazy { okHttpClient.withOnlineDirectoryRequestTimeouts() }
 
     val isBackendConfigured: Boolean
         get() = backendBaseUrl.isNotBlank()
@@ -368,11 +368,3 @@ private fun AsmrOneAvailabilityItem.matchedRequestRjs(requested: Set<String>): L
         .distinct()
         .toList()
 }
-
-private fun OkHttpClient.withBackendTrackTreeTimeouts(): OkHttpClient =
-    newBuilder()
-        .callTimeout(3, TimeUnit.SECONDS)
-        .connectTimeout(2, TimeUnit.SECONDS)
-        .readTimeout(3, TimeUnit.SECONDS)
-        .writeTimeout(3, TimeUnit.SECONDS)
-        .build()

--- a/app/src/main/java/com/asmr/player/data/remote/crawler/AsmrOneCrawler.kt
+++ b/app/src/main/java/com/asmr/player/data/remote/crawler/AsmrOneCrawler.kt
@@ -1,6 +1,7 @@
 package com.asmr.player.data.remote.crawler
 
 import com.asmr.player.data.remote.NetworkHeaders
+import com.asmr.player.data.remote.ONLINE_DIRECTORY_REQUEST_TIMEOUT_MS
 import com.asmr.player.data.remote.api.Asmr100Api
 import com.asmr.player.data.remote.api.Asmr200Api
 import com.asmr.player.data.remote.api.AsmrOneApi
@@ -55,8 +56,7 @@ class AsmrOneCrawler @Inject constructor(
         val normalized = keyword.trim()
         if (normalized.isBlank()) return emptySet()
         val preferredSite = runCatching { settingsRepository.asmrOneSite.first() }.getOrDefault(200)
-        val backupApis = backupApisInOrder(preferredSite, asmr100Api, asmr200Api, asmr300Api)
-        val backup = backupApis.firstOrNull() ?: return emptySet()
+        val backup = selectedBackupApi(preferredSite, asmr100Api, asmr200Api, asmr300Api)
         val from = tryTwice {
             backup.api.search(keyword = normalized, page = page, silentIoError = NetworkHeaders.SILENT_IO_ERROR_ON)
         } ?: return emptySet()
@@ -117,33 +117,31 @@ class AsmrOneCrawler @Inject constructor(
         val digitCandidates = linkedSetOf(digits, digitsTrimmed).filter { it.isNotBlank() }
 
         val preferredSite = runCatching { settingsRepository.asmrOneSite.first() }.getOrDefault(200)
-        val backupApis = backupApisInOrder(preferredSite, asmr100Api, asmr200Api, asmr300Api)
-        for (backup in backupApis) {
-            for (digitsCandidate in digitCandidates) {
-                val from = runCatching {
-                    backup.api.search(
-                        keyword = " $digitsCandidate",
-                        page = page,
-                        silentIoError = NetworkHeaders.SILENT_IO_ERROR_ON
+        val backup = selectedBackupApi(preferredSite, asmr100Api, asmr200Api, asmr300Api)
+        for (digitsCandidate in digitCandidates) {
+            val from = runCatching {
+                backup.api.search(
+                    keyword = " $digitsCandidate",
+                    page = page,
+                    silentIoError = NetworkHeaders.SILENT_IO_ERROR_ON
+                )
+            }.getOrNull()
+            val mapped = mapBackupWorks(from?.works.orEmpty(), rj)
+            if (mapped.isNotEmpty()) {
+                return AsmrOneSearchResult(
+                    response = SearchResponse(
+                        works = mapped,
+                        pagination = Pagination(totalCount = mapped.size, pageSize = mapped.size, page = page)
+                    ),
+                    trace = AsmrOneSearchTrace(
+                        keyword = normalized,
+                        primarySucceeded = primarySucceeded,
+                        primaryHasWorks = false,
+                        fallbackAttempted = true,
+                        fallbackUsed = true,
+                        fallbackSite = backup.site
                     )
-                }.getOrNull()
-                val mapped = mapBackupWorks(from?.works.orEmpty(), rj)
-                if (mapped.isNotEmpty()) {
-                    return AsmrOneSearchResult(
-                        response = SearchResponse(
-                            works = mapped,
-                            pagination = Pagination(totalCount = mapped.size, pageSize = mapped.size, page = page)
-                        ),
-                        trace = AsmrOneSearchTrace(
-                            keyword = normalized,
-                            primarySucceeded = primarySucceeded,
-                            primaryHasWorks = false,
-                            fallbackAttempted = true,
-                            fallbackUsed = true,
-                            fallbackSite = backup.site
-                        )
-                    )
-                }
+                )
             }
         }
 
@@ -208,16 +206,14 @@ class AsmrOneCrawler @Inject constructor(
         }
 
         val preferredSite = runCatching { settingsRepository.asmrOneSite.first() }.getOrDefault(200)
-        val backupApis = backupApisInOrder(preferredSite, asmr100Api, asmr200Api, asmr300Api)
-        for (backup in backupApis) {
-            for (digitsCandidate in digitCandidates) {
-                val from = runCatching {
-                    backup.api.search(keyword = " $digitsCandidate", page = 1, silentIoError = NetworkHeaders.SILENT_IO_ERROR_ON)
-                }.getOrNull()
-                if (from != null) anySucceeded = true
-                val mapped = mapBackupWorks(from?.works.orEmpty(), rj)
-                if (mapped.any { w -> asmrOneWorkMatchesRj(w, rj) }) return true
-            }
+        val backup = selectedBackupApi(preferredSite, asmr100Api, asmr200Api, asmr300Api)
+        for (digitsCandidate in digitCandidates) {
+            val from = runCatching {
+                backup.api.search(keyword = " $digitsCandidate", page = 1, silentIoError = NetworkHeaders.SILENT_IO_ERROR_ON)
+            }.getOrNull()
+            if (from != null) anySucceeded = true
+            val mapped = mapBackupWorks(from?.works.orEmpty(), rj)
+            if (mapped.any { w -> asmrOneWorkMatchesRj(w, rj) }) return true
         }
 
         return if (anySucceeded) false else null
@@ -232,23 +228,21 @@ class AsmrOneCrawler @Inject constructor(
         if (digitCandidates.isEmpty()) return null
 
         val preferredSite = runCatching { settingsRepository.asmrOneSite.first() }.getOrDefault(200)
-        val backupApis = backupApisInOrder(preferredSite, asmr100Api, asmr200Api, asmr300Api)
+        val backup = selectedBackupApi(preferredSite, asmr100Api, asmr200Api, asmr300Api)
         var anySucceeded = false
-        for (backup in backupApis) {
-            for (digitsCandidate in digitCandidates) {
-                val from = runCatching {
-                    withTimeoutOrNull(timeoutMs) {
-                        backup.api.search(
-                            keyword = " $digitsCandidate",
-                            page = 1,
-                            silentIoError = NetworkHeaders.SILENT_IO_ERROR_ON
-                        )
-                    }
-                }.getOrNull()
-                if (from != null) anySucceeded = true
-                val mapped = mapBackupWorks(from?.works.orEmpty(), rj)
-                if (mapped.any { w -> asmrOneWorkMatchesRj(w, rj) }) return true
-            }
+        for (digitsCandidate in digitCandidates) {
+            val from = runCatching {
+                withTimeoutOrNull(timeoutMs) {
+                    backup.api.search(
+                        keyword = " $digitsCandidate",
+                        page = 1,
+                        silentIoError = NetworkHeaders.SILENT_IO_ERROR_ON
+                    )
+                }
+            }.getOrNull()
+            if (from != null) anySucceeded = true
+            val mapped = mapBackupWorks(from?.works.orEmpty(), rj)
+            if (mapped.any { w -> asmrOneWorkMatchesRj(w, rj) }) return true
         }
         return if (anySucceeded) false else null
     }
@@ -256,7 +250,7 @@ class AsmrOneCrawler @Inject constructor(
     suspend fun getDetails(workId: String): WorkDetailsResponse {
         val normalized = workId.trim()
         val preferredSite = runCatching { settingsRepository.asmrOneSite.first() }.getOrDefault(200)
-        val backupApis = backupApisInOrder(preferredSite, asmr100Api, asmr200Api, asmr300Api)
+        val backup = selectedBackupApi(preferredSite, asmr100Api, asmr200Api, asmr300Api)
         val primaryTry = runCatching {
             withTimeout(PRIMARY_CALL_TIMEOUT_MS) {
                 api.getWorkDetails(normalized, silentIoError = NetworkHeaders.SILENT_IO_ERROR_ON)
@@ -267,113 +261,76 @@ class AsmrOneCrawler @Inject constructor(
 
         var last: Throwable = primaryTry.exceptionOrNull() ?: RuntimeException("unknown error")
         if (last is CancellationException && last !is TimeoutCancellationException) throw last
-        for (backupApi in backupApis) {
-            val result = runCatching {
-                withTimeout(BACKUP_CALL_TIMEOUT_MS) {
-                    backupApi.api.getWorkDetails(normalized, silentIoError = NetworkHeaders.SILENT_IO_ERROR_ON)
-                }
-            }.getOrElse { e ->
-                if (e is CancellationException && e !is TimeoutCancellationException) throw e
-                last = e
-                null
+        val result = runCatching {
+            withTimeout(BACKUP_CALL_TIMEOUT_MS) {
+                backup.api.getWorkDetails(normalized, silentIoError = NetworkHeaders.SILENT_IO_ERROR_ON)
             }
-            if (result != null) return result
+        }.getOrElse { e ->
+            if (e is CancellationException && e !is TimeoutCancellationException) throw e
+            last = e
+            null
         }
+        if (result != null) return result
         throw last
     }
 
     suspend fun getDetailsFromSite(site: Int, workId: String): WorkDetailsResponse {
         val normalized = workId.trim()
-        val result = runCatching {
-            withTimeout(PRIMARY_CALL_TIMEOUT_MS) {
-                when (site) {
-                    100 -> asmr100Api.getWorkDetails(normalized, silentIoError = NetworkHeaders.SILENT_IO_ERROR_ON)
-                    300 -> asmr300Api.getWorkDetails(normalized, silentIoError = NetworkHeaders.SILENT_IO_ERROR_ON)
-                    200 -> asmr200Api.getWorkDetails(normalized, silentIoError = NetworkHeaders.SILENT_IO_ERROR_ON)
-                    else -> api.getWorkDetails(normalized, silentIoError = NetworkHeaders.SILENT_IO_ERROR_ON)
-                }
+        return withTimeout(PRIMARY_CALL_TIMEOUT_MS) {
+            when (selectedAsmrOneBackupSite(site)) {
+                100 -> asmr100Api.getWorkDetails(normalized, silentIoError = NetworkHeaders.SILENT_IO_ERROR_ON)
+                300 -> asmr300Api.getWorkDetails(normalized, silentIoError = NetworkHeaders.SILENT_IO_ERROR_ON)
+                else -> asmr200Api.getWorkDetails(normalized, silentIoError = NetworkHeaders.SILENT_IO_ERROR_ON)
             }
-        }.getOrElse { e ->
-            if (e is CancellationException && e !is TimeoutCancellationException) throw e
-            null
         }
-        return result ?: getDetails(normalized)
     }
 
     suspend fun getTracks(workId: String): List<AsmrOneTrackNodeResponse> {
         val normalized = workId.trim()
         val preferredSite = runCatching { settingsRepository.asmrOneSite.first() }.getOrDefault(200)
-        val backupApis = backupApisInOrder(preferredSite, asmr100Api, asmr200Api, asmr300Api)
-        val primaryTry1 = runCatching {
-            withTimeout(TRACKS_CALL_TIMEOUT_SHORT_MS) {
+        val backup = selectedBackupApi(preferredSite, asmr100Api, asmr200Api, asmr300Api)
+        val primaryTry = runCatching {
+            withTimeout(ONLINE_DIRECTORY_REQUEST_TIMEOUT_MS) {
                 api.getTracks(normalized, silentIoError = NetworkHeaders.SILENT_IO_ERROR_ON)
             }
         }
-        val primary1 = primaryTry1.getOrNull()
-        if (primaryTry1.isSuccess && primary1 != null) return primary1
+        val primary = primaryTry.getOrNull()
+        if (primaryTry.isSuccess && primary != null) return primary
 
-        val primaryTry2 = if (primaryTry1.exceptionOrNull() is TimeoutCancellationException) {
-            runCatching {
-                withTimeout(TRACKS_CALL_TIMEOUT_LONG_MS) {
-                    api.getTracks(normalized, silentIoError = NetworkHeaders.SILENT_IO_ERROR_ON)
-                }
-            }
-        } else primaryTry1
-        val primary2 = primaryTry2.getOrNull()
-        if (primaryTry2.isSuccess && primary2 != null) return primary2
-
-        var last: Throwable = primaryTry2.exceptionOrNull() ?: RuntimeException("unknown error")
+        var last: Throwable = primaryTry.exceptionOrNull() ?: RuntimeException("unknown error")
         if (last is CancellationException && last !is TimeoutCancellationException) throw last
-        for (backupApi in backupApis) {
-            val result = runCatching {
-                withTimeout(TRACKS_CALL_TIMEOUT_LONG_MS) {
-                    backupApi.api.getTracks(normalized, silentIoError = NetworkHeaders.SILENT_IO_ERROR_ON)
-                }
-            }.getOrElse { e ->
-                if (e is CancellationException && e !is TimeoutCancellationException) throw e
-                last = e
-                null
+        val result = runCatching {
+            withTimeout(ONLINE_DIRECTORY_REQUEST_TIMEOUT_MS) {
+                backup.api.getTracks(normalized, silentIoError = NetworkHeaders.SILENT_IO_ERROR_ON)
             }
-            if (result != null) return result
+        }.getOrElse { e ->
+            if (e is CancellationException && e !is TimeoutCancellationException) throw e
+            last = e
+            null
         }
+        if (result != null) return result
         throw last
     }
 
     suspend fun getTracksFromSite(site: Int, workId: String): List<AsmrOneTrackNodeResponse> {
         val normalized = workId.trim()
-        val result = runCatching {
-            withTimeout(TRACKS_CALL_TIMEOUT_SHORT_MS) {
-                when (site) {
-                    100 -> asmr100Api.getTracks(normalized, silentIoError = NetworkHeaders.SILENT_IO_ERROR_ON)
-                    300 -> asmr300Api.getTracks(normalized, silentIoError = NetworkHeaders.SILENT_IO_ERROR_ON)
-                    200 -> asmr200Api.getTracks(normalized, silentIoError = NetworkHeaders.SILENT_IO_ERROR_ON)
-                    else -> api.getTracks(normalized, silentIoError = NetworkHeaders.SILENT_IO_ERROR_ON)
-                }
-            }
-        }.getOrElse { e ->
-            if (e is CancellationException && e !is TimeoutCancellationException) throw e
-            if (e is TimeoutCancellationException) {
-                runCatching {
-                    withTimeout(TRACKS_CALL_TIMEOUT_LONG_MS) {
-                        when (site) {
-                            100 -> asmr100Api.getTracks(normalized, silentIoError = NetworkHeaders.SILENT_IO_ERROR_ON)
-                            300 -> asmr300Api.getTracks(normalized, silentIoError = NetworkHeaders.SILENT_IO_ERROR_ON)
-                            200 -> asmr200Api.getTracks(normalized, silentIoError = NetworkHeaders.SILENT_IO_ERROR_ON)
-                            else -> api.getTracks(normalized, silentIoError = NetworkHeaders.SILENT_IO_ERROR_ON)
-                        }
-                    }
-                }.getOrNull()
-            } else null
+        return withTimeout(ONLINE_DIRECTORY_REQUEST_TIMEOUT_MS) {
+            getTracksFromSelectedSite(site, normalized)
         }
-        return result ?: getTracks(normalized)
+    }
+
+    private suspend fun getTracksFromSelectedSite(site: Int, workId: String): List<AsmrOneTrackNodeResponse> {
+        return when (selectedAsmrOneBackupSite(site)) {
+            100 -> asmr100Api.getTracks(workId, silentIoError = NetworkHeaders.SILENT_IO_ERROR_ON)
+            300 -> asmr300Api.getTracks(workId, silentIoError = NetworkHeaders.SILENT_IO_ERROR_ON)
+            else -> asmr200Api.getTracks(workId, silentIoError = NetworkHeaders.SILENT_IO_ERROR_ON)
+        }
     }
 }
 
 private val RJ_CODE_REGEX = Regex("""RJ\d{6,}""")
 private const val PRIMARY_CALL_TIMEOUT_MS = 1_500L
 private const val BACKUP_CALL_TIMEOUT_MS = 1_500L
-private const val TRACKS_CALL_TIMEOUT_SHORT_MS = 2_000L
-private const val TRACKS_CALL_TIMEOUT_LONG_MS = 6_000L
 
 private suspend fun <T> tryTwice(delayMs: Long = 150L, block: suspend () -> T): T? {
     repeat(2) { idx ->
@@ -426,31 +383,23 @@ private fun Asmr300Api.asBackup(): AsmrBackupApi = object : AsmrBackupApi {
         this@asBackup.getTracks(workId, silentIoError = silentIoError)
 }
 
-private fun backupApisInOrder(
+internal fun selectedAsmrOneBackupSite(preferredSite: Int): Int {
+    return when (preferredSite) {
+        100, 300 -> preferredSite
+        else -> 200
+    }
+}
+
+private fun selectedBackupApi(
     preferredSite: Int,
     asmr100Api: Asmr100Api,
     asmr200Api: Asmr200Api,
     asmr300Api: Asmr300Api
-): List<AsmrBackupApiEntry> {
-    val api100 = asmr100Api.asBackup()
-    val api200 = asmr200Api.asBackup()
-    val api300 = asmr300Api.asBackup()
-    return when (preferredSite) {
-        100 -> listOf(
-            AsmrBackupApiEntry(100, api100),
-            AsmrBackupApiEntry(200, api200),
-            AsmrBackupApiEntry(300, api300)
-        )
-        300 -> listOf(
-            AsmrBackupApiEntry(300, api300),
-            AsmrBackupApiEntry(200, api200),
-            AsmrBackupApiEntry(100, api100)
-        )
-        else -> listOf(
-            AsmrBackupApiEntry(200, api200),
-            AsmrBackupApiEntry(100, api100),
-            AsmrBackupApiEntry(300, api300)
-        )
+): AsmrBackupApiEntry {
+    return when (val selectedSite = selectedAsmrOneBackupSite(preferredSite)) {
+        100 -> AsmrBackupApiEntry(selectedSite, asmr100Api.asBackup())
+        300 -> AsmrBackupApiEntry(selectedSite, asmr300Api.asBackup())
+        else -> AsmrBackupApiEntry(selectedSite, asmr200Api.asBackup())
     }
 }
 

--- a/app/src/main/java/com/asmr/player/ui/library/AlbumDetailScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/AlbumDetailScreen.kt
@@ -289,8 +289,10 @@ internal data class AlbumDetailOnlineLoadPlan(
 
 internal fun albumDetailOnlineLoadPlan(
     selectedTab: Int,
-    hasResolvedInitialDlsiteTarget: Boolean
+    hasResolvedInitialDlsiteTarget: Boolean,
+    isInitialRouteReady: Boolean
 ): AlbumDetailOnlineLoadPlan {
+    if (!isInitialRouteReady) return AlbumDetailOnlineLoadPlan()
     return when (selectedTab) {
         1 -> AlbumDetailOnlineLoadPlan(loadDlsite = true, loadAsmrOne = true)
         2 -> AlbumDetailOnlineLoadPlan(
@@ -358,6 +360,7 @@ fun AlbumDetailScreen(
     val selectedTab = remember(albumId, initialTab) {
         initialTab?.coerceIn(0, 2) ?: if (albumId != null && albumId > 0) 0 else 1
     }
+    var isInitialRouteReady by remember(screenKey) { mutableStateOf(false) }
     val initialIntroState = remember(screenKey) { AlbumDetailIntroState(settled = false) }
     var showAsmrDownloadDialog by remember { mutableStateOf(false) }
     var showOnlineSaveDialog by remember { mutableStateOf(false) }
@@ -376,8 +379,10 @@ fun AlbumDetailScreen(
         viewModel.setListenTogetherRjSummaryPollingEnabled(true)
     }
     LaunchedEffect(albumId, rjCode) {
+        isInitialRouteReady = false
         withFrameNanos { }
-        viewModel.loadAlbum(albumId, rjCode, force = false)
+        viewModel.loadAlbumAndAwait(albumId, rjCode, force = false)
+        isInitialRouteReady = true
     }
     DisposableEffect(screenKey, viewModel) {
         onDispose {
@@ -756,11 +761,13 @@ fun AlbumDetailScreen(
                                 selectedTab,
                                 model.rjCode,
                                 model.dlsiteWorkno,
-                                model.hasResolvedInitialDlsiteTarget
+                                model.hasResolvedInitialDlsiteTarget,
+                                isInitialRouteReady
                             ) {
                                 val loadPlan = albumDetailOnlineLoadPlan(
                                     selectedTab = selectedTab,
-                                    hasResolvedInitialDlsiteTarget = model.hasResolvedInitialDlsiteTarget
+                                    hasResolvedInitialDlsiteTarget = model.hasResolvedInitialDlsiteTarget,
+                                    isInitialRouteReady = isInitialRouteReady
                                 )
                                 if (loadPlan.loadDlsite) {
                                     viewModel.ensureDlsiteLoaded()

--- a/app/src/main/java/com/asmr/player/ui/library/AlbumDetailViewModel.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/AlbumDetailViewModel.kt
@@ -29,6 +29,7 @@ import com.asmr.player.data.local.db.entities.TrackTagEntity
 import com.asmr.player.data.lyrics.LyricsLoader
 import com.asmr.player.data.lyrics.deriveLyricsRelativePathNoExt
 import com.asmr.player.data.remote.NetworkHeaders
+import com.asmr.player.data.remote.ONLINE_DIRECTORY_REQUEST_TIMEOUT_MS
 import com.asmr.player.data.remote.api.AsmrOneAvailabilityApi
 import com.asmr.player.data.remote.api.AsmrOneOtherLanguageEditionInDb
 import com.asmr.player.data.remote.api.AsmrOneTrackNodeResponse
@@ -81,6 +82,7 @@ import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
@@ -98,6 +100,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Semaphore
 import kotlinx.coroutines.sync.withPermit
 import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeout
 import kotlinx.coroutines.withTimeoutOrNull
 import okhttp3.OkHttpClient
 import okhttp3.Request
@@ -635,6 +638,11 @@ class AlbumDetailViewModel @Inject constructor(
             }
         }
         return resolvedWorkno
+    }
+
+    suspend fun loadAlbumAndAwait(albumId: Long?, rjCode: String?, force: Boolean = false) {
+        loadAlbum(albumId, rjCode, force)
+        albumLoadJob?.join()
     }
 
     fun loadAlbum(albumId: Long?, rjCode: String?, force: Boolean = false) {
@@ -1842,7 +1850,14 @@ class AlbumDetailViewModel @Inject constructor(
                 var sawNotAvailable = false
                 for (workno in candidates) {
                     val res = try {
-                        dlsitePlayWorkClient.fetchPlayableTree(workno)
+                        withTimeout(ONLINE_DIRECTORY_REQUEST_TIMEOUT_MS) {
+                            dlsitePlayWorkClient.fetchPlayableTree(workno)
+                        }
+                    } catch (e: TimeoutCancellationException) {
+                        lastError = e
+                        continue
+                    } catch (e: CancellationException) {
+                        throw e
                     } catch (e: Exception) {
                         lastError = e
                         continue

--- a/app/src/test/java/com/asmr/player/data/remote/OnlineDirectoryRequestTimeoutsTest.kt
+++ b/app/src/test/java/com/asmr/player/data/remote/OnlineDirectoryRequestTimeoutsTest.kt
@@ -1,0 +1,17 @@
+package com.asmr.player.data.remote
+
+import okhttp3.OkHttpClient
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class OnlineDirectoryRequestTimeoutsTest {
+    @Test
+    fun withOnlineDirectoryRequestTimeouts_setsAllTimeoutsTo2500Milliseconds() {
+        val client = OkHttpClient().withOnlineDirectoryRequestTimeouts()
+
+        assertEquals(2_500, client.callTimeoutMillis)
+        assertEquals(2_500, client.connectTimeoutMillis)
+        assertEquals(2_500, client.readTimeoutMillis)
+        assertEquals(2_500, client.writeTimeoutMillis)
+    }
+}

--- a/app/src/test/java/com/asmr/player/data/remote/crawler/AsmrOneSiteSelectionTest.kt
+++ b/app/src/test/java/com/asmr/player/data/remote/crawler/AsmrOneSiteSelectionTest.kt
@@ -1,0 +1,18 @@
+package com.asmr.player.data.remote.crawler
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class AsmrOneSiteSelectionTest {
+    @Test
+    fun selectedAsmrOneBackupSite_usesOnlyConfiguredDomain() {
+        assertEquals(100, selectedAsmrOneBackupSite(100))
+        assertEquals(200, selectedAsmrOneBackupSite(200))
+        assertEquals(300, selectedAsmrOneBackupSite(300))
+    }
+
+    @Test
+    fun selectedAsmrOneBackupSite_defaultsTo200ForUnexpectedValue() {
+        assertEquals(200, selectedAsmrOneBackupSite(0))
+    }
+}

--- a/app/src/test/java/com/asmr/player/ui/library/AlbumDetailOneStateTest.kt
+++ b/app/src/test/java/com/asmr/player/ui/library/AlbumDetailOneStateTest.kt
@@ -78,7 +78,8 @@ class AlbumDetailOneStateTest {
             AlbumDetailOnlineLoadPlan(loadDlsite = true, loadAsmrOne = true),
             albumDetailOnlineLoadPlan(
                 selectedTab = 1,
-                hasResolvedInitialDlsiteTarget = false
+                hasResolvedInitialDlsiteTarget = false,
+                isInitialRouteReady = true
             )
         )
     }
@@ -89,14 +90,36 @@ class AlbumDetailOneStateTest {
             AlbumDetailOnlineLoadPlan(loadDlsite = true, loadDlsitePlay = false),
             albumDetailOnlineLoadPlan(
                 selectedTab = 2,
-                hasResolvedInitialDlsiteTarget = false
+                hasResolvedInitialDlsiteTarget = false,
+                isInitialRouteReady = true
             )
         )
         assertEquals(
             AlbumDetailOnlineLoadPlan(loadDlsite = true, loadDlsitePlay = true),
             albumDetailOnlineLoadPlan(
                 selectedTab = 2,
-                hasResolvedInitialDlsiteTarget = true
+                hasResolvedInitialDlsiteTarget = true,
+                isInitialRouteReady = true
+            )
+        )
+    }
+
+    @Test
+    fun albumDetailOnlineLoadPlan_waitsForInitialRouteHydration() {
+        assertEquals(
+            AlbumDetailOnlineLoadPlan(),
+            albumDetailOnlineLoadPlan(
+                selectedTab = 1,
+                hasResolvedInitialDlsiteTarget = false,
+                isInitialRouteReady = false
+            )
+        )
+        assertEquals(
+            AlbumDetailOnlineLoadPlan(),
+            albumDetailOnlineLoadPlan(
+                selectedTab = 2,
+                hasResolvedInitialDlsiteTarget = true,
+                isInitialRouteReady = false
             )
         )
     }


### PR DESCRIPTION
## Changes

- Limit asmr.one fallback to the domain selected in settings
- Keep Eara Server fallback and unify online directory timeouts to 2.5 seconds, including DLsite Play
- Fix the album-detail initialization race that canceled first-load requests and left skeletons active

## Verification

- Release APK compiled and installed successfully on a connected device
- Verified album details and directory tree load automatically without manual refresh
- Added timeout, selected-site, and initial-load planning tests
- Full release unit-test compilation is still blocked by pre-existing stale test fixtures in AlbumDetailViewModelSupportTest and AlbumCoverHintStoreTest