### PR TITLE
fix: 修复部分音频播放回音与卡顿

### DIFF
--- a/app/src/main/java/com/asmr/player/playback/DynamicAudioProcessorChain.kt
+++ b/app/src/main/java/com/asmr/player/playback/DynamicAudioProcessorChain.kt
@@ -4,6 +4,7 @@ import androidx.media3.common.audio.AudioProcessor.AudioFormat
 import androidx.media3.common.audio.AudioProcessor
 import androidx.media3.common.util.UnstableApi
 import java.nio.ByteBuffer
+import java.nio.ByteOrder
 
 /**
  * 把可即时开关的应用音效合并成一个 Media3 音频处理节点。
@@ -20,6 +21,7 @@ internal class DynamicAudioProcessorChain(
     private var pendingOutputAudioFormat = AudioFormat.NOT_SET
     private var outputAudioFormat = AudioFormat.NOT_SET
     private var outputBuffer = AudioProcessor.EMPTY_BUFFER
+    private var passthroughBuffer = AudioProcessor.EMPTY_BUFFER
     private var inputEnded = false
 
     override fun configure(inputAudioFormat: AudioFormat): AudioFormat {
@@ -43,6 +45,7 @@ internal class DynamicAudioProcessorChain(
     override fun reset() {
         flush()
         outputBuffer = AudioProcessor.EMPTY_BUFFER
+        passthroughBuffer = AudioProcessor.EMPTY_BUFFER
         pendingOutputAudioFormat = AudioFormat.NOT_SET
         outputAudioFormat = AudioFormat.NOT_SET
         processors.forEach(RuntimeAudioProcessor::reset)
@@ -65,12 +68,20 @@ internal class DynamicAudioProcessorChain(
         outputBuffer = if (appliedProcessor) {
             currentBuffer
         } else {
-            // 默认音效全关时直接把输入的独立读取窗口交给 AudioSink。底层 PCM 内存不会复制，
-            // 原输入仍按 AudioProcessor 契约推进到末尾。
-            inputBuffer.slice().also {
-                inputBuffer.position(inputBuffer.limit())
-            }
+            copyToPassthroughBuffer(inputBuffer)
         }
+    }
+
+    private fun copyToPassthroughBuffer(inputBuffer: ByteBuffer): ByteBuffer {
+        val size = inputBuffer.remaining()
+        passthroughBuffer = if (passthroughBuffer.capacity() < size) {
+            ByteBuffer.allocateDirect(size).order(ByteOrder.nativeOrder())
+        } else {
+            passthroughBuffer.also { it.clear() }
+        }
+        passthroughBuffer.put(inputBuffer)
+        passthroughBuffer.flip()
+        return passthroughBuffer
     }
 
     override fun queueEndOfStream() {

--- a/app/src/test/java/com/asmr/player/playback/DynamicAudioProcessorChainTest.kt
+++ b/app/src/test/java/com/asmr/player/playback/DynamicAudioProcessorChainTest.kt
@@ -13,7 +13,7 @@ import org.junit.Test
 class DynamicAudioProcessorChainTest {
 
     @Test
-    fun inactiveProcessorsAreSkippedAndPcmIsPreserved() {
+    fun inactiveProcessorsCopyPcmIntoOwnedOutputBuffer() {
         val first = RecordingProcessor(active = false, delta = 10)
         val second = RecordingProcessor(active = false, delta = 20)
         val chain = configuredChain(first, second)
@@ -26,9 +26,10 @@ class DynamicAudioProcessorChainTest {
         assertEquals(0, first.inputCount)
         assertEquals(0, second.inputCount)
         assertEquals(inputBuffer.limit(), inputBuffer.position())
+        inputBuffer.clear()
         inputBuffer.put(0, 9)
-        assertEquals(9, output.get(0).toInt())
-        assertArrayEquals(byteArrayOf(9, 2, 3, 4), output.toByteArray())
+        assertEquals(1, output.get(0).toInt())
+        assertArrayEquals(input, output.toByteArray())
     }
 
     @Test

--- a/app/src/test/java/com/asmr/player/ui/library/AlbumDetailViewModelSupportTest.kt
+++ b/app/src/test/java/com/asmr/player/ui/library/AlbumDetailViewModelSupportTest.kt
@@ -108,7 +108,8 @@ class AlbumDetailViewModelSupportTest {
             priceJpy = 0,
             hasAsmrOne = false,
             description = "",
-            hasResolvedDlsiteInfo = false
+            hasResolvedDlsiteInfo = false,
+            localAlbum = null
         )
         val resolvedHint = partialHint.copy(hasResolvedDlsiteInfo = true)
 

--- a/app/src/test/java/com/asmr/player/ui/nav/AlbumCoverHintStoreTest.kt
+++ b/app/src/test/java/com/asmr/player/ui/nav/AlbumCoverHintStoreTest.kt
@@ -21,7 +21,8 @@ class AlbumCoverHintStoreTest {
             priceJpy = 990,
             hasAsmrOne = true,
             description = "简介",
-            hasResolvedDlsiteInfo = true
+            hasResolvedDlsiteInfo = true,
+            localAlbum = null
         )
 
         val album = albumFromCoverHint("", hint)


### PR DESCRIPTION
## 问题

部分 PCM/WAV 音频播放时会出现回音、重复片段或卡顿。音效全部旁路时，`DynamicAudioProcessorChain` 将上游输入缓冲的共享切片直接作为输出；Media3 已将输入视为消费完成后可能复用该内存，而 AudioTrack 的非阻塞写入仍可能持有未消费数据，导致待播放 PCM 被覆盖。

## 修复

- 旁路路径改为复制到可复用的 native-order direct buffer，遵守 Media3 的缓冲所有权契约。
- 缓冲容量足够时直接复用，避免持续分配；默认路径仍只有一次必要 PCM 拷贝。
- 更新回归测试，验证上游输入缓冲被复用/覆盖后，待输出 PCM 保持不变。
- 修复两个 `AlbumCoverHint` 测试漏传 `localAlbum` 的编译错误。

## 验证

- `./gradlew-local.bat :app:compileReleaseUnitTestKotlin`：通过。
- `./gradlew-local.bat :app:installRelease`：通过，并安装到连接设备 `23078RKD5C`。
- 原问题音频（44.1 kHz、双声道、16-bit PCM WAV）在修复版连续播放超过 20 秒，应用 AudioTrack `Underruns=0`，未发现 PlaybackException、DefaultAudioSink 或写入错误。
- `testReleaseUnitTest` 的测试执行器受本机全局 Java PATH/CLASSPATH 格式异常影响，启动时出现 `ClassNotFoundException: Files\Java\jdk-17\bin;C:\Program`；全部 Release 单测源码已成功编译。