### PR TITLE
feat: 按需安装字幕运行时并精简发布包

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -7,4 +7,3 @@ gradlew text eol=lf
 *.sh text eol=lf
 
 app/src/main/assets/models/*.bin filter=lfs diff=lfs merge=lfs -text
-app/libs/*.aar filter=lfs diff=lfs merge=lfs -text

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
           fi
           printf '%s' "${EARA_RELEASE_JKS_BASE64}" | base64 --decode > eara-release.jks
           chmod 600 eara-release.jks
-      - name: Build release APKs
+      - name: Build release APK
         run: ./gradlew :app:assembleRelease
         env:
           EARA_RELEASE_STORE_FILE: eara-release.jks
@@ -51,36 +51,28 @@ jobs:
           set -euo pipefail
           mkdir -p dist
           mapfile -t APK_PATHS < <(find . -type f -path '*/outputs/apk/release/*.apk' -name '*.apk' | sort)
-          if [ "${#APK_PATHS[@]}" -eq 0 ]; then
-            echo "Release APK not found under outputs/apk/release"
+          if [ "${#APK_PATHS[@]}" -ne 1 ]; then
+            echo "Expected exactly one release APK, found ${#APK_PATHS[@]}"
             find . -maxdepth 4 -type d -name outputs -print
+            printf '%s\n' "${APK_PATHS[@]}"
             exit 1
           fi
-          for apk in "${APK_PATHS[@]}"; do
-            file_name="$(basename "$apk")"
-            case "$file_name" in
-              *universal*.apk)
-                target="AsmrPlayer-${{ github.ref_name }}-universal.apk"
-                ;;
-              *arm64-v8a*.apk)
-                target="AsmrPlayer-${{ github.ref_name }}-arm64-v8a.apk"
-                ;;
-              *armeabi-v7a*.apk)
-                target="AsmrPlayer-${{ github.ref_name }}-armeabi-v7a.apk"
-                ;;
-              *x86_64*.apk)
-                target="AsmrPlayer-${{ github.ref_name }}-x86_64.apk"
-                ;;
-              *x86*.apk)
-                target="AsmrPlayer-${{ github.ref_name }}-x86.apk"
-                ;;
-              *)
-                target="AsmrPlayer-${{ github.ref_name }}-${file_name}"
-                ;;
-            esac
-            echo "Copying $apk -> dist/$target"
-            cp "$apk" "dist/$target"
-          done
+
+          apk="${APK_PATHS[0]}"
+          max_apk_bytes=$((20 * 1024 * 1024))
+          apk_bytes="$(stat -c '%s' "$apk")"
+          if [ "$apk_bytes" -gt "$max_apk_bytes" ]; then
+            echo "Release APK is too large: $apk_bytes bytes (limit: $max_apk_bytes)"
+            exit 1
+          fi
+          if unzip -Z1 "$apk" | grep -Ei '^lib/[^/]+/lib(onnxruntime|sherpa-onnx).*\.so$'; then
+            echo "Release APK must not contain the on-demand sherpa-onnx runtime"
+            exit 1
+          fi
+
+          target="AsmrPlayer-${{ github.ref_name }}-universal.apk"
+          echo "Copying $apk -> dist/$target"
+          cp "$apk" "dist/$target"
           ls -lh dist
       - uses: softprops/action-gh-release@v2
         with:

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -73,18 +73,23 @@ android {
         System.getenv("SUBTITLE_MODEL_HUGGING_FACE_URL")
             ?: (project.findProperty("SUBTITLE_MODEL_HUGGING_FACE_URL") as? String)
             ?: "https://huggingface.co/csukuangfj/sherpa-onnx-nemo-parakeet-tdt_ctc-0.6b-ja-35000-int8/resolve/main/"
+    val subtitleRuntimeUrl =
+        System.getenv("SUBTITLE_RUNTIME_URL")
+            ?: (project.findProperty("SUBTITLE_RUNTIME_URL") as? String)
+            ?: "https://github.com/eValDoll/EaraAsmrPlayer/releases/download/subtitle-model-parakeet-ja-int8/sherpa-onnx-runtime-1.13.2-android-arm64-v8a.zip"
 
     defaultConfig {
         applicationId = "com.asmr.player"
         minSdk = 24
         targetSdk = 34
-        versionCode = 10107
-        versionName = "1.1.6"
+        versionCode = 10200
+        versionName = "1.2.0"
         buildConfigField("String", "UPDATE_REPO_OWNER", "\"eValDoll\"")
         buildConfigField("String", "UPDATE_REPO_NAME", "\"EaraAsmrPlayer\"")
         buildConfigField("String", "LISTEN_TOGETHER_BASE_URL", "\"$listenTogetherBaseUrl\"")
         buildConfigField("String", "SUBTITLE_MODEL_GITHUB_URL", "\"$subtitleModelGitHubUrl\"")
         buildConfigField("String", "SUBTITLE_MODEL_HUGGING_FACE_URL", "\"$subtitleModelHuggingFaceUrl\"")
+        buildConfigField("String", "SUBTITLE_RUNTIME_URL", "\"$subtitleRuntimeUrl\"")
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {
@@ -120,14 +125,6 @@ android {
         compose = true
         buildConfig = true
     }
-    splits {
-        abi {
-            isEnable = true
-            reset()
-            include("arm64-v8a", "armeabi-v7a", "x86", "x86_64")
-            isUniversalApk = true
-        }
-    }
     composeOptions {
         kotlinCompilerExtensionVersion = "1.5.8"
     }
@@ -142,6 +139,14 @@ android {
             excludes += "/META-INF/{AL2.0,LGPL2.1}"
         }
     }
+    if (project.hasProperty("releaseAndroidTest")) {
+        testBuildType = "release"
+    }
+    (project.findProperty("subtitleRuntimeTestAssets") as? String)
+        ?.takeIf(String::isNotBlank)
+        ?.let { assetDirectory ->
+            sourceSets.getByName("androidTest").assets.srcDir(rootProject.file(assetDirectory))
+        }
 }
 
 dependencies {
@@ -149,8 +154,6 @@ dependencies {
     val room_version = "2.6.1"
     val hilt_version = "2.49"
     val paging_version = "3.2.1"
-
-    implementation(files("libs/sherpa-onnx-1.13.2.aar"))
 
     implementation("androidx.core:core-ktx:1.12.0")
     implementation("androidx.lifecycle:lifecycle-runtime:2.7.0")
@@ -222,6 +225,7 @@ dependencies {
     testImplementation("androidx.test.ext:junit:1.1.5")
     testImplementation("androidx.compose.ui:ui-test-junit4")
     testImplementation("org.robolectric:robolectric:4.11.1")
+    testImplementation("com.squareup.okhttp3:mockwebserver:4.12.0")
     androidTestImplementation("androidx.test.ext:junit:1.1.5")
     androidTestImplementation("androidx.test.espresso:espresso-core:3.5.1")
     androidTestImplementation(platform("androidx.compose:compose-bom:2024.02.00"))

--- a/app/libs/README.md
+++ b/app/libs/README.md
@@ -1,12 +1,20 @@
 # sherpa-onnx Android 运行库
 
-- 文件：`sherpa-onnx-1.13.2.aar`
-- 上游：<https://github.com/k2-fsa/sherpa-onnx/releases/tag/v1.13.2>
-- SHA-256：`aa5505c0ec4f8bdaee5f214a64ba3012be64f2aecc022e82a64f33392b8dd245`
-- 许可证：Apache License 2.0，见 `sherpa-onnx-LICENSE.txt`
+应用 APK 不再打包 sherpa-onnx AAR 或原生库。用户第一次在设置页手动下载日语字幕模型时，
+后台任务会先安装固定版本的 arm64-v8a 运行时，再继续下载模型。删除模型时保留运行时，
+避免以后重复下载约 11 MiB 的运行时压缩包。
 
-AAR 通过 Git LFS 管理，应用只打包 `arm64-v8a` 原生库。Silero VAD 模型位于
-`app/src/main/assets/subtitle/silero_vad.onnx`，SHA-256 为
+- 上游：<https://github.com/k2-fsa/sherpa-onnx/releases/tag/v1.13.2>
+- 上游 AAR SHA-256：`aa5505c0ec4f8bdaee5f214a64ba3012be64f2aecc022e82a64f33392b8dd245`
+- 许可证：Apache License 2.0，见 `sherpa-onnx-LICENSE.txt`
+- 运行时打包脚本：`tools/package_sherpa_runtime.py`
+- 运行时 ZIP：`sherpa-onnx-runtime-1.13.2-android-arm64-v8a.zip`
+- 运行时 ZIP 大小：`11,311,151` 字节
+- 运行时 ZIP SHA-256：`bfa564c5da27a7ab734d4c788cafd7c95c1e4934e02056be24358532d3d33c2e`
+
+运行时 ZIP 只包含 `libonnxruntime.so` 与 `libsherpa-onnx-jni.so`。应用会校验压缩包及内部
+每个文件的固定大小和 SHA-256，并只解压到应用内部目录；原生库在加载前会被设置为只读。
+Silero VAD 模型仍位于 `app/src/main/assets/subtitle/silero_vad.onnx`，SHA-256 为
 `9e2449e1087496d8d4caba907f23e0bd3f78d91fa552479bb9c23ac09cbb1fd6`。
 
 日语字幕模型使用运行时下载的

--- a/app/libs/sherpa-onnx-1.13.2.aar
+++ b/app/libs/sherpa-onnx-1.13.2.aar
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:aa5505c0ec4f8bdaee5f214a64ba3012be64f2aecc022e82a64f33392b8dd245
-size 56655608

--- a/app/src/androidTest/java/com/asmr/player/subtitle/SherpaOnnxRuntimeLoadingTest.kt
+++ b/app/src/androidTest/java/com/asmr/player/subtitle/SherpaOnnxRuntimeLoadingTest.kt
@@ -1,0 +1,43 @@
+package com.asmr.player.subtitle
+
+import android.os.Build
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.k2fsa.sherpa.onnx.SileroVadModelConfig
+import com.k2fsa.sherpa.onnx.Vad
+import com.k2fsa.sherpa.onnx.VadModelConfig
+import org.junit.Assert.assertTrue
+import org.junit.Assume.assumeTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class SherpaOnnxRuntimeLoadingTest {
+    @Test
+    fun installsPinnedLocalAssetAndLoadsJni() {
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        val context = instrumentation.targetContext
+        val testAssets = instrumentation.context.assets
+        val repository = SherpaOnnxRuntimeRepository.get(context)
+        val descriptor = repository.descriptor
+        assumeTrue(Build.SUPPORTED_ABIS.any { it == descriptor.abi })
+        assumeTrue(testAssets.list("").orEmpty().contains(descriptor.archiveFileName))
+
+        val partialArchive = repository.partialArchiveFile()
+        testAssets.open(descriptor.archiveFileName).use { input ->
+            partialArchive.outputStream().use { output -> input.copyTo(output) }
+        }
+        repository.installDownloadedArchive()
+        assertTrue(repository.isInstalled())
+
+        SherpaOnnxNativeLoader.load(context)
+        Vad(
+            assetManager = context.assets,
+            config = VadModelConfig(
+                sileroVadModelConfig = SileroVadModelConfig(
+                    model = "subtitle/silero_vad.onnx"
+                )
+            )
+        ).release()
+    }
+}

--- a/app/src/main/java/com/asmr/player/data/remote/update/GitHubUpdateClient.kt
+++ b/app/src/main/java/com/asmr/player/data/remote/update/GitHubUpdateClient.kt
@@ -1,5 +1,6 @@
 package com.asmr.player.data.remote.update
 
+import android.os.Build
 import com.asmr.player.data.remote.NetworkHeaders
 import com.google.gson.Gson
 import com.google.gson.annotations.SerializedName
@@ -19,7 +20,8 @@ data class UpdateRelease(
 
 class GitHubUpdateClient(
     private val okHttpClient: OkHttpClient,
-    private val gson: Gson = Gson()
+    private val gson: Gson = Gson(),
+    private val supportedAbis: List<String> = Build.SUPPORTED_ABIS.toList()
 ) {
     suspend fun fetchLatestRelease(owner: String, repo: String): UpdateRelease {
         val url = "https://api.github.com/repos/$owner/$repo/releases/latest"
@@ -42,7 +44,7 @@ class GitHubUpdateClient(
             val parsed = gson.fromJson(bodyStr, GitHubReleaseResponse::class.java)
             val tag = parsed.tagName.orEmpty().trim()
             val version = normalizeVersionName(tag)
-            val asset = pickApkAsset(parsed.assets.orEmpty())
+            val asset = pickApkAssetForDevice(parsed.assets.orEmpty(), supportedAbis)
                 ?: throw IllegalStateException("Release 未包含 APK 资源")
             return UpdateRelease(
                 tagName = tag,
@@ -65,16 +67,6 @@ class GitHubUpdateClient(
         val s = tagOrVersion.trim()
         if (s.startsWith("v", ignoreCase = true) && s.length > 1) return s.substring(1)
         return s
-    }
-
-    private fun pickApkAsset(assets: List<GitHubReleaseAsset>): GitHubReleaseAsset? {
-        val apks = assets.filter { it.name.orEmpty().lowercase().endsWith(".apk") }
-        if (apks.isEmpty()) return null
-        val prefer = apks.firstOrNull { it.name.orEmpty().contains("universal", ignoreCase = true) }
-            ?: apks.firstOrNull { it.name.orEmpty().contains("arm64", ignoreCase = true) }
-            ?: apks.firstOrNull { it.name.orEmpty().contains("debug", ignoreCase = true) }
-            ?: apks.first()
-        return prefer.takeIf { it.browserDownloadUrl.orEmpty().startsWith("http", ignoreCase = true) }
     }
 
     private fun compareVersion(a: String, b: String): Int {
@@ -120,3 +112,30 @@ data class GitHubReleaseAsset(
     @SerializedName("browser_download_url") val browserDownloadUrl: String? = null,
     val size: Long? = null
 )
+
+internal fun pickApkAssetForDevice(
+    assets: List<GitHubReleaseAsset>,
+    supportedAbis: List<String>
+): GitHubReleaseAsset? {
+    val apks = assets.filter { it.name.orEmpty().lowercase().endsWith(".apk") }
+    if (apks.isEmpty()) return null
+    val preferred = supportedAbis.firstNotNullOfOrNull { abi ->
+        apks.firstOrNull { asset -> assetNameMatchesAbi(asset.name.orEmpty(), abi) }
+    }
+        ?: apks.firstOrNull { it.name.orEmpty().contains("universal", ignoreCase = true) }
+        ?: apks.firstOrNull { it.name.orEmpty().contains("debug", ignoreCase = true) }
+        ?: apks.first()
+    return preferred.takeIf {
+        it.browserDownloadUrl.orEmpty().startsWith("http", ignoreCase = true)
+    }
+}
+
+private fun assetNameMatchesAbi(name: String, abi: String): Boolean = when (abi.lowercase()) {
+    "arm64-v8a" -> name.contains("arm64-v8a", ignoreCase = true) ||
+        name.contains("arm64", ignoreCase = true)
+    "armeabi-v7a" -> name.contains("armeabi-v7a", ignoreCase = true) ||
+        name.contains("armv7", ignoreCase = true)
+    "x86_64" -> name.contains("x86_64", ignoreCase = true)
+    "x86" -> Regex("(^|[-_])x86([-.]|$)", RegexOption.IGNORE_CASE).containsMatchIn(name)
+    else -> name.contains(abi, ignoreCase = true)
+}

--- a/app/src/main/java/com/asmr/player/subtitle/ParakeetEngine.kt
+++ b/app/src/main/java/com/asmr/player/subtitle/ParakeetEngine.kt
@@ -23,6 +23,10 @@ internal class ParakeetEngine(
     modelDirectory: File,
     override val model: SubtitleTranscriptionModel
 ) : SubtitleTranscriptionEngine {
+    init {
+        SherpaOnnxNativeLoader.load(context)
+    }
+
     private var recognizer: OfflineRecognizer? = createRecognizer(modelDirectory)
     private var vad: Vad? = Vad(
         assetManager = context.assets,

--- a/app/src/main/java/com/asmr/player/subtitle/SherpaOnnxRuntime.kt
+++ b/app/src/main/java/com/asmr/player/subtitle/SherpaOnnxRuntime.kt
@@ -1,0 +1,279 @@
+package com.asmr.player.subtitle
+
+import android.content.Context
+import android.os.Build
+import com.asmr.player.BuildConfig
+import java.io.BufferedInputStream
+import java.io.File
+import java.io.FileInputStream
+import java.io.FileOutputStream
+import java.security.MessageDigest
+import java.util.zip.ZipInputStream
+
+internal data class SherpaOnnxRuntimeLibrary(
+    val archivePath: String,
+    val fileName: String,
+    val bytes: Long,
+    val sha256: String
+)
+
+internal data class SherpaOnnxRuntimeDescriptor(
+    val version: String,
+    val abi: String,
+    val url: String,
+    val archiveFileName: String,
+    val archiveBytes: Long,
+    val archiveSha256: String,
+    val libraries: List<SherpaOnnxRuntimeLibrary>
+) {
+    val extractedBytes: Long = libraries.sumOf(SherpaOnnxRuntimeLibrary::bytes)
+}
+
+internal object SherpaOnnxRuntimeRelease {
+    val current: SherpaOnnxRuntimeDescriptor
+        get() = SherpaOnnxRuntimeDescriptor(
+            version = "1.13.2",
+            abi = "arm64-v8a",
+            url = BuildConfig.SUBTITLE_RUNTIME_URL,
+            archiveFileName = "sherpa-onnx-runtime-1.13.2-android-arm64-v8a.zip",
+            archiveBytes = 11_311_151L,
+            archiveSha256 = "bfa564c5da27a7ab734d4c788cafd7c95c1e4934e02056be24358532d3d33c2e",
+            libraries = listOf(
+                SherpaOnnxRuntimeLibrary(
+                    archivePath = "arm64-v8a/libonnxruntime.so",
+                    fileName = "libonnxruntime.so",
+                    bytes = 25_831_632L,
+                    sha256 = "4d2318b3849abb8862133d3068fc7e807ed8b2671cc6d83657fff2fcb9e1caad"
+                ),
+                SherpaOnnxRuntimeLibrary(
+                    archivePath = "arm64-v8a/libsherpa-onnx-jni.so",
+                    fileName = "libsherpa-onnx-jni.so",
+                    bytes = 4_623_192L,
+                    sha256 = "fc072f201dc1923ee98b594eb61c796b538ef087f7f18d08dcfdf0565167a8bd"
+                )
+            )
+        )
+}
+
+internal class SherpaOnnxRuntimeRepository private constructor(context: Context) {
+    private val appContext = context.applicationContext
+    val descriptor: SherpaOnnxRuntimeDescriptor = SherpaOnnxRuntimeRelease.current
+
+    fun isInstalled(): Boolean = SherpaOnnxRuntimeInstaller.isInstalled(
+        directory = runtimeDirectory(),
+        descriptor = descriptor
+    )
+
+    fun requireInstalledDirectory(): File = runtimeDirectory().takeIf {
+        SherpaOnnxRuntimeInstaller.isInstalled(it, descriptor)
+    } ?: throw IllegalStateException(RUNTIME_REQUIRED_MESSAGE)
+
+    internal fun ensureDownloadDirectory(): File = downloadDirectory().apply {
+        check(exists() || mkdirs()) { "无法创建字幕运行时下载目录" }
+    }
+
+    internal fun partialArchiveFile(): File = File(
+        ensureDownloadDirectory(),
+        "${descriptor.archiveFileName}.part"
+    )
+
+    internal fun downloadedArchiveBytes(): Long = partialArchiveFile()
+        .length()
+        .coerceIn(0L, descriptor.archiveBytes)
+
+    internal fun deletePartialArchive(): Boolean {
+        val partial = File(downloadDirectory(), "${descriptor.archiveFileName}.part")
+        return !partial.exists() || partial.delete()
+    }
+
+    internal fun installDownloadedArchive() {
+        val archive = partialArchiveFile()
+        try {
+            SherpaOnnxRuntimeInstaller.install(
+                archive = archive,
+                destinationDirectory = runtimeDirectory(),
+                descriptor = descriptor
+            )
+        } catch (error: Throwable) {
+            archive.delete()
+            throw error
+        }
+        check(archive.delete()) { "无法清理字幕运行时压缩包" }
+        downloadDirectory().takeIf { it.isDirectory && it.list().isNullOrEmpty() }?.delete()
+    }
+
+    private fun runtimeDirectory(): File = File(
+        File(File(appContext.filesDir, RUNTIME_ROOT_DIRECTORY_NAME), descriptor.version),
+        descriptor.abi
+    )
+
+    private fun downloadDirectory(): File = File(
+        appContext.filesDir,
+        RUNTIME_DOWNLOAD_DIRECTORY_NAME
+    )
+
+    companion object {
+        const val RUNTIME_REQUIRED_MESSAGE = "请先在设置中下载日语字幕组件"
+        private const val RUNTIME_ROOT_DIRECTORY_NAME = "subtitle-runtimes"
+        private const val RUNTIME_DOWNLOAD_DIRECTORY_NAME = "subtitle-runtime-downloads"
+
+        @Volatile
+        private var instance: SherpaOnnxRuntimeRepository? = null
+
+        fun get(context: Context): SherpaOnnxRuntimeRepository {
+            return instance ?: synchronized(this) {
+                instance ?: SherpaOnnxRuntimeRepository(context).also { instance = it }
+            }
+        }
+    }
+}
+
+internal object SherpaOnnxRuntimeInstaller {
+    fun isInstalled(
+        directory: File,
+        descriptor: SherpaOnnxRuntimeDescriptor
+    ): Boolean = directory.isDirectory && descriptor.libraries.all { library ->
+        val file = File(directory, library.fileName)
+        file.isFile && file.length() == library.bytes && !file.canWrite()
+    }
+
+    fun install(
+        archive: File,
+        destinationDirectory: File,
+        descriptor: SherpaOnnxRuntimeDescriptor
+    ) {
+        requirePinnedFile(archive, descriptor.archiveBytes, descriptor.archiveSha256)
+        val parent = destinationDirectory.parentFile
+            ?: throw IllegalStateException("字幕运行时目录无效")
+        check(parent.exists() || parent.mkdirs()) { "无法创建字幕运行时目录" }
+        val stagingDirectory = File(parent, "${destinationDirectory.name}.installing")
+        if (stagingDirectory.exists()) {
+            check(stagingDirectory.deleteRecursively()) { "无法清理旧的字幕运行时临时目录" }
+        }
+        check(stagingDirectory.mkdir()) { "无法创建字幕运行时临时目录" }
+
+        try {
+            extractPinnedLibraries(archive, stagingDirectory, descriptor)
+            check(isInstalled(stagingDirectory, descriptor)) { "字幕运行时安装结果无效" }
+            if (destinationDirectory.exists()) {
+                check(destinationDirectory.deleteRecursively()) { "无法替换旧的字幕运行时" }
+            }
+            check(stagingDirectory.renameTo(destinationDirectory)) { "无法保存字幕运行时" }
+        } catch (error: Throwable) {
+            stagingDirectory.deleteRecursively()
+            throw error
+        }
+    }
+
+    fun verifyForLoading(
+        directory: File,
+        descriptor: SherpaOnnxRuntimeDescriptor
+    ) {
+        check(isInstalled(directory, descriptor)) { "字幕运行时缺失或仍可写" }
+        descriptor.libraries.forEach { library ->
+            requirePinnedFile(File(directory, library.fileName), library.bytes, library.sha256)
+        }
+    }
+
+    private fun extractPinnedLibraries(
+        archive: File,
+        stagingDirectory: File,
+        descriptor: SherpaOnnxRuntimeDescriptor
+    ) {
+        val expectedByPath = descriptor.libraries.associateBy(SherpaOnnxRuntimeLibrary::archivePath)
+        val extractedPaths = mutableSetOf<String>()
+        ZipInputStream(BufferedInputStream(FileInputStream(archive))).use { input ->
+            while (true) {
+                val entry = input.nextEntry ?: break
+                check(!entry.isDirectory) { "字幕运行时压缩包包含多余目录" }
+                val library = expectedByPath[entry.name]
+                    ?: throw IllegalStateException("字幕运行时压缩包包含未知文件：${entry.name}")
+                check(extractedPaths.add(entry.name)) { "字幕运行时压缩包包含重复文件：${entry.name}" }
+                val outputFile = File(stagingDirectory, library.fileName)
+                check(outputFile.canonicalFile.parentFile == stagingDirectory.canonicalFile) {
+                    "字幕运行时文件路径无效"
+                }
+                writePinnedLibrary(input, outputFile, library)
+                input.closeEntry()
+            }
+        }
+        check(extractedPaths == expectedByPath.keys) { "字幕运行时压缩包缺少必要文件" }
+    }
+
+    private fun writePinnedLibrary(
+        input: ZipInputStream,
+        outputFile: File,
+        library: SherpaOnnxRuntimeLibrary
+    ) {
+        val digest = MessageDigest.getInstance("SHA-256")
+        var writtenBytes = 0L
+        FileOutputStream(outputFile).use { output ->
+            val buffer = ByteArray(FILE_BUFFER_BYTES)
+            while (true) {
+                val read = input.read(buffer)
+                if (read < 0) break
+                if (read == 0) continue
+                writtenBytes += read.toLong()
+                check(writtenBytes <= library.bytes) { "字幕运行时文件大小异常：${library.fileName}" }
+                output.write(buffer, 0, read)
+                digest.update(buffer, 0, read)
+            }
+            output.flush()
+            output.fd.sync()
+        }
+        check(writtenBytes == library.bytes) { "字幕运行时文件不完整：${library.fileName}" }
+        check(digest.toHex().equals(library.sha256, ignoreCase = true)) {
+            "字幕运行时文件校验失败：${library.fileName}"
+        }
+        outputFile.setReadable(true, false)
+        outputFile.setExecutable(true, false)
+        check(outputFile.setWritable(false, false) && !outputFile.canWrite()) {
+            "无法将字幕运行时文件设为只读：${library.fileName}"
+        }
+    }
+
+    private fun requirePinnedFile(file: File, expectedBytes: Long, expectedSha256: String) {
+        check(file.isFile && file.length() == expectedBytes) { "文件大小校验失败：${file.name}" }
+        val digest = MessageDigest.getInstance("SHA-256")
+        FileInputStream(file).use { input ->
+            val buffer = ByteArray(FILE_BUFFER_BYTES)
+            while (true) {
+                val read = input.read(buffer)
+                if (read < 0) break
+                if (read > 0) digest.update(buffer, 0, read)
+            }
+        }
+        check(digest.toHex().equals(expectedSha256, ignoreCase = true)) {
+            "文件校验失败：${file.name}"
+        }
+    }
+
+    private fun MessageDigest.toHex(): String = digest().joinToString("") { byte ->
+        "%02x".format(byte)
+    }
+
+    private const val FILE_BUFFER_BYTES = 1024 * 1024
+}
+
+internal object SherpaOnnxNativeLoader {
+    @Volatile
+    private var loaded = false
+
+    fun load(context: Context) {
+        if (loaded) return
+        synchronized(this) {
+            if (loaded) return
+            val repository = SherpaOnnxRuntimeRepository.get(context)
+            val descriptor = repository.descriptor
+            check(Build.SUPPORTED_ABIS.any { it == descriptor.abi }) {
+                "当前设备不支持 ${descriptor.abi} 字幕运行时"
+            }
+            val directory = repository.requireInstalledDirectory()
+            SherpaOnnxRuntimeInstaller.verifyForLoading(directory, descriptor)
+            descriptor.libraries.forEach { library ->
+                System.load(File(directory, library.fileName).absolutePath)
+            }
+            loaded = true
+        }
+    }
+}

--- a/app/src/main/java/com/asmr/player/subtitle/SubtitleArtifactDownloader.kt
+++ b/app/src/main/java/com/asmr/player/subtitle/SubtitleArtifactDownloader.kt
@@ -1,0 +1,82 @@
+package com.asmr.player.subtitle
+
+import com.asmr.player.data.remote.NetworkHeaders
+import java.io.File
+import java.io.FileOutputStream
+import java.io.IOException
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.ensureActive
+import okhttp3.OkHttpClient
+import okhttp3.Request
+
+internal object SubtitleArtifactDownloader {
+    suspend fun download(
+        client: OkHttpClient,
+        url: String,
+        destination: File,
+        expectedBytes: Long,
+        onProgress: suspend (downloadedBytes: Long) -> Unit
+    ) {
+        var existingBytes = destination.length().coerceIn(0L, expectedBytes)
+        if (destination.length() != existingBytes) {
+            check(destination.delete()) { "无法清理无效的临时下载文件" }
+            existingBytes = 0L
+        }
+        onProgress(existingBytes)
+        if (existingBytes == expectedBytes) return
+
+        val requestBuilder = Request.Builder()
+            .url(url)
+            .header("User-Agent", "Eara-Android")
+            .header(NetworkHeaders.HEADER_SILENT_IO_ERROR, NetworkHeaders.SILENT_IO_ERROR_ON)
+        if (existingBytes > 0L) requestBuilder.header("Range", "bytes=$existingBytes-")
+
+        client.newCall(requestBuilder.get().build()).execute().use { response ->
+            if (!response.isSuccessful) {
+                throw IOException("下载失败：${response.code} ${response.message}")
+            }
+            val append = existingBytes > 0L && response.code == 206
+            if (append) {
+                val expectedRangePrefix = "bytes $existingBytes-"
+                val contentRange = response.header("Content-Range").orEmpty()
+                if (!contentRange.startsWith(expectedRangePrefix)) {
+                    destination.delete()
+                    throw IOException("下载源返回了无效的断点数据")
+                }
+            }
+            if (!append) existingBytes = 0L
+
+            val body = response.body ?: throw IOException("下载失败：空响应体")
+            var downloadedBytes = existingBytes
+            var lastUpdateAt = 0L
+            FileOutputStream(destination, append).use { output ->
+                body.byteStream().use { input ->
+                    val buffer = ByteArray(DOWNLOAD_BUFFER_BYTES)
+                    while (true) {
+                        currentCoroutineContext().ensureActive()
+                        val read = input.read(buffer)
+                        if (read < 0) break
+                        if (read == 0) continue
+                        output.write(buffer, 0, read)
+                        downloadedBytes += read.toLong()
+                        check(downloadedBytes <= expectedBytes) { "下载文件大小异常" }
+                        val now = System.nanoTime() / 1_000_000L
+                        if (now - lastUpdateAt >= PROGRESS_UPDATE_INTERVAL_MS) {
+                            onProgress(downloadedBytes)
+                            lastUpdateAt = now
+                        }
+                    }
+                }
+                output.flush()
+                output.fd.sync()
+            }
+            if (downloadedBytes != expectedBytes) {
+                throw IOException("下载不完整（${downloadedBytes}/${expectedBytes} 字节）")
+            }
+            onProgress(downloadedBytes)
+        }
+    }
+
+    private const val DOWNLOAD_BUFFER_BYTES = 256 * 1024
+    private const val PROGRESS_UPDATE_INTERVAL_MS = 250L
+}

--- a/app/src/main/java/com/asmr/player/subtitle/SubtitleModelDownloadWorker.kt
+++ b/app/src/main/java/com/asmr/player/subtitle/SubtitleModelDownloadWorker.kt
@@ -6,21 +6,18 @@ import android.content.Context
 import android.content.pm.ServiceInfo
 import android.os.Build
 import android.os.StatFs
-import android.os.SystemClock
 import androidx.core.app.NotificationCompat
 import androidx.work.CoroutineWorker
 import androidx.work.ForegroundInfo
 import androidx.work.WorkerParameters
 import androidx.work.workDataOf
 import com.asmr.player.R
-import com.asmr.player.data.remote.NetworkHeaders
 import dagger.hilt.EntryPoint
 import dagger.hilt.InstallIn
 import dagger.hilt.android.EntryPointAccessors
 import dagger.hilt.components.SingletonComponent
 import java.io.File
 import java.io.FileInputStream
-import java.io.FileOutputStream
 import java.io.IOException
 import java.security.MessageDigest
 import kotlinx.coroutines.CancellationException
@@ -29,7 +26,6 @@ import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.withContext
 import okhttp3.OkHttpClient
-import okhttp3.Request
 
 internal class SubtitleModelDownloadWorker(
     appContext: Context,
@@ -48,44 +44,88 @@ internal class SubtitleModelDownloadWorker(
         if (!baseUrl.startsWith("https://")) return@withContext Result.failure()
 
         val repository = SubtitleModelRepository.get(applicationContext)
+        val runtimeRepository = SherpaOnnxRuntimeRepository.get(applicationContext)
+        val runtime = runtimeRepository.descriptor
+        if (!runtime.url.startsWith("https://")) return@withContext Result.failure()
         val model = SubtitleTranscriptionModels.PARAKEET_TDT_CTC_06B_JA_INT8
+        val totalBytes = repository.installationBytes()
+        var activeStage = SubtitleModelInstallStage.Runtime
         try {
             val modelDirectory = repository.ensureModelDirectory()
             if (repository.isModelAvailable()) {
                 repository.updateAvailable(source)
                 return@withContext Result.success()
             }
-            setForeground(createForegroundInfo(0L, model.artifactBytes, "准备下载"))
-            ensureFreeSpace(
-                destinationDirectory = modelDirectory,
-                expectedBytes = model.artifactBytes,
-                existingBytes = repository.downloadedModelBytes()
+            setForeground(
+                createForegroundInfo(
+                    repository.downloadedInstallationBytes(),
+                    totalBytes,
+                    "准备下载字幕组件"
+                )
             )
             val client = EntryPointAccessors.fromApplication(
                 applicationContext,
                 WorkerEntryPoint::class.java
             ).okHttpClient()
+
+            if (!runtimeRepository.isInstalled()) {
+                val runtimeDirectory = runtimeRepository.ensureDownloadDirectory()
+                val partialRuntime = runtimeRepository.partialArchiveFile()
+                ensureFreeSpace(
+                    destinationDirectory = runtimeDirectory,
+                    expectedBytes = runtime.archiveBytes + runtime.extractedBytes,
+                    existingBytes = runtimeRepository.downloadedArchiveBytes()
+                )
+                download(
+                    client = client,
+                    url = runtime.url,
+                    source = source,
+                    stage = SubtitleModelInstallStage.Runtime,
+                    destination = partialRuntime,
+                    expectedBytes = runtime.archiveBytes,
+                    completedBefore = repository.downloadedModelBytes(),
+                    totalBytes = totalBytes,
+                    repository = repository
+                )
+                activeStage = SubtitleModelInstallStage.RuntimeVerification
+                repository.updateVerifying(source, activeStage)
+                publishStage(
+                    stage = activeStage,
+                    downloadedBytes = runtime.archiveBytes + repository.downloadedModelBytes(),
+                    totalBytes = totalBytes
+                )
+                runtimeRepository.installDownloadedArchive()
+            }
+
+            activeStage = SubtitleModelInstallStage.Model
+            ensureFreeSpace(
+                destinationDirectory = modelDirectory,
+                expectedBytes = model.artifactBytes,
+                existingBytes = repository.downloadedModelBytes()
+            )
             model.artifacts.forEach { artifact ->
                 if (isInstalledSubtitleModelArtifact(repository.artifactFile(artifact), artifact.bytes)) {
                     return@forEach
                 }
                 val partialFile = repository.partialArtifactFile(artifact)
                 val currentPartialBytes = partialFile.length().coerceIn(0L, artifact.bytes)
-                val completedBefore = repository.downloadedModelBytes() - currentPartialBytes
+                val completedBefore = runtime.archiveBytes +
+                    repository.downloadedModelBytes() - currentPartialBytes
                 download(
                     client = client,
                     url = buildSubtitleModelArtifactUrl(baseUrl, artifact.fileName),
                     source = source,
+                    stage = activeStage,
                     destination = partialFile,
                     expectedBytes = artifact.bytes,
                     completedBefore = completedBefore,
-                    totalBytes = model.artifactBytes,
+                    totalBytes = totalBytes,
                     repository = repository
                 )
             }
-            repository.updateVerifying(source)
-            setProgress(workDataOf(KEY_STAGE to STAGE_VERIFYING))
-            setForeground(createForegroundInfo(model.artifactBytes, model.artifactBytes, "正在校验"))
+            activeStage = SubtitleModelInstallStage.ModelVerification
+            repository.updateVerifying(source, activeStage)
+            publishStage(activeStage, totalBytes, totalBytes)
             model.artifacts.forEach { artifact ->
                 val targetFile = repository.artifactFile(artifact)
                 if (isInstalledSubtitleModelArtifact(targetFile, artifact.bytes)) return@forEach
@@ -102,20 +142,21 @@ internal class SubtitleModelDownloadWorker(
             repository.updateAvailable(source)
             Result.success(
                 workDataOf(
-                    KEY_DOWNLOADED_BYTES to model.artifactBytes,
-                    KEY_TOTAL_BYTES to model.artifactBytes
+                    KEY_DOWNLOADED_BYTES to totalBytes,
+                    KEY_TOTAL_BYTES to totalBytes
                 )
             )
         } catch (cancelled: CancellationException) {
             repository.updateMissing()
             throw cancelled
         } catch (error: Throwable) {
-            val message = error.message?.trim().orEmpty().ifBlank { "模型下载失败" }
+            val message = error.message?.trim().orEmpty().ifBlank { "字幕组件下载失败" }
             if (runAttemptCount < MAX_RETRY_COUNT && error is IOException) {
                 repository.updateDownloading(
                     source,
-                    repository.downloadedModelBytes(),
-                    model.artifactBytes
+                    activeStage,
+                    repository.downloadedInstallationBytes(),
+                    totalBytes
                 )
                 Result.retry()
             } else {
@@ -129,84 +170,22 @@ internal class SubtitleModelDownloadWorker(
         client: OkHttpClient,
         url: String,
         source: SubtitleModelDownloadSource,
+        stage: SubtitleModelInstallStage,
         destination: File,
         expectedBytes: Long,
         completedBefore: Long,
         totalBytes: Long,
         repository: SubtitleModelRepository
     ) {
-        var existingBytes = destination.length().coerceIn(0L, expectedBytes)
-        if (destination.length() != existingBytes) {
-            check(destination.delete()) { "无法清理无效的临时模型" }
-            existingBytes = 0L
-        }
-        repository.updateDownloading(source, completedBefore + existingBytes, totalBytes)
-        if (existingBytes == expectedBytes) {
+        SubtitleArtifactDownloader.download(
+            client = client,
+            url = url,
+            destination = destination,
+            expectedBytes = expectedBytes
+        ) { downloadedBytes ->
             publishProgress(
                 source,
-                repository,
-                completedBefore + existingBytes,
-                totalBytes
-            )
-            return
-        }
-
-        val requestBuilder = Request.Builder()
-            .url(url)
-            .header("User-Agent", "Eara-Android")
-            .header(NetworkHeaders.HEADER_SILENT_IO_ERROR, NetworkHeaders.SILENT_IO_ERROR_ON)
-        if (existingBytes > 0L) requestBuilder.header("Range", "bytes=$existingBytes-")
-
-        client.newCall(requestBuilder.get().build()).execute().use { response ->
-            if (!response.isSuccessful) {
-                throw IOException("下载失败：${response.code} ${response.message}")
-            }
-            val append = existingBytes > 0L && response.code == 206
-            if (append) {
-                val expectedRangePrefix = "bytes $existingBytes-"
-                val contentRange = response.header("Content-Range").orEmpty()
-                if (!contentRange.startsWith(expectedRangePrefix)) {
-                    destination.delete()
-                    throw IOException("下载源返回了无效的断点数据")
-                }
-            }
-            if (!append) {
-                existingBytes = 0L
-            }
-            val body = response.body ?: throw IOException("下载失败：空响应体")
-            var downloadedBytes = existingBytes
-            var lastUpdateAt = 0L
-            FileOutputStream(destination, append).use { output ->
-                body.byteStream().use { input ->
-                    val buffer = ByteArray(DOWNLOAD_BUFFER_BYTES)
-                    while (true) {
-                        currentCoroutineContext().ensureActive()
-                        val read = input.read(buffer)
-                        if (read < 0) break
-                        if (read == 0) continue
-                        output.write(buffer, 0, read)
-                        downloadedBytes += read.toLong()
-                        check(downloadedBytes <= expectedBytes) { "下载的模型文件大小异常" }
-                        val now = SystemClock.elapsedRealtime()
-                        if (now - lastUpdateAt >= PROGRESS_UPDATE_INTERVAL_MS) {
-                            publishProgress(
-                                source,
-                                repository,
-                                completedBefore + downloadedBytes,
-                                totalBytes
-                            )
-                            lastUpdateAt = now
-                        }
-                    }
-                }
-                output.flush()
-                output.fd.sync()
-            }
-            if (downloadedBytes != expectedBytes) {
-                throw IOException("模型下载不完整（${downloadedBytes}/${expectedBytes} 字节）")
-            }
-            publishProgress(
-                source,
+                stage,
                 repository,
                 completedBefore + downloadedBytes,
                 totalBytes
@@ -216,19 +195,35 @@ internal class SubtitleModelDownloadWorker(
 
     private suspend fun publishProgress(
         source: SubtitleModelDownloadSource,
+        stage: SubtitleModelInstallStage,
         repository: SubtitleModelRepository,
         downloadedBytes: Long,
         totalBytes: Long
     ) {
-        repository.updateDownloading(source, downloadedBytes, totalBytes)
+        repository.updateDownloading(source, stage, downloadedBytes, totalBytes)
         setProgress(
             workDataOf(
-                KEY_STAGE to STAGE_DOWNLOADING,
+                KEY_STAGE to stage.name,
                 KEY_DOWNLOADED_BYTES to downloadedBytes,
                 KEY_TOTAL_BYTES to totalBytes
             )
         )
-        setForeground(createForegroundInfo(downloadedBytes, totalBytes, "正在下载"))
+        setForeground(createForegroundInfo(downloadedBytes, totalBytes, stage.displayName))
+    }
+
+    private suspend fun publishStage(
+        stage: SubtitleModelInstallStage,
+        downloadedBytes: Long,
+        totalBytes: Long
+    ) {
+        setProgress(
+            workDataOf(
+                KEY_STAGE to stage.name,
+                KEY_DOWNLOADED_BYTES to downloadedBytes,
+                KEY_TOTAL_BYTES to totalBytes
+            )
+        )
+        setForeground(createForegroundInfo(downloadedBytes, totalBytes, stage.displayName))
     }
 
     private suspend fun sha256(file: File): String {
@@ -266,7 +261,7 @@ internal class SubtitleModelDownloadWorker(
             notificationManager.createNotificationChannel(
                 NotificationChannel(
                     NOTIFICATION_CHANNEL_ID,
-                    "日语字幕模型下载",
+                    "日语字幕组件下载",
                     NotificationManager.IMPORTANCE_LOW
                 )
             )
@@ -278,7 +273,7 @@ internal class SubtitleModelDownloadWorker(
         }
         val notification = NotificationCompat.Builder(applicationContext, NOTIFICATION_CHANNEL_ID)
             .setSmallIcon(R.drawable.ic_launcher_foreground)
-            .setContentTitle("日语字幕模型")
+            .setContentTitle("日语字幕组件")
             .setContentText(stage)
             .setOnlyAlertOnce(true)
             .setOngoing(true)
@@ -299,12 +294,7 @@ internal class SubtitleModelDownloadWorker(
         const val KEY_DOWNLOADED_BYTES = "downloadedBytes"
         const val KEY_TOTAL_BYTES = "totalBytes"
         const val KEY_ERROR_MESSAGE = "errorMessage"
-        const val STAGE_DOWNLOADING = "downloading"
-        const val STAGE_VERIFYING = "verifying"
-
-        private const val DOWNLOAD_BUFFER_BYTES = 256 * 1024
         private const val HASH_BUFFER_BYTES = 1024 * 1024
-        private const val PROGRESS_UPDATE_INTERVAL_MS = 250L
         private const val FREE_SPACE_RESERVE_BYTES = 128L * 1024L * 1024L
         private const val MAX_RETRY_COUNT = 2
         private const val NOTIFICATION_CHANNEL_ID = "subtitle_model_download"

--- a/app/src/main/java/com/asmr/player/subtitle/SubtitleModelRepository.kt
+++ b/app/src/main/java/com/asmr/player/subtitle/SubtitleModelRepository.kt
@@ -52,12 +52,14 @@ internal sealed interface SubtitleModelState {
 
     data class Downloading(
         val source: SubtitleModelDownloadSource,
+        val stage: SubtitleModelInstallStage,
         val downloadedBytes: Long,
         val totalBytes: Long
     ) : SubtitleModelState
 
     data class Verifying(
-        val source: SubtitleModelDownloadSource
+        val source: SubtitleModelDownloadSource,
+        val stage: SubtitleModelInstallStage
     ) : SubtitleModelState
 
     data class Available(
@@ -68,6 +70,13 @@ internal sealed interface SubtitleModelState {
         val source: SubtitleModelDownloadSource,
         val message: String
     ) : SubtitleModelState
+}
+
+internal enum class SubtitleModelInstallStage(val displayName: String) {
+    Runtime("正在下载字幕运行时"),
+    RuntimeVerification("正在校验并安装字幕运行时"),
+    Model("正在下载日语字幕模型"),
+    ModelVerification("正在校验日语字幕模型")
 }
 
 internal fun buildSubtitleModelArtifactUrl(baseUrl: String, fileName: String): String {
@@ -87,11 +96,13 @@ internal fun isInstalledSubtitleModelArtifact(
 internal class SubtitleModelRepository private constructor(context: Context) {
     private val appContext = context.applicationContext
     private val model = SubtitleTranscriptionModels.PARAKEET_TDT_CTC_06B_JA_INT8
+    private val runtimeRepository = SherpaOnnxRuntimeRepository.get(appContext)
     private val preferences = appContext.getSharedPreferences(PREFERENCES_NAME, Context.MODE_PRIVATE)
     private val _state = MutableStateFlow(initialState())
     val state: StateFlow<SubtitleModelState> = _state.asStateFlow()
 
-    fun isModelAvailable(): Boolean = installedModelDirectoryOrNull() != null
+    fun isModelAvailable(): Boolean =
+        runtimeRepository.isInstalled() && installedModelDirectoryOrNull() != null
 
     fun requireInstalledModelDirectory(): File {
         return installedModelDirectoryOrNull()
@@ -105,6 +116,9 @@ internal class SubtitleModelRepository private constructor(context: Context) {
         }
         val baseUrl = source.downloadBaseUrl().trim()
         require(baseUrl.startsWith("https://")) { "模型下载地址未配置" }
+        require(runtimeRepository.descriptor.url.trim().startsWith("https://")) {
+            "字幕运行时下载地址未配置"
+        }
         _state.value = SubtitleModelState.Queued(source)
         val request = OneTimeWorkRequestBuilder<SubtitleModelDownloadWorker>()
             .setInputData(
@@ -140,6 +154,7 @@ internal class SubtitleModelRepository private constructor(context: Context) {
             .result
             .get()
         deletePartialModelFiles()
+        runtimeRepository.deletePartialArchive()
         _state.value = initialState()
     }
 
@@ -159,18 +174,23 @@ internal class SubtitleModelRepository private constructor(context: Context) {
 
     internal fun updateDownloading(
         source: SubtitleModelDownloadSource,
+        stage: SubtitleModelInstallStage,
         downloadedBytes: Long,
         totalBytes: Long
     ) {
         _state.value = SubtitleModelState.Downloading(
             source = source,
+            stage = stage,
             downloadedBytes = downloadedBytes.coerceAtLeast(0L),
             totalBytes = totalBytes.coerceAtLeast(0L)
         )
     }
 
-    internal fun updateVerifying(source: SubtitleModelDownloadSource) {
-        _state.value = SubtitleModelState.Verifying(source)
+    internal fun updateVerifying(
+        source: SubtitleModelDownloadSource,
+        stage: SubtitleModelInstallStage
+    ) {
+        _state.value = SubtitleModelState.Verifying(source, stage)
     }
 
     internal fun updateAvailable(source: SubtitleModelDownloadSource) {
@@ -204,6 +224,18 @@ internal class SubtitleModelRepository private constructor(context: Context) {
         }
     }
 
+    internal fun downloadedInstallationBytes(): Long {
+        val runtimeBytes = if (runtimeRepository.isInstalled()) {
+            runtimeRepository.descriptor.archiveBytes
+        } else {
+            runtimeRepository.downloadedArchiveBytes()
+        }
+        return runtimeBytes + downloadedModelBytes()
+    }
+
+    internal fun installationBytes(): Long =
+        runtimeRepository.descriptor.archiveBytes + model.artifactBytes
+
     internal fun deletePartialModelFiles(): Boolean = model.artifacts.all { artifact ->
         deleteIfPresent(partialArtifactFile(artifact))
     }
@@ -226,6 +258,7 @@ internal class SubtitleModelRepository private constructor(context: Context) {
     }
 
     private fun initialState(): SubtitleModelState {
+        if (!runtimeRepository.isInstalled()) return SubtitleModelState.Missing
         installedModelDirectoryOrNull() ?: return SubtitleModelState.Missing
         val source = SubtitleModelDownloadSource.fromId(
             preferences.getString(KEY_INSTALLED_SOURCE, null)
@@ -240,7 +273,7 @@ internal class SubtitleModelRepository private constructor(context: Context) {
     private fun deleteIfPresent(file: File): Boolean = !file.exists() || file.delete()
 
     companion object {
-        const val MODEL_REQUIRED_MESSAGE = "请先在设置中下载日语字幕模型"
+        const val MODEL_REQUIRED_MESSAGE = "请先在设置中下载日语字幕组件"
 
         private const val MODEL_ROOT_DIRECTORY_NAME = "subtitle-models"
         private const val PREFERENCES_NAME = "subtitle_model_preferences"

--- a/app/src/main/java/com/asmr/player/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/settings/SettingsScreen.kt
@@ -965,7 +965,7 @@ fun SettingsScreen(
     if (showDeleteSubtitleModelConfirmation) {
         FlatActionDialog(
             onDismissRequest = { showDeleteSubtitleModelConfirmation = false },
-            message = "确定删除字幕模型？",
+            message = "确定删除字幕模型？约 29 MiB 的字幕运行时会保留，之后重新下载模型时无需重复安装。",
             actions = listOf(
                 FlatDialogAction("取消", onClick = { showDeleteSubtitleModelConfirmation = false }),
                 FlatDialogAction(
@@ -1152,6 +1152,11 @@ private fun SubtitleModelSettingsSection(
         style = MaterialTheme.typography.bodyMedium,
         fontWeight = FontWeight.SemiBold
     )
+    Text(
+        text = "首次下载会同时安装约 11 MiB 的字幕运行时；删除模型后运行时会保留。",
+        style = MaterialTheme.typography.bodySmall,
+        color = MaterialTheme.colorScheme.onSurfaceVariant
+    )
 
     if (state !is SubtitleModelState.Available) {
         SingleChoiceSegmentedButtonRow(modifier = Modifier.fillMaxWidth()) {
@@ -1177,8 +1182,20 @@ private fun SubtitleModelSettingsSection(
 
     when (state) {
         SubtitleModelState.Missing -> Unit
-        is SubtitleModelState.Queued -> LinearProgressIndicator(modifier = Modifier.fillMaxWidth())
+        is SubtitleModelState.Queued -> {
+            Text(
+                text = "等待下载字幕组件",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+            LinearProgressIndicator(modifier = Modifier.fillMaxWidth())
+        }
         is SubtitleModelState.Downloading -> {
+            Text(
+                text = state.stage.displayName,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
             val progress = if (state.totalBytes > 0L) {
                 (state.downloadedBytes.toFloat() / state.totalBytes.toFloat()).coerceIn(0f, 1f)
             } else {
@@ -1190,7 +1207,14 @@ private fun SubtitleModelSettingsSection(
                 LinearProgressIndicator(modifier = Modifier.fillMaxWidth())
             }
         }
-        is SubtitleModelState.Verifying -> LinearProgressIndicator(modifier = Modifier.fillMaxWidth())
+        is SubtitleModelState.Verifying -> {
+            Text(
+                text = state.stage.displayName,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+            LinearProgressIndicator(modifier = Modifier.fillMaxWidth())
+        }
         is SubtitleModelState.Available -> Unit
         is SubtitleModelState.Failed -> {
             Text(
@@ -1236,7 +1260,7 @@ private fun SubtitleModelSettingsSection(
                     when {
                         !deviceSupported -> "设备不支持"
                         !sourceConfigured -> "来源不可用"
-                        else -> "下载模型"
+                        else -> "下载字幕组件"
                     }
                 )
             }

--- a/app/src/main/java/com/k2fsa/sherpa/onnx/OfflineRecognizer.kt
+++ b/app/src/main/java/com/k2fsa/sherpa/onnx/OfflineRecognizer.kt
@@ -1,0 +1,212 @@
+package com.k2fsa.sherpa.onnx
+
+import android.content.res.AssetManager
+
+data class OfflineRecognizerResult(
+    val text: String,
+    val tokens: Array<String>,
+    val timestamps: FloatArray,
+    val lang: String,
+    val emotion: String,
+    val event: String,
+    val durations: FloatArray
+)
+
+data class OfflineTransducerModelConfig(
+    var encoder: String = "",
+    var decoder: String = "",
+    var joiner: String = ""
+)
+
+data class OfflineParaformerModelConfig(
+    var model: String = "",
+    var qnnConfig: QnnConfig = QnnConfig()
+)
+
+data class OfflineNemoEncDecCtcModelConfig(
+    var model: String = ""
+)
+
+data class OfflineDolphinModelConfig(
+    var model: String = ""
+)
+
+data class OfflineZipformerCtcModelConfig(
+    var model: String = "",
+    var qnnConfig: QnnConfig = QnnConfig()
+)
+
+data class OfflineWenetCtcModelConfig(
+    var model: String = ""
+)
+
+data class OfflineOmnilingualAsrCtcModelConfig(
+    var model: String = ""
+)
+
+data class OfflineMedAsrCtcModelConfig(
+    var model: String = ""
+)
+
+data class OfflineFireRedAsrCtcModelConfig(
+    var model: String = ""
+)
+
+data class OfflineFunAsrNanoModelConfig(
+    var encoderAdaptor: String = "",
+    var llm: String = "",
+    var embedding: String = "",
+    var tokenizer: String = "",
+    var systemPrompt: String = "You are a helpful assistant.",
+    var userPrompt: String = "语音转写：",
+    var maxNewTokens: Int = 512,
+    var temperature: Float = 1e-6f,
+    var topP: Float = 0.8f,
+    var seed: Int = 42,
+    var language: String = "",
+    var itn: Boolean = true,
+    var hotwords: String = ""
+)
+
+data class OfflineQwen3AsrModelConfig(
+    var convFrontend: String = "",
+    var encoder: String = "",
+    var decoder: String = "",
+    var tokenizer: String = "",
+    var maxTotalLen: Int = 512,
+    var maxNewTokens: Int = 128,
+    var temperature: Float = 1e-6f,
+    var topP: Float = 0.8f,
+    var seed: Int = 42,
+    var hotwords: String = ""
+)
+
+data class OfflineWhisperModelConfig(
+    var encoder: String = "",
+    var decoder: String = "",
+    var language: String = "en",
+    var task: String = "transcribe",
+    var tailPaddings: Int = 1000,
+    var enableTokenTimestamps: Boolean = false,
+    var enableSegmentTimestamps: Boolean = false
+)
+
+data class OfflineCanaryModelConfig(
+    var encoder: String = "",
+    var decoder: String = "",
+    var srcLang: String = "en",
+    var tgtLang: String = "en",
+    var usePnc: Boolean = true
+)
+
+data class OfflineCohereTranscribeModelConfig(
+    var encoder: String = "",
+    var decoder: String = "",
+    var language: String = "",
+    var usePunct: Boolean = true,
+    var useItn: Boolean = true
+)
+
+data class OfflineFireRedAsrModelConfig(
+    var encoder: String = "",
+    var decoder: String = ""
+)
+
+data class OfflineMoonshineModelConfig(
+    var preprocessor: String = "",
+    var encoder: String = "",
+    var uncachedDecoder: String = "",
+    var cachedDecoder: String = "",
+    var mergedDecoder: String = ""
+)
+
+data class OfflineSenseVoiceModelConfig(
+    var model: String = "",
+    var language: String = "",
+    var useInverseTextNormalization: Boolean = true,
+    var qnnConfig: QnnConfig = QnnConfig()
+)
+
+data class OfflineModelConfig(
+    var transducer: OfflineTransducerModelConfig = OfflineTransducerModelConfig(),
+    var paraformer: OfflineParaformerModelConfig = OfflineParaformerModelConfig(),
+    var whisper: OfflineWhisperModelConfig = OfflineWhisperModelConfig(),
+    var fireRedAsr: OfflineFireRedAsrModelConfig = OfflineFireRedAsrModelConfig(),
+    var moonshine: OfflineMoonshineModelConfig = OfflineMoonshineModelConfig(),
+    var nemo: OfflineNemoEncDecCtcModelConfig = OfflineNemoEncDecCtcModelConfig(),
+    var senseVoice: OfflineSenseVoiceModelConfig = OfflineSenseVoiceModelConfig(),
+    var dolphin: OfflineDolphinModelConfig = OfflineDolphinModelConfig(),
+    var zipformerCtc: OfflineZipformerCtcModelConfig = OfflineZipformerCtcModelConfig(),
+    var wenetCtc: OfflineWenetCtcModelConfig = OfflineWenetCtcModelConfig(),
+    var omnilingual: OfflineOmnilingualAsrCtcModelConfig = OfflineOmnilingualAsrCtcModelConfig(),
+    var medasr: OfflineMedAsrCtcModelConfig = OfflineMedAsrCtcModelConfig(),
+    var funasrNano: OfflineFunAsrNanoModelConfig = OfflineFunAsrNanoModelConfig(),
+    var qwen3Asr: OfflineQwen3AsrModelConfig = OfflineQwen3AsrModelConfig(),
+    var fireRedAsrCtc: OfflineFireRedAsrCtcModelConfig = OfflineFireRedAsrCtcModelConfig(),
+    var canary: OfflineCanaryModelConfig = OfflineCanaryModelConfig(),
+    var cohereTranscribe: OfflineCohereTranscribeModelConfig = OfflineCohereTranscribeModelConfig(),
+    var teleSpeech: String = "",
+    var numThreads: Int = 1,
+    var debug: Boolean = false,
+    var provider: String = "cpu",
+    var modelType: String = "",
+    var tokens: String = "",
+    var modelingUnit: String = "",
+    var bpeVocab: String = ""
+)
+
+data class OfflineRecognizerConfig(
+    var featConfig: FeatureConfig = FeatureConfig(),
+    var modelConfig: OfflineModelConfig = OfflineModelConfig(),
+    var hr: HomophoneReplacerConfig = HomophoneReplacerConfig(),
+    var decodingMethod: String = "greedy_search",
+    var maxActivePaths: Int = 4,
+    var hotwordsFile: String = "",
+    var hotwordsScore: Float = 1.5f,
+    var ruleFsts: String = "",
+    var ruleFars: String = "",
+    var blankPenalty: Float = 0.0f
+)
+
+class OfflineRecognizer(
+    assetManager: AssetManager? = null,
+    val config: OfflineRecognizerConfig
+) {
+    private var ptr: Long = if (assetManager != null) {
+        newFromAsset(assetManager, config)
+    } else {
+        newFromFile(config)
+    }
+
+    protected fun finalize() {
+        if (ptr != 0L) {
+            delete(ptr)
+            ptr = 0L
+        }
+    }
+
+    fun release() = finalize()
+
+    fun createStream(): OfflineStream = OfflineStream(createStream(ptr))
+
+    fun createStream(hotwords: String): OfflineStream =
+        OfflineStream(createStreamWithHotwords(ptr, hotwords))
+
+    fun getResult(stream: OfflineStream): OfflineRecognizerResult = getResult(stream.ptr)
+
+    fun decode(stream: OfflineStream) = decode(ptr, stream.ptr)
+
+    fun setConfig(config: OfflineRecognizerConfig) = setConfig(ptr, config)
+
+    private external fun delete(ptr: Long)
+    private external fun createStream(ptr: Long): Long
+    private external fun createStreamWithHotwords(ptr: Long, hotwords: String): Long
+    private external fun setConfig(ptr: Long, config: OfflineRecognizerConfig)
+    private external fun newFromAsset(
+        assetManager: AssetManager,
+        config: OfflineRecognizerConfig
+    ): Long
+    private external fun newFromFile(config: OfflineRecognizerConfig): Long
+    private external fun decode(ptr: Long, streamPtr: Long)
+    private external fun getResult(streamPtr: Long): OfflineRecognizerResult
+}

--- a/app/src/main/java/com/k2fsa/sherpa/onnx/OfflineStream.kt
+++ b/app/src/main/java/com/k2fsa/sherpa/onnx/OfflineStream.kt
@@ -1,0 +1,24 @@
+package com.k2fsa.sherpa.onnx
+
+class OfflineStream(var ptr: Long) {
+    fun acceptWaveform(samples: FloatArray, sampleRate: Int) =
+        acceptWaveform(ptr, samples, sampleRate)
+
+    fun setOption(key: String, value: String) = setOption(ptr, key, value)
+
+    fun getOption(key: String): String = getOption(ptr, key)
+
+    protected fun finalize() {
+        if (ptr != 0L) {
+            delete(ptr)
+            ptr = 0L
+        }
+    }
+
+    fun release() = finalize()
+
+    private external fun acceptWaveform(ptr: Long, samples: FloatArray, sampleRate: Int)
+    private external fun setOption(ptr: Long, key: String, value: String)
+    private external fun getOption(ptr: Long, key: String): String
+    private external fun delete(ptr: Long)
+}

--- a/app/src/main/java/com/k2fsa/sherpa/onnx/README.md
+++ b/app/src/main/java/com/k2fsa/sherpa/onnx/README.md
@@ -1,0 +1,8 @@
+# sherpa-onnx Kotlin API
+
+这里保留了 sherpa-onnx `v1.13.2` Android Kotlin API 中本项目实际需要的 JNI 数据结构与包装类，
+上游源码位于 <https://github.com/k2-fsa/sherpa-onnx/tree/v1.13.2/sherpa-onnx/kotlin-api>。
+
+与上游的唯一行为差异是移除了各包装类中的 `System.loadLibrary("sherpa-onnx-jni")` 静态加载。
+应用必须先通过 `SherpaOnnxNativeLoader` 校验并按绝对路径加载按需安装的只读原生库。
+许可证见 `app/libs/sherpa-onnx-LICENSE.txt`。

--- a/app/src/main/java/com/k2fsa/sherpa/onnx/SupportConfigs.kt
+++ b/app/src/main/java/com/k2fsa/sherpa/onnx/SupportConfigs.kt
@@ -1,0 +1,19 @@
+package com.k2fsa.sherpa.onnx
+
+data class QnnConfig(
+    var backendLib: String = "",
+    var contextBinary: String = "",
+    var systemLib: String = ""
+)
+
+data class FeatureConfig(
+    var sampleRate: Int = 16000,
+    var featureDim: Int = 80,
+    var dither: Float = 0.0f
+)
+
+data class HomophoneReplacerConfig(
+    var dictDir: String = "",
+    var lexicon: String = "",
+    var ruleFsts: String = ""
+)

--- a/app/src/main/java/com/k2fsa/sherpa/onnx/Vad.kt
+++ b/app/src/main/java/com/k2fsa/sherpa/onnx/Vad.kt
@@ -1,0 +1,75 @@
+// Copyright (c) 2023 Xiaomi Corporation
+package com.k2fsa.sherpa.onnx
+
+import android.content.res.AssetManager
+
+data class SileroVadModelConfig(
+    var model: String = "",
+    var threshold: Float = 0.5F,
+    var minSilenceDuration: Float = 0.25F,
+    var minSpeechDuration: Float = 0.25F,
+    var windowSize: Int = 512,
+    var maxSpeechDuration: Float = 5.0F
+)
+
+data class TenVadModelConfig(
+    var model: String = "",
+    var threshold: Float = 0.5F,
+    var minSilenceDuration: Float = 0.25F,
+    var minSpeechDuration: Float = 0.25F,
+    var windowSize: Int = 256,
+    var maxSpeechDuration: Float = 5.0F
+)
+
+data class VadModelConfig(
+    var sileroVadModelConfig: SileroVadModelConfig = SileroVadModelConfig(),
+    var tenVadModelConfig: TenVadModelConfig = TenVadModelConfig(),
+    var sampleRate: Int = 16000,
+    var numThreads: Int = 1,
+    var provider: String = "cpu",
+    var debug: Boolean = false
+)
+
+class SpeechSegment(val start: Int, val samples: FloatArray)
+
+class Vad(
+    assetManager: AssetManager? = null,
+    var config: VadModelConfig
+) {
+    private var ptr: Long = if (assetManager != null) {
+        newFromAsset(assetManager, config)
+    } else {
+        newFromFile(config)
+    }
+
+    protected fun finalize() {
+        if (ptr != 0L) {
+            delete(ptr)
+            ptr = 0L
+        }
+    }
+
+    fun release() = finalize()
+    fun compute(samples: FloatArray): Float = compute(ptr, samples)
+    fun acceptWaveform(samples: FloatArray) = acceptWaveform(ptr, samples)
+    fun empty(): Boolean = empty(ptr)
+    fun pop() = pop(ptr)
+    fun front(): SpeechSegment = front(ptr)
+    fun clear() = clear(ptr)
+    fun isSpeechDetected(): Boolean = isSpeechDetected(ptr)
+    fun reset() = reset(ptr)
+    fun flush() = flush(ptr)
+
+    private external fun delete(ptr: Long)
+    private external fun newFromAsset(assetManager: AssetManager, config: VadModelConfig): Long
+    private external fun newFromFile(config: VadModelConfig): Long
+    private external fun acceptWaveform(ptr: Long, samples: FloatArray)
+    private external fun compute(ptr: Long, samples: FloatArray): Float
+    private external fun empty(ptr: Long): Boolean
+    private external fun pop(ptr: Long)
+    private external fun clear(ptr: Long)
+    private external fun front(ptr: Long): SpeechSegment
+    private external fun isSpeechDetected(ptr: Long): Boolean
+    private external fun reset(ptr: Long)
+    private external fun flush(ptr: Long)
+}

--- a/app/src/test/java/com/asmr/player/data/remote/update/GitHubUpdateClientTest.kt
+++ b/app/src/test/java/com/asmr/player/data/remote/update/GitHubUpdateClientTest.kt
@@ -1,0 +1,67 @@
+package com.asmr.player.data.remote.update
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class GitHubUpdateClientTest {
+    @Test
+    fun `prefers the device ABI before universal`() {
+        val assets = listOf(
+            asset("AsmrPlayer-v1.2.1-universal.apk"),
+            asset("AsmrPlayer-v1.2.1-arm64-v8a.apk")
+        )
+
+        val selected = pickApkAssetForDevice(assets, listOf("arm64-v8a"))
+
+        assertEquals("AsmrPlayer-v1.2.1-arm64-v8a.apk", selected?.name)
+    }
+
+    @Test
+    fun `falls back to the universal release artifact`() {
+        val assets = listOf(asset("AsmrPlayer-v1.2.0-universal.apk"))
+
+        val selected = pickApkAssetForDevice(assets, listOf("arm64-v8a"))
+
+        assertEquals("AsmrPlayer-v1.2.0-universal.apk", selected?.name)
+    }
+
+    @Test
+    fun `x86 does not select x86_64`() {
+        val assets = listOf(
+            asset("AsmrPlayer-v1.2.1-x86_64.apk"),
+            asset("AsmrPlayer-v1.2.1-x86.apk")
+        )
+
+        val selected = pickApkAssetForDevice(assets, listOf("x86"))
+
+        assertEquals("AsmrPlayer-v1.2.1-x86.apk", selected?.name)
+    }
+
+    @Test
+    fun `v1_1_6 legacy picker accepts the new single universal APK`() {
+        val assets = listOf(asset("AsmrPlayer-v1.2.0-universal.apk"))
+
+        val selected = legacyV116PickApkAsset(assets)
+
+        assertEquals("AsmrPlayer-v1.2.0-universal.apk", selected?.name)
+    }
+
+    private fun asset(name: String) = GitHubReleaseAsset(
+        name = name,
+        browserDownloadUrl = "https://example.com/$name"
+    )
+
+    private fun legacyV116PickApkAsset(
+        assets: List<GitHubReleaseAsset>
+    ): GitHubReleaseAsset? {
+        val apks = assets.filter { it.name.orEmpty().lowercase().endsWith(".apk") }
+        return (
+            apks.firstOrNull { it.name.orEmpty().contains("universal", ignoreCase = true) }
+                ?: apks.firstOrNull { it.name.orEmpty().contains("arm64", ignoreCase = true) }
+                ?: apks.firstOrNull { it.name.orEmpty().contains("debug", ignoreCase = true) }
+                ?: apks.firstOrNull()
+            )?.takeIf {
+            it.browserDownloadUrl.orEmpty().startsWith("http", ignoreCase = true)
+        }
+    }
+}

--- a/app/src/test/java/com/asmr/player/subtitle/SherpaOnnxRuntimeInstallerTest.kt
+++ b/app/src/test/java/com/asmr/player/subtitle/SherpaOnnxRuntimeInstallerTest.kt
@@ -1,0 +1,149 @@
+package com.asmr.player.subtitle
+
+import java.io.File
+import java.io.FileInputStream
+import java.security.MessageDigest
+import java.util.zip.ZipEntry
+import java.util.zip.ZipOutputStream
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+class SherpaOnnxRuntimeInstallerTest {
+    @get:Rule
+    val temporaryFolder = TemporaryFolder()
+
+    @Test
+    fun `installs only the pinned libraries as read only files`() {
+        val onnx = "onnx-runtime".toByteArray()
+        val jni = "sherpa-jni".toByteArray()
+        val archive = createArchive(
+            "arm64-v8a/libonnxruntime.so" to onnx,
+            "arm64-v8a/libsherpa-onnx-jni.so" to jni
+        )
+        val descriptor = descriptor(archive, onnx, jni)
+        val destination = File(temporaryFolder.root, "runtime/arm64-v8a")
+
+        SherpaOnnxRuntimeInstaller.install(archive, destination, descriptor)
+
+        val onnxFile = File(destination, "libonnxruntime.so")
+        val jniFile = File(destination, "libsherpa-onnx-jni.so")
+        assertArrayEquals(onnx, onnxFile.readBytes())
+        assertArrayEquals(jni, jniFile.readBytes())
+        assertFalse(onnxFile.canWrite())
+        assertFalse(jniFile.canWrite())
+        assertTrue(SherpaOnnxRuntimeInstaller.isInstalled(destination, descriptor))
+        makeWritable(destination)
+    }
+
+    @Test
+    fun `rejects an archive containing an unexpected entry`() {
+        val onnx = "onnx-runtime".toByteArray()
+        val jni = "sherpa-jni".toByteArray()
+        val archive = createArchive(
+            "arm64-v8a/libonnxruntime.so" to onnx,
+            "arm64-v8a/libsherpa-onnx-jni.so" to jni,
+            "../unexpected.so" to byteArrayOf(1)
+        )
+        val descriptor = descriptor(archive, onnx, jni)
+        val destination = File(temporaryFolder.root, "runtime/arm64-v8a")
+
+        val failure = runCatching {
+            SherpaOnnxRuntimeInstaller.install(archive, destination, descriptor)
+        }.exceptionOrNull()
+
+        assertTrue(failure?.message.orEmpty().contains("未知文件"))
+        assertFalse(destination.exists())
+    }
+
+    @Test
+    fun `rejects a library whose pinned digest does not match`() {
+        val onnx = "onnx-runtime".toByteArray()
+        val jni = "sherpa-jni".toByteArray()
+        val archive = createArchive(
+            "arm64-v8a/libonnxruntime.so" to onnx,
+            "arm64-v8a/libsherpa-onnx-jni.so" to jni
+        )
+        val validDescriptor = descriptor(archive, onnx, jni)
+        val descriptor = validDescriptor.copy(
+            libraries = validDescriptor.libraries.map { library ->
+                if (library.fileName == "libsherpa-onnx-jni.so") {
+                    library.copy(sha256 = "0".repeat(64))
+                } else {
+                    library
+                }
+            }
+        )
+        val destination = File(temporaryFolder.root, "runtime/arm64-v8a")
+
+        val failure = runCatching {
+            SherpaOnnxRuntimeInstaller.install(archive, destination, descriptor)
+        }.exceptionOrNull()
+
+        assertTrue(failure?.message.orEmpty().contains("校验失败"))
+        assertFalse(destination.exists())
+    }
+
+    private fun descriptor(
+        archive: File,
+        onnx: ByteArray,
+        jni: ByteArray
+    ) = SherpaOnnxRuntimeDescriptor(
+        version = "test",
+        abi = "arm64-v8a",
+        url = "https://example.com/runtime.zip",
+        archiveFileName = archive.name,
+        archiveBytes = archive.length(),
+        archiveSha256 = sha256(archive),
+        libraries = listOf(
+            SherpaOnnxRuntimeLibrary(
+                archivePath = "arm64-v8a/libonnxruntime.so",
+                fileName = "libonnxruntime.so",
+                bytes = onnx.size.toLong(),
+                sha256 = sha256(onnx)
+            ),
+            SherpaOnnxRuntimeLibrary(
+                archivePath = "arm64-v8a/libsherpa-onnx-jni.so",
+                fileName = "libsherpa-onnx-jni.so",
+                bytes = jni.size.toLong(),
+                sha256 = sha256(jni)
+            )
+        )
+    )
+
+    private fun createArchive(vararg entries: Pair<String, ByteArray>): File {
+        val archive = temporaryFolder.newFile("runtime-${System.nanoTime()}.zip")
+        ZipOutputStream(archive.outputStream()).use { output ->
+            entries.forEach { (name, data) ->
+                output.putNextEntry(ZipEntry(name))
+                output.write(data)
+                output.closeEntry()
+            }
+        }
+        return archive
+    }
+
+    private fun sha256(file: File): String {
+        val digest = MessageDigest.getInstance("SHA-256")
+        FileInputStream(file).use { input ->
+            val buffer = ByteArray(8 * 1024)
+            while (true) {
+                val read = input.read(buffer)
+                if (read < 0) break
+                if (read > 0) digest.update(buffer, 0, read)
+            }
+        }
+        return digest.digest().joinToString("") { byte -> "%02x".format(byte) }
+    }
+
+    private fun sha256(bytes: ByteArray): String = MessageDigest.getInstance("SHA-256")
+        .digest(bytes)
+        .joinToString("") { byte -> "%02x".format(byte) }
+
+    private fun makeWritable(directory: File) {
+        directory.walkBottomUp().forEach { file -> file.setWritable(true, false) }
+    }
+}

--- a/app/src/test/java/com/asmr/player/subtitle/SubtitleArtifactDownloaderTest.kt
+++ b/app/src/test/java/com/asmr/player/subtitle/SubtitleArtifactDownloaderTest.kt
@@ -1,0 +1,103 @@
+package com.asmr.player.subtitle
+
+import kotlinx.coroutines.runBlocking
+import okhttp3.OkHttpClient
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import okio.Buffer
+import org.junit.After
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+class SubtitleArtifactDownloaderTest {
+    @get:Rule
+    val temporaryFolder = TemporaryFolder()
+
+    private lateinit var server: MockWebServer
+
+    @Before
+    fun setUp() {
+        server = MockWebServer().apply { start() }
+    }
+
+    @After
+    fun tearDown() {
+        server.shutdown()
+    }
+
+    @Test
+    fun `downloads a pinned-size file and publishes completion`() = runBlocking {
+        val data = ByteArray(32 * 1024) { index -> (index % 251).toByte() }
+        server.enqueue(MockResponse().setResponseCode(200).setBody(Buffer().write(data)))
+        val destination = temporaryFolder.newFile("artifact.part")
+        val progress = mutableListOf<Long>()
+
+        SubtitleArtifactDownloader.download(
+            client = OkHttpClient(),
+            url = server.url("/artifact").toString(),
+            destination = destination,
+            expectedBytes = data.size.toLong(),
+            onProgress = progress::add
+        )
+
+        assertArrayEquals(data, destination.readBytes())
+        assertEquals(data.size.toLong(), progress.last())
+    }
+
+    @Test
+    fun `resumes when the server returns the matching content range`() = runBlocking {
+        val data = "0123456789".toByteArray()
+        val destination = temporaryFolder.newFile("artifact.part").apply {
+            writeBytes(data.copyOfRange(0, 4))
+        }
+        server.enqueue(
+            MockResponse()
+                .setResponseCode(206)
+                .setHeader("Content-Range", "bytes 4-9/10")
+                .setBody(Buffer().write(data.copyOfRange(4, data.size)))
+        )
+
+        SubtitleArtifactDownloader.download(
+            client = OkHttpClient(),
+            url = server.url("/artifact").toString(),
+            destination = destination,
+            expectedBytes = data.size.toLong(),
+            onProgress = {}
+        )
+
+        assertArrayEquals(data, destination.readBytes())
+        assertEquals("bytes=4-", server.takeRequest().getHeader("Range"))
+    }
+
+    @Test
+    fun `deletes partial data when the content range is invalid`() = runBlocking {
+        val destination = temporaryFolder.newFile("artifact.part").apply {
+            writeText("part")
+        }
+        server.enqueue(
+            MockResponse()
+                .setResponseCode(206)
+                .setHeader("Content-Range", "bytes 0-3/4")
+                .setBody("rest")
+        )
+
+        val failure = runCatching {
+            SubtitleArtifactDownloader.download(
+                client = OkHttpClient(),
+                url = server.url("/artifact").toString(),
+                destination = destination,
+                expectedBytes = 8L,
+                onProgress = {}
+            )
+        }.exceptionOrNull()
+
+        assertTrue(failure?.message.orEmpty().contains("无效的断点数据"))
+        assertFalse(destination.exists())
+    }
+}

--- a/tools/package_sherpa_runtime.py
+++ b/tools/package_sherpa_runtime.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""Build the pinned arm64 sherpa-onnx runtime asset used by the Android app."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import shutil
+import tempfile
+import urllib.request
+from pathlib import Path
+from zipfile import ZIP_DEFLATED, ZipFile, ZipInfo
+
+
+VERSION = "1.13.2"
+ASSET_NAME = f"sherpa-onnx-runtime-{VERSION}-android-arm64-v8a.zip"
+UPSTREAM_AAR_URL = (
+    "https://github.com/k2-fsa/sherpa-onnx/releases/download/"
+    f"v{VERSION}/sherpa-onnx-{VERSION}.aar"
+)
+UPSTREAM_AAR_SHA256 = "aa5505c0ec4f8bdaee5f214a64ba3012be64f2aecc022e82a64f33392b8dd245"
+EXPECTED_ARCHIVE_SHA256 = "bfa564c5da27a7ab734d4c788cafd7c95c1e4934e02056be24358532d3d33c2e"
+ZIP_TIMESTAMP = (1980, 1, 1, 0, 0, 0)
+RUNTIME_LIBRARIES = {
+    "arm64-v8a/libonnxruntime.so": {
+        "source": "jni/arm64-v8a/libonnxruntime.so",
+        "bytes": 25_831_632,
+        "sha256": "4d2318b3849abb8862133d3068fc7e807ed8b2671cc6d83657fff2fcb9e1caad",
+    },
+    "arm64-v8a/libsherpa-onnx-jni.so": {
+        "source": "jni/arm64-v8a/libsherpa-onnx-jni.so",
+        "bytes": 4_623_192,
+        "sha256": "fc072f201dc1923ee98b594eb61c796b538ef087f7f18d08dcfdf0565167a8bd",
+    },
+}
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as source:
+        for chunk in iter(lambda: source.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def require_file(path: Path, expected_bytes: int, expected_sha256: str) -> None:
+    actual_bytes = path.stat().st_size
+    if actual_bytes != expected_bytes:
+        raise ValueError(f"Unexpected size for {path}: {actual_bytes} != {expected_bytes}")
+    actual_sha256 = sha256_file(path)
+    if actual_sha256 != expected_sha256:
+        raise ValueError(f"Unexpected SHA-256 for {path}: {actual_sha256}")
+
+
+def download_upstream_aar(destination: Path) -> None:
+    request = urllib.request.Request(UPSTREAM_AAR_URL, headers={"User-Agent": "Eara-runtime-packager"})
+    with urllib.request.urlopen(request) as response, destination.open("wb") as output:
+        shutil.copyfileobj(response, output, length=1024 * 1024)
+
+
+def write_runtime_zip(aar_path: Path, output_path: Path) -> None:
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    temporary_output = output_path.with_suffix(".zip.part")
+    temporary_output.unlink(missing_ok=True)
+    with ZipFile(aar_path) as aar, ZipFile(
+        temporary_output,
+        mode="w",
+        compression=ZIP_DEFLATED,
+        compresslevel=9,
+        strict_timestamps=True,
+    ) as output:
+        for archive_name in sorted(RUNTIME_LIBRARIES):
+            descriptor = RUNTIME_LIBRARIES[archive_name]
+            data = aar.read(str(descriptor["source"]))
+            if len(data) != descriptor["bytes"]:
+                raise ValueError(f"Unexpected size for {descriptor['source']}")
+            if hashlib.sha256(data).hexdigest() != descriptor["sha256"]:
+                raise ValueError(f"Unexpected SHA-256 for {descriptor['source']}")
+            info = ZipInfo(filename=archive_name, date_time=ZIP_TIMESTAMP)
+            info.compress_type = ZIP_DEFLATED
+            info.create_system = 3
+            info.external_attr = 0o100444 << 16
+            output.writestr(info, data, compress_type=ZIP_DEFLATED, compresslevel=9)
+    temporary_output.replace(output_path)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--aar", type=Path, help="Use an existing pinned upstream AAR")
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=Path("build/runtime-assets"),
+        help="Directory for the runtime ZIP and manifest",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    with tempfile.TemporaryDirectory(prefix="eara-sherpa-runtime-") as temporary_dir:
+        if args.aar is None:
+            aar_path = Path(temporary_dir) / f"sherpa-onnx-{VERSION}.aar"
+            download_upstream_aar(aar_path)
+        else:
+            aar_path = args.aar.resolve()
+        require_file(aar_path, 56_655_608, UPSTREAM_AAR_SHA256)
+
+        output_path = args.output_dir.resolve() / ASSET_NAME
+        write_runtime_zip(aar_path, output_path)
+        archive_sha256 = sha256_file(output_path)
+        if EXPECTED_ARCHIVE_SHA256 and archive_sha256 != EXPECTED_ARCHIVE_SHA256:
+            output_path.unlink(missing_ok=True)
+            raise ValueError(
+                "Runtime ZIP differs from the pinned release artifact: "
+                f"{archive_sha256} != {EXPECTED_ARCHIVE_SHA256}"
+            )
+
+        manifest = {
+            "asset": output_path.name,
+            "bytes": output_path.stat().st_size,
+            "sha256": archive_sha256,
+            "upstream": UPSTREAM_AAR_URL,
+            "libraries": RUNTIME_LIBRARIES,
+        }
+        manifest_path = output_path.with_suffix(".json")
+        manifest_path.write_text(
+            json.dumps(manifest, ensure_ascii=False, indent=2) + "\n",
+            encoding="utf-8",
+            newline="\n",
+        )
+        print(json.dumps(manifest, ensure_ascii=False, indent=2))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## 变更
- 将 sherpa-onnx arm64 运行时改为首次手动下载字幕模型时按需安装
- 校验运行时 ZIP 与内部原生库的大小和 SHA-256，内部只读存储后按绝对路径加载
- 删除模型时保留运行时，避免重复下载
- 移除完整 AAR 与 ABI 拆包，Release 只产出一个 universal APK
- 更新版本为 1.2.0 (10200)，调整新客户端 ABI 选择并兼容 v1.1.6 universal 选择
- 增加发布产物数量、体积和 sherpa 原生库门禁

## 验证
- `:app:testReleaseUnitTest` 新增及相关测试通过
- arm64 实机完成运行时安装、JNI 加载与 Silero VAD 创建
- `:app:installRelease` 成功，设备安装 1.2.0 (10200)
- Release APK 单产物，8,824,330 字节（8.42 MiB）
- APK 不包含 sherpa/onnxruntime 原生库

## 发布前待办
- 将 `sherpa-onnx-runtime-1.13.2-android-arm64-v8a.zip` 上传到 `subtitle-model-parakeet-ja-int8` Release；本 PR 不上传资产、不创建版本标签。