### PR TITLE
fix(player): 适配小尺寸机型的当前播放页布局

### DIFF
--- a/app/src/main/java/com/asmr/player/ui/player/NowPlayingScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/player/NowPlayingScreen.kt
@@ -137,10 +137,9 @@ private const val NowPlayingHomeLayoutAnimationDurationMillis = 620
 private const val NowPlayingHomeLyricsFadeInDurationMillis = 240
 private const val NowPlayingHomeLyricsFadeOutDurationMillis = 160
 private val NowPlayingPortraitMaxContentWidth = 600.dp
-private val NowPlayingCompactShortScreenHeight = 620.dp
-private val NowPlayingHomeCompactTopPadding = 20.dp
+private val NowPlayingCompactShortScreenHeight = 700.dp
 private val NowPlayingClassicAudienceHeight = 18.dp
-private val NowPlayingClassicTrackInfoSingleLineHeight = 82.dp
+private val NowPlayingClassicTrackInfoSingleLineHeight = 88.dp
 private val NowPlayingClassicTrackInfoExtraTitleLineHeight = 20.dp
 private val NowPlayingHomeClassicLyricsReserveHeight = 56.dp
 private val NowPlayingHomeExpandedLyricsReserveHeight = 118.dp
@@ -154,38 +153,78 @@ private val NowPlayingLandscapeCoreRowHeight = 82.dp
 private val NowPlayingLandscapeProgressTopPadding = 12.dp
 private const val NowPlayingHomeClassicCompactCoverScale = 0.92f
 
-internal fun nowPlayingClassicTrackInfoHeight(titleLineCount: Int): Dp {
+internal data class NowPlayingPortraitLayoutMetrics(
+    val compact: Boolean,
+    val contentHorizontalPadding: Dp,
+    val topPadding: Dp,
+    val coverVerticalPadding: Dp,
+    val audienceHeight: Dp,
+    val trackInfoSingleLineHeight: Dp,
+    val trackInfoExtraTitleLineHeight: Dp,
+    val classicLyricsReserveHeight: Dp,
+    val expandedLyricsReserveHeight: Dp,
+    val minimumCoverWidth: Dp,
+    val expandedLyricsTopPadding: Dp,
+    val classicLyricsContainerHeight: Dp,
+    val classicLyricsBottomPadding: Dp,
+    val bottomPadding: Dp,
+    val bottomSectionSpacing: Dp
+)
+
+internal fun nowPlayingPortraitLayoutMetrics(
+    screenHeight: Dp,
+    widthClass: WindowWidthSizeClass
+): NowPlayingPortraitLayoutMetrics {
+    val compact = widthClass == WindowWidthSizeClass.Compact &&
+        screenHeight.isFiniteDp() &&
+        screenHeight <= NowPlayingCompactShortScreenHeight
+    if (compact) {
+        return NowPlayingPortraitLayoutMetrics(
+            compact = true,
+            contentHorizontalPadding = 20.dp,
+            topPadding = 8.dp,
+            coverVerticalPadding = 4.dp,
+            audienceHeight = 16.dp,
+            trackInfoSingleLineHeight = 65.dp,
+            trackInfoExtraTitleLineHeight = 15.dp,
+            classicLyricsReserveHeight = 46.dp,
+            expandedLyricsReserveHeight = 96.dp,
+            minimumCoverWidth = 148.dp,
+            expandedLyricsTopPadding = 8.dp,
+            classicLyricsContainerHeight = 48.dp,
+            classicLyricsBottomPadding = 2.dp,
+            bottomPadding = 8.dp,
+            bottomSectionSpacing = 2.dp
+        )
+    }
+    return NowPlayingPortraitLayoutMetrics(
+        compact = false,
+        contentHorizontalPadding = 24.dp,
+        topPadding = 24.dp,
+        coverVerticalPadding = if (widthClass == WindowWidthSizeClass.Compact) 16.dp else 32.dp,
+        audienceHeight = NowPlayingClassicAudienceHeight,
+        trackInfoSingleLineHeight = NowPlayingClassicTrackInfoSingleLineHeight,
+        trackInfoExtraTitleLineHeight = NowPlayingClassicTrackInfoExtraTitleLineHeight,
+        classicLyricsReserveHeight = NowPlayingHomeClassicLyricsReserveHeight,
+        expandedLyricsReserveHeight = NowPlayingHomeExpandedLyricsReserveHeight,
+        minimumCoverWidth = nowPlayingHomeMinCoverWidth(widthClass),
+        expandedLyricsTopPadding = 14.dp,
+        classicLyricsContainerHeight = 58.dp,
+        classicLyricsBottomPadding = NowPlayingHomeClassicLyricsBottomPadding,
+        bottomPadding = 16.dp,
+        bottomSectionSpacing = 4.dp
+    )
+}
+
+internal fun nowPlayingClassicTrackInfoHeight(
+    titleLineCount: Int,
+    metrics: NowPlayingPortraitLayoutMetrics? = null
+): Dp {
     val extraLineCount = titleLineCount.coerceIn(1, 2) - 1
-    return NowPlayingClassicTrackInfoSingleLineHeight +
-        NowPlayingClassicTrackInfoExtraTitleLineHeight * extraLineCount
-}
-
-internal fun nowPlayingHomeTopPadding(
-    expanded: Boolean,
-    screenHeight: Dp,
-    widthClass: WindowWidthSizeClass
-): Dp {
-    if (expanded) return 0.dp
-    return if (widthClass == WindowWidthSizeClass.Compact && screenHeight.isFiniteDp() &&
-        screenHeight < NowPlayingCompactShortScreenHeight
-    ) {
-        NowPlayingHomeCompactTopPadding
-    } else {
-        24.dp
-    }
-}
-
-internal fun nowPlayingHomeCoverVerticalPadding(
-    expanded: Boolean,
-    screenHeight: Dp,
-    widthClass: WindowWidthSizeClass
-): Dp {
-    if (expanded) return 0.dp
-    return when {
-        widthClass != WindowWidthSizeClass.Compact -> 32.dp
-        screenHeight.isFiniteDp() && screenHeight < NowPlayingCompactShortScreenHeight -> 8.dp
-        else -> 16.dp
-    }
+    val singleLineHeight = metrics?.trackInfoSingleLineHeight ?: NowPlayingClassicTrackInfoSingleLineHeight
+    val extraTitleLineHeight = metrics?.trackInfoExtraTitleLineHeight
+        ?: NowPlayingClassicTrackInfoExtraTitleLineHeight
+    return singleLineHeight + extraTitleLineHeight * extraLineCount
 }
 
 internal fun nowPlayingHomeCoverWidth(
@@ -202,7 +241,8 @@ internal fun nowPlayingHomeCoverWidth(
     } else {
         NowPlayingClassicAudienceHeight + nowPlayingClassicTrackInfoHeight(titleLineCount = 1)
     },
-    lyricsReserveHeight: Dp = if (expanded) NowPlayingHomeExpandedLyricsReserveHeight else NowPlayingHomeClassicLyricsReserveHeight
+    lyricsReserveHeight: Dp = if (expanded) NowPlayingHomeExpandedLyricsReserveHeight else NowPlayingHomeClassicLyricsReserveHeight,
+    minimumCoverWidth: Dp = nowPlayingHomeMinCoverWidth(widthClass)
 ): Dp {
     val fullWidth = availableWidth.coerceAtLeast(1.dp)
     val widthBound = if (expanded) {
@@ -226,7 +266,7 @@ internal fun nowPlayingHomeCoverWidth(
         identityHeight +
         lyricsReserveHeight
     val heightLimitedWidth = ((availableHeight - reservedHeight).coerceAtLeast(1.dp) * safeAspectRatio)
-        .coerceAtLeast(nowPlayingHomeMinCoverWidth(widthClass).coerceAtMost(widthBound))
+        .coerceAtLeast(minimumCoverWidth.coerceAtMost(widthBound))
     return widthBound.coerceAtMost(heightLimitedWidth)
 }
 
@@ -694,6 +734,7 @@ private fun ClassicPlayerIdentity(
     artistMeta: NowPlayingArtistMeta,
     accentColor: Color,
     onTitleLineCountChanged: (Int) -> Unit,
+    compactLayout: Boolean,
     modifier: Modifier = Modifier
 ) {
     val colorScheme = AsmrTheme.colorScheme
@@ -717,16 +758,17 @@ private fun ClassicPlayerIdentity(
         modifier = modifier
             .fillMaxWidth()
             .clipToBounds()
-            .padding(horizontal = 24.dp),
+            .padding(horizontal = if (compactLayout) 20.dp else 24.dp),
         horizontalAlignment = Alignment.CenterHorizontally,
-        verticalArrangement = Arrangement.spacedBy(5.dp)
+        verticalArrangement = Arrangement.spacedBy(if (compactLayout) 3.dp else 5.dp)
     ) {
         Text(
             text = title.ifBlank { "未播放" },
             modifier = Modifier.fillMaxWidth(),
             style = MaterialTheme.typography.titleMedium.copy(
                 fontWeight = FontWeight.SemiBold,
-                lineHeight = 20.sp,
+                fontSize = if (compactLayout) 13.sp else 18.sp,
+                lineHeight = if (compactLayout) 15.sp else 20.sp,
                 shadow = textShadow
             ),
             color = colorScheme.textPrimary,
@@ -740,6 +782,7 @@ private fun ClassicPlayerIdentity(
         ClassicArtistRows(
             artistMeta = artistMeta,
             accentColor = accentColor,
+            compactLayout = compactLayout,
             modifier = Modifier.fillMaxWidth()
         )
     }
@@ -749,6 +792,7 @@ private fun ClassicPlayerIdentity(
 private fun ClassicArtistRows(
     artistMeta: NowPlayingArtistMeta,
     accentColor: Color,
+    compactLayout: Boolean,
     modifier: Modifier = Modifier
 ) {
     if (artistMeta.circle.isBlank() && artistMeta.cvNames.isEmpty()) return
@@ -756,20 +800,21 @@ private fun ClassicArtistRows(
     Column(
         modifier = modifier,
         horizontalAlignment = Alignment.CenterHorizontally,
-        verticalArrangement = Arrangement.spacedBy(12.dp)
+        verticalArrangement = Arrangement.spacedBy(if (compactLayout) 6.dp else 10.dp)
     ) {
         if (artistMeta.circle.isNotBlank()) {
             Box(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .height(22.dp),
+                    .height(NowPlayingClassicArtistChipHeight),
                 contentAlignment = Alignment.Center
             ) {
                 ClassicArtistChip(
                     label = "社团",
                     value = artistMeta.circle,
                     accentColor = accentColor,
-                    emphasized = true
+                    emphasized = true,
+                    compactLayout = compactLayout
                 )
             }
         }
@@ -777,10 +822,12 @@ private fun ClassicArtistRows(
             Row(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .height(22.dp)
-                    .clipToBounds()
+                    .height(NowPlayingClassicArtistChipHeight)
                     .horizontalScroll(rememberScrollState()),
-                horizontalArrangement = Arrangement.spacedBy(7.dp, Alignment.CenterHorizontally),
+                horizontalArrangement = Arrangement.spacedBy(
+                    if (compactLayout) 5.dp else 7.dp,
+                    Alignment.CenterHorizontally
+                ),
                 verticalAlignment = Alignment.CenterVertically
             ) {
                 artistMeta.cvNames.forEach { cv ->
@@ -788,7 +835,8 @@ private fun ClassicArtistRows(
                         label = "CV",
                         value = cv,
                         accentColor = accentColor,
-                        emphasized = false
+                        emphasized = false,
+                        compactLayout = compactLayout
                     )
                 }
             }
@@ -796,39 +844,50 @@ private fun ClassicArtistRows(
     }
 }
 
+private val NowPlayingClassicArtistChipHeight = 20.dp
+
 @Composable
 private fun ClassicArtistChip(
     label: String,
     value: String,
     accentColor: Color,
-    emphasized: Boolean
+    emphasized: Boolean,
+    compactLayout: Boolean
 ) {
     val colorScheme = AsmrTheme.colorScheme
     val containerColor = accentColor.copy(alpha = if (emphasized) 0.16f else 0.10f)
-    Row(
+    val chipTextStyle = MaterialTheme.typography.labelMedium.copy(
+        fontSize = if (compactLayout) 11.sp else 12.sp,
+        lineHeight = if (compactLayout) 13.sp else 14.sp
+    )
+    Box(
         modifier = Modifier
+            .height(NowPlayingClassicArtistChipHeight)
             .background(containerColor, RoundedCornerShape(999.dp))
-            .padding(horizontal = 9.dp, vertical = 2.dp),
-        horizontalArrangement = Arrangement.spacedBy(4.dp),
-        verticalAlignment = Alignment.CenterVertically
+            .padding(horizontal = if (compactLayout) 7.dp else 9.dp),
+        contentAlignment = Alignment.Center
     ) {
-        Text(
-            text = label,
-            style = MaterialTheme.typography.labelMedium.copy(
-                fontWeight = FontWeight.SemiBold,
-                lineHeight = 16.sp
-            ),
-            color = accentColor.copy(alpha = 0.92f),
-            maxLines = 1
-        )
-        Text(
-            text = value,
-            modifier = Modifier.widthIn(max = if (emphasized) 220.dp else 180.dp),
-            style = MaterialTheme.typography.labelMedium.copy(lineHeight = 16.sp),
-            color = if (emphasized) colorScheme.textPrimary else colorScheme.textSecondary,
-            maxLines = 1,
-            overflow = TextOverflow.Ellipsis
-        )
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(if (compactLayout) 3.dp else 4.dp)
+        ) {
+            Text(
+                text = label,
+                modifier = Modifier.alignByBaseline(),
+                style = chipTextStyle.copy(fontWeight = FontWeight.SemiBold),
+                color = accentColor.copy(alpha = 0.92f),
+                maxLines = 1
+            )
+            Text(
+                text = value,
+                modifier = Modifier
+                    .widthIn(max = if (emphasized) 220.dp else 180.dp)
+                    .alignByBaseline(),
+                style = chipTextStyle,
+                color = if (emphasized) colorScheme.textPrimary else colorScheme.textSecondary,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
+            )
+        }
     }
 }
 
@@ -1799,12 +1858,21 @@ internal fun NowPlayingScreen(
                 parseNowPlayingArtistMeta(portraitArtistText)
             }
             var classicTitleLineCount by remember(playerHeaderTitle) { mutableIntStateOf(1) }
-            val classicTrackInfoTargetHeight = nowPlayingClassicTrackInfoHeight(classicTitleLineCount)
+            val portraitScreenHeight = configuration.screenHeightDp.dp
+            val portraitLayoutMetrics = remember(portraitScreenHeight, widthClass) {
+                nowPlayingPortraitLayoutMetrics(
+                    screenHeight = portraitScreenHeight,
+                    widthClass = widthClass
+                )
+            }
+            val classicTrackInfoTargetHeight = nowPlayingClassicTrackInfoHeight(
+                titleLineCount = classicTitleLineCount,
+                metrics = portraitLayoutMetrics
+            )
             val homeLayoutSwipeHintAllowed = !nowPlayingHomeLayoutHintDismissed &&
                 !homeLayoutHintDismissedInSession &&
                 !isVideo
-            val portraitContentHorizontalPadding = 24.dp
-            val portraitScreenHeight = configuration.screenHeightDp.dp
+            val portraitContentHorizontalPadding = portraitLayoutMetrics.contentHorizontalPadding
             val homeBezier = remember { CubicBezierEasing(0.20f, 0f, 0f, 1f) }
             val homeLayoutDurationMillis = NowPlayingHomeLayoutAnimationDurationMillis
             val homeFadeInDurationMillis = NowPlayingHomeLyricsFadeInDurationMillis
@@ -1832,7 +1900,7 @@ internal fun NowPlayingScreen(
                 },
                 label = "nowPlayingHomeClassicAudienceHeight"
             ) { expanded ->
-                if (expanded) 0.dp else NowPlayingClassicAudienceHeight
+                if (expanded) 0.dp else portraitLayoutMetrics.audienceHeight
             }
             val classicTrackInfoHeight by homeLayoutTransition.animateDp(
                 transitionSpec = {
@@ -1870,11 +1938,7 @@ internal fun NowPlayingScreen(
                 },
                 label = "nowPlayingHomeTopPadding"
             ) { expanded ->
-                nowPlayingHomeTopPadding(
-                    expanded = expanded,
-                    screenHeight = portraitScreenHeight,
-                    widthClass = widthClass
-                )
+                if (expanded) 0.dp else portraitLayoutMetrics.topPadding
             }
             val coverVerticalPadding by homeLayoutTransition.animateDp(
                 transitionSpec = {
@@ -1882,13 +1946,9 @@ internal fun NowPlayingScreen(
                 },
                 label = "nowPlayingHomeCoverVerticalPadding"
             ) { expanded ->
-                nowPlayingHomeCoverVerticalPadding(
-                    expanded = expanded,
-                    screenHeight = portraitScreenHeight,
-                    widthClass = widthClass
-                )
+                if (expanded) 0.dp else portraitLayoutMetrics.coverVerticalPadding
             }
-            val expandedLyricsTopPadding = 14.dp
+            val expandedLyricsTopPadding = portraitLayoutMetrics.expandedLyricsTopPadding
             val homeCoverAspectRatio by homeLayoutTransition.animateFloat(
                 transitionSpec = {
                     tween(durationMillis = homeLayoutDurationMillis, easing = homeBezier)
@@ -2005,21 +2065,19 @@ internal fun NowPlayingScreen(
                                             widthClass = widthClass,
                                             contentHorizontalPadding = portraitContentHorizontalPadding,
                                             coverAspectRatio = if (expanded) artworkAspectRatio else 1f,
-                                            topPadding = nowPlayingHomeTopPadding(
-                                                expanded = expanded,
-                                                screenHeight = portraitScreenHeight,
-                                                widthClass = widthClass
-                                            ),
-                                            coverVerticalPadding = nowPlayingHomeCoverVerticalPadding(
-                                                expanded = expanded,
-                                                screenHeight = portraitScreenHeight,
-                                                widthClass = widthClass
-                                            ),
+                                            topPadding = if (expanded) 0.dp else portraitLayoutMetrics.topPadding,
+                                            coverVerticalPadding = if (expanded) 0.dp else portraitLayoutMetrics.coverVerticalPadding,
                                             identityHeight = if (expanded) {
                                                 0.dp
                                             } else {
-                                                NowPlayingClassicAudienceHeight + classicTrackInfoTargetHeight
-                                            }
+                                                portraitLayoutMetrics.audienceHeight + classicTrackInfoTargetHeight
+                                            },
+                                            lyricsReserveHeight = if (expanded) {
+                                                portraitLayoutMetrics.expandedLyricsReserveHeight
+                                            } else {
+                                                portraitLayoutMetrics.classicLyricsReserveHeight
+                                            },
+                                            minimumCoverWidth = portraitLayoutMetrics.minimumCoverWidth
                                         )
                                     }
                                     Box(
@@ -2081,6 +2139,7 @@ internal fun NowPlayingScreen(
                                         classicTitleLineCount = lineCount
                                     }
                                 },
+                                compactLayout = portraitLayoutMetrics.compact,
                                 modifier = portraitContentWidthModifier
                                     .height(classicTrackInfoHeight)
                                     .graphicsLayer { alpha = classicIdentityAlpha }
@@ -2132,10 +2191,10 @@ internal fun NowPlayingScreen(
                                         Box(
                                             modifier = Modifier
                                                 .fillMaxWidth()
-                                                .height(58.dp)
+                                                .height(portraitLayoutMetrics.classicLyricsContainerHeight)
                                                 .align(Alignment.BottomCenter)
                                                 .padding(horizontal = portraitContentHorizontalPadding)
-                                                .padding(bottom = NowPlayingHomeClassicLyricsBottomPadding)
+                                                .padding(bottom = portraitLayoutMetrics.classicLyricsBottomPadding)
                                                 .graphicsLayer { alpha = classicLyricsAlpha },
                                             contentAlignment = Alignment.Center
                                         ) {
@@ -2146,6 +2205,7 @@ internal fun NowPlayingScreen(
                                                     onOpenLyrics = showLyricsSurface,
                                                     colors = lyricColors,
                                                     interactionEnabled = lyricsClassicInteractionEnabled,
+                                                    compactLayout = portraitLayoutMetrics.compact,
                                                     modifier = Modifier.fillMaxWidth()
                                                 )
                                             }
@@ -2160,8 +2220,8 @@ internal fun NowPlayingScreen(
 
                     Column(
                         modifier = portraitContentWidthModifier
-                            .padding(bottom = 16.dp),
-                        verticalArrangement = Arrangement.spacedBy(4.dp)
+                            .padding(bottom = portraitLayoutMetrics.bottomPadding),
+                        verticalArrangement = Arrangement.spacedBy(portraitLayoutMetrics.bottomSectionSpacing)
                     ) {
                         key(item?.mediaId) {
                             Box(
@@ -2187,7 +2247,8 @@ internal fun NowPlayingScreen(
                                             viewModel.updateSliceRange(sliceId, startMs, endMs, progressDurationMs)
                                         },
                                         activeColor = accentColor,
-                                        inactiveColor = accentColor.copy(alpha = 0.2f)
+                                        inactiveColor = accentColor.copy(alpha = 0.2f),
+                                        compactLayout = portraitLayoutMetrics.compact
                                     )
                                 }
                             }
@@ -2212,7 +2273,8 @@ internal fun NowPlayingScreen(
                             actionRowModifier = actionRowMotion,
                             coreControlsModifier = controlsMotion,
                             primaryColor = accentColor,
-                            onPrimaryColor = onAccentColor
+                            onPrimaryColor = onAccentColor,
+                            compactLayout = portraitLayoutMetrics.compact
                         )
 
                         VolumeControl(
@@ -2229,7 +2291,8 @@ internal fun NowPlayingScreen(
                             audioOutputRouteKind = audioOutputRouteKind,
                             warningSessionState = warningSessionState,
                             expanded = volumeControlExpanded,
-                            onExpandedChange = { volumeControlExpanded = it }
+                            onExpandedChange = { volumeControlExpanded = it },
+                            compactLayout = portraitLayoutMetrics.compact
                         )
                     }
                 }

--- a/app/src/main/java/com/asmr/player/ui/player/nowplaying/NowPlayingControls.kt
+++ b/app/src/main/java/com/asmr/player/ui/player/nowplaying/NowPlayingControls.kt
@@ -1,4 +1,4 @@
-﻿package com.asmr.player.ui.player
+package com.asmr.player.ui.player
 
 import android.app.Activity
 import android.content.Context
@@ -122,9 +122,17 @@ internal fun PlaybackControls(
     coreControlsModifier: Modifier = Modifier,
     supplementalAction: (@Composable () -> Unit)? = null,
     primaryColor: Color = AsmrTheme.colorScheme.primary,
-    onPrimaryColor: Color = AsmrTheme.colorScheme.onPrimary
+    onPrimaryColor: Color = AsmrTheme.colorScheme.onPrimary,
+    compactLayout: Boolean = false
 ) {
     val colorScheme = AsmrTheme.colorScheme
+    val actionButtonSize = if (compactLayout) 40.dp else 48.dp
+    val actionIconSize = if (compactLayout) 22.dp else 24.dp
+    val coreButtonSize = if (compactLayout) 40.dp else 48.dp
+    val modeIconSize = if (compactLayout) 24.dp else 28.dp
+    val skipIconSize = if (compactLayout) 30.dp else 36.dp
+    val playButtonSize = if (compactLayout) 60.dp else 72.dp
+    val playIconSize = if (compactLayout) 30.dp else 36.dp
     val currentMediaId = playback.currentMediaItem?.mediaId
     var optimisticIsPlaying by remember { mutableStateOf<Boolean?>(null) }
     var stableMediaId by remember { mutableStateOf<String?>(currentMediaId) }
@@ -150,42 +158,57 @@ internal fun PlaybackControls(
         modifier = modifier
             .fillMaxWidth()
             .padding(bottom = bottomPadding),
-        verticalArrangement = Arrangement.spacedBy(if (showActionRow) 20.dp else 12.dp)
+        verticalArrangement = Arrangement.spacedBy(
+            if (showActionRow) {
+                if (compactLayout) 8.dp else 20.dp
+            } else {
+                12.dp
+            }
+        )
     ) {
         if (showActionRow) {
             Row(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(horizontal = 16.dp)
+                    .padding(horizontal = if (compactLayout) 8.dp else 16.dp)
                     .then(actionRowModifier),
                 horizontalArrangement = Arrangement.SpaceAround,
                 verticalAlignment = Alignment.CenterVertically
             ) {
-                IconButton(onClick = { viewModel.toggleFavorite() }) {
+                IconButton(
+                    onClick = { viewModel.toggleFavorite() },
+                    modifier = Modifier.size(actionButtonSize)
+                ) {
                     Icon(
                         imageVector = if (isFavorite) Icons.Rounded.Favorite else Icons.Outlined.FavoriteBorder,
                         contentDescription = "喜欢",
                         tint = if (isFavorite) Color.Red else colorScheme.onSurface.copy(alpha = 0.8f),
-                        modifier = Modifier.size(24.dp)
+                        modifier = Modifier.size(actionIconSize)
                     )
                 }
 
-                IconButton(onClick = onShowPlaylistPicker) {
+                IconButton(
+                    onClick = onShowPlaylistPicker,
+                    modifier = Modifier.size(actionButtonSize)
+                ) {
                     Icon(
                         Icons.AutoMirrored.Outlined.PlaylistAdd,
                         contentDescription = "添加到播放列表",
                         tint = colorScheme.onSurface.copy(alpha = 0.8f),
-                        modifier = Modifier.size(24.dp)
+                        modifier = Modifier.size(actionIconSize)
                     )
                 }
 
                 val floatingEnabled by viewModel.floatingLyricsEnabled.collectAsState()
-                IconButton(onClick = { viewModel.toggleFloatingLyrics() }) {
+                IconButton(
+                    onClick = { viewModel.toggleFloatingLyrics() },
+                    modifier = Modifier.size(actionButtonSize)
+                ) {
                     Icon(
                         imageVector = Icons.Rounded.Subtitles,
                         contentDescription = "悬浮歌词",
                         tint = if (floatingEnabled) primaryColor else colorScheme.onSurface.copy(alpha = 0.8f),
-                        modifier = Modifier.size(24.dp)
+                        modifier = Modifier.size(actionIconSize)
                     )
                 }
 
@@ -193,22 +216,26 @@ internal fun PlaybackControls(
                 IconButton(
                     onClick = {
                         if (isOnlineMedia) viewModel.showOnlineTagManageUnsupported() else onManageTags()
-                    }
+                    },
+                    modifier = Modifier.size(actionButtonSize)
                 ) {
                     Icon(
                         imageVector = if (isOnlineMedia) Icons.AutoMirrored.Outlined.LabelOff else Icons.AutoMirrored.Rounded.Label,
                         contentDescription = "标签管理",
                         tint = colorScheme.onSurface.copy(alpha = if (isOnlineMedia) 0.38f else 0.8f),
-                        modifier = Modifier.size(24.dp)
+                        modifier = Modifier.size(actionIconSize)
                     )
                 }
 
-                IconButton(onClick = onShowEqualizer) {
+                IconButton(
+                    onClick = onShowEqualizer,
+                    modifier = Modifier.size(actionButtonSize)
+                ) {
                     Icon(
                         imageVector = Icons.Rounded.Tune,
                         contentDescription = "均衡器",
                         tint = colorScheme.onSurface.copy(alpha = 0.8f),
-                        modifier = Modifier.size(24.dp)
+                        modifier = Modifier.size(actionIconSize)
                     )
                 }
 
@@ -219,12 +246,15 @@ internal fun PlaybackControls(
                     animationSpec = tween(240, easing = FastOutSlowInEasing),
                     label = "sliceModeTint"
                 )
-                IconButton(onClick = { viewModel.toggleSliceMode() }) {
+                IconButton(
+                    onClick = { viewModel.toggleSliceMode() },
+                    modifier = Modifier.size(actionButtonSize)
+                ) {
                     Icon(
                         painter = painterResource(R.drawable.ic_segment),
                         contentDescription = "切片播放",
                         tint = tint,
-                        modifier = Modifier.size(24.dp)
+                        modifier = Modifier.size(actionIconSize)
                     )
                 }
 
@@ -244,7 +274,10 @@ internal fun PlaybackControls(
             },
             verticalAlignment = Alignment.CenterVertically
         ) {
-            IconButton(onClick = { viewModel.cyclePlayMode() }) {
+            IconButton(
+                onClick = { viewModel.cyclePlayMode() },
+                modifier = Modifier.size(coreButtonSize)
+            ) {
                 val icon = when {
                     playback.shuffleEnabled -> Icons.Rounded.Shuffle
                     playback.repeatMode == Player.REPEAT_MODE_ONE -> Icons.Rounded.RepeatOne
@@ -254,27 +287,34 @@ internal fun PlaybackControls(
                     icon,
                     contentDescription = "播放模式",
                     tint = colorScheme.onSurface,
-                    modifier = Modifier.size(28.dp)
+                    modifier = Modifier.size(modeIconSize)
                 )
             }
 
-            IconButton(onClick = { viewModel.previous() }) {
+            IconButton(
+                onClick = { viewModel.previous() },
+                modifier = Modifier.size(coreButtonSize)
+            ) {
                 Icon(
                     Icons.Rounded.SkipPrevious,
                     contentDescription = "上一首",
                     tint = colorScheme.onSurface,
-                    modifier = Modifier.size(36.dp)
+                    modifier = Modifier.size(skipIconSize)
                 )
             }
 
             val playButtonCorner by animateDpAsState(
-                targetValue = if (isPlayingEffective) 24.dp else 36.dp,
+                targetValue = if (isPlayingEffective) {
+                    if (compactLayout) 20.dp else 24.dp
+                } else {
+                    if (compactLayout) 30.dp else 36.dp
+                },
                 animationSpec = tween(durationMillis = 220, easing = FastOutSlowInEasing),
                 label = "playButtonCorner"
             )
             val playButtonInteractionSource = remember { MutableInteractionSource() }
             Surface(
-                modifier = Modifier.size(72.dp),
+                modifier = Modifier.size(playButtonSize),
                 shape = RoundedCornerShape(playButtonCorner),
                 color = primaryColor,
                 contentColor = onPrimaryColor
@@ -302,27 +342,33 @@ internal fun PlaybackControls(
                         Icon(
                             imageVector = if (playing) Icons.Rounded.Pause else Icons.Rounded.PlayArrow,
                             contentDescription = "播放/暂停",
-                            modifier = Modifier.size(36.dp)
+                            modifier = Modifier.size(playIconSize)
                         )
                     }
                 }
             }
 
-            IconButton(onClick = { viewModel.next() }) {
+            IconButton(
+                onClick = { viewModel.next() },
+                modifier = Modifier.size(coreButtonSize)
+            ) {
                 Icon(
                     Icons.Rounded.SkipNext,
                     contentDescription = "下一首",
                     tint = colorScheme.onSurface,
-                    modifier = Modifier.size(36.dp)
+                    modifier = Modifier.size(skipIconSize)
                 )
             }
 
-            IconButton(onClick = { viewModel.seekForward10s() }) {
+            IconButton(
+                onClick = { viewModel.seekForward10s() },
+                modifier = Modifier.size(coreButtonSize)
+            ) {
                 Icon(
                     Icons.Rounded.FastForward,
                     contentDescription = "快进10秒",
                     tint = colorScheme.onSurface,
-                    modifier = Modifier.size(28.dp)
+                    modifier = Modifier.size(modeIconSize)
                 )
             }
             if (!showActionRow) {
@@ -340,6 +386,7 @@ internal fun SingleLineLyrics(
     onOpenLyrics: () -> Unit,
     colors: LyricReadableColors,
     interactionEnabled: Boolean = true,
+    compactLayout: Boolean = false,
     modifier: Modifier = Modifier,
 ) {
     val sortedLyrics = remember(lyrics) {
@@ -379,8 +426,11 @@ internal fun SingleLineLyrics(
     Column(
         modifier = modifier
             .clickable(enabled = interactionEnabled) { onOpenLyrics() }
-            .padding(horizontal = 16.dp, vertical = 4.dp),
-        verticalArrangement = Arrangement.spacedBy(4.dp),
+            .padding(
+                horizontal = if (compactLayout) 14.dp else 16.dp,
+                vertical = if (compactLayout) 2.dp else 4.dp
+            ),
+        verticalArrangement = Arrangement.spacedBy(if (compactLayout) 2.dp else 4.dp),
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
         AnimatedLyricLine(
@@ -388,11 +438,12 @@ internal fun SingleLineLyrics(
             durationMs = lineDuration,
             colors = colors,
             fontWeight = FontWeight.ExtraBold,
+            compactLayout = compactLayout,
             modifier = Modifier.fillMaxWidth()
         )
         Box(
             modifier = Modifier
-                .width(52.dp)
+                .width(if (compactLayout) 44.dp else 52.dp)
                 .height(2.dp)
                 .clip(RoundedCornerShape(percent = 50))
                 .background(colors.accentEmphasis.copy(alpha = if (AsmrTheme.colorScheme.isDark) 0.72f else 0.56f))
@@ -407,6 +458,7 @@ private fun AnimatedLyricLine(
     durationMs: Long,
     colors: LyricReadableColors,
     fontWeight: FontWeight,
+    compactLayout: Boolean,
     modifier: Modifier = Modifier
 ) {
     AnimatedContent(
@@ -423,7 +475,11 @@ private fun AnimatedLyricLine(
         SlowMarqueeText(
             text = target,
             durationMs = durationMs,
-            style = MaterialTheme.typography.titleMedium,
+            style = if (compactLayout) {
+                MaterialTheme.typography.titleMedium.copy(fontSize = 16.sp, lineHeight = 18.sp)
+            } else {
+                MaterialTheme.typography.titleMedium
+            },
             colors = colors,
             fontWeight = fontWeight,
             modifier = modifier
@@ -529,7 +585,8 @@ internal fun VolumeControl(
     audioOutputRouteKind: AudioOutputRouteKind,
     warningSessionState: AppVolumeWarningSessionState,
     expanded: Boolean,
-    onExpandedChange: (Boolean) -> Unit
+    onExpandedChange: (Boolean) -> Unit,
+    compactLayout: Boolean = false
 ) {
     val volume by viewModel.appVolumePercent.collectAsState()
     var lastNonZeroVolume by remember { mutableIntStateOf(AppVolume.DefaultPercent) }
@@ -598,7 +655,7 @@ internal fun VolumeControl(
             Row(
                 modifier = modifier
                     .fillMaxWidth()
-                    .padding(vertical = 6.dp)
+                    .padding(vertical = if (compactLayout) 2.dp else 6.dp)
                     .combinedClickable(
                         onClick = {
                             if (volume > 0) {
@@ -619,12 +676,12 @@ internal fun VolumeControl(
                     routeKind = audioOutputRouteKind,
                     isMuted = isMuted,
                     tint = accentColor,
-                    modifier = Modifier.size(22.dp)
+                    modifier = Modifier.size(if (compactLayout) 20.dp else 22.dp)
                 )
-                Spacer(modifier = Modifier.width(10.dp))
+                Spacer(modifier = Modifier.width(if (compactLayout) 8.dp else 10.dp))
                 Text(
                     text = "长按调整音量",
-                    style = MaterialTheme.typography.bodySmall,
+                    style = if (compactLayout) MaterialTheme.typography.labelSmall else MaterialTheme.typography.bodySmall,
                     color = colorScheme.textTertiary
                 )
             }
@@ -632,9 +689,12 @@ internal fun VolumeControl(
             Column(
                 modifier = modifier
                     .fillMaxWidth()
-                    .padding(top = 6.dp, bottom = 2.dp)
+                    .padding(
+                        top = if (compactLayout) 2.dp else 6.dp,
+                        bottom = if (compactLayout) 0.dp else 2.dp
+                    )
                     .animateContentSize(),
-                verticalArrangement = Arrangement.spacedBy(6.dp)
+                verticalArrangement = Arrangement.spacedBy(if (compactLayout) 4.dp else 6.dp)
             ) {
                 Row(
                     modifier = Modifier.fillMaxWidth(),
@@ -645,7 +705,7 @@ internal fun VolumeControl(
                         isMuted = isMuted,
                         tint = accentColor,
                         modifier = Modifier
-                            .size(20.dp)
+                            .size(if (compactLayout) 18.dp else 20.dp)
                             .combinedClickable(
                                 onClick = {
                                     if (volume > 0) {
@@ -658,16 +718,16 @@ internal fun VolumeControl(
                                 onLongClick = {}
                             )
                     )
-                    Spacer(modifier = Modifier.width(10.dp))
+                    Spacer(modifier = Modifier.width(if (compactLayout) 8.dp else 10.dp))
                     Text(
                         text = "音量",
-                        style = MaterialTheme.typography.bodySmall,
+                        style = if (compactLayout) MaterialTheme.typography.labelSmall else MaterialTheme.typography.bodySmall,
                         color = colorScheme.textTertiary
                     )
                     Spacer(modifier = Modifier.weight(1f))
                     Text(
                         text = "${AppVolume.clampPercent(volume)}%",
-                        style = MaterialTheme.typography.bodySmall,
+                        style = if (compactLayout) MaterialTheme.typography.labelSmall else MaterialTheme.typography.bodySmall,
                         color = colorScheme.textTertiary
                     )
                 }

--- a/app/src/main/java/com/asmr/player/ui/player/nowplaying/NowPlayingProgress.kt
+++ b/app/src/main/java/com/asmr/player/ui/player/nowplaying/NowPlayingProgress.kt
@@ -1,4 +1,4 @@
-﻿package com.asmr.player.ui.player
+package com.asmr.player.ui.player
 
 import android.app.Activity
 import android.content.Context
@@ -115,7 +115,8 @@ internal fun PlayerProgress(
     onLongPressSlice: (Long) -> Unit,
     onUpdateSliceRange: (sliceId: Long, startMs: Long, endMs: Long) -> Unit,
     activeColor: Color,
-    inactiveColor: Color
+    inactiveColor: Color,
+    compactLayout: Boolean = false
 ) {
     val colorScheme = AsmrTheme.colorScheme
     val safeDuration = durationMs.coerceAtLeast(0L)
@@ -151,7 +152,10 @@ internal fun PlayerProgress(
         effectivePosition
     }
 
-    Column(modifier = Modifier.fillMaxWidth(), verticalArrangement = Arrangement.spacedBy(4.dp)) {
+    Column(
+        modifier = Modifier.fillMaxWidth(),
+        verticalArrangement = Arrangement.spacedBy(if (compactLayout) 2.dp else 4.dp)
+    ) {
         Row(modifier = Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
             SliceScrubbableSeekBar(
                 enabled = rangeDuration > 0L,
@@ -163,6 +167,7 @@ internal fun PlayerProgress(
                 tempStartMs = sliceUiState.tempStartMs,
                 highlightedSliceId = highlightedSliceId,
                 selectedSliceId = sliceUiState.selectedSliceId,
+                compactLayout = compactLayout,
                 onSelectSlice = onSelectSlice,
                 onLongPressSlice = onLongPressSlice,
                 onEditCommit = onUpdateSliceRange,
@@ -187,12 +192,16 @@ internal fun PlayerProgress(
                     onScrubbingChanged(false)
                 }
             )
-            IconButton(onClick = onCutPressed, enabled = rangeDuration > 0L) {
+            IconButton(
+                onClick = onCutPressed,
+                enabled = rangeDuration > 0L,
+                modifier = Modifier.size(if (compactLayout) 40.dp else 48.dp)
+            ) {
                 Icon(
                     imageVector = Icons.Outlined.ContentCut,
                     contentDescription = "Cut",
                     tint = if (sliceUiState.tempStartMs != null) activeColor else colorScheme.onSurface.copy(alpha = 0.85f),
-                    modifier = Modifier.size(22.dp)
+                    modifier = Modifier.size(if (compactLayout) 20.dp else 22.dp)
                 )
             }
         }
@@ -231,6 +240,7 @@ private fun SliceScrubbableSeekBar(
     onLongPressSlice: (Long) -> Unit,
     onEditCommit: (sliceId: Long, startMs: Long, endMs: Long) -> Unit,
     onGestureActiveChanged: (Boolean) -> Unit,
+    compactLayout: Boolean,
     modifier: Modifier = Modifier,
     onScrubStart: (Float) -> Unit,
     onScrub: (Float) -> Unit,
@@ -277,7 +287,7 @@ private fun SliceScrubbableSeekBar(
     Canvas(
         modifier = modifier
             .fillMaxWidth()
-            .height(32.dp)
+            .height(if (compactLayout) 28.dp else 32.dp)
             .pointerInput(enabled, rangeDurationMs, slices, selectedSliceId) {
                 if (!enabled) return@pointerInput
                 val thumbRadiusPx = thumbRadius.toPx()

--- a/app/src/test/java/com/asmr/player/ui/player/NowPlayingHomeLayoutCoverTest.kt
+++ b/app/src/test/java/com/asmr/player/ui/player/NowPlayingHomeLayoutCoverTest.kt
@@ -8,9 +8,39 @@ import org.junit.Test
 class NowPlayingHomeLayoutCoverTest {
     @Test
     fun classicTrackInfoHeightOnlyExpandsWhenTitleWraps() {
-        assertEquals(82.dp, nowPlayingClassicTrackInfoHeight(titleLineCount = 1))
-        assertEquals(102.dp, nowPlayingClassicTrackInfoHeight(titleLineCount = 2))
-        assertEquals(102.dp, nowPlayingClassicTrackInfoHeight(titleLineCount = 3))
+        assertEquals(88.dp, nowPlayingClassicTrackInfoHeight(titleLineCount = 1))
+        assertEquals(108.dp, nowPlayingClassicTrackInfoHeight(titleLineCount = 2))
+        assertEquals(108.dp, nowPlayingClassicTrackInfoHeight(titleLineCount = 3))
+    }
+
+    @Test
+    fun compactHeightUsesCompactPortraitMetrics() {
+        val metrics = nowPlayingPortraitLayoutMetrics(
+            screenHeight = 640.dp,
+            widthClass = WindowWidthSizeClass.Compact
+        )
+
+        assertEquals(true, metrics.compact)
+        assertEquals(8.dp, metrics.topPadding)
+        assertEquals(4.dp, metrics.coverVerticalPadding)
+        assertEquals(148.dp, metrics.minimumCoverWidth)
+        assertEquals(65.dp, nowPlayingClassicTrackInfoHeight(titleLineCount = 1, metrics = metrics))
+        assertEquals(80.dp, nowPlayingClassicTrackInfoHeight(titleLineCount = 2, metrics = metrics))
+    }
+
+    @Test
+    fun normalHeightKeepsRegularPortraitMetrics() {
+        val metrics = nowPlayingPortraitLayoutMetrics(
+            screenHeight = 904.dp,
+            widthClass = WindowWidthSizeClass.Compact
+        )
+
+        assertEquals(false, metrics.compact)
+        assertEquals(24.dp, metrics.topPadding)
+        assertEquals(16.dp, metrics.coverVerticalPadding)
+        assertEquals(180.dp, metrics.minimumCoverWidth)
+        assertEquals(88.dp, nowPlayingClassicTrackInfoHeight(titleLineCount = 1, metrics = metrics))
+        assertEquals(108.dp, nowPlayingClassicTrackInfoHeight(titleLineCount = 2, metrics = metrics))
     }
 
     @Test
@@ -54,66 +84,51 @@ class NowPlayingHomeLayoutCoverTest {
     }
 
     @Test
-    fun compactClassicCoverReservesIdentityHierarchyWhenTopContentHeightIsShort() {
-        val screenHeight = 592.dp
+    fun compactClassicCoverReservesBothCvAndLyricsRowsWhenTopContentHeightIsShort() {
+        val metrics = nowPlayingPortraitLayoutMetrics(
+            screenHeight = 640.dp,
+            widthClass = WindowWidthSizeClass.Compact
+        )
 
         assertEquals(
-            180.dp,
+            202.dp,
             nowPlayingHomeCoverWidth(
                 expanded = false,
                 availableWidth = 360.dp,
                 availableHeight = 360.dp,
                 widthClass = WindowWidthSizeClass.Compact,
-                contentHorizontalPadding = 24.dp,
-                topPadding = nowPlayingHomeTopPadding(
-                    expanded = false,
-                    screenHeight = screenHeight,
-                    widthClass = WindowWidthSizeClass.Compact
-                ),
-                coverVerticalPadding = nowPlayingHomeCoverVerticalPadding(
-                    expanded = false,
-                    screenHeight = screenHeight,
-                    widthClass = WindowWidthSizeClass.Compact
-                )
-            )
-        )
-    }
-
-    @Test
-    fun compactClassicTopPaddingKeepsCoverAwayFromHeader() {
-        assertEquals(
-            20.dp,
-            nowPlayingHomeTopPadding(
-                expanded = false,
-                screenHeight = 592.dp,
-                widthClass = WindowWidthSizeClass.Compact
+                contentHorizontalPadding = metrics.contentHorizontalPadding,
+                topPadding = metrics.topPadding,
+                coverVerticalPadding = metrics.coverVerticalPadding,
+                identityHeight = metrics.audienceHeight +
+                    nowPlayingClassicTrackInfoHeight(titleLineCount = 2, metrics = metrics),
+                lyricsReserveHeight = metrics.classicLyricsReserveHeight,
+                minimumCoverWidth = metrics.minimumCoverWidth
             )
         )
     }
 
     @Test
     fun compactExpandedCoverOnlyReservesLyricsRoomWhenTopContentHeightIsShort() {
-        val screenHeight = 592.dp
+        val metrics = nowPlayingPortraitLayoutMetrics(
+            screenHeight = 640.dp,
+            widthClass = WindowWidthSizeClass.Compact
+        )
 
         assertEquals(
-            242.dp,
+            264.dp,
             nowPlayingHomeCoverWidth(
                 expanded = true,
                 availableWidth = 360.dp,
                 availableHeight = 360.dp,
                 widthClass = WindowWidthSizeClass.Compact,
-                contentHorizontalPadding = 24.dp,
+                contentHorizontalPadding = metrics.contentHorizontalPadding,
                 coverAspectRatio = 1f,
-                topPadding = nowPlayingHomeTopPadding(
-                    expanded = true,
-                    screenHeight = screenHeight,
-                    widthClass = WindowWidthSizeClass.Compact
-                ),
-                coverVerticalPadding = nowPlayingHomeCoverVerticalPadding(
-                    expanded = true,
-                    screenHeight = screenHeight,
-                    widthClass = WindowWidthSizeClass.Compact
-                )
+                topPadding = 0.dp,
+                coverVerticalPadding = 0.dp,
+                identityHeight = 0.dp,
+                lyricsReserveHeight = metrics.expandedLyricsReserveHeight,
+                minimumCoverWidth = metrics.minimumCoverWidth
             )
         )
     }


### PR DESCRIPTION
## 修改内容
- 为高度较小的紧凑宽度设备启用专用播放主页布局参数
- 缩小封面区域、标题字号、歌词区域、进度条与播放控制间距，避免内容被底部遮挡
- 统一社团与 CV 胶囊的高度、字号和基线对齐，宽度继续按文字内容自适应
- 补充紧凑与常规设备的封面布局计算测试

## 验证
- `:app:testReleaseUnitTest --tests com.asmr.player.ui.player.NowPlayingHomeLayoutCoverTest`
- `:app:compileReleaseKotlin`
- `:app:installRelease`，已成功安装到 3 台不同尺寸的设备进行实机验证