### PR TITLE
feat: 优化专辑详情展开动画与加载性能

### DIFF
--- a/app/src/main/java/com/asmr/player/main/MainContainer.kt
+++ b/app/src/main/java/com/asmr/player/main/MainContainer.kt
@@ -240,7 +240,7 @@ import androidx.media3.common.MediaItem
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
-import androidx.compose.ui.platform.LocalLifecycleOwner
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import com.asmr.player.data.settings.SettingsRepository
 import com.asmr.player.playback.AppVolume
 import com.asmr.player.ui.common.AppVolumeVerticalSlider

--- a/app/src/main/java/com/asmr/player/playback/PlayerConnection.kt
+++ b/app/src/main/java/com/asmr/player/playback/PlayerConnection.kt
@@ -358,9 +358,9 @@ class PlayerConnection @Inject constructor(
                 if (mediaId.isBlank()) return@mapNotNull null
                 val uri = runCatching { item.uri }.getOrNull().orEmpty().trim()
                 val remoteSubtitleSources = runCatching { item.remoteSubtitleSources }.getOrNull().orEmpty()
-                    .mapNotNull { sourceItem ->
+                    .mapNotNull subtitleSource@{ sourceItem ->
                         val url = runCatching { sourceItem.url }.getOrNull().orEmpty().trim()
-                        if (url.isBlank()) return@mapNotNull null
+                        if (url.isBlank()) return@subtitleSource null
                         PersistedRemoteSubtitleSource(
                             url = url,
                             language = sourceItem.language,
@@ -436,9 +436,9 @@ class PlayerConnection @Inject constructor(
                     duration = track.duration,
                     group = track.group,
                     lyricsRelativePathNoExt = "",
-                    remoteSubtitleSources = persisted.remoteSubtitleSources.mapNotNull { persistedSource ->
+                    remoteSubtitleSources = persisted.remoteSubtitleSources.mapNotNull subtitleSource@{ persistedSource ->
                         val url = persistedSource.url.trim()
-                        if (url.isBlank()) return@mapNotNull null
+                        if (url.isBlank()) return@subtitleSource null
                         RemoteSubtitleSource(
                             url = url,
                             language = persistedSource.language.orEmpty().ifBlank { "default" },
@@ -448,9 +448,9 @@ class PlayerConnection @Inject constructor(
                 )
                 MediaItemFactory.fromTrack(album, t)
             } else {
-                val restoredRemoteSubtitleSources = persisted.remoteSubtitleSources.mapNotNull { persistedSource ->
+                val restoredRemoteSubtitleSources = persisted.remoteSubtitleSources.mapNotNull subtitleSource@{ persistedSource ->
                     val url = persistedSource.url.trim()
-                    if (url.isBlank()) return@mapNotNull null
+                    if (url.isBlank()) return@subtitleSource null
                     RemoteSubtitleSource(
                         url = url,
                         language = persistedSource.language.orEmpty().ifBlank { "default" },

--- a/app/src/main/java/com/asmr/player/ui/calendar/ListeningCalendarScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/calendar/ListeningCalendarScreen.kt
@@ -63,7 +63,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.platform.LocalLifecycleOwner
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign

--- a/app/src/main/java/com/asmr/player/ui/common/ActiveDropdownMenuItem.kt
+++ b/app/src/main/java/com/asmr/player/ui/common/ActiveDropdownMenuItem.kt
@@ -71,13 +71,13 @@ private fun Modifier.activeWavyUnderline(active: Boolean, color: Color): Modifie
         val path = Path().apply { moveTo(0f, baselineY) }
         var x = 0f
         while (x < size.width) {
-            path.relativeQuadraticBezierTo(
+            path.relativeQuadraticTo(
                 wavelength / 4f,
                 -amplitude,
                 wavelength / 2f,
                 0f
             )
-            path.relativeQuadraticBezierTo(
+            path.relativeQuadraticTo(
                 wavelength / 4f,
                 amplitude,
                 wavelength / 2f,

--- a/app/src/main/java/com/asmr/player/ui/common/AsmrShimmerPlaceholder.kt
+++ b/app/src/main/java/com/asmr/player/ui/common/AsmrShimmerPlaceholder.kt
@@ -5,6 +5,7 @@ import androidx.compose.animation.core.animateFloat
 import androidx.compose.animation.core.infiniteRepeatable
 import androidx.compose.animation.core.rememberInfiniteTransition
 import androidx.compose.animation.core.tween
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -50,8 +51,23 @@ fun AsmrShimmerPlaceholder(
     modifier: Modifier = Modifier,
     cornerRadius: Int = 6,
     sharedProgress: State<Float>? = null,
+    animateHighlight: Boolean = true,
 ) {
     val colorScheme = AsmrTheme.colorScheme
+    val shape = RoundedCornerShape(cornerRadius.dp)
+    if (!animateHighlight) {
+        val staticBaseColor = remember(colorScheme) {
+            colorScheme.onSurface
+                .copy(alpha = if (colorScheme.isDark) 0.14f else 0.16f)
+                .compositeOver(colorScheme.surfaceVariant)
+        }
+        Box(
+            modifier = modifier
+                .clip(shape)
+                .background(staticBaseColor)
+        )
+        return
+    }
     val isLight = remember(colorScheme) { colorScheme.surface.luminance() > 0.5f }
     val baseColor: Color = remember(colorScheme) {
         if (isLight) colorScheme.surfaceVariant else colorScheme.surfaceVariant.copy(alpha = 0.80f)
@@ -68,7 +84,7 @@ fun AsmrShimmerPlaceholder(
 
     Box(
         modifier = modifier
-            .clip(RoundedCornerShape(cornerRadius.dp))
+            .clip(shape)
             .drawWithCache {
                 val w = size.width.coerceAtLeast(1f)
                 val h = size.height.coerceAtLeast(1f)

--- a/app/src/main/java/com/asmr/player/ui/common/reorderable/ReorderableItem.kt
+++ b/app/src/main/java/com/asmr/player/ui/common/reorderable/ReorderableItem.kt
@@ -24,7 +24,10 @@ fun LazyItemScope.ReorderableItem(
     key = key,
     modifier = modifier,
     draggingDecorationModifier = draggingDecorationModifier,
-    defaultDraggingModifier = Modifier.animateItemPlacement(),
+    defaultDraggingModifier = Modifier.animateItem(
+        fadeInSpec = null,
+        fadeOutSpec = null,
+    ),
     orientationLocked = orientationLocked,
     index = index,
     content = content

--- a/app/src/main/java/com/asmr/player/ui/library/AlbumDetailScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/AlbumDetailScreen.kt
@@ -79,7 +79,6 @@ import androidx.compose.ui.layout.layout
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
-import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.stateDescription

--- a/app/src/main/java/com/asmr/player/ui/library/AlbumDetailScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/AlbumDetailScreen.kt
@@ -50,7 +50,6 @@ import androidx.compose.material3.*
 import androidx.compose.material3.windowsizeclass.WindowSizeClass
 import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
 import androidx.compose.runtime.*
-import androidx.compose.runtime.saveable.Saver
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -211,21 +210,11 @@ private const val AlbumDetailHeroFlingOvershootMaxPortion = 0.14f
 private const val AlbumDetailHeroFlingApproachMillis = 560
 private const val AlbumDetailHeroFlingSettleMillis = 980
 private const val AlbumDetailRevealSettleMs = 420L
-private const val AlbumDetailHeroTitleRevealDelayMs = 120
-private const val AlbumDetailHeroMetaRevealDelayMs = 280
 private const val AlbumDetailCvRevealDelayMs = 220
 private const val AlbumDetailTagsRevealDelayMs = 360
-private const val AlbumDetailActionsRevealDelayMs = 500
 internal val AlbumDetailHorizontalPadding = 8.dp
 
-private class AlbumHeaderAlphaRevealState(var hasPlayed: Boolean)
-
 private class AlbumDetailIntroState(var settled: Boolean)
-
-private val AlbumHeaderAlphaRevealStateSaver = Saver<AlbumHeaderAlphaRevealState, Boolean>(
-    save = { it.hasPlayed },
-    restore = { AlbumHeaderAlphaRevealState(it) }
-)
 
 private val AlbumDetailHeroBounceBackSpec = spring<Float>(
     dampingRatio = Spring.DampingRatioNoBouncy,
@@ -1507,7 +1496,6 @@ private fun AlbumDetailHeroBackground(
         AlbumHeroIdentityOverlay(
             album = album,
             introSessionKey = introSessionKey,
-            animateIntro = animateIntro,
             listenTogetherRjListenerCount = listenTogetherRjListenerCount,
             messageManager = messageManager,
             onMetaLongClick = onMetaLongClick,
@@ -1524,7 +1512,6 @@ private fun AlbumDetailHeroBackground(
 private fun AlbumHeroIdentityOverlay(
     album: Album,
     introSessionKey: String,
-    animateIntro: Boolean,
     listenTogetherRjListenerCount: Int?,
     messageManager: MessageManager,
     onMetaLongClick: (String) -> Unit,
@@ -1537,7 +1524,6 @@ private fun AlbumHeroIdentityOverlay(
     val circle = identity.circle
     val showMetaRow = rj.isNotBlank() || circle.isNotBlank() ||
         (listenTogetherRjListenerCount != null && rj.isNotBlank())
-    val heroRevealKey = remember(introSessionKey) { "albumHero:$introSessionKey" }
 
     Column(
         modifier = modifier
@@ -1549,57 +1535,43 @@ private fun AlbumHeroIdentityOverlay(
             ),
         verticalArrangement = Arrangement.spacedBy(9.dp)
     ) {
-        AlbumHeaderInfoReveal(
-            revealKey = "$heroRevealKey:title",
-            delayMillis = AlbumDetailHeroTitleRevealDelayMs,
-            enabled = animateIntro,
-            expandLayout = false
-        ) {
-            Text(
-                text = identity.title,
-                modifier = Modifier.clickable { copyMeta("标题", identity.title) },
-                style = MaterialTheme.typography.titleMedium.copy(
-                    fontWeight = FontWeight.Bold,
-                    fontSize = 20.sp,
-                    shadow = Shadow(
-                        color = if (colorScheme.isDark) Color.White.copy(alpha = 0.58f) else Color.Black.copy(alpha = 0.58f),
-                        offset = Offset(0f, 2f),
-                        blurRadius = 8f
-                    )
-                ),
-                color = if (colorScheme.isDark) Color.White else Color.Black,
-                maxLines = 3,
-                overflow = TextOverflow.Ellipsis
-            )
-        }
+        Text(
+            text = identity.title,
+            modifier = Modifier.clickable { copyMeta("标题", identity.title) },
+            style = MaterialTheme.typography.titleMedium.copy(
+                fontWeight = FontWeight.Bold,
+                fontSize = 20.sp,
+                shadow = Shadow(
+                    color = if (colorScheme.isDark) Color.White.copy(alpha = 0.58f) else Color.Black.copy(alpha = 0.58f),
+                    offset = Offset(0f, 2f),
+                    blurRadius = 8f
+                )
+            ),
+            color = if (colorScheme.isDark) Color.White else Color.Black,
+            maxLines = 3,
+            overflow = TextOverflow.Ellipsis
+        )
 
         if (showMetaRow) {
-            AlbumHeaderInfoReveal(
-                revealKey = "$heroRevealKey:meta",
-                delayMillis = AlbumDetailHeroMetaRevealDelayMs,
-                enabled = animateIntro,
-                expandLayout = false
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically
             ) {
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    verticalAlignment = Alignment.CenterVertically
-                ) {
-                    AlbumPrimaryMetaRow(
-                        rjCode = rj,
-                        circle = circle,
-                        modifier = Modifier.weight(1f),
-                        rjOnClick = { copyMeta("RJ", rj) },
-                        circleOnClick = { copyMeta("社团", circle) },
-                        circleOnLongClick = { onMetaLongClick(circle) },
-                        appearance = AlbumMetaAppearance.OnImage,
-                        leadingVisual = AlbumMetaLeadingVisual.Icon,
-                    )
-                    AlbumOnlineListenerInfo(
-                        listenerCount = listenTogetherRjListenerCount,
-                        visible = rj.isNotBlank(),
-                        modifier = Modifier.padding(start = 8.dp)
-                    )
-                }
+                AlbumPrimaryMetaRow(
+                    rjCode = rj,
+                    circle = circle,
+                    modifier = Modifier.weight(1f),
+                    rjOnClick = { copyMeta("RJ", rj) },
+                    circleOnClick = { copyMeta("社团", circle) },
+                    circleOnLongClick = { onMetaLongClick(circle) },
+                    appearance = AlbumMetaAppearance.OnImage,
+                    leadingVisual = AlbumMetaLeadingVisual.Icon,
+                )
+                AlbumOnlineListenerInfo(
+                    listenerCount = listenTogetherRjListenerCount,
+                    visible = rj.isNotBlank(),
+                    modifier = Modifier.padding(start = 8.dp)
+                )
             }
         }
     }
@@ -1776,7 +1748,7 @@ private fun AlbumHeader(
 
     val headerAnimationScopeKey = remember(introSessionKey) { "albumHeader:$introSessionKey" }
 
-    // 记录“首帧时各信息块是否已存在”：本地库专辑进入时 cv/tags 已就绪，应直接淡入不撑开（消除下沉抖动）；
+    // 记录“首帧时各信息块是否已存在”：本地库专辑进入时 cv/tags 已就绪，应直接显示，不做渐入或撑开；
     // 列表 hint 已经提供的信息首帧直接占住最终高度，只有网络到达后才新增的信息才纵向展开。
     val cvPresentInitially = remember(headerAnimationScopeKey) { album.cv.isNotBlank() }
     val tagsPresentInitially = remember(headerAnimationScopeKey) { album.tags.isNotEmpty() }
@@ -1809,11 +1781,11 @@ private fun AlbumHeader(
                 // cv 行与 tags 行同属“信息行”，行间距与行内换行间距（6.dp）保持一致；
                 // 末尾信息行携带 8.dp 底部 padding 作为与下方按钮行的间距。
                 if (album.cv.isNotBlank()) {
-                    AlbumHeaderInfoReveal(
+                    AlbumHeaderLateMetaReveal(
                         revealKey = "$headerAnimationScopeKey:cv",
                         delayMillis = AlbumDetailCvRevealDelayMs,
                         enabled = animateIntro,
-                        expandLayout = cvExpandLayout
+                        lateArrival = cvExpandLayout
                     ) {
                         Box(modifier = Modifier.padding(bottom = if (album.tags.isNotEmpty()) 6.dp else 8.dp)) {
                             AlbumHeaderCvFlow(
@@ -1826,11 +1798,11 @@ private fun AlbumHeader(
                 }
 
                 if (album.tags.isNotEmpty()) {
-                    AlbumHeaderInfoReveal(
+                    AlbumHeaderLateMetaReveal(
                         revealKey = "$headerAnimationScopeKey:tags",
                         delayMillis = AlbumDetailTagsRevealDelayMs,
                         enabled = animateIntro,
-                        expandLayout = tagsExpandLayout
+                        lateArrival = tagsExpandLayout
                     ) {
                         Box(modifier = Modifier.padding(bottom = 8.dp)) {
                             AlbumHeaderTagsFlow(
@@ -1842,16 +1814,10 @@ private fun AlbumHeader(
                     }
                 }
 
-                AlbumHeaderInfoReveal(
-                    revealKey = "$headerAnimationScopeKey:actions",
-                    delayMillis = AlbumDetailActionsRevealDelayMs,
-                    enabled = animateIntro,
-                    expandLayout = false
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
                 ) {
-                    Box(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                    ) {
                         val compact = availableWidth < 400.dp
                         val ultraCompact = availableWidth < 340.dp
                         val actionGap = if (compact) 8.dp else 10.dp
@@ -2037,7 +2003,6 @@ private fun AlbumHeader(
                                 }
                             }
                         }
-                    }
                 }
             }
         }
@@ -2272,70 +2237,19 @@ private fun AlbumHeaderDownloadAction(
 }
 
 @Composable
-private fun AlbumHeaderInfoReveal(
+private fun AlbumHeaderLateMetaReveal(
     revealKey: String,
-    delayMillis: Int = 0,
-    enabled: Boolean = true,
-    ready: Boolean = true,
-    expandLayout: Boolean = true,
+    delayMillis: Int,
+    enabled: Boolean,
+    lateArrival: Boolean,
     content: @Composable () -> Unit
 ) {
-    if (!expandLayout) {
-        val playbackState = rememberSaveable(
-            revealKey,
-            saver = AlbumHeaderAlphaRevealStateSaver
-        ) {
-            AlbumHeaderAlphaRevealState(false)
-        }
-        if (!enabled) {
-            SideEffect { playbackState.hasPlayed = true }
-            content()
-            return
-        }
-        if (!ready) {
-            content()
-            return
-        }
-        val alpha = remember(revealKey) {
-            Animatable(if (playbackState.hasPlayed) 1f else 0f)
-        }
-        LaunchedEffect(revealKey, ready, enabled) {
-            if (playbackState.hasPlayed) {
-                alpha.snapTo(1f)
-                return@LaunchedEffect
-            }
-            alpha.snapTo(0f)
-            if (delayMillis > 0) {
-                delay(delayMillis.toLong())
-            }
-            withFrameNanos { }
-            alpha.animateTo(
-                targetValue = 1f,
-                animationSpec = AlbumHeaderEnterTweenSpec
-            )
-            // 原实现会在可见状态切换 420ms 后记录完成；保持同一时间语义，但使用普通
-            // saveable 对象，避免纯 bookkeeping 在动画中途触发一次额外重组。
-            delay(
-                (AlbumDetailRevealSettleMs - AlbumDetailHeaderEnterDurationMs)
-                    .coerceAtLeast(0L)
-            )
-            playbackState.hasPlayed = true
-        }
-        Box(
-            modifier = Modifier.graphicsLayer {
-                this.alpha = alpha.value
-                // 信息块内部元素互不重叠，逐指令调制与离屏 alpha 的像素结果一致。
-                // 避免为入场淡入临时分配并上传多张纹理，属性仍只在 RenderNode 更新。
-                compositingStrategy = CompositingStrategy.ModulateAlpha
-            }
-        ) {
-            content()
-        }
+    if (!lateArrival) {
+        content()
         return
     }
-
     var hasPlayed by rememberSaveable(revealKey) { mutableStateOf(false) }
-    LaunchedEffect(revealKey, enabled, ready) {
+    LaunchedEffect(revealKey, enabled) {
         if (!enabled && !hasPlayed) {
             hasPlayed = true
         }
@@ -2344,12 +2258,8 @@ private fun AlbumHeaderInfoReveal(
         content()
         return
     }
-    if (!ready) {
-        content()
-        return
-    }
     var visible by remember(revealKey) { mutableStateOf(false) }
-    LaunchedEffect(revealKey, ready, enabled) {
+    LaunchedEffect(revealKey, enabled) {
         visible = false
         if (delayMillis > 0) {
             delay(delayMillis.toLong())

--- a/app/src/main/java/com/asmr/player/ui/library/AlbumMetaChips.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/AlbumMetaChips.kt
@@ -1,5 +1,8 @@
 package com.asmr.player.ui.library
 
+import androidx.compose.animation.animateContentSize
+import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.ExperimentalFoundationApi
@@ -43,6 +46,7 @@ import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
 import com.asmr.player.R
 import com.asmr.player.ui.theme.AsmrTheme
@@ -51,6 +55,10 @@ import com.asmr.player.util.MessageManager
 private val AlbumMetaPillShape = RoundedCornerShape(999.dp)
 private val AlbumMetaTagShape = RoundedCornerShape(7.dp)
 private val AlbumMetaDenseTagShape = RoundedCornerShape(6.dp)
+private val AlbumHeaderMetaExpandCollapseSpec = tween<IntSize>(
+    durationMillis = 280,
+    easing = FastOutSlowInEasing,
+)
 private const val AlbumHeaderMetaCollapsedLines = 2
 
 private data class AlbumMetaPalette(
@@ -435,7 +443,12 @@ private fun AlbumHeaderMetaFlow(
         minOf(horizontalSpacing, MaterialTheme.typography.labelSmall.fontSize.toDp() / 2f)
     }
     Row(
-        modifier = modifier.fillMaxWidth(),
+        modifier = modifier
+            .fillMaxWidth()
+            .animateContentSize(
+                animationSpec = AlbumHeaderMetaExpandCollapseSpec,
+                alignment = Alignment.TopStart,
+            ),
         horizontalArrangement = Arrangement.spacedBy(labelGap),
         verticalAlignment = Alignment.Top,
     ) {

--- a/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailDialogs.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailDialogs.kt
@@ -1,4 +1,4 @@
-﻿package com.asmr.player.ui.library
+package com.asmr.player.ui.library
 
 import android.content.Intent
 import android.net.Uri
@@ -59,7 +59,6 @@ import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
-import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.stateDescription
 import androidx.compose.ui.state.ToggleableState

--- a/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailDirectorySupport.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailDirectorySupport.kt
@@ -64,7 +64,6 @@ import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
-import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.stateDescription
 import androidx.compose.ui.state.ToggleableState

--- a/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailDlsiteTabs.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailDlsiteTabs.kt
@@ -20,6 +20,7 @@ import androidx.compose.animation.slideInVertically
 import androidx.compose.animation.slideOutHorizontally
 import androidx.compose.animation.slideOutVertically
 import androidx.compose.animation.togetherWith
+import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
@@ -132,7 +133,6 @@ import com.asmr.player.ui.common.DiscPlaceholder
 import com.asmr.player.ui.common.AsmrAsyncImage
 import com.asmr.player.ui.common.NoImageLoadingIndicator
 import com.asmr.player.ui.common.AsmrShimmerPlaceholder
-import com.asmr.player.ui.common.rememberAsmrShimmerProgress
 import com.asmr.player.ui.common.CvChipsFlow
 import com.asmr.player.ui.common.EaraLogoLoadingIndicator
 import com.asmr.player.ui.common.ImagePreviewItem
@@ -158,7 +158,6 @@ private const val DlsiteGalleryThumbCornerRadius = 12
 @Composable
 private fun DlsiteGalleryLoadingRow() {
     val placeholders = remember { listOf(0, 1, 2, 3) }
-    val shimmerProgress = rememberAsmrShimmerProgress()
     LazyRow(
         modifier = Modifier
             .fillMaxWidth()
@@ -171,7 +170,7 @@ private fun DlsiteGalleryLoadingRow() {
             AsmrShimmerPlaceholder(
                 modifier = Modifier.size(width = DlsiteGalleryThumbWidth, height = DlsiteGalleryThumbHeight),
                 cornerRadius = DlsiteGalleryThumbCornerRadius,
-                sharedProgress = shimmerProgress,
+                animateHighlight = false,
             )
         }
     }
@@ -183,14 +182,14 @@ private fun DlsiteSectionPlaceholderLine(
     modifier: Modifier = Modifier,
     height: Dp = 14.dp,
     cornerRadius: Int = 8,
-    sharedProgress: State<Float>? = null,
+    animateHighlight: Boolean = true,
 ) {
     AsmrShimmerPlaceholder(
         modifier = modifier
             .fillMaxWidth(widthFraction)
             .height(height),
         cornerRadius = cornerRadius,
-        sharedProgress = sharedProgress,
+        animateHighlight = animateHighlight,
     )
 }
 
@@ -210,94 +209,220 @@ private fun rememberStableOneDirectoryContainerHeight(): Dp {
 @Composable
 private fun DlsiteDirectoryLoadingPanel() {
     val fixedHeight = rememberDlsiteDirectoryListHeight()
-    val shimmerProgress = rememberAsmrShimmerProgress()
+    val colorScheme = AsmrTheme.colorScheme
+    val headerSectionColor = colorScheme.primarySoft.copy(alpha = if (colorScheme.isDark) 0.14f else 0.22f)
+    val actionSectionColor = colorScheme.surfaceVariant.copy(alpha = if (colorScheme.isDark) 0.24f else 0.42f)
+    val listSectionColor = colorScheme.surface.copy(alpha = if (colorScheme.isDark) 0.28f else 0.62f)
+    val sectionDividerColor = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.12f)
     Surface(
         shape = RoundedCornerShape(12.dp),
         tonalElevation = 1.dp,
-        color = AsmrTheme.colorScheme.surface.copy(alpha = 0.44f),
+        color = colorScheme.surfaceVariant.copy(alpha = if (colorScheme.isDark) 0.28f else 0.46f),
+        border = BorderStroke(0.5.dp, sectionDividerColor),
         modifier = Modifier
             .fillMaxWidth()
             .padding(horizontal = AlbumDetailHorizontalPadding, vertical = 4.dp)
     ) {
-        Column(modifier = Modifier.fillMaxWidth()) {
-            Column(
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(listSectionColor)
+        ) {
+            Row(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(horizontal = 12.dp, vertical = 12.dp),
-                verticalArrangement = Arrangement.spacedBy(8.dp)
+                    .background(headerSectionColor)
+                    .padding(horizontal = 10.dp, vertical = 8.dp),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(4.dp),
             ) {
-                DlsiteSectionPlaceholderLine(
-                    widthFraction = 0.56f,
-                    height = 16.dp,
-                    sharedProgress = shimmerProgress,
+                AsmrShimmerPlaceholder(
+                    modifier = Modifier.size(22.dp),
+                    cornerRadius = 7,
+                    animateHighlight = false,
                 )
-                DlsiteSectionPlaceholderLine(
-                    widthFraction = 0.32f,
-                    height = 12.dp,
-                    sharedProgress = shimmerProgress,
+                AsmrShimmerPlaceholder(
+                    modifier = Modifier.size(width = 54.dp, height = 22.dp),
+                    cornerRadius = 8,
+                    animateHighlight = false,
+                )
+                AsmrShimmerPlaceholder(
+                    modifier = Modifier.size(width = 5.dp, height = 12.dp),
+                    cornerRadius = 3,
+                    animateHighlight = false,
+                )
+                AsmrShimmerPlaceholder(
+                    modifier = Modifier.size(width = 82.dp, height = 22.dp),
+                    cornerRadius = 8,
+                    animateHighlight = false,
                 )
             }
             HorizontalDivider(
-                modifier = Modifier.padding(horizontal = 12.dp),
                 thickness = 0.5.dp,
-                color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.18f)
+                color = sectionDividerColor,
             )
             Row(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(horizontal = 12.dp, vertical = 10.dp),
+                    .background(actionSectionColor)
+                    .padding(horizontal = 10.dp, vertical = 6.dp),
                 horizontalArrangement = Arrangement.spacedBy(10.dp),
                 verticalAlignment = Alignment.CenterVertically
             ) {
+                Column(
+                    modifier = Modifier.weight(1f),
+                    verticalArrangement = Arrangement.spacedBy(4.dp),
+                ) {
+                    DlsiteSectionPlaceholderLine(
+                        widthFraction = 0.42f,
+                        height = 12.dp,
+                        cornerRadius = 6,
+                        animateHighlight = false,
+                    )
+                    DlsiteSectionPlaceholderLine(
+                        widthFraction = 0.64f,
+                        height = 9.dp,
+                        cornerRadius = 5,
+                        animateHighlight = false,
+                    )
+                }
                 AsmrShimmerPlaceholder(
-                    modifier = Modifier
-                        .weight(1f)
-                        .height(40.dp),
-                    cornerRadius = 12,
-                    sharedProgress = shimmerProgress,
-                )
-                AsmrShimmerPlaceholder(
-                    modifier = Modifier.size(width = 92.dp, height = 34.dp),
-                    cornerRadius = 16,
-                    sharedProgress = shimmerProgress,
+                    modifier = Modifier.size(width = 78.dp, height = 30.dp),
+                    cornerRadius = 15,
+                    animateHighlight = false,
                 )
             }
             HorizontalDivider(
-                modifier = Modifier.padding(horizontal = 12.dp),
                 thickness = 0.5.dp,
-                color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.18f)
+                color = sectionDividerColor,
             )
-            Column(
+            LazyColumn(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .height(fixedHeight)
-                    .padding(horizontal = 12.dp, vertical = 10.dp),
-                verticalArrangement = Arrangement.spacedBy(10.dp)
+                    .height(fixedHeight),
+                contentPadding = PaddingValues(horizontal = 8.dp, vertical = 5.dp),
+                userScrollEnabled = false,
             ) {
-                repeat(5) { index ->
-                    Row(
+                item(key = "directoryLoadingFolders", contentType = "folderLoadingGroup") {
+                    Column(
                         modifier = Modifier
                             .fillMaxWidth()
-                            .padding(start = if (index % 3 == 0) 0.dp else 14.dp),
-                        verticalAlignment = Alignment.CenterVertically,
-                        horizontalArrangement = Arrangement.spacedBy(10.dp)
+                            .clip(RoundedCornerShape(10.dp))
+                            .background(
+                                colorScheme.surfaceVariant.copy(
+                                    alpha = if (colorScheme.isDark) 0.52f else 0.72f
+                                )
+                            )
                     ) {
-                        val iconSize = if (index % 3 == 0) 18.dp else 14.dp
-                        AsmrShimmerPlaceholder(
-                            modifier = Modifier.size(iconSize),
-                            cornerRadius = 999,
-                            sharedProgress = shimmerProgress,
-                        )
-                        DlsiteSectionPlaceholderLine(
-                            widthFraction = if (index % 3 == 0) 0.72f else 0.54f,
-                            modifier = Modifier.weight(1f),
-                            height = 14.dp,
-                            sharedProgress = shimmerProgress,
-                        )
+                        repeat(2) { index ->
+                            DlsiteDirectoryFolderPlaceholder(
+                                titleWidthFraction = if (index == 0) 0.64f else 0.48f,
+                            )
+                        }
                     }
+                }
+                items(
+                    count = 4,
+                    key = { index -> "directoryLoadingFile:$index" },
+                    contentType = { "fileLoading" },
+                ) { index ->
+                    DlsiteDirectoryFilePlaceholder(
+                        titleWidthFraction = when (index) {
+                            0 -> 0.78f
+                            1 -> 0.58f
+                            2 -> 0.70f
+                            else -> 0.52f
+                        },
+                        metaWidthFraction = if (index % 2 == 0) 0.36f else 0.24f,
+                        showThumbnail = index == 1,
+                    )
                 }
             }
         }
+    }
+}
+
+@Composable
+private fun DlsiteDirectoryFolderPlaceholder(
+    titleWidthFraction: Float,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .defaultMinSize(minHeight = 42.dp)
+            .padding(horizontal = 12.dp, vertical = 5.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        AsmrShimmerPlaceholder(
+            modifier = Modifier.size(18.dp),
+            cornerRadius = 5,
+            animateHighlight = false,
+        )
+        Spacer(modifier = Modifier.width(10.dp))
+        Box(modifier = Modifier.weight(1f)) {
+            DlsiteSectionPlaceholderLine(
+                widthFraction = titleWidthFraction,
+                height = 14.dp,
+                cornerRadius = 7,
+                animateHighlight = false,
+            )
+        }
+        AsmrShimmerPlaceholder(
+            modifier = Modifier.size(18.dp),
+            cornerRadius = 6,
+            animateHighlight = false,
+        )
+    }
+}
+
+@Composable
+private fun DlsiteDirectoryFilePlaceholder(
+    titleWidthFraction: Float,
+    metaWidthFraction: Float,
+    showThumbnail: Boolean,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .defaultMinSize(minHeight = 58.dp)
+            .padding(start = 8.dp, top = 8.dp, end = 4.dp, bottom = 8.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Box(
+            modifier = Modifier.width(if (showThumbnail) 42.dp else 24.dp),
+            contentAlignment = Alignment.Center,
+        ) {
+            AsmrShimmerPlaceholder(
+                modifier = Modifier.size(if (showThumbnail) 42.dp else 21.dp),
+                cornerRadius = if (showThumbnail) 8 else 5,
+                animateHighlight = false,
+            )
+        }
+        Spacer(modifier = Modifier.width(8.dp))
+        Column(
+            modifier = Modifier.weight(1f),
+            verticalArrangement = Arrangement.spacedBy(5.dp),
+        ) {
+            DlsiteSectionPlaceholderLine(
+                widthFraction = titleWidthFraction,
+                height = 13.dp,
+                cornerRadius = 7,
+                animateHighlight = false,
+            )
+            DlsiteSectionPlaceholderLine(
+                widthFraction = metaWidthFraction,
+                height = 9.dp,
+                cornerRadius = 5,
+                animateHighlight = false,
+            )
+        }
+        Spacer(modifier = Modifier.width(8.dp))
+        AsmrShimmerPlaceholder(
+            modifier = Modifier.size(20.dp),
+            cornerRadius = 6,
+            animateHighlight = false,
+        )
+        Spacer(modifier = Modifier.width(8.dp))
     }
 }
 
@@ -685,7 +810,8 @@ private fun DlsiteRecommendationsLoadingBlocks() {
                                     modifier = Modifier
                                         .fillMaxWidth()
                                         .aspectRatio(1f),
-                                    cornerRadius = 14
+                                    cornerRadius = 14,
+                                    animateHighlight = false,
                                 )
                                 Column(
                                     modifier = Modifier.padding(horizontal = 10.dp),

--- a/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailDlsiteTabs.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailDlsiteTabs.kt
@@ -66,7 +66,7 @@ import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
-import androidx.compose.ui.platform.LocalLifecycleOwner
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.stateDescription
 import androidx.compose.ui.state.ToggleableState
@@ -773,7 +773,11 @@ private fun LazyItemScope.dlsiteAnimatedSectionModifier(
     animateIntro: Boolean = true
 ): Modifier {
     if (!animateIntro) return modifier
-    return modifier.animateItemPlacement(animationSpec = DlsiteSectionPlacementTweenSpec)
+    return modifier.animateItem(
+        fadeInSpec = null,
+        placementSpec = DlsiteSectionPlacementTweenSpec,
+        fadeOutSpec = null,
+    )
 }
 
 @Composable

--- a/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailLocalTab.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailLocalTab.kt
@@ -56,7 +56,6 @@ import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
-import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.stateDescription
 import androidx.compose.ui.state.ToggleableState

--- a/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailSharedSections.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailSharedSections.kt
@@ -53,7 +53,6 @@ import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
-import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.stateDescription
 import androidx.compose.ui.state.ToggleableState

--- a/app/src/main/java/com/asmr/player/ui/nav/BottomChrome.kt
+++ b/app/src/main/java/com/asmr/player/ui/nav/BottomChrome.kt
@@ -1,4 +1,4 @@
-﻿package com.asmr.player.ui.nav
+package com.asmr.player.ui.nav
 
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.SizeTransform
@@ -1225,7 +1225,7 @@ private fun buildBottomNavContainerPath(
     return Path().apply {
         moveTo(barRadius, bottom)
         lineTo(rightCornerStartX, bottom)
-        quadraticBezierTo(right, bottom, right, bottomCornerStartY)
+        quadraticTo(right, bottom, right, bottomCornerStartY)
         lineTo(right, barTop + barRadius)
         arcTo(
             rect = rightArcRect,
@@ -1271,9 +1271,9 @@ private fun buildBottomNavContainerPath(
             barTop
         )
         lineTo(barRadius, barTop)
-        quadraticBezierTo(0f, barTop, 0f, barTop + barRadius)
+        quadraticTo(0f, barTop, 0f, barTop + barRadius)
         lineTo(0f, bottomCornerStartY)
-        quadraticBezierTo(0f, bottom, barRadius, bottom)
+        quadraticTo(0f, bottom, barRadius, bottom)
         close()
     }
 }

--- a/app/src/main/java/com/asmr/player/ui/player/CoverMotion.kt
+++ b/app/src/main/java/com/asmr/player/ui/player/CoverMotion.kt
@@ -14,7 +14,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.BiasAlignment
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.LocalLifecycleOwner
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.compose.ui.platform.LocalView
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver

--- a/app/src/main/java/com/asmr/player/ui/search/SearchScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/search/SearchScreen.kt
@@ -1078,7 +1078,11 @@ fun SearchScreen(
                                             AlbumItem(
                                                 album = album,
                                                 onClick = { onAlbumClick(album, state.purchasedOnly, hasResolvedDetail) },
-                                                modifier = Modifier.animateItemPlacement(SearchResultPlacementSpring),
+                                                modifier = Modifier.animateItem(
+                                                    fadeInSpec = null,
+                                                    placementSpec = SearchResultPlacementSpring,
+                                                    fadeOutSpec = null,
+                                                ),
                                                 onlineDetailLoading = onlineDetailLoading,
                                                 onlineCvLoading = onlineDetailLoading,
                                                 coverFadeIn = coverFadeIn,
@@ -1144,7 +1148,11 @@ fun SearchScreen(
                                             AlbumGridItem(
                                                 album = album,
                                                 onClick = { onAlbumClick(album, state.purchasedOnly, hasResolvedDetail) },
-                                                modifier = Modifier.animateItemPlacement(SearchResultPlacementSpring),
+                                                modifier = Modifier.animateItem(
+                                                    fadeInSpec = null,
+                                                    placementSpec = SearchResultPlacementSpring,
+                                                    fadeOutSpec = null,
+                                                ),
                                                 onlineDetailLoading = onlineDetailLoading,
                                                 onlineCvLoading = onlineDetailLoading,
                                                 coverFadeIn = coverFadeIn,

--- a/app/src/main/java/com/asmr/player/util/SubtitleParser.kt
+++ b/app/src/main/java/com/asmr/player/util/SubtitleParser.kt
@@ -47,7 +47,7 @@ object SubtitleParser {
         val trimmed = content.trimStart()
         if (!(trimmed.startsWith("{") || trimmed.startsWith("["))) return content
 
-        val element = runCatching { JsonParser().parse(trimmed) }.getOrNull() ?: return content
+        val element = runCatching { JsonParser.parseString(trimmed) }.getOrNull() ?: return content
         val items = extractWebvttItems(element) ?: return content
 
         val lines = mutableListOf("WEBVTT", "")

--- a/app/src/test/java/com/asmr/player/ui/library/AlbumMetaChipsTest.kt
+++ b/app/src/test/java/com/asmr/player/ui/library/AlbumMetaChipsTest.kt
@@ -2,17 +2,23 @@ package com.asmr.player.ui.library
 
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.Text
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.semantics.SemanticsActions
 import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.getUnclippedBoundsInRoot
 import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performSemanticsAction
 import androidx.compose.ui.text.TextLayoutResult
 import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.dp
 import com.asmr.player.ui.theme.AsmrPlayerTheme
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
 
@@ -35,6 +41,42 @@ class AlbumMetaChipsTest {
 
         assertTextDoesNotOverflow("声优")
         assertTextDoesNotOverflow("标签")
+    }
+
+    @Test
+    fun headerTags_expandAndCollapseMoveFollowingContentSmoothly() {
+        composeRule.mainClock.autoAdvance = false
+        composeRule.setContent {
+            AsmrPlayerTheme {
+                Column(modifier = Modifier.width(240.dp)) {
+                    AlbumHeaderTagsFlow(
+                        tags = List(12) { index -> "标签${index + 1}" },
+                    )
+                    Text("后续内容")
+                }
+            }
+        }
+
+        val followingContent = composeRule.onNodeWithText("后续内容")
+        val collapsedTop = followingContent.getUnclippedBoundsInRoot().top
+
+        composeRule.onNodeWithText("展开", substring = true).performClick()
+        composeRule.mainClock.advanceTimeBy(140)
+        val expandingTop = followingContent.getUnclippedBoundsInRoot().top
+        composeRule.mainClock.advanceTimeBy(300)
+        val expandedTop = followingContent.getUnclippedBoundsInRoot().top
+
+        assertTrue(expandingTop > collapsedTop)
+        assertTrue(expandingTop < expandedTop)
+
+        composeRule.onNodeWithText("收起").performClick()
+        composeRule.mainClock.advanceTimeBy(140)
+        val collapsingTop = followingContent.getUnclippedBoundsInRoot().top
+        composeRule.mainClock.advanceTimeBy(300)
+        val collapsedAgainTop = followingContent.getUnclippedBoundsInRoot().top
+
+        assertTrue(collapsingTop < expandedTop)
+        assertTrue(collapsingTop > collapsedAgainTop)
     }
 
     private fun assertTextDoesNotOverflow(text: String) {


### PR DESCRIPTION
## 变更内容

- 为专辑详情页标签与 CV 的展开、折叠增加平移动画
- 修复 Release Kotlin 编译中的弃用与标签警告
- 移除专辑详情标题、CV、社团、标签和按钮的进入渐入动画
- 移除图片与目录树骨架高光，改用深浅色自适应的静态骨架
- 让目录树骨架结构贴近实际面包屑、操作栏、文件夹和文件行

## 验证

- `./gradlew-local.bat :app:compileReleaseKotlin`