### PR TITLE
fix: 修复专辑详情页再次进入闪烁

### DIFF
--- a/app/src/main/java/com/asmr/player/main/MainContainer.kt
+++ b/app/src/main/java/com/asmr/player/main/MainContainer.kt
@@ -738,9 +738,15 @@ fun MainContainer(
     volumeKeyEventTick: Long
 ) {
     val navController = rememberNavController()
+    val navBackStackEntry by navController.currentBackStackEntryAsState()
+    val currentRoute = navBackStackEntry?.destination?.route
     val mainRootView = LocalView.current
     val albumDetailPageWidthPx = mainRootView.width.toFloat().coerceAtLeast(1f)
-    val albumDetailPageOffsetX = remember(albumDetailPageWidthPx) {
+    val albumDetailTransitionKey = resolveAlbumDetailTransitionKey(
+        currentRoute = currentRoute,
+        backStackEntryId = navBackStackEntry?.id
+    )
+    val albumDetailPageOffsetX = remember(albumDetailPageWidthPx, albumDetailTransitionKey) {
         Animatable(albumDetailPageWidthPx)
     }
     val albumDetailHeroBlurGraphicsLayer = rememberGraphicsLayer()
@@ -777,8 +783,6 @@ fun MainContainer(
             }
         }
     }
-    val navBackStackEntry by navController.currentBackStackEntryAsState()
-    val currentRoute = navBackStackEntry?.destination?.route
     val hasPreviousBackStackEntry = navController.previousBackStackEntry != null
     val currentPlaylistSystemType = navBackStackEntry?.arguments?.getString("type")
     val startRoute = remember(startRouteFromIntent) {

--- a/app/src/main/java/com/asmr/player/main/MainNavigationSupport.kt
+++ b/app/src/main/java/com/asmr/player/main/MainNavigationSupport.kt
@@ -304,6 +304,13 @@ internal fun shouldHideStatusBarForImmersivePage(
     return currentRoute?.startsWith("album_detail") == true
 }
 
+internal fun resolveAlbumDetailTransitionKey(
+    currentRoute: String?,
+    backStackEntryId: String?
+): String? {
+    return backStackEntryId.takeIf { currentRoute?.startsWith("album_detail") == true }
+}
+
 internal fun NavHostController.navigateSingleTop(route: String, popUpToRoute: String? = null) {
     navigate(route) {
         launchSingleTop = true

--- a/app/src/test/java/com/asmr/player/MainNavigationSupportTest.kt
+++ b/app/src/test/java/com/asmr/player/MainNavigationSupportTest.kt
@@ -208,6 +208,19 @@ class MainNavigationSupportTest {
     }
 
     @Test
+    fun resolveAlbumDetailTransitionKey_isolatesEachDetailBackStackEntry() {
+        assertEquals(
+            "online-detail-entry",
+            resolveAlbumDetailTransitionKey("album_detail_online/{rj}", "online-detail-entry")
+        )
+        assertEquals(
+            "local-detail-entry",
+            resolveAlbumDetailTransitionKey("album_detail/{albumId}", "local-detail-entry")
+        )
+        assertEquals(null, resolveAlbumDetailTransitionKey("library", "library-entry"))
+    }
+
+    @Test
     fun toThemeMediaSource_prefersArtworkForVideoWhenAvailable() {
         val item = MediaItem.Builder()
             .setUri("file:///sample.mp4")


### PR DESCRIPTION
## 变更

- 将专辑详情页的横向过渡状态按 back stack entry 隔离
- 防止在线详情被底部导航直接移除后，新详情继承旧的全屏可见位移
- 增加详情页过渡状态隔离的回归测试

## 验证

- `resolveAlbumDetailTransitionKey_isolatesEachDetailBackStackEntry` 通过
- `MainNavigationSupportTest` 共 19 项，新增用例及相关导航用例通过；2 个既有媒体主题用例因 JVM 环境未模拟 `android.net.Uri.parse` 失败，与本次改动无关
- `./gradlew-local.bat :app:installRelease` 成功，Release APK 已安装到 Android 16 真机