### PR TITLE
feat: 新增 APP 缓存空间设置与清理

### DIFF
--- a/app/src/main/java/com/asmr/player/AsmrApp.kt
+++ b/app/src/main/java/com/asmr/player/AsmrApp.kt
@@ -2,10 +2,10 @@ package com.asmr.player
 
 import android.app.Application
 import androidx.work.Configuration
-import coil.disk.DiskCache
 import coil.ImageLoader
 import coil.ImageLoaderFactory
 import coil.memory.MemoryCache
+import com.asmr.player.cache.AppCacheManager
 import com.asmr.player.data.local.db.AppDatabaseProvider
 import com.asmr.player.cache.ImageCacheManager
 import com.asmr.player.data.remote.download.DownloadQueueCoordinator
@@ -17,7 +17,6 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
 import okhttp3.OkHttpClient
-import java.io.File
 import javax.inject.Inject
 import javax.inject.Named
 
@@ -32,8 +31,12 @@ class AsmrApp : Application(), ImageLoaderFactory, Configuration.Provider {
     @Inject
     lateinit var settingsRepository: SettingsRepository
 
+    @Inject
+    lateinit var appCacheManager: AppCacheManager
+
     override fun onCreate() {
         super.onCreate()
+        appCacheManager.start()
         applicationScope.launch {
             runCatching {
                 getSharedPreferences("album_detail_tree_prefs", MODE_PRIVATE).all
@@ -66,12 +69,7 @@ class AsmrApp : Application(), ImageLoaderFactory, Configuration.Provider {
                     .maxSizePercent(0.15)
                     .build()
             }
-            .diskCache {
-                DiskCache.Builder()
-                    .directory(File(cacheDir, "coil_cache"))
-                    .maxSizeBytes(200L * 1024 * 1024)
-                    .build()
-            }
+            .diskCache(null)
             .build()
     }
 }

--- a/app/src/main/java/com/asmr/player/cache/AppCacheLimits.kt
+++ b/app/src/main/java/com/asmr/player/cache/AppCacheLimits.kt
@@ -1,0 +1,25 @@
+package com.asmr.player.cache
+
+object AppCacheLimits {
+    const val MinSizeMb = 50
+    const val MaxSizeMb = 1000
+    const val DefaultSizeMb = 150
+    const val SizeStepMb = 10
+
+    private const val BytesPerMb = 1024L * 1024L
+    private const val ImageBudgetPercent = 60L
+    private const val PlaybackBudgetPercent = 35L
+
+    fun clampSizeMb(sizeMb: Int): Int = sizeMb.coerceIn(MinSizeMb, MaxSizeMb)
+
+    fun totalSizeBytes(sizeMb: Int): Long = clampSizeMb(sizeMb) * BytesPerMb
+
+    fun imageMaxSizeBytes(sizeMb: Int): Long = totalSizeBytes(sizeMb) * ImageBudgetPercent / 100L
+
+    fun playbackMaxSizeBytes(sizeMb: Int): Long = totalSizeBytes(sizeMb) * PlaybackBudgetPercent / 100L
+
+    fun previewMaxSizeBytes(sizeMb: Int): Long {
+        val total = totalSizeBytes(sizeMb)
+        return total - imageMaxSizeBytes(sizeMb) - playbackMaxSizeBytes(sizeMb)
+    }
+}

--- a/app/src/main/java/com/asmr/player/cache/AppCacheManager.kt
+++ b/app/src/main/java/com/asmr/player/cache/AppCacheManager.kt
@@ -1,0 +1,166 @@
+package com.asmr.player.cache
+
+import android.content.Context
+import android.util.Log
+import com.asmr.player.data.settings.SettingsRepository
+import com.asmr.player.playback.PlaybackMediaCache
+import dagger.hilt.android.qualifiers.ApplicationContext
+import java.io.File
+import java.util.concurrent.atomic.AtomicBoolean
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+data class AppCacheState(
+    val maxSizeMb: Int = AppCacheLimits.DefaultSizeMb,
+    val usedSizeBytes: Long = 0L,
+    val isClearing: Boolean = false,
+)
+
+@Singleton
+class AppCacheManager @Inject constructor(
+    @ApplicationContext private val context: Context,
+    private val settingsRepository: SettingsRepository,
+    private val imageCacheManager: ImageCacheManager,
+) {
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    private val started = AtomicBoolean(false)
+    private val clearing = AtomicBoolean(false)
+    private val previewDirectory = File(context.cacheDir, DLSITE_PREVIEW_CACHE_DIR_NAME)
+    private val legacyCoilDirectory = File(context.cacheDir, LEGACY_COIL_CACHE_DIR_NAME)
+    private val _state = MutableStateFlow(AppCacheState())
+    val state: StateFlow<AppCacheState> = _state.asStateFlow()
+    private var sizeRefreshJob: Job? = null
+
+    fun start() {
+        if (!started.compareAndSet(false, true)) return
+        scope.launch {
+            settingsRepository.appCacheMaxSizeMb
+                .distinctUntilChanged()
+                .collect { requestedSizeMb ->
+                    applyMaxSize(AppCacheLimits.clampSizeMb(requestedSizeMb))
+                }
+        }
+    }
+
+    fun refreshSize() {
+        start()
+        sizeRefreshJob?.cancel()
+        sizeRefreshJob = scope.launch { refreshSizeNow() }
+    }
+
+    fun clearCache() {
+        start()
+        if (!clearing.compareAndSet(false, true)) return
+        scope.launch {
+            _state.update { it.copy(isClearing = true) }
+            try {
+                runCacheOperation("clear image cache") { imageCacheManager.clearCaches() }
+                runCacheOperation("clear playback cache") { PlaybackMediaCache.clear(context) }
+                runCacheOperation("clear preview cache") { clearDirectoryContents(previewDirectory) }
+                runCacheOperation("clear legacy Coil cache") { clearDirectoryContents(legacyCoilDirectory) }
+                refreshSizeNow()
+            } finally {
+                clearing.set(false)
+                _state.update { it.copy(isClearing = false) }
+            }
+        }
+    }
+
+    fun onPreviewCacheChanged(retainedFile: File) {
+        start()
+        scope.launch {
+            trimDirectoryToSize(
+                directory = previewDirectory,
+                maxSizeBytes = AppCacheLimits.previewMaxSizeBytes(_state.value.maxSizeMb),
+                retainedFile = retainedFile,
+            )
+            refreshSizeNow()
+        }
+    }
+
+    private fun applyMaxSize(sizeMb: Int) {
+        _state.update { it.copy(maxSizeMb = sizeMb) }
+        runCacheOperation("resize image cache") {
+            imageCacheManager.updateDiskMaxSizeBytes(AppCacheLimits.imageMaxSizeBytes(sizeMb))
+        }
+        runCacheOperation("resize playback cache") {
+            PlaybackMediaCache.updateMaxCacheBytes(AppCacheLimits.playbackMaxSizeBytes(sizeMb))
+        }
+        runCacheOperation("resize preview cache") {
+            trimDirectoryToSize(previewDirectory, AppCacheLimits.previewMaxSizeBytes(sizeMb))
+        }
+        runCacheOperation("clear legacy Coil cache") { clearDirectoryContents(legacyCoilDirectory) }
+        refreshSizeNow()
+    }
+
+    private fun refreshSizeNow() {
+        val usedBytes = cacheSizeOrZero("measure image cache") { imageCacheManager.diskSizeBytes() } +
+            cacheSizeOrZero("measure playback cache") { PlaybackMediaCache.sizeBytes(context) } +
+            cacheSizeOrZero("measure preview cache") { directorySizeBytes(previewDirectory) } +
+            cacheSizeOrZero("measure legacy Coil cache") { directorySizeBytes(legacyCoilDirectory) }
+        _state.update { it.copy(usedSizeBytes = usedBytes.coerceAtLeast(0L)) }
+    }
+
+    private fun trimDirectoryToSize(
+        directory: File,
+        maxSizeBytes: Long,
+        retainedFile: File? = null,
+    ) {
+        val files = directory.listFiles()
+            ?.asSequence()
+            ?.filter(File::isFile)
+            ?.sortedBy(File::lastModified)
+            ?.toList()
+            .orEmpty()
+        var currentSize = files.sumOf(File::length)
+        if (currentSize <= maxSizeBytes) return
+        val targetSize = (maxSizeBytes - maxSizeBytes / 10L).coerceAtLeast(0L)
+        for (file in files) {
+            if (currentSize <= targetSize) break
+            if (file == retainedFile) continue
+            val length = file.length()
+            if (file.delete()) currentSize = (currentSize - length).coerceAtLeast(0L)
+        }
+    }
+
+    private fun directorySizeBytes(directory: File): Long {
+        return directory.walkTopDown()
+            .filter(File::isFile)
+            .sumOf(File::length)
+    }
+
+    private fun clearDirectoryContents(directory: File) {
+        if (!directory.isDirectory) return
+        directory.walkBottomUp()
+            .filter { it != directory }
+            .forEach(File::delete)
+    }
+
+    private inline fun runCacheOperation(operation: String, block: () -> Unit) {
+        runCatching(block).onFailure { error ->
+            Log.w(TAG, "$operation failed", error)
+        }
+    }
+
+    private inline fun cacheSizeOrZero(operation: String, block: () -> Long): Long {
+        return runCatching(block).onFailure { error ->
+            Log.w(TAG, "$operation failed", error)
+        }.getOrDefault(0L)
+    }
+
+    companion object {
+        private const val TAG = "AppCacheManager"
+        const val DLSITE_PREVIEW_CACHE_DIR_NAME = "dlsite_play_preview"
+        private const val LEGACY_COIL_CACHE_DIR_NAME = "coil_cache"
+    }
+}

--- a/app/src/main/java/com/asmr/player/cache/CacheConfig.kt
+++ b/app/src/main/java/com/asmr/player/cache/CacheConfig.kt
@@ -3,7 +3,7 @@ package com.asmr.player.cache
 data class CacheConfig(
     val cacheVersion: String,
     val memoryMaxSizePercent: Double = 0.20,
-    val diskMaxSizeBytes: Long = 200L * 1024 * 1024,
+    val diskMaxSizeBytes: Long = AppCacheLimits.imageMaxSizeBytes(AppCacheLimits.DefaultSizeMb),
     val diskTtlMs: Long = 14L * 24 * 60 * 60 * 1000,
     val decodeParallelism: Int = 3,
     val loadParallelism: Int = 3,

--- a/app/src/main/java/com/asmr/player/cache/DiskCache.kt
+++ b/app/src/main/java/com/asmr/player/cache/DiskCache.kt
@@ -9,7 +9,7 @@ import java.io.IOException
 
 class DiskCache(
     private val directory: File,
-    private val maxSizeBytes: Long,
+    maxSizeBytes: Long,
     private val ttlMs: Long
 ) {
     private val lock = Any()
@@ -18,6 +18,7 @@ class DiskCache(
     private var clearGeneration = 0L
     private val removeGenerations = mutableMapOf<String, Long>()
     private var directoryReady = false
+    private var maxSizeBytes = maxSizeBytes.coerceAtLeast(0L)
 
     data class Entry(
         val bytes: ByteArray,
@@ -126,6 +127,19 @@ class DiskCache(
         }
         directory.listFiles()?.forEach { it.delete() }
         currentSizeBytes = calculateSizeBytes()
+    }
+
+    fun updateMaxSizeBytes(maxSizeBytes: Long) = synchronized(lock) {
+        this.maxSizeBytes = maxSizeBytes.coerceAtLeast(0L)
+        if (!ensureDirectoryReady()) return@synchronized
+        ensureSizeInitialized()
+        trimToSize()
+    }
+
+    fun sizeBytes(): Long = synchronized(lock) {
+        if (!ensureDirectoryReady()) return@synchronized 0L
+        ensureSizeInitialized()
+        currentSizeBytes ?: 0L
     }
 
     private fun fileForKey(key: String): File {

--- a/app/src/main/java/com/asmr/player/cache/ImageCacheManager.kt
+++ b/app/src/main/java/com/asmr/player/cache/ImageCacheManager.kt
@@ -352,6 +352,21 @@ class ImageCacheManager(
 
     fun statsSnapshot(): CacheStats.Snapshot = stats.snapshot()
 
+    fun updateDiskMaxSizeBytes(maxSizeBytes: Long) {
+        diskCache.updateMaxSizeBytes(maxSizeBytes)
+    }
+
+    fun diskSizeBytes(): Long = diskCache.sizeBytes()
+
+    fun clearCaches() {
+        synchronized(memoryStateLock) {
+            memoryGeneration += 1L
+            memoryCache.clear()
+            dataKeyToLatestFullKey.clear()
+        }
+        diskCache.clear()
+    }
+
     fun onTrimMemory(level: Int) {
         val maxSize = memoryCache.maxSizeBytes()
         val targetSize = when {

--- a/app/src/main/java/com/asmr/player/data/settings/SettingsDataStore.kt
+++ b/app/src/main/java/com/asmr/player/data/settings/SettingsDataStore.kt
@@ -12,6 +12,7 @@ val Context.settingsDataStore by preferencesDataStore(name = "settings")
 
 object SettingsKeys {
     val APP_VOLUME_PERCENT = intPreferencesKey("app_volume_percent")
+    val APP_CACHE_MAX_SIZE_MB = intPreferencesKey("app_cache_max_size_mb")
 
     val EQ_ENABLED = booleanPreferencesKey("eq_enabled")
     fun eqBandLevel(index: Int) = intPreferencesKey("eq_band_$index")

--- a/app/src/main/java/com/asmr/player/data/settings/SettingsRepository.kt
+++ b/app/src/main/java/com/asmr/player/data/settings/SettingsRepository.kt
@@ -1,6 +1,7 @@
 package com.asmr.player.data.settings
 
 import android.content.Context
+import com.asmr.player.cache.AppCacheLimits
 import com.asmr.player.playback.AppVolume
 import com.asmr.player.hotlistening.HotListeningSortMode
 import dagger.hilt.android.qualifiers.ApplicationContext
@@ -33,6 +34,12 @@ class SettingsRepository @Inject constructor(
 
     val appVolumePercent: Flow<Int> = context.settingsDataStore.data.map { prefs ->
         AppVolume.clampPercent(prefs[SettingsKeys.APP_VOLUME_PERCENT] ?: AppVolume.DefaultPercent)
+    }
+
+    val appCacheMaxSizeMb: Flow<Int> = context.settingsDataStore.data.map { prefs ->
+        AppCacheLimits.clampSizeMb(
+            prefs[SettingsKeys.APP_CACHE_MAX_SIZE_MB] ?: AppCacheLimits.DefaultSizeMb
+        )
     }
 
     val libraryViewMode: Flow<Int> = context.settingsDataStore.data.map { prefs ->
@@ -416,6 +423,14 @@ class SettingsRepository @Inject constructor(
         withContext(Dispatchers.IO) {
             context.settingsDataStore.edit {
                 it[SettingsKeys.APP_VOLUME_PERCENT] = AppVolume.clampPercent(percent)
+            }
+        }
+    }
+
+    suspend fun setAppCacheMaxSizeMb(sizeMb: Int) {
+        withContext(Dispatchers.IO) {
+            context.settingsDataStore.edit {
+                it[SettingsKeys.APP_CACHE_MAX_SIZE_MB] = AppCacheLimits.clampSizeMb(sizeMb)
             }
         }
     }

--- a/app/src/main/java/com/asmr/player/playback/PlaybackMediaCache.kt
+++ b/app/src/main/java/com/asmr/player/playback/PlaybackMediaCache.kt
@@ -2,27 +2,75 @@ package com.asmr.player.playback
 
 import android.content.Context
 import androidx.media3.database.StandaloneDatabaseProvider
-import androidx.media3.datasource.cache.LeastRecentlyUsedCacheEvictor
+import androidx.media3.datasource.cache.Cache
+import androidx.media3.datasource.cache.CacheEvictor
+import androidx.media3.datasource.cache.CacheSpan
 import androidx.media3.datasource.cache.SimpleCache
+import com.asmr.player.cache.AppCacheLimits
 import java.io.File
+import java.util.TreeSet
 
 object PlaybackMediaCache {
     private const val CACHE_DIR_NAME = "playback_media_cache"
-    private const val MAX_CACHE_BYTES = 256L * 1024L * 1024L
 
     @Volatile
     private var cache: SimpleCache? = null
+    private var maxCacheBytes = AppCacheLimits.playbackMaxSizeBytes(AppCacheLimits.DefaultSizeMb)
+    private var evictor: AdjustableLruCacheEvictor? = null
 
     fun getInstance(context: Context): SimpleCache {
         cache?.let { return it }
         return synchronized(this) {
             cache?.let { return@synchronized it }
             val directory = File(context.cacheDir, CACHE_DIR_NAME).apply { mkdirs() }
+            val newEvictor = AdjustableLruCacheEvictor(maxCacheBytes)
             SimpleCache(
                 directory,
-                LeastRecentlyUsedCacheEvictor(MAX_CACHE_BYTES),
+                newEvictor,
                 StandaloneDatabaseProvider(context.applicationContext)
-            ).also { cache = it }
+            ).also {
+                evictor = newEvictor
+                cache = it
+            }
+        }
+    }
+
+    fun updateMaxCacheBytes(maxCacheBytes: Long) {
+        synchronized(this) {
+            this.maxCacheBytes = maxCacheBytes.coerceAtLeast(0L)
+            val activeCache = cache ?: return
+            synchronized(activeCache) {
+                evictor?.updateMaxBytes(activeCache, this.maxCacheBytes)
+            }
+        }
+    }
+
+    fun sizeBytes(context: Context): Long {
+        return synchronized(this) {
+            cache?.let { return@synchronized it.cacheSpace }
+            File(context.cacheDir, CACHE_DIR_NAME)
+                .walkTopDown()
+                .filter(File::isFile)
+                .sumOf(File::length)
+        }
+    }
+
+    fun clear(context: Context) {
+        synchronized(this) {
+            val activeCache = cache
+            if (activeCache != null) {
+                synchronized(activeCache) {
+                    activeCache.keys.toList().forEach(activeCache::removeResource)
+                }
+                return
+            }
+            val directory = File(context.cacheDir, CACHE_DIR_NAME)
+            if (!directory.isDirectory) return
+            directory.listFiles()
+                ?.filter { file ->
+                    file.isFile && (file.name.endsWith(".exo") || file.name.endsWith(".tmp"))
+                }
+                ?.forEach(File::delete)
         }
     }
 
@@ -30,6 +78,54 @@ object PlaybackMediaCache {
         synchronized(this) {
             cache?.release()
             cache = null
+            evictor = null
+        }
+    }
+}
+
+private class AdjustableLruCacheEvictor(initialMaxBytes: Long) : CacheEvictor {
+    private var maxBytes = initialMaxBytes.coerceAtLeast(0L)
+    private val leastRecentlyUsed = TreeSet<CacheSpan> { first, second ->
+        if (first.lastTouchTimestamp == second.lastTouchTimestamp) {
+            first.compareTo(second)
+        } else {
+            first.lastTouchTimestamp.compareTo(second.lastTouchTimestamp)
+        }
+    }
+    private var currentSizeBytes = 0L
+
+    override fun requiresCacheSpanTouches(): Boolean = true
+
+    override fun onCacheInitialized() = Unit
+
+    override fun onStartFile(cache: Cache, key: String, position: Long, length: Long) {
+        if (length != -1L) evictCache(cache, length)
+    }
+
+    override fun onSpanAdded(cache: Cache, span: CacheSpan) {
+        leastRecentlyUsed.add(span)
+        currentSizeBytes += span.length
+        evictCache(cache, 0L)
+    }
+
+    override fun onSpanRemoved(cache: Cache, span: CacheSpan) {
+        leastRecentlyUsed.remove(span)
+        currentSizeBytes = (currentSizeBytes - span.length).coerceAtLeast(0L)
+    }
+
+    override fun onSpanTouched(cache: Cache, oldSpan: CacheSpan, newSpan: CacheSpan) {
+        onSpanRemoved(cache, oldSpan)
+        onSpanAdded(cache, newSpan)
+    }
+
+    fun updateMaxBytes(cache: Cache, maxBytes: Long) {
+        this.maxBytes = maxBytes.coerceAtLeast(0L)
+        evictCache(cache, 0L)
+    }
+
+    private fun evictCache(cache: Cache, incomingLength: Long) {
+        while (currentSizeBytes + incomingLength > maxBytes && leastRecentlyUsed.isNotEmpty()) {
+            cache.removeSpan(leastRecentlyUsed.first())
         }
     }
 }

--- a/app/src/main/java/com/asmr/player/ui/library/AlbumDetailViewModel.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/AlbumDetailViewModel.kt
@@ -14,6 +14,7 @@ import androidx.work.OneTimeWorkRequestBuilder
 import androidx.work.WorkManager
 import androidx.work.workDataOf
 import com.asmr.player.BuildConfig
+import com.asmr.player.cache.AppCacheManager
 import com.asmr.player.data.local.db.AppDatabase
 import com.asmr.player.data.local.db.dao.AlbumDao
 import com.asmr.player.data.local.db.dao.TagWithCount
@@ -123,6 +124,7 @@ class AlbumDetailViewModel @Inject constructor(
     private val lyricsLoader: LyricsLoader,
     private val syncCoordinator: SyncCoordinator,
     private val listenTogetherRepository: ListenTogetherRepository,
+    private val appCacheManager: AppCacheManager,
     @Named("image") private val imageOkHttpClient: OkHttpClient,
     val messageManager: MessageManager,
     @ApplicationContext private val context: Context
@@ -462,7 +464,9 @@ class AlbumDetailViewModel @Inject constructor(
         }
         val seed = parseDlsitePlayImageSeed(name) ?: return@withContext null
 
-        val previewDir = File(context.cacheDir, "dlsite_play_preview").apply { if (!exists()) mkdirs() }
+        val previewDir = File(context.cacheDir, AppCacheManager.DLSITE_PREVIEW_CACHE_DIR_NAME).apply {
+            if (!exists()) mkdirs()
+        }
         val previewKey = listOf(
             DLSITE_PLAY_PREVIEW_CACHE_VERSION.toString(),
             normalizedUrl,
@@ -497,6 +501,7 @@ class AlbumDetailViewModel @Inject constructor(
         }
         if (descrambled !== scrambled && !descrambled.isRecycled) descrambled.recycle()
         if (!scrambled.isRecycled) scrambled.recycle()
+        appCacheManager.onPreviewCacheChanged(previewFile)
         previewFile.absolutePath
     }
 

--- a/app/src/main/java/com/asmr/player/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/settings/SettingsScreen.kt
@@ -65,6 +65,8 @@ import androidx.compose.ui.window.PopupProperties
 import androidx.core.content.ContextCompat
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.asmr.player.BuildConfig
+import com.asmr.player.cache.AppCacheLimits
+import com.asmr.player.cache.AppCacheState
 import com.asmr.player.data.settings.CoverPreviewMode
 import com.asmr.player.data.settings.FloatingLyricsSettings
 import com.asmr.player.data.settings.LyricsPageSettings
@@ -85,6 +87,7 @@ import com.asmr.player.ui.common.withAddedBottomPadding
 import com.asmr.player.ui.common.collectAsStateWhileActive
 import com.asmr.player.ui.update.launchDownloadedApkInstall
 import kotlin.math.abs
+import kotlin.math.roundToInt
 
 private val SettingsPageHorizontalPadding = 8.dp
 private const val MONOCHROME_THEME_SENTINEL = 0x01000000
@@ -118,6 +121,7 @@ fun SettingsScreen(
     val sfwHideSystemControls by viewModel.sfwHideSystemControls.collectAsStateWhileActive(isDataActive)
     val showMiniPlayerBar by viewModel.showMiniPlayerBar.collectAsStateWhileActive(isDataActive)
     val searchBlockedKeywords by viewModel.searchBlockedKeywords.collectAsStateWhileActive(isDataActive)
+    val appCacheState by viewModel.appCacheState.collectAsStateWhileActive(isDataActive)
     val updateState by viewModel.updateState.collectAsStateWhileActive(isDataActive)
     val autoUpdateCheckEnabled by viewModel.autoUpdateCheckEnabled.collectAsStateWhileActive(isDataActive)
     val scanRoots by libraryViewModel.scanRoots.collectAsStateWhileActive(isDataActive)
@@ -138,6 +142,7 @@ fun SettingsScreen(
     var overlayGranted by remember { mutableStateOf(Settings.canDrawOverlays(context)) }
     var activeTipKey by remember { mutableStateOf<String?>(null) }
     var searchBlockedKeywordInput by rememberSaveable { mutableStateOf("") }
+    var showClearAppCacheConfirmation by remember { mutableStateOf(false) }
     DisposableEffect(onHorizontalControlInteractionChanged) {
         onDispose { onHorizontalControlInteractionChanged(false) }
     }
@@ -172,6 +177,9 @@ fun SettingsScreen(
         LaunchedEffect(isActive) {
             if (isActive) return@LaunchedEffect
             listState.stopScroll(MutatePriority.PreventUserInput)
+        }
+        LaunchedEffect(isDataActive) {
+            if (isDataActive) viewModel.refreshAppCacheSize()
         }
         LaunchedEffect(scrollToTopSignal) {
             if (scrollToTopSignal == 0L) return@LaunchedEffect
@@ -841,6 +849,17 @@ fun SettingsScreen(
                     }
                 }
 
+                item(key = "group:app_cache") {
+                    SettingsGroup(title = "APP 缓存") {
+                        AppCacheSettingsSection(
+                            state = appCacheState,
+                            onMaxSizeChanged = viewModel::setAppCacheMaxSizeMb,
+                            onClearClick = { showClearAppCacheConfirmation = true },
+                            onHorizontalControlInteractionChanged = onHorizontalControlInteractionChanged,
+                        )
+                    }
+                }
+
                 item(key = "bottom_spacer") {
                     Spacer(modifier = Modifier.height(40.dp))
                 }
@@ -870,6 +889,111 @@ fun SettingsScreen(
                 )
             )
         )
+    }
+    if (showClearAppCacheConfirmation) {
+        FlatActionDialog(
+            onDismissRequest = { showClearAppCacheConfirmation = false },
+            message = "将清理网络图片、在线音频播放和在线预览产生的缓存，不会删除下载内容、本地媒体或收藏数据。",
+            actions = listOf(
+                FlatDialogAction("取消", onClick = { showClearAppCacheConfirmation = false }),
+                FlatDialogAction(
+                    text = "清理",
+                    tone = FlatDialogActionTone.Danger,
+                    onClick = {
+                        showClearAppCacheConfirmation = false
+                        viewModel.clearAppCache()
+                    }
+                )
+            )
+        )
+    }
+}
+
+@Composable
+private fun AppCacheSettingsSection(
+    state: AppCacheState,
+    onMaxSizeChanged: (Int) -> Unit,
+    onClearClick: () -> Unit,
+    onHorizontalControlInteractionChanged: (Boolean) -> Unit,
+) {
+    val colorScheme = AsmrTheme.colorScheme
+    val interactionSource = remember { MutableInteractionSource() }
+    val isDragging by interactionSource.collectIsDraggedAsState()
+    val isPressed by interactionSource.collectIsPressedAsState()
+    val isInteracting = isDragging || isPressed
+    var draftSizeMb by remember { mutableFloatStateOf(state.maxSizeMb.toFloat()) }
+
+    LaunchedEffect(state.maxSizeMb, isInteracting) {
+        if (!isInteracting) draftSizeMb = state.maxSizeMb.toFloat()
+    }
+
+    Text(
+        text = "当前占用：${formatCacheSize(state.usedSizeBytes)}",
+        style = MaterialTheme.typography.bodyMedium,
+        fontWeight = FontWeight.SemiBold,
+    )
+    Text(
+        text = "空间由网络图片、在线音频播放和在线预览缓存共享。缓存满后会优先清理较早使用的资源。",
+        style = MaterialTheme.typography.bodySmall,
+        color = colorScheme.textSecondary,
+    )
+    SettingsSliderRow(
+        text = "缓存空间上限：${draftSizeMb.roundToInt()} MB",
+        value = draftSizeMb,
+        range = AppCacheLimits.MinSizeMb.toFloat()..AppCacheLimits.MaxSizeMb.toFloat(),
+        stepSize = AppCacheLimits.SizeStepMb.toFloat(),
+        onValueChange = { draftSizeMb = it },
+        onValueChangeFinished = { onMaxSizeChanged(draftSizeMb.roundToInt()) },
+        interactionSource = interactionSource,
+        onHorizontalControlInteractionChanged = onHorizontalControlInteractionChanged,
+    )
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceBetween,
+    ) {
+        Text(
+            text = "最小 ${AppCacheLimits.MinSizeMb} MB",
+            style = MaterialTheme.typography.labelSmall,
+            color = colorScheme.textSecondary,
+        )
+        Text(
+            text = "最大 ${AppCacheLimits.MaxSizeMb} MB",
+            style = MaterialTheme.typography.labelSmall,
+            color = colorScheme.textSecondary,
+        )
+    }
+    FilledTonalButton(
+        onClick = onClearClick,
+        modifier = Modifier
+            .fillMaxWidth()
+            .testTag("clearAppCacheButton"),
+        enabled = !state.isClearing,
+        colors = ButtonDefaults.filledTonalButtonColors(
+            containerColor = colorScheme.primarySoft,
+            contentColor = if (colorScheme.isDark) colorScheme.onPrimaryContainer else colorScheme.primaryStrong,
+        ),
+    ) {
+        if (state.isClearing) {
+            EaraLogoLoadingIndicator(size = 18.dp)
+            Spacer(modifier = Modifier.width(10.dp))
+            Text("正在清理…")
+        } else {
+            Icon(Icons.Rounded.Delete, contentDescription = null)
+            Spacer(modifier = Modifier.width(8.dp))
+            Text("清理 APP 缓存")
+        }
+    }
+}
+
+private fun formatCacheSize(sizeBytes: Long): String {
+    val safeBytes = sizeBytes.coerceAtLeast(0L)
+    val megabytes = safeBytes / (1024.0 * 1024.0)
+    return if (megabytes < 0.1) {
+        "0 MB"
+    } else if (megabytes < 10.0) {
+        String.format(java.util.Locale.ROOT, "%.1f MB", megabytes)
+    } else {
+        "${megabytes.roundToInt()} MB"
     }
 }
 

--- a/app/src/main/java/com/asmr/player/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/asmr/player/ui/settings/SettingsViewModel.kt
@@ -6,6 +6,8 @@ import android.os.SystemClock
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.asmr.player.BuildConfig
+import com.asmr.player.cache.AppCacheManager
+import com.asmr.player.cache.AppCacheState
 import com.asmr.player.data.local.datastore.SettingsDataStore
 import com.asmr.player.data.remote.NetworkHeaders
 import com.asmr.player.data.remote.update.GitHubUpdateClient
@@ -72,6 +74,7 @@ sealed interface AppUpdateState {
 class SettingsViewModel @Inject constructor(
     private val settingsRepository: SettingsRepository,
     private val settingsDataStore: SettingsDataStore,
+    private val appCacheManager: AppCacheManager,
     private val okHttpClient: OkHttpClient,
     @ApplicationContext private val context: Context
 ) : ViewModel() {
@@ -135,11 +138,17 @@ class SettingsViewModel @Inject constructor(
     val searchBlockedKeywords: StateFlow<List<String>> = settingsRepository.searchBlockedKeywords
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyList())
 
+    val appCacheState: StateFlow<AppCacheState> = appCacheManager.state
+
     private val updateClient = GitHubUpdateClient(okHttpClient)
     private val _updateState = MutableStateFlow<AppUpdateState>(AppUpdateState.Idle)
     val updateState = _updateState.asStateFlow()
     private var updateJob: Job? = null
     private var automaticCheckStarted = false
+
+    init {
+        appCacheManager.start()
+    }
 
     fun setFloatingLyricsEnabled(enabled: Boolean) {
         viewModelScope.launch { settingsRepository.setFloatingLyricsEnabled(enabled) }
@@ -211,6 +220,18 @@ class SettingsViewModel @Inject constructor(
 
     fun removeSearchBlockedKeyword(keyword: String) {
         viewModelScope.launch { settingsRepository.removeSearchBlockedKeyword(keyword) }
+    }
+
+    fun setAppCacheMaxSizeMb(sizeMb: Int) {
+        viewModelScope.launch { settingsRepository.setAppCacheMaxSizeMb(sizeMb) }
+    }
+
+    fun refreshAppCacheSize() {
+        appCacheManager.refreshSize()
+    }
+
+    fun clearAppCache() {
+        appCacheManager.clearCache()
     }
 
     fun setAutoUpdateCheckEnabled(enabled: Boolean) {

--- a/app/src/test/java/com/asmr/player/cache/AppCacheLimitsTest.kt
+++ b/app/src/test/java/com/asmr/player/cache/AppCacheLimitsTest.kt
@@ -1,0 +1,24 @@
+package com.asmr.player.cache
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class AppCacheLimitsTest {
+    @Test
+    fun clampSizeMb_enforcesConfiguredRange() {
+        assertEquals(AppCacheLimits.MinSizeMb, AppCacheLimits.clampSizeMb(1))
+        assertEquals(150, AppCacheLimits.clampSizeMb(150))
+        assertEquals(AppCacheLimits.MaxSizeMb, AppCacheLimits.clampSizeMb(2_000))
+    }
+
+    @Test
+    fun cacheBudgets_addUpToConfiguredTotal() {
+        val configuredSizeMb = 150
+
+        val allocatedBytes = AppCacheLimits.imageMaxSizeBytes(configuredSizeMb) +
+            AppCacheLimits.playbackMaxSizeBytes(configuredSizeMb) +
+            AppCacheLimits.previewMaxSizeBytes(configuredSizeMb)
+
+        assertEquals(AppCacheLimits.totalSizeBytes(configuredSizeMb), allocatedBytes)
+    }
+}

--- a/app/src/test/java/com/asmr/player/cache/DiskCacheTest.kt
+++ b/app/src/test/java/com/asmr/player/cache/DiskCacheTest.kt
@@ -1,6 +1,7 @@
 package com.asmr.player.cache
 
 import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Rule
@@ -44,6 +45,25 @@ class DiskCacheTest {
 
         assertArrayEquals(ByteArray(10) { 3 }, cache.get("first")?.bytes)
         assertArrayEquals(ByteArray(50) { 4 }, cache.get("second")?.bytes)
+    }
+
+    @Test
+    fun updateMaxSizeBytes_trimsExistingEntriesImmediately() {
+        val directory = temporaryFolder.newFolder("resize")
+        val cache = DiskCache(
+            directory = directory,
+            maxSizeBytes = 200L,
+            ttlMs = 0L,
+        )
+        cache.put("first", entry(size = 60, fill = 1))
+        assertTrue(directory.resolve("first.bin").setLastModified(1L))
+        cache.put("second", entry(size = 60, fill = 2))
+
+        cache.updateMaxSizeBytes(100L)
+
+        assertNull(cache.get("first"))
+        assertArrayEquals(ByteArray(60) { 2 }, cache.get("second")?.bytes)
+        assertEquals(directory.resolve("second.bin").length(), cache.sizeBytes())
     }
 
     private fun entry(size: Int, fill: Int): DiskCache.Entry {

--- a/app/src/test/java/com/asmr/player/data/settings/SettingsRepositoryTest.kt
+++ b/app/src/test/java/com/asmr/player/data/settings/SettingsRepositoryTest.kt
@@ -1,5 +1,6 @@
 package com.asmr.player.data.settings
 
+import com.asmr.player.cache.AppCacheLimits
 import kotlinx.coroutines.runBlocking
 import org.junit.After
 import org.junit.Assert.assertEquals
@@ -91,6 +92,20 @@ class SettingsRepositoryTest {
         repository.setAppVolumePercent(48)
 
         assertEquals(false, repository.consumePendingSystemVolumeSync(32))
+    }
+
+    @Test
+    fun appCacheMaxSizeMb_defaultsTo150() = runBlocking {
+        assertEquals(AppCacheLimits.DefaultSizeMb, repository.appCacheMaxSizeMb.first())
+    }
+
+    @Test
+    fun setAppCacheMaxSizeMb_clampsToSupportedRange() = runBlocking {
+        repository.setAppCacheMaxSizeMb(1)
+        assertEquals(AppCacheLimits.MinSizeMb, repository.appCacheMaxSizeMb.first())
+
+        repository.setAppCacheMaxSizeMb(2_000)
+        assertEquals(AppCacheLimits.MaxSizeMb, repository.appCacheMaxSizeMb.first())
     }
 
     @Test


### PR DESCRIPTION
## 变更内容

- 在设置页底部新增“APP 缓存”分组，支持 50–1000 MB，默认 150 MB
- 将网络图片、在线播放音频和 DLsite 在线预览纳入统一缓存预算
- 支持动态收缩缓存上限与手动清理，并保留下载、本地媒体封面和业务数据
- 移除重复的 Coil 磁盘缓存，避免图片缓存重复占用
- 补充容量边界、预算分配、动态收缩和设置持久化测试

## 验证

- `./gradlew-local.bat :app:installRelease --console=plain --no-daemon`：通过
- 已在真机核对设置分组、默认值、上下限和清理确认弹窗
- 定向单测首次执行被本地 KSP 增量缓存损坏阻断；清理本地构建缓存后，完整 Release 构建与安装成功