### PR TITLE
优先展示 ONE 目录并增强目录树 Header 对比度

### DIFF
--- a/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailDirectorySupport.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailDirectorySupport.kt
@@ -178,6 +178,10 @@ private val DirectoryBrowserPanelCornerRadius = 10.dp
 private val DirectoryFolderRowCornerRadius = 10.dp
 private val DirectoryBrowserPanelVerticalPadding = 4.dp
 
+internal fun directoryBrowserHeaderBackground(colorScheme: AsmrColorScheme): Color {
+    return colorScheme.primarySoft.copy(alpha = if (colorScheme.isDark) 0.28f else 0.88f)
+}
+
 internal enum class DirectoryFolderPosition {
     Single,
     First,
@@ -2785,7 +2789,7 @@ internal fun DirectoryBrowserPanelV4(
         (screenHeight * 0.48f).coerceIn(240.dp, 460.dp)
     }
     val colorScheme = AsmrTheme.colorScheme
-    val headerSectionColor = colorScheme.primarySoft.copy(alpha = if (colorScheme.isDark) 0.14f else 0.22f)
+    val headerSectionColor = directoryBrowserHeaderBackground(colorScheme)
     val actionSectionColor = colorScheme.surfaceVariant.copy(alpha = if (colorScheme.isDark) 0.24f else 0.42f)
     val listSectionColor = colorScheme.surface.copy(alpha = if (colorScheme.isDark) 0.28f else 0.62f)
     val sectionDividerColor = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.12f)

--- a/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailDlsiteTabs.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailDlsiteTabs.kt
@@ -209,7 +209,7 @@ private fun rememberStableOneDirectoryContainerHeight(): Dp {
 private fun DlsiteDirectoryLoadingPanel() {
     val fixedHeight = rememberDlsiteDirectoryListHeight()
     val colorScheme = AsmrTheme.colorScheme
-    val headerSectionColor = colorScheme.primarySoft.copy(alpha = if (colorScheme.isDark) 0.14f else 0.22f)
+    val headerSectionColor = directoryBrowserHeaderBackground(colorScheme)
     val actionSectionColor = colorScheme.surfaceVariant.copy(alpha = if (colorScheme.isDark) 0.24f else 0.42f)
     val listSectionColor = colorScheme.surface.copy(alpha = if (colorScheme.isDark) 0.28f else 0.62f)
     val sectionDividerColor = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.12f)

--- a/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailDlsiteTabs.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailDlsiteTabs.kt
@@ -1100,80 +1100,6 @@ internal fun AlbumDlsiteInfoBreadcrumbTabV2(
         contentPadding = PaddingValues(top = topContentPadding, bottom = LocalBottomOverlayPadding.current)
     ) {
         item(key = "dlsite-header") { header() }
-        item(key = "dlsite-gallery-section") {
-            Column(modifier = dlsiteAnimatedSectionModifier(Modifier.fillMaxWidth(), animateIntro)) {
-                AlbumDetailSectionHeading(
-                    title = "Gallery",
-                    modifier = Modifier.padding(horizontal = AlbumDetailHorizontalPadding, vertical = 8.dp)
-                )
-                Box(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .height(DlsiteGallerySectionHeight)
-                        .dlsiteContentFade(galleryFadeState),
-                    contentAlignment = Alignment.Center
-                ) {
-                    when (galleryFadeState.panel.kind) {
-                        DlsiteContentKind.Loading -> DlsiteGalleryLoadingRow()
-                        DlsiteContentKind.Empty -> {
-                            DlsiteSectionEmptyState(
-                                text = "暂无样图",
-                                artworkKind = DlsiteEmptyArtworkKind.Gallery,
-                                modifier = Modifier.then(dlsiteAnimatedSectionModifier(Modifier, animateIntro))
-                            )
-                        }
-                        DlsiteContentKind.Content -> {
-                            val displayedGalleryUrls = galleryFadeState.panel.value.orEmpty()
-                            LazyRow(
-                                modifier = Modifier.fillMaxWidth().padding(horizontal = AlbumDetailHorizontalPadding),
-                                horizontalArrangement = Arrangement.spacedBy(DlsiteGalleryThumbGap),
-                                contentPadding = PaddingValues(vertical = 10.dp)
-                            ) {
-                                items(items = displayedGalleryUrls, key = { it }, contentType = { "galleryThumb" }) { url ->
-                                    val model = remember(url) {
-                                        val headers = DlsiteAntiHotlink.headersForImageUrl(url)
-                                        if (headers.isEmpty()) url else CacheImageModel(data = url, headers = headers, keyTag = "dlsite")
-                                    }
-                                    Card(
-                                        modifier = Modifier.size(width = DlsiteGalleryThumbWidth, height = DlsiteGalleryThumbHeight).clickable {
-                                            buildGalleryImagePreviewRequest(
-                                                galleryUrls = displayedGalleryUrls,
-                                                clickedUrl = url,
-                                                toPreviewItem = { galleryUrl ->
-                                                    val headers = DlsiteAntiHotlink.headersForImageUrl(galleryUrl)
-                                                    val previewModel: Any = if (headers.isEmpty()) {
-                                                        galleryUrl
-                                                    } else {
-                                                        CacheImageModel(data = galleryUrl, headers = headers, keyTag = "dlsite")
-                                                    }
-                                                    ImagePreviewItem(
-                                                        key = galleryUrl,
-                                                        title = galleryUrl.substringBefore('?').substringAfterLast('/').ifBlank { "Gallery" },
-                                                        imageModel = previewModel,
-                                                        openPathOrUrl = galleryUrl
-                                                    )
-                                                }
-                                            )?.let(onPreviewImages)
-                                        },
-                                        shape = RoundedCornerShape(10.dp),
-                                        colors = CardDefaults.cardColors(containerColor = Color.Transparent)
-                                    ) {
-                                        AsmrAsyncImage(
-                                            model = model,
-                                            contentDescription = null,
-                                            contentScale = ContentScale.Crop,
-                                            placeholderCornerRadius = DlsiteGalleryThumbCornerRadius,
-                                            loading = NoImageLoadingIndicator,
-                                            modifier = Modifier.fillMaxSize()
-                                        )
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        }
         item(key = "dlsite-one-header") {
             AlbumDetailSectionHeading(
                 title = if (asmrOneTree.isNotEmpty()) "ONE（已收录）" else "ONE",
@@ -1330,6 +1256,80 @@ internal fun AlbumDlsiteInfoBreadcrumbTabV2(
                             modifier = Modifier
                         )
                         DirectoryTreePanelState.MissingRj -> Unit
+                    }
+                }
+            }
+        }
+        item(key = "dlsite-gallery-section") {
+            Column(modifier = dlsiteAnimatedSectionModifier(Modifier.fillMaxWidth(), animateIntro)) {
+                AlbumDetailSectionHeading(
+                    title = "Gallery",
+                    modifier = Modifier.padding(horizontal = AlbumDetailHorizontalPadding, vertical = 8.dp)
+                )
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(DlsiteGallerySectionHeight)
+                        .dlsiteContentFade(galleryFadeState),
+                    contentAlignment = Alignment.Center
+                ) {
+                    when (galleryFadeState.panel.kind) {
+                        DlsiteContentKind.Loading -> DlsiteGalleryLoadingRow()
+                        DlsiteContentKind.Empty -> {
+                            DlsiteSectionEmptyState(
+                                text = "暂无样图",
+                                artworkKind = DlsiteEmptyArtworkKind.Gallery,
+                                modifier = Modifier.then(dlsiteAnimatedSectionModifier(Modifier, animateIntro))
+                            )
+                        }
+                        DlsiteContentKind.Content -> {
+                            val displayedGalleryUrls = galleryFadeState.panel.value.orEmpty()
+                            LazyRow(
+                                modifier = Modifier.fillMaxWidth().padding(horizontal = AlbumDetailHorizontalPadding),
+                                horizontalArrangement = Arrangement.spacedBy(DlsiteGalleryThumbGap),
+                                contentPadding = PaddingValues(vertical = 10.dp)
+                            ) {
+                                items(items = displayedGalleryUrls, key = { it }, contentType = { "galleryThumb" }) { url ->
+                                    val model = remember(url) {
+                                        val headers = DlsiteAntiHotlink.headersForImageUrl(url)
+                                        if (headers.isEmpty()) url else CacheImageModel(data = url, headers = headers, keyTag = "dlsite")
+                                    }
+                                    Card(
+                                        modifier = Modifier.size(width = DlsiteGalleryThumbWidth, height = DlsiteGalleryThumbHeight).clickable {
+                                            buildGalleryImagePreviewRequest(
+                                                galleryUrls = displayedGalleryUrls,
+                                                clickedUrl = url,
+                                                toPreviewItem = { galleryUrl ->
+                                                    val headers = DlsiteAntiHotlink.headersForImageUrl(galleryUrl)
+                                                    val previewModel: Any = if (headers.isEmpty()) {
+                                                        galleryUrl
+                                                    } else {
+                                                        CacheImageModel(data = galleryUrl, headers = headers, keyTag = "dlsite")
+                                                    }
+                                                    ImagePreviewItem(
+                                                        key = galleryUrl,
+                                                        title = galleryUrl.substringBefore('?').substringAfterLast('/').ifBlank { "Gallery" },
+                                                        imageModel = previewModel,
+                                                        openPathOrUrl = galleryUrl
+                                                    )
+                                                }
+                                            )?.let(onPreviewImages)
+                                        },
+                                        shape = RoundedCornerShape(10.dp),
+                                        colors = CardDefaults.cardColors(containerColor = Color.Transparent)
+                                    ) {
+                                        AsmrAsyncImage(
+                                            model = model,
+                                            contentDescription = null,
+                                            contentScale = ContentScale.Crop,
+                                            placeholderCornerRadius = DlsiteGalleryThumbCornerRadius,
+                                            loading = NoImageLoadingIndicator,
+                                            modifier = Modifier.fillMaxSize()
+                                        )
+                                    }
+                                }
+                            }
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## 变更

- 在线专辑详情页优先展示 ONE 目录树，将 Gallery 调整到 ONE 之后
- 提升本地库与在线专辑目录树 Header 的背景区分度
- 深色模式使用 28% 强度，浅色模式单独增强到 88%
- 在线目录加载骨架复用同一 Header 颜色规则

## 验证

- `.\gradlew-local.bat :app:installRelease`
- Release 构建成功并安装到连接设备