### PR TITLE
fix: 修复在线下载与保存的本地库行为

### DIFF
--- a/app/src/main/java/com/asmr/player/data/local/db/AppDatabaseMigrations.kt
+++ b/app/src/main/java/com/asmr/player/data/local/db/AppDatabaseMigrations.kt
@@ -413,4 +413,21 @@ object AppDatabaseMigrations {
             )
         }
     }
+
+    val MIGRATION_23_24: Migration = object : Migration(23, 24) {
+        override fun migrate(db: SupportSQLiteDatabase) {
+            db.execSQL(
+                "CREATE TABLE IF NOT EXISTS `online_saved_resources` (" +
+                    "`id` INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT, " +
+                    "`albumId` INTEGER NOT NULL, " +
+                    "`relativePath` TEXT NOT NULL, " +
+                    "`url` TEXT NOT NULL, " +
+                    "`fileType` TEXT NOT NULL)"
+            )
+            db.execSQL(
+                "CREATE INDEX IF NOT EXISTS `index_online_saved_resources_albumId` " +
+                    "ON `online_saved_resources` (`albumId`)"
+            )
+        }
+    }
 }

--- a/app/src/main/java/com/asmr/player/data/local/db/AppDatabaseProvider.kt
+++ b/app/src/main/java/com/asmr/player/data/local/db/AppDatabaseProvider.kt
@@ -38,7 +38,8 @@ object AppDatabaseProvider {
                 AppDatabaseMigrations.MIGRATION_19_20,
                 AppDatabaseMigrations.MIGRATION_20_21,
                 AppDatabaseMigrations.MIGRATION_21_22,
-                AppDatabaseMigrations.MIGRATION_22_23
+                AppDatabaseMigrations.MIGRATION_22_23,
+                AppDatabaseMigrations.MIGRATION_23_24
             )
             // Never wipe the local database during app upgrades.
             // If a migration is missing, fail loudly so user data can still be recovered.

--- a/app/src/main/java/com/asmr/player/data/local/db/appdatabase.kt
+++ b/app/src/main/java/com/asmr/player/data/local/db/appdatabase.kt
@@ -11,6 +11,7 @@ import com.asmr.player.data.local.db.dao.DownloadDao
 import com.asmr.player.data.local.db.dao.ListeningSessionDao
 import com.asmr.player.data.local.db.dao.LocalTreeCacheDao
 import com.asmr.player.data.local.db.dao.ManualLyricsSourceDao
+import com.asmr.player.data.local.db.dao.OnlineSavedResourceDao
 import com.asmr.player.data.local.db.dao.PlaylistDao
 import com.asmr.player.data.local.db.dao.PlaylistItemDao
 import com.asmr.player.data.local.db.dao.PlayStatDao
@@ -32,6 +33,7 @@ import com.asmr.player.data.local.db.entities.DownloadTaskEntity
 import com.asmr.player.data.local.db.entities.ListeningSessionEntity
 import com.asmr.player.data.local.db.entities.LocalTreeCacheEntity
 import com.asmr.player.data.local.db.entities.ManualLyricsSourceEntity
+import com.asmr.player.data.local.db.entities.OnlineSavedResourceEntity
 import com.asmr.player.data.local.db.entities.PlaylistEntity
 import com.asmr.player.data.local.db.entities.PlaylistItemEntity
 import com.asmr.player.data.local.db.entities.PlaylistTrackCrossRef
@@ -66,9 +68,10 @@ import com.asmr.player.data.local.db.entities.TrackPlaybackProgressEntity
         ManualLyricsSourceEntity::class,
         TrackSliceEntity::class,
         TrackPlaybackProgressEntity::class,
-        ListeningSessionEntity::class
+        ListeningSessionEntity::class,
+        OnlineSavedResourceEntity::class
     ],
-    version = 23,
+    version = 24,
     exportSchema = false
 )
 abstract class AppDatabase : RoomDatabase() {
@@ -90,6 +93,7 @@ abstract class AppDatabase : RoomDatabase() {
     abstract fun trackSliceDao(): TrackSliceDao
     abstract fun trackPlaybackProgressDao(): TrackPlaybackProgressDao
     abstract fun listeningSessionDao(): ListeningSessionDao
+    abstract fun onlineSavedResourceDao(): OnlineSavedResourceDao
 
     companion object {
         const val DATABASE_NAME = "asmr_player.db"

--- a/app/src/main/java/com/asmr/player/data/local/db/dao/OnlineSavedResourceDao.kt
+++ b/app/src/main/java/com/asmr/player/data/local/db/dao/OnlineSavedResourceDao.kt
@@ -1,0 +1,26 @@
+package com.asmr.player.data.local.db.dao
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import com.asmr.player.data.local.db.entities.OnlineSavedResourceEntity
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface OnlineSavedResourceDao {
+    @Query("SELECT * FROM online_saved_resources WHERE albumId = :albumId ORDER BY relativePath ASC, id ASC")
+    fun observeForAlbum(albumId: Long): Flow<List<OnlineSavedResourceEntity>>
+
+    @Query("SELECT * FROM online_saved_resources WHERE albumId = :albumId ORDER BY relativePath ASC, id ASC")
+    suspend fun getForAlbumOnce(albumId: Long): List<OnlineSavedResourceEntity>
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertAll(resources: List<OnlineSavedResourceEntity>): List<Long>
+
+    @Query("DELETE FROM online_saved_resources WHERE albumId = :albumId")
+    suspend fun deleteByAlbumId(albumId: Long)
+
+    @Query("UPDATE online_saved_resources SET albumId = :toAlbumId WHERE albumId = :fromAlbumId")
+    suspend fun moveToAlbum(fromAlbumId: Long, toAlbumId: Long)
+}

--- a/app/src/main/java/com/asmr/player/data/local/db/entities/OnlineSavedResourceEntity.kt
+++ b/app/src/main/java/com/asmr/player/data/local/db/entities/OnlineSavedResourceEntity.kt
@@ -1,0 +1,17 @@
+package com.asmr.player.data.local.db.entities
+
+import androidx.room.Entity
+import androidx.room.Index
+import androidx.room.PrimaryKey
+
+@Entity(
+    tableName = "online_saved_resources",
+    indices = [Index(value = ["albumId"])]
+)
+data class OnlineSavedResourceEntity(
+    @PrimaryKey(autoGenerate = true) val id: Long = 0L,
+    val albumId: Long,
+    val relativePath: String,
+    val url: String,
+    val fileType: String
+)

--- a/app/src/main/java/com/asmr/player/ui/downloads/DownloadsViewModel.kt
+++ b/app/src/main/java/com/asmr/player/ui/downloads/DownloadsViewModel.kt
@@ -497,6 +497,7 @@ class DownloadsViewModel @Inject constructor(
                 runCatching { trackDao.deleteTracksForAlbum(albumId) }
                 runCatching { tagDao.deleteAlbumTagsByAlbumId(albumId) }
                 runCatching { albumFtsDao.deleteByAlbumId(albumId) }
+                runCatching { db.onlineSavedResourceDao().deleteByAlbumId(albumId) }
                 runCatching { albumDao.deleteAlbum(album) }
             }
             return

--- a/app/src/main/java/com/asmr/player/ui/library/AlbumDetailViewModel.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/AlbumDetailViewModel.kt
@@ -22,6 +22,7 @@ import com.asmr.player.data.local.db.entities.AlbumEntity
 import com.asmr.player.data.local.db.entities.AlbumFtsEntity
 import com.asmr.player.data.local.db.entities.AlbumTagEntity
 import com.asmr.player.data.local.db.entities.RemoteSubtitleSourceEntity
+import com.asmr.player.data.local.db.entities.OnlineSavedResourceEntity
 import com.asmr.player.data.local.db.entities.TagEntity
 import com.asmr.player.data.local.db.entities.TagSource
 import com.asmr.player.data.local.db.entities.TrackEntity
@@ -74,7 +75,6 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
 import java.io.File
 import java.io.FileOutputStream
-import java.io.IOException
 import java.util.concurrent.atomic.AtomicBoolean
 import javax.inject.Inject
 import javax.inject.Named
@@ -876,45 +876,18 @@ class AlbumDetailViewModel @Inject constructor(
 
         viewModelScope.launch {
             try {
-                var resolvedCoverPath = value
                 withContext(Dispatchers.IO) {
                     val entity = albumDao.getAlbumById(local.id) ?: return@withContext
-                    resolvedCoverPath = resolveCoverPathForLocalAlbum(entity, value)
-                    albumDao.updateAlbum(entity.copy(coverPath = resolvedCoverPath, coverThumbPath = ""))
+                    albumDao.updateAlbum(entity.copy(coverPath = value, coverThumbPath = ""))
                     runCatching { database.localTreeCacheDao().deleteByAlbum(entity.id) }
                 }
-                updateCurrentCoverState(local.id, resolvedCoverPath, "")
+                updateCurrentCoverState(local.id, value, "")
                 enqueueAlbumCoverThumbWork(local.id)
                 messageManager.showSuccess("已设置封面")
             } catch (e: Exception) {
                 messageManager.showError("设置封面失败，请检查后重试")
             }
         }
-    }
-
-    private fun resolveCoverPathForLocalAlbum(entity: AlbumEntity, value: String): String {
-        if (!value.startsWith("http", ignoreCase = true)) return value
-        val url = value.trim()
-        val root = listOfNotNull(entity.localPath, entity.downloadPath, entity.path)
-            .map { it.trim() }
-            .firstOrNull { it.isNotBlank() && !it.startsWith("content://") && !it.startsWith("web://") && !it.startsWith("http", ignoreCase = true) }
-            ?.let { File(it) }
-            ?: onlineSaveAlbumDir(entity.toAlbumForCover(), entity.rjCode.ifBlank { entity.workId })
-        val coverPrefix = "cover_${url.hashCode().toString().replace("-", "n")}"
-        return saveOnlineCoverToAlbumDir(url, root, fileNamePrefix = coverPrefix)?.absolutePath ?: value
-    }
-
-    private fun AlbumEntity.toAlbumForCover(): Album {
-        return Album(
-            id = id,
-            title = title,
-            path = path,
-            localPath = localPath,
-            downloadPath = downloadPath,
-            coverUrl = coverUrl,
-            workId = workId,
-            rjCode = rjCode
-        )
     }
 
     private fun updateCurrentCoverState(albumId: Long, coverPath: String, coverThumbPath: String) {
@@ -2164,11 +2137,7 @@ class AlbumDetailViewModel @Inject constructor(
                     return@withContext SaveOnlineToLibraryResult(
                         selectedCount = 0,
                         insertedCount = 0,
-                        resourceEnqueuedCount = 0,
-                        resourceSkippedCount = 0,
-                        albumId = 0L,
-                        coverUrl = "",
-                        coverPath = ""
+                        resourceSavedCount = 0
                     )
                 }
 
@@ -2179,7 +2148,6 @@ class AlbumDetailViewModel @Inject constructor(
                     mkdirs()
                     ensureNoMediaMarkers(this)
                 }
-                val coverFile = saveOnlineCoverToAlbumDir(displayAlbum.coverUrl, albumDir)
                 val playableSelected = selected.filter { isPlayableTreeFileType(it.fileType) }
                 val resourceSelected = selected.filter { !isPlayableTreeFileType(it.fileType) }
 
@@ -2188,9 +2156,8 @@ class AlbumDetailViewModel @Inject constructor(
                 }
 
                 var insertedCount = 0
+                var resourceSavedCount = 0
                 var albumIdResult = 0L
-                var coverUrlResult = ""
-                var coverPathResult = ""
                 database.withTransaction {
                     val existing = if (workKey.isNotBlank()) {
                         runCatching { albumDao.getAlbumByWorkIdOnce(workKey) }.getOrNull()
@@ -2209,7 +2176,7 @@ class AlbumDetailViewModel @Inject constructor(
                         cv = existing?.cv?.takeIf { it.isNotBlank() } ?: displayAlbum.cv,
                         tags = existing?.tags?.takeIf { it.isNotBlank() } ?: tagsCsv,
                         coverUrl = existing?.coverUrl?.takeIf { it.isNotBlank() } ?: displayAlbum.coverUrl,
-                        coverPath = coverFile?.absolutePath ?: existing?.coverPath.orEmpty(),
+                        coverPath = existing?.coverPath.orEmpty(),
                         coverThumbPath = existing?.coverThumbPath.orEmpty(),
                         workId = existing?.workId?.takeIf { it.isNotBlank() } ?: displayAlbum.workId.trim().ifBlank { workKey },
                         rjCode = existing?.rjCode?.takeIf { it.isNotBlank() } ?: displayAlbum.rjCode.trim().ifBlank { rj },
@@ -2219,8 +2186,6 @@ class AlbumDetailViewModel @Inject constructor(
                     val albumId = if (insertedId > 0L) insertedId else (existing?.id ?: 0L)
                     if (albumId <= 0L) return@withTransaction
                     albumIdResult = albumId
-                    coverUrlResult = entity.coverUrl.trim().takeIf { it.isNotBlank() && !it.equals("null", ignoreCase = true) }.orEmpty()
-                    coverPathResult = entity.coverPath.trim().takeIf { it.isNotBlank() && !it.equals("null", ignoreCase = true) }.orEmpty()
                     runCatching { database.localTreeCacheDao().deleteByAlbum(albumId) }
 
                     val fts = AlbumFtsEntity(
@@ -2282,23 +2247,29 @@ class AlbumDetailViewModel @Inject constructor(
                             runCatching { database.remoteSubtitleSourceDao().insertAll(sources) }
                         }
                     }
-                }
 
-                var resourceEnqueuedCount = 0
-                var resourceSkippedCount = 0
-                val resourceTaskKey = "album:${safeFolderName(workKey.ifBlank { displayAlbum.title })}"
-                resourceSelected.forEach { leaf ->
-                    val enqueued = enqueueOnlineSavedResourceDownload(
-                        album = displayAlbum,
-                        leaf = leaf,
-                        albumDir = albumDir,
-                        taskKey = resourceTaskKey,
-                        taskSubtitle = displayAlbum.title
-                    )
-                    if (enqueued) {
-                        resourceEnqueuedCount += 1
-                    } else {
-                        resourceSkippedCount += 1
+                    val resourceDao = database.onlineSavedResourceDao()
+                    val existingResourcesByPath = resourceDao.getForAlbumOnce(albumId)
+                        .associateBy { it.relativePath }
+                    val changedResources = resourceSelected.mapNotNull { leaf ->
+                        val relativePath = leaf.relativePath.replace('\\', '/').trim().trimStart('/')
+                        val url = leaf.url.trim()
+                        if (relativePath.isBlank() || !url.startsWith("http", ignoreCase = true)) {
+                            return@mapNotNull null
+                        }
+                        val existingResource = existingResourcesByPath[relativePath]
+                        val resource = OnlineSavedResourceEntity(
+                            id = existingResource?.id ?: 0L,
+                            albumId = albumId,
+                            relativePath = relativePath,
+                            url = url,
+                            fileType = leaf.fileType.name
+                        )
+                        resource.takeUnless { it == existingResource }
+                    }.distinctBy { it.relativePath }
+                    if (changedResources.isNotEmpty()) {
+                        resourceDao.insertAll(changedResources)
+                        resourceSavedCount = changedResources.size
                     }
                 }
 
@@ -2309,25 +2280,14 @@ class AlbumDetailViewModel @Inject constructor(
                 SaveOnlineToLibraryResult(
                     selectedCount = selected.size,
                     insertedCount = insertedCount,
-                    resourceEnqueuedCount = resourceEnqueuedCount,
-                    resourceSkippedCount = resourceSkippedCount,
-                    albumId = albumIdResult,
-                    coverUrl = coverUrlResult,
-                    coverPath = coverPathResult
+                    resourceSavedCount = resourceSavedCount
                 )
             }
 
             val selectedCount = result.selectedCount
-            val changedCount = result.insertedCount + result.resourceEnqueuedCount
+            val changedCount = result.insertedCount + result.resourceSavedCount
             val skippedCount = selectedCount - changedCount
 
-            if (result.albumId > 0L) {
-                try {
-                    ensureAlbumCoverSaved(result.albumId, result.coverPath, result.coverUrl)
-                } catch (_: Exception) {
-                }
-                enqueueAlbumCoverThumbWork(result.albumId)
-            }
             if (selectedCount <= 0) {
                 messageManager.showInfo("没有可保存文件")
             } else if (changedCount <= 0) {
@@ -2343,11 +2303,7 @@ class AlbumDetailViewModel @Inject constructor(
     private data class SaveOnlineToLibraryResult(
         val selectedCount: Int,
         val insertedCount: Int,
-        val resourceEnqueuedCount: Int,
-        val resourceSkippedCount: Int,
-        val albumId: Long,
-        val coverUrl: String,
-        val coverPath: String
+        val resourceSavedCount: Int
     )
 
     private fun isLikelyPlaceholderCover(url: String): Boolean {
@@ -2670,98 +2626,6 @@ class AlbumDetailViewModel @Inject constructor(
             val marker = File(dir, ".nomedia")
             if (!marker.exists()) marker.createNewFile()
         }
-    }
-
-    private fun saveOnlineCoverToAlbumDir(
-        coverUrl: String,
-        albumDir: File,
-        fileNamePrefix: String = "cover"
-    ): File? {
-        val url = coverUrl.trim()
-        if (!url.startsWith("http", ignoreCase = true) || isLikelyPlaceholderCover(url)) return null
-        val ext = url.substringBefore('?').substringAfterLast('.', "").takeIf { it.length in 2..5 } ?: "jpg"
-        val target = File(albumDir, "${safeFileName(fileNamePrefix)}.$ext")
-        if (target.exists() && target.length() > 0L) return target
-        return runCatching {
-            if (!albumDir.exists()) albumDir.mkdirs()
-            val request = Request.Builder()
-                .url(url)
-                .header("Accept", "image/*")
-                .get()
-                .build()
-            imageOkHttpClient.newCall(request).execute().use { response ->
-                if (!response.isSuccessful) throw IOException("HTTP ${response.code}")
-                val body = response.body ?: throw IOException("empty body")
-                FileOutputStream(target).use { output ->
-                    body.byteStream().use { input -> input.copyTo(output) }
-                }
-            }
-            target.takeIf { it.exists() && it.length() > 0L }
-        }.getOrNull()
-    }
-
-    private fun enqueueOnlineSavedResourceDownload(
-        album: Album,
-        leaf: OnlineSaveLeaf,
-        albumDir: File,
-        taskKey: String,
-        taskSubtitle: String
-    ): Boolean {
-        val url = leaf.url.trim()
-        if (!url.startsWith("http", ignoreCase = true)) return false
-        val relPath = leaf.relativePath.replace('\\', '/').trim().trimStart('/')
-        if (relPath.isBlank()) return false
-        val rawName = relPath.substringAfterLast('/', relPath)
-        val fileName = resolveRemoteResourceFileName(rawName, url, leaf.fileType)
-        val relDir = relPath.substringBeforeLast('/', "")
-        val targetDir = if (relDir.isBlank()) albumDir else File(albumDir, relDir)
-        if (!targetDir.exists()) targetDir.mkdirs()
-        ensureNoMediaMarkers(albumDir)
-
-        val outFile = File(targetDir, fileName)
-        if (outFile.exists() && outFile.isFile && outFile.length() > 0L) return false
-        val relativeFilePath = if (relDir.isBlank()) fileName else "$relDir/$fileName"
-
-        downloadManager.enqueueDownload(
-            url = url,
-            fileName = fileName,
-            targetDir = targetDir.absolutePath,
-            taskRootDir = albumDir.absolutePath,
-            relativePath = relativeFilePath,
-            taskSubtitle = taskSubtitle,
-            tags = listOf(taskKey),
-            albumTitle = album.title,
-            albumCircle = album.circle,
-            albumCv = album.cv,
-            albumTagsCsv = album.tags.joinToString(","),
-            albumCoverUrl = album.coverUrl,
-            albumWorkId = album.workId,
-            albumRjCode = album.rjCode
-        )
-        return true
-    }
-
-    private fun resolveRemoteResourceFileName(rawName: String, url: String, fileType: TreeFileType): String {
-        val baseName = safeFileName(rawName)
-        val extFromName = baseName.substringAfterLast('.', "").takeIf { it.isNotBlank() }
-        if (extFromName != null) return baseName
-        val extFromUrl = url.substringBefore('?').substringAfterLast('.', "").takeIf { it.length in 2..6 }
-        val defaultExt = when (fileType) {
-            TreeFileType.Video -> "mp4"
-            TreeFileType.Image -> "jpg"
-            TreeFileType.Pdf -> "pdf"
-            TreeFileType.Archive -> "zip"
-            TreeFileType.Document -> "doc"
-            TreeFileType.Spreadsheet -> "csv"
-            TreeFileType.Presentation -> "ppt"
-            TreeFileType.Code -> "txt"
-            TreeFileType.Ebook -> "epub"
-            TreeFileType.Font -> "ttf"
-            TreeFileType.AppPackage -> "apk"
-            TreeFileType.Text -> "txt"
-            else -> "mp3"
-        }
-        return "$baseName.${extFromUrl ?: defaultExt}"
     }
 
     private fun normalizeRj(raw: String): String {

--- a/app/src/main/java/com/asmr/player/ui/library/AlbumDetailViewModel.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/AlbumDetailViewModel.kt
@@ -661,7 +661,6 @@ class AlbumDetailViewModel @Inject constructor(
                 model = createInitialAlbumDetailModel(
                     rj = initialRj,
                     displayAlbum = initialHintAlbum,
-                    localAlbum = initialHint?.localAlbum,
                     dlsiteInfo = initialHintAlbum.takeIf { shouldPreserveHeaderAlbumMetadata(initialHint) },
                     preserveHeaderAlbumMetadata = shouldPreserveHeaderAlbumMetadata(initialHint)
                 )
@@ -685,17 +684,13 @@ class AlbumDetailViewModel @Inject constructor(
                 val hintAlbum = albumFromInitialHint(rj, hint)
                 val preserveHeaderAlbumMetadata = shouldPreserveHeaderAlbumMetadata(hint)
                 val dlsiteInfo = hintAlbum.takeIf { preserveHeaderAlbumMetadata }
-                val hydratedLocalAlbum = localAlbum?.let { loaded ->
-                    val prefetchedTracks = hint?.localAlbum?.tracks.orEmpty()
-                    if (prefetchedTracks.isEmpty()) loaded else loaded.copy(tracks = prefetchedTracks)
-                }
                 // 种入列表点击时记录的封面与元信息：让 hero 与列表卡片使用相同图片 model，
                 // 在网络解析完成前即可命中跨尺寸内存缓存，避免重复请求封面。
                 val displayAlbum = if (hint != null) hintAlbum else localAlbum ?: hintAlbum
                 val loadedModel = createInitialAlbumDetailModel(
                     rj = rj,
                     displayAlbum = displayAlbum,
-                    localAlbum = hydratedLocalAlbum,
+                    localAlbum = localAlbum,
                     dlsiteInfo = dlsiteInfo,
                     preserveHeaderAlbumMetadata = preserveHeaderAlbumMetadata
                 )
@@ -707,7 +702,7 @@ class AlbumDetailViewModel @Inject constructor(
                 }
                 localTracksObserveJob?.cancel()
                 localTracksObserveJob = null
-                val localId = hydratedLocalAlbum?.id ?: 0L
+                val localId = localAlbum?.id ?: 0L
                 if (localId > 0L) {
                     localTracksObserveJob = viewModelScope.launch {
                         trackDao.getTracksForAlbum(localId)
@@ -1927,7 +1922,6 @@ class AlbumDetailViewModel @Inject constructor(
             model = createInitialAlbumDetailModel(
                 rj = initialRj,
                 displayAlbum = hintAlbum,
-                localAlbum = hint?.localAlbum,
                 dlsiteInfo = hintAlbum.takeIf { preserveHeaderMetadata },
                 preserveHeaderAlbumMetadata = preserveHeaderMetadata
             )

--- a/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailDirectorySupport.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailDirectorySupport.kt
@@ -906,7 +906,7 @@ internal suspend fun loadOrBuildLocalTreeIndex(
 ): LocalTreeIndex {
     val gson = Gson()
     val cacheKey = albumPaths.map { it.trim() }.filter { it.isNotBlank() }.sorted().joinToString("|")
-    val stamp = computeAlbumPathsStamp(context, albumPaths)
+    val stamp = computeLocalTreeCacheStamp(context, albumPaths, tracks)
     val dao = AppDatabaseProvider.get(context).localTreeCacheDao()
     val onlineTracks = tracks.filter { it.path.trim().startsWith("http", ignoreCase = true) }
     val onlineUrlSet = onlineTracks.map { it.path.trim() }.filter { it.isNotBlank() }.toSet()
@@ -1012,6 +1012,28 @@ internal fun computeAlbumPathsStamp(context: android.content.Context, albumPaths
         }
         acc = (acc xor v) * 1099511628211L
     }
+    return acc
+}
+
+internal fun computeLocalTreeCacheStamp(
+    context: android.content.Context,
+    albumPaths: List<String>,
+    tracks: List<Track>
+): Long {
+    return combineLocalTreeCacheStamp(computeAlbumPathsStamp(context, albumPaths), tracks)
+}
+
+internal fun combineLocalTreeCacheStamp(albumPathsStamp: Long, tracks: List<Track>): Long {
+    var acc = albumPathsStamp
+    val localTrackPaths = tracks.asSequence()
+        .map { it.path.trim() }
+        .filter { it.isNotBlank() && !it.startsWith("http", ignoreCase = true) }
+        .sorted()
+        .toList()
+    localTrackPaths.forEach { path ->
+        acc = (acc xor path.hashCode().toLong()) * 1099511628211L
+    }
+    acc = (acc xor localTrackPaths.size.toLong()) * 1099511628211L
     return acc
 }
 

--- a/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailDirectorySupport.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailDirectorySupport.kt
@@ -87,6 +87,7 @@ import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.ui.PlayerView
 import com.asmr.player.data.local.db.AppDatabaseProvider
 import com.asmr.player.data.local.db.entities.LocalTreeCacheEntity
+import com.asmr.player.data.local.db.entities.OnlineSavedResourceEntity
 import com.asmr.player.data.remote.auth.DlsiteAuthStore
 import com.asmr.player.data.remote.api.AsmrOneTrackNodeResponse
 import com.asmr.player.data.remote.scraper.DlsiteRecommendedWork
@@ -619,6 +620,7 @@ internal fun buildLocalDirectoryBrowser(
         .sortedBy { SmartSortKey.of(it.name) }
         .mapNotNull { child ->
             val absolutePath = child.absolutePath ?: return@mapNotNull null
+            val isRemoteResource = absolutePath.startsWith("http", ignoreCase = true)
             val displayTitle = child.track?.title?.ifBlank { child.name.substringBeforeLast('.') }
                 ?: child.name.substringBeforeLast('.')
             val playlistTarget = when (child.fileType) {
@@ -633,7 +635,11 @@ internal fun buildLocalDirectoryBrowser(
                 isPlayable = child.track != null || child.fileType == TreeFileType.Video,
                 isOnline = isOnlineDirectoryAudio(child.fileType, absolutePath, child.track),
                 durationSeconds = child.track?.duration?.takeIf { it > 0.0 },
-                sizeSource = FileSizeSource.Local(path = absolutePath, sizeBytes = child.sizeBytes),
+                sizeSource = if (isRemoteResource) {
+                    FileSizeSource.Remote(absolutePath)
+                } else {
+                    FileSizeSource.Local(path = absolutePath, sizeBytes = child.sizeBytes)
+                },
                 absolutePath = absolutePath,
                 url = absolutePath,
                 track = child.track,
@@ -649,6 +655,11 @@ internal fun buildLocalDirectoryBrowser(
         folders = folders,
         files = files
     )
+}
+
+internal fun canSetDirectoryImageAsLocalCover(file: DirectoryFileItem): Boolean {
+    return file.fileType == TreeFileType.Image &&
+        !file.absolutePath.startsWith("http", ignoreCase = true)
 }
 
 internal class RemoteTreeNode(
@@ -893,6 +904,22 @@ internal data class LocalTreeLeafCacheEntry(
     val sizeBytes: Long? = null
 )
 
+internal fun onlineSavedResourceTreeLeaf(
+    resource: OnlineSavedResourceEntity
+): LocalTreeLeafCacheEntry? {
+    val relativePath = resource.relativePath.replace('\\', '/').trim().trimStart('/')
+    val url = resource.url.trim()
+    if (relativePath.isBlank() || !url.startsWith("http", ignoreCase = true)) return null
+    val fileType = runCatching { TreeFileType.valueOf(resource.fileType) }
+        .getOrElse { treeFileTypeForNode(relativePath, url) }
+    if (!isLibraryResourceSavableTreeFileType(fileType) || isPlayableTreeFileType(fileType)) return null
+    return LocalTreeLeafCacheEntry(
+        relativePath = relativePath,
+        absolutePath = url,
+        fileType = fileType
+    )
+}
+
 internal data class LocalTreeIndexBuildResult(
     val index: LocalTreeIndex,
     val leaves: List<LocalTreeLeafCacheEntry>
@@ -902,7 +929,8 @@ internal suspend fun loadOrBuildLocalTreeIndex(
     context: android.content.Context,
     albumId: Long,
     albumPaths: List<String>,
-    tracks: List<Track>
+    tracks: List<Track>,
+    onlineSavedResources: List<OnlineSavedResourceEntity> = emptyList()
 ): LocalTreeIndex {
     val gson = Gson()
     val cacheKey = albumPaths.map { it.trim() }.filter { it.isNotBlank() }.sorted().joinToString("|")
@@ -910,6 +938,11 @@ internal suspend fun loadOrBuildLocalTreeIndex(
     val dao = AppDatabaseProvider.get(context).localTreeCacheDao()
     val onlineTracks = tracks.filter { it.path.trim().startsWith("http", ignoreCase = true) }
     val onlineUrlSet = onlineTracks.map { it.path.trim() }.filter { it.isNotBlank() }.toSet()
+    val savedResourceKeys = onlineSavedResources.mapNotNull { resource ->
+        val relativePath = resource.relativePath.replace('\\', '/').trim().trimStart('/')
+        val url = resource.url.trim()
+        if (relativePath.isBlank() || url.isBlank()) null else relativePath to url
+    }.toSet()
 
     fun sanitizeSeg(name: String): String {
         return name.trim().ifEmpty { "item" }.replace(Regex("""[\\/:*?"<>|]"""), "_")
@@ -950,14 +983,27 @@ internal suspend fun loadOrBuildLocalTreeIndex(
         }
     }
 
-    fun mergeLeaves(localLeaves: List<LocalTreeLeafCacheEntry>, onlineLeaves: List<LocalTreeLeafCacheEntry>): List<LocalTreeLeafCacheEntry> {
+    fun buildSavedResourceLeaves(): List<LocalTreeLeafCacheEntry> {
+        return onlineSavedResources.mapNotNull(::onlineSavedResourceTreeLeaf)
+    }
+
+    fun mergeLeaves(
+        localLeaves: List<LocalTreeLeafCacheEntry>,
+        onlineLeaves: List<LocalTreeLeafCacheEntry>,
+        savedResourceLeaves: List<LocalTreeLeafCacheEntry>
+    ): List<LocalTreeLeafCacheEntry> {
         val filteredLocal = localLeaves.filter { leaf ->
             val abs = leaf.absolutePath.trim()
-            !(abs.startsWith("http", ignoreCase = true) && !onlineUrlSet.contains(abs))
+            !(
+                abs.startsWith("http", ignoreCase = true) &&
+                    !onlineUrlSet.contains(abs) &&
+                    !savedResourceKeys.contains(leaf.relativePath to abs)
+            )
         }
         val byRel = linkedMapOf<String, LocalTreeLeafCacheEntry>()
         filteredLocal.forEach { byRel[it.relativePath] = it }
-        onlineLeaves.forEach { leaf ->
+
+        fun mergeRemoteLeaf(leaf: LocalTreeLeafCacheEntry) {
             val existing = byRel[leaf.relativePath]
             if (existing == null) {
                 byRel[leaf.relativePath] = leaf
@@ -966,16 +1012,24 @@ internal suspend fun loadOrBuildLocalTreeIndex(
                 if (abs.startsWith("http", ignoreCase = true)) byRel[leaf.relativePath] = leaf
             }
         }
+
+        onlineLeaves.forEach(::mergeRemoteLeaf)
+        savedResourceLeaves.forEach(::mergeRemoteLeaf)
         return byRel.values.toList()
     }
     val onlineLeaves = buildOnlineLeaves()
+    val savedResourceLeaves = buildSavedResourceLeaves()
 
     val cached = dao.getByAlbumAndKey(albumId = albumId, cacheKey = cacheKey)
     if (cached != null && cached.stamp == stamp && cached.payloadJson.isNotBlank()) {
         val type = object : TypeToken<List<LocalTreeLeafCacheEntry>>() {}.type
         val leaves = runCatching { gson.fromJson<List<LocalTreeLeafCacheEntry>>(cached.payloadJson, type) }
             .getOrDefault(emptyList())
-        val merged = mergeLeaves(localLeaves = leaves, onlineLeaves = onlineLeaves)
+        val merged = mergeLeaves(
+            localLeaves = leaves,
+            onlineLeaves = onlineLeaves,
+            savedResourceLeaves = savedResourceLeaves
+        )
         val missingLocalSizeMetadata = leaves.any { leaf ->
             val abs = leaf.absolutePath.trim()
             abs.isNotBlank() &&
@@ -988,7 +1042,11 @@ internal suspend fun loadOrBuildLocalTreeIndex(
     }
 
     val built = buildLocalTreeIndexByScanning(context = context, albumPaths = albumPaths, tracks = tracks)
-    val merged = mergeLeaves(localLeaves = built.leaves, onlineLeaves = onlineLeaves)
+    val merged = mergeLeaves(
+        localLeaves = built.leaves,
+        onlineLeaves = onlineLeaves,
+        savedResourceLeaves = savedResourceLeaves
+    )
     dao.upsert(
         LocalTreeCacheEntity(
             albumId = albumId,

--- a/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailLocalTab.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailLocalTab.kt
@@ -193,13 +193,28 @@ internal fun AlbumLocalBreadcrumbTabV2(
                 .toSet()
         }
     }
-    val treeIndex by produceState<LocalTreeIndex?>(initialValue = null, key1 = allPaths, key2 = queueTracks) {
+    val onlineSavedResources by produceState(
+        initialValue = emptyList<com.asmr.player.data.local.db.entities.OnlineSavedResourceEntity>(),
+        key1 = album.id
+    ) {
+        if (album.id <= 0L) return@produceState
+        AppDatabaseProvider.get(context).onlineSavedResourceDao()
+            .observeForAlbum(album.id)
+            .collect { value = it }
+    }
+    val treeIndex by produceState<LocalTreeIndex?>(
+        initialValue = null,
+        key1 = allPaths,
+        key2 = queueTracks,
+        key3 = onlineSavedResources
+    ) {
         value = withContext(Dispatchers.IO) {
             loadOrBuildLocalTreeIndex(
                 context = context,
                 albumId = album.id,
                 albumPaths = allPaths,
-                tracks = queueTracks
+                tracks = queueTracks,
+                onlineSavedResources = onlineSavedResources
             )
         }
     }
@@ -362,7 +377,11 @@ internal fun AlbumLocalBreadcrumbTabV2(
                             selected = selected,
                             onEnterSelectionMode = enterSelectionMode,
                             onSelectedChange = onSelectedChange,
-                            onSetAsCover = if (file.fileType == TreeFileType.Image) ({ onSetCoverFromImage(file.absolutePath) }) else null,
+                            onSetAsCover = if (canSetDirectoryImageAsLocalCover(file)) {
+                                { onSetCoverFromImage(file.absolutePath) }
+                            } else {
+                                null
+                            },
                             onDownload = null,
                             onAddToQueue = track?.let { { onAddToQueue(it); Unit } },
                             onAddToPlaylist = track?.let { { onAddToPlaylist(it) } },

--- a/app/src/main/java/com/asmr/player/ui/library/libraryviewmodel.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/libraryviewmodel.kt
@@ -964,7 +964,7 @@ class LibraryViewModel @Inject constructor(
                     if (!hasOnline) {
                         trackDao.deleteSubtitlesForAlbum(entity.id)
                         trackDao.deleteTracksForAlbum(entity.id)
-                        albumDao.deleteAlbum(entity)
+                        deleteAlbumEntity(entity)
                     } else {
                         tracks.filter { it.path.startsWith(uriString) }.forEach { track ->
                             trackDao.deleteSubtitlesForTrack(track.id)
@@ -1582,7 +1582,7 @@ class LibraryViewModel @Inject constructor(
                         if (!hasOnline) {
                             trackDao.deleteSubtitlesForAlbum(entity.id)
                             trackDao.deleteTracksForAlbum(entity.id)
-                            albumDao.deleteAlbum(entity)
+                            deleteAlbumEntity(entity)
                             removed = true
                         } else {
                             val prefixes = localPaths.map { it.trim() }.filter { it.isNotBlank() }
@@ -1650,7 +1650,7 @@ class LibraryViewModel @Inject constructor(
                 database.withTransaction {
                     trackDao.deleteSubtitlesForAlbum(album.id)
                     trackDao.deleteTracksForAlbum(album.id)
-                    albumDao.deleteAlbum(entity)
+                    deleteAlbumEntity(entity)
                     database.tagDao().deleteAlbumTagsByAlbumId(album.id)
                     database.albumFtsDao().deleteByAlbumId(album.id)
                 }
@@ -1965,7 +1965,7 @@ class LibraryViewModel @Inject constructor(
                 if (entity.localPath.isNullOrBlank() && !entity.path.startsWith("content://")) {
                     trackDao.deleteSubtitlesForAlbum(entity.id)
                     trackDao.deleteTracksForAlbum(entity.id)
-                    albumDao.deleteAlbum(entity)
+                    deleteAlbumEntity(entity)
                 } else {
                     val dl = entity.downloadPath?.trim().orEmpty()
                     val tracks = trackDao.getTracksForAlbumOnce(entity.id)
@@ -2366,7 +2366,7 @@ class LibraryViewModel @Inject constructor(
                     if (!hasOnline) {
                         trackDao.deleteSubtitlesForAlbum(entity.id)
                         trackDao.deleteTracksForAlbum(entity.id)
-                        albumDao.deleteAlbum(entity)
+                        deleteAlbumEntity(entity)
                     } else {
                         val root = rootUriString.trim()
                         tracks.filter { it.path.startsWith(root) }.forEach { track ->
@@ -2444,12 +2444,13 @@ class LibraryViewModel @Inject constructor(
                 if (!anyValid) {
                     val hasOnlineTracks = cachedHasOnlineTracks ?: run {
                         val ts = cachedTracks ?: trackDao.getTracksForAlbumOnce(entity.id).also { cachedTracks = it }
-                        ts.any { isOnlineTrackPath(it.path) }.also { cachedHasOnlineTracks = it }
+                        (isVirtualAlbumPath(entity.path) || ts.any { isOnlineTrackPath(it.path) })
+                            .also { cachedHasOnlineTracks = it }
                     }
                     if (!hasOnlineTracks) {
                         trackDao.deleteSubtitlesForAlbum(entity.id)
                         trackDao.deleteTracksForAlbum(entity.id)
-                        albumDao.deleteAlbum(entity)
+                        deleteAlbumEntity(entity)
                         return@forEach
                     }
                 }
@@ -2513,7 +2514,7 @@ class LibraryViewModel @Inject constructor(
                         if (!hasOnlineTracks) {
                             trackDao.deleteSubtitlesForAlbum(entity.id)
                             trackDao.deleteTracksForAlbum(entity.id)
-                            albumDao.deleteAlbum(entity)
+                            deleteAlbumEntity(entity)
                             return@forEach
                         }
                         val onlinePath = buildOnlineAlbumPath(updated)
@@ -2676,7 +2677,8 @@ class LibraryViewModel @Inject constructor(
                 val canonical = matches.firstOrNull { !it.localPath.isNullOrBlank() } ?: matches.first()
                 matches.filter { it.id != canonical.id }.forEach { other ->
                     trackDao.moveTracksToAlbum(other.id, canonical.id)
-                    albumDao.deleteAlbum(other)
+                    database.onlineSavedResourceDao().moveToAlbum(other.id, canonical.id)
+                    deleteAlbumEntity(other)
                 }
                 val merged = canonical.copy(
                     title = canonical.title.ifBlank { fallbackTitle },
@@ -2697,6 +2699,11 @@ class LibraryViewModel @Inject constructor(
             return albumDao.getAllAlbumsOnce().firstOrNull { it.title == fallbackTitle }
         }
         return null
+    }
+
+    private suspend fun deleteAlbumEntity(entity: AlbumEntity) {
+        database.onlineSavedResourceDao().deleteByAlbumId(entity.id)
+        albumDao.deleteAlbum(entity)
     }
 
     private data class DocNode(

--- a/app/src/test/java/com/asmr/player/ui/library/AlbumDetailDirectorySupportTest.kt
+++ b/app/src/test/java/com/asmr/player/ui/library/AlbumDetailDirectorySupportTest.kt
@@ -6,9 +6,23 @@ import com.asmr.player.domain.model.Track
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotEquals
 import org.junit.Test
 
 class AlbumDetailDirectorySupportTest {
+
+    @Test
+    fun combineLocalTreeCacheStamp_changesWhenDatabaseTracksArrive() {
+        val withoutTracks = combineLocalTreeCacheStamp(albumPathsStamp = 42L, tracks = emptyList())
+        val withTracks = combineLocalTreeCacheStamp(
+            albumPathsStamp = 42L,
+            tracks = listOf(
+                Track(albumId = 7L, title = "01", path = "/album/mp3/01.mp3")
+            )
+        )
+
+        assertNotEquals(withoutTracks, withTracks)
+    }
 
     @Test
     fun buildBreadcrumbSegments_preservesHierarchyOrder() {

--- a/app/src/test/java/com/asmr/player/ui/library/AlbumDetailDirectorySupportTest.kt
+++ b/app/src/test/java/com/asmr/player/ui/library/AlbumDetailDirectorySupportTest.kt
@@ -1,6 +1,7 @@
 package com.asmr.player.ui.library
 
 import com.asmr.player.data.remote.api.AsmrOneTrackNodeResponse
+import com.asmr.player.data.local.db.entities.OnlineSavedResourceEntity
 import com.asmr.player.domain.model.Album
 import com.asmr.player.domain.model.Track
 import org.junit.Assert.assertEquals
@@ -266,6 +267,29 @@ class AlbumDetailDirectorySupportTest {
 
         assertEquals("在线音频", directoryFileTypeLabel(browser.files.single { it.title == "online" }))
         assertEquals("本地音频", directoryFileTypeLabel(browser.files.single { it.title == "local" }))
+    }
+
+    @Test
+    fun onlineSavedResourceTreeLeaf_keepsLogicalImageWithoutLocalCoverAction() {
+        val leaf = onlineSavedResourceTreeLeaf(
+            OnlineSavedResourceEntity(
+                albumId = 9L,
+                relativePath = "booklet/images/scene.jpg",
+                url = "https://example.com/scene.jpg",
+                fileType = TreeFileType.Image.name
+            )
+        ) ?: error("resource should be retained")
+        val index = buildLocalTreeIndexFromLeaves(leaves = listOf(leaf), tracks = emptyList())
+        val browser = buildLocalDirectoryBrowser(
+            index = index,
+            currentPath = "booklet/images",
+            album = Album(id = 9L, title = "album", path = "web://rj/RJ000009"),
+            shouldShowSubtitleStamp = { false }
+        )
+
+        val file = browser.files.single()
+        assertEquals(FileSizeSource.Remote("https://example.com/scene.jpg"), file.sizeSource)
+        assertFalse(canSetDirectoryImageAsLocalCover(file))
     }
 
     @Test


### PR DESCRIPTION
## 修复内容

1. 修复在线下载完成后，本地库专辑详情只显示封面的问题
   - 回退 `ddf3ab7` 引入的不完整本地专辑首屏预填充
   - 本地目录缓存戳加入数据库曲目路径，已有的“仅封面”错误缓存会自动失效并重建
2. 修复在线保存作品时下载图片的问题
   - 非播放资源仅保存为逻辑目录记录，不再加入下载队列
   - 逻辑保存的远程图片不提供“设置为封面”操作

## 回归原因

`ddf3ab7` 为优化详情页首屏，提前使用本地库列表中的专辑对象构建目录树。该对象尚未包含完整曲目时会缓存出“只有封面”的目录；数据库曲目随后加载完成，但旧缓存不会因曲目集合变化而失效。

`DownloadManager` 在 `v1.1.6..release/v1.2.0` 之间没有变化，本次修复不修改下载落库链路。

## 验证

- `./gradlew-local.bat :app:installRelease` 构建并安装成功
- 设备上已有问题的 `RJ01636129` 从仅显示封面恢复为 `mp3` 目录，进入后显示 6 个媒体文件
- 验证旧错误缓存无需重新下载作品即可自动修复
- 两项修复分别提交