### PR TITLE
feat: 完善字幕任务错误提示与 DeepSeek 用量展示

### DIFF
--- a/app/src/androidTest/java/com/asmr/player/ui/settings/DeepSeekTranslationSettingsSectionTest.kt
+++ b/app/src/androidTest/java/com/asmr/player/ui/settings/DeepSeekTranslationSettingsSectionTest.kt
@@ -16,6 +16,7 @@ import com.asmr.player.subtitle.DeepSeekAccountState
 import com.asmr.player.subtitle.DeepSeekBalance
 import com.asmr.player.ui.theme.AsmrPlayerTheme
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -87,5 +88,13 @@ class DeepSeekTranslationSettingsSectionTest {
         composeRule.onNodeWithContentDescription("API Key 已配置").assertExists()
         composeRule.onNodeWithTag("deepseek_reasoning_high").assertIsNotEnabled()
         composeRule.onNodeWithTag("deepseek_reasoning_max").assertIsNotEnabled()
+        val summaryBounds = composeRule.onNodeWithTag("deepseek_account_summary")
+            .getUnclippedBoundsInRoot()
+        val summaryWidth = summaryBounds.right - summaryBounds.left
+        assertTrue(summaryWidth.value >= 170f)
+        val modelBounds = composeRule.onNodeWithTag("deepseek_model_name")
+            .getUnclippedBoundsInRoot()
+        val modelHeight = modelBounds.bottom - modelBounds.top
+        assertTrue(modelHeight.value <= 24f)
     }
 }

--- a/app/src/androidTest/java/com/asmr/player/ui/settings/DeepSeekTranslationSettingsSectionTest.kt
+++ b/app/src/androidTest/java/com/asmr/player/ui/settings/DeepSeekTranslationSettingsSectionTest.kt
@@ -12,6 +12,8 @@ import androidx.compose.ui.test.onNodeWithText
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.asmr.player.data.settings.DeepSeekReasoningEffort
 import com.asmr.player.data.settings.DeepSeekTranslationSettings
+import com.asmr.player.subtitle.DeepSeekAccountState
+import com.asmr.player.subtitle.DeepSeekBalance
 import com.asmr.player.ui.theme.AsmrPlayerTheme
 import org.junit.Assert.assertEquals
 import org.junit.Rule
@@ -59,6 +61,11 @@ class DeepSeekTranslationSettingsSectionTest {
                 Column {
                     DeepSeekTranslationSettingsSection(
                         state = DeepSeekApiKeyUiState(configured = true),
+                        accountState = DeepSeekAccountState(
+                            totalTokens = 12_345L,
+                            balances = listOf(DeepSeekBalance("CNY", "8.50")),
+                            balanceAvailable = true
+                        ),
                         settings = DeepSeekTranslationSettings(
                             thinkingEnabled = false,
                             reasoningEffort = DeepSeekReasoningEffort.MAX
@@ -76,6 +83,7 @@ class DeepSeekTranslationSettingsSectionTest {
         }
 
         composeRule.onNodeWithText("替换").assertExists()
+        composeRule.onNodeWithText("Token 12.3K · 余额 ¥8.5").assertExists()
         composeRule.onNodeWithContentDescription("API Key 已配置").assertExists()
         composeRule.onNodeWithTag("deepseek_reasoning_high").assertIsNotEnabled()
         composeRule.onNodeWithTag("deepseek_reasoning_max").assertIsNotEnabled()

--- a/app/src/main/java/com/asmr/player/subtitle/DeepSeekAccountRepository.kt
+++ b/app/src/main/java/com/asmr/player/subtitle/DeepSeekAccountRepository.kt
@@ -1,0 +1,221 @@
+package com.asmr.player.subtitle
+
+import android.content.Context
+import com.asmr.player.data.remote.NetworkHeaders
+import com.asmr.player.di.DEEPSEEK_HTTP_CLIENT
+import com.google.gson.Gson
+import com.google.gson.annotations.SerializedName
+import dagger.hilt.android.qualifiers.ApplicationContext
+import java.io.IOException
+import java.math.RoundingMode
+import java.security.MessageDigest
+import java.util.Locale
+import javax.inject.Inject
+import javax.inject.Named
+import javax.inject.Singleton
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.withContext
+import okhttp3.Call
+import okhttp3.Callback
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.Response
+
+internal data class DeepSeekBalance(
+    val currency: String,
+    val totalBalance: String
+)
+
+internal data class DeepSeekAccountState(
+    val totalTokens: Long = 0L,
+    val balances: List<DeepSeekBalance> = emptyList(),
+    val balanceAvailable: Boolean? = null
+)
+
+private data class DeepSeekBalanceResponse(
+    @SerializedName("is_available")
+    val isAvailable: Boolean = false,
+    @SerializedName("balance_infos")
+    val balanceInfos: List<DeepSeekBalanceInfo> = emptyList()
+)
+
+private data class DeepSeekBalanceInfo(
+    val currency: String = "",
+    @SerializedName("total_balance")
+    val totalBalance: String = ""
+)
+
+@Singleton
+class DeepSeekAccountRepository @Inject internal constructor(
+    @ApplicationContext context: Context,
+    @Named(DEEPSEEK_HTTP_CLIENT) private val okHttpClient: OkHttpClient,
+    private val gson: Gson
+) {
+    private val preferences = context.getSharedPreferences(PREFERENCES_NAME, Context.MODE_PRIVATE)
+    private val lock = Any()
+    private var apiKeyFingerprint = preferences.getString(KEY_API_KEY_FINGERPRINT, "").orEmpty()
+    private val _state = MutableStateFlow(loadState())
+    internal val state = _state.asStateFlow()
+
+    internal fun bindApiKey(apiKey: String) {
+        val fingerprint = fingerprint(apiKey)
+        synchronized(lock) {
+            if (apiKeyFingerprint == fingerprint) return
+            apiKeyFingerprint = fingerprint
+            val resetState = DeepSeekAccountState()
+            _state.value = resetState
+            preferences.edit()
+                .putString(KEY_API_KEY_FINGERPRINT, fingerprint)
+                .putLong(KEY_TOTAL_TOKENS, 0L)
+                .remove(KEY_BALANCES)
+                .remove(KEY_BALANCE_AVAILABLE)
+                .apply()
+        }
+    }
+
+    internal fun recordTokenUsage(apiKey: String, totalTokens: Long) {
+        if (totalTokens <= 0L) return
+        val requestFingerprint = fingerprint(apiKey)
+        synchronized(lock) {
+            if (apiKeyFingerprint != requestFingerprint) return
+            val current = _state.value
+            val updatedTotal = if (Long.MAX_VALUE - current.totalTokens < totalTokens) {
+                Long.MAX_VALUE
+            } else {
+                current.totalTokens + totalTokens
+            }
+            _state.value = current.copy(totalTokens = updatedTotal)
+            preferences.edit().putLong(KEY_TOTAL_TOKENS, updatedTotal).apply()
+        }
+    }
+
+    internal suspend fun refreshBalance(apiKey: String) {
+        val normalized = apiKey.trim()
+        if (normalized.isEmpty()) return
+        bindApiKey(normalized)
+        val requestFingerprint = fingerprint(normalized)
+        try {
+            val responseBody = withContext(Dispatchers.IO) {
+                val request = Request.Builder()
+                    .url(DEEPSEEK_BALANCE_URL)
+                    .header("Authorization", "Bearer $normalized")
+                    .header(NetworkHeaders.HEADER_SILENT_IO_ERROR, NetworkHeaders.SILENT_IO_ERROR_ON)
+                    .get()
+                    .build()
+                executeCancellable(okHttpClient.newCall(request)).use { response ->
+                    if (!response.isSuccessful) throw IOException("DeepSeek balance HTTP ${response.code}")
+                    response.body?.string().orEmpty()
+                }
+            }
+            val parsed = gson.fromJson(responseBody, DeepSeekBalanceResponse::class.java)
+            val balances = parsed.balanceInfos.mapNotNull { info ->
+                val currency = info.currency.trim().uppercase(Locale.US)
+                val amount = info.totalBalance.trim()
+                if (currency.isEmpty() || amount.toBigDecimalOrNull() == null) null
+                else DeepSeekBalance(currency = currency, totalBalance = amount)
+            }
+            synchronized(lock) {
+                if (apiKeyFingerprint != requestFingerprint) return@synchronized
+                val updated = _state.value.copy(
+                    balances = balances,
+                    balanceAvailable = parsed.isAvailable
+                )
+                _state.value = updated
+                preferences.edit()
+                    .putString(KEY_BALANCES, gson.toJson(balances))
+                    .putBoolean(KEY_BALANCE_AVAILABLE, parsed.isAvailable)
+                    .apply()
+            }
+        } catch (cancelled: CancellationException) {
+            throw cancelled
+        } catch (_: Exception) {
+            // 余额查询失败不影响翻译，继续展示上次成功查询的结果。
+        }
+    }
+
+    private fun loadState(): DeepSeekAccountState {
+        val balances = preferences.getString(KEY_BALANCES, null)?.let { raw ->
+            runCatching {
+                gson.fromJson(raw, Array<DeepSeekBalance>::class.java).toList()
+            }.getOrDefault(emptyList())
+        }.orEmpty()
+        return DeepSeekAccountState(
+            totalTokens = preferences.getLong(KEY_TOTAL_TOKENS, 0L).coerceAtLeast(0L),
+            balances = balances,
+            balanceAvailable = if (preferences.contains(KEY_BALANCE_AVAILABLE)) {
+                preferences.getBoolean(KEY_BALANCE_AVAILABLE, false)
+            } else {
+                null
+            }
+        )
+    }
+
+    private suspend fun executeCancellable(call: Call): Response =
+        suspendCancellableCoroutine { continuation ->
+            continuation.invokeOnCancellation { call.cancel() }
+            call.enqueue(object : Callback {
+                override fun onFailure(call: Call, e: IOException) {
+                    if (!continuation.isActive) return
+                    if (call.isCanceled()) {
+                        continuation.resumeWithException(CancellationException("余额查询已取消", e))
+                    } else {
+                        continuation.resumeWithException(e)
+                    }
+                }
+
+                override fun onResponse(call: Call, response: Response) {
+                    if (continuation.isActive) continuation.resume(response) else response.close()
+                }
+            })
+        }
+
+    private fun fingerprint(apiKey: String): String {
+        val digest = MessageDigest.getInstance("SHA-256")
+            .digest(apiKey.trim().toByteArray(Charsets.UTF_8))
+        return digest.joinToString(separator = "") { byte -> "%02x".format(byte) }
+    }
+
+    private companion object {
+        const val PREFERENCES_NAME = "deepseek_account_usage"
+        const val KEY_API_KEY_FINGERPRINT = "api_key_fingerprint"
+        const val KEY_TOTAL_TOKENS = "total_tokens"
+        const val KEY_BALANCES = "balances"
+        const val KEY_BALANCE_AVAILABLE = "balance_available"
+    }
+}
+
+internal fun formatDeepSeekTokenTotal(tokens: Long): String {
+    val safeTokens = tokens.coerceAtLeast(0L)
+    val (divisor, suffix) = when {
+        safeTokens >= 1_000_000_000L -> 1_000_000_000.0 to "B"
+        safeTokens >= 1_000_000L -> 1_000_000.0 to "M"
+        safeTokens >= 1_000L -> 1_000.0 to "K"
+        else -> return safeTokens.toString()
+    }
+    return String.format(Locale.US, "%.1f", safeTokens / divisor)
+        .removeSuffix(".0") + suffix
+}
+
+internal fun formatDeepSeekBalances(balances: List<DeepSeekBalance>): String {
+    if (balances.isEmpty()) return "--"
+    return balances.joinToString(separator = " / ") { balance ->
+        val amount = balance.totalBalance.toBigDecimalOrNull()
+            ?.setScale(2, RoundingMode.HALF_UP)
+            ?.stripTrailingZeros()
+            ?.toPlainString()
+            ?: balance.totalBalance
+        when (balance.currency.uppercase(Locale.US)) {
+            "CNY" -> "¥$amount"
+            "USD" -> "$$amount"
+            else -> "${balance.currency} $amount"
+        }
+    }
+}
+
+internal const val DEEPSEEK_BALANCE_URL = "https://api.deepseek.com/user/balance"

--- a/app/src/main/java/com/asmr/player/subtitle/SubtitleFailureMessages.kt
+++ b/app/src/main/java/com/asmr/player/subtitle/SubtitleFailureMessages.kt
@@ -1,0 +1,174 @@
+package com.asmr.player.subtitle
+
+import java.io.IOException
+import java.net.ConnectException
+import java.net.NoRouteToHostException
+import java.net.SocketTimeoutException
+import java.net.UnknownHostException
+import java.util.Collections
+import java.util.IdentityHashMap
+import java.util.Locale
+import javax.net.ssl.SSLException
+
+internal data class DeepSeekHttpFailure(
+    val message: String,
+    val retryable: Boolean
+)
+
+internal object SubtitleFailureMessages {
+    fun isUserActionWarning(message: String): Boolean {
+        val normalized = message.trim()
+        return normalized.contains("API Key") ||
+            normalized.contains("账户余额不足") ||
+            normalized.startsWith(SubtitleModelRepository.MODEL_REQUIRED_MESSAGE) ||
+            normalized.startsWith("当前设备不支持本地字幕生成")
+    }
+
+    fun transcription(error: Throwable): String {
+        val causes = error.causeChain()
+        val details = causes.joinToString(" ") { cause -> cause.message.orEmpty() }
+            .lowercase(Locale.ROOT)
+        return when {
+            causes.any { it is OutOfMemoryError } || details.containsAny(MEMORY_ERROR_MARKERS) ->
+                "本地转录失败：运行模型时内存不足（OOM）。已保留已完成的转录进度；" +
+                    "请关闭占用内存的应用后重试，若仍失败则当前设备可能无法稳定运行此模型。"
+
+            causes.any { it is UnsatisfiedLinkError || it is LinkageError } ||
+                details.containsAny(RUNTIME_ERROR_MARKERS) ->
+                "本地转录失败：字幕运行环境与当前设备不兼容。已保留已完成的转录进度；" +
+                    "本功能仅支持 arm64-v8a 设备，请确认系统兼容性，或在设置中重新下载字幕组件后重试。"
+
+            details.containsAny(COMPONENT_ERROR_MARKERS) ->
+                "本地转录失败：字幕模型或运行组件缺失、损坏。已保留已完成的转录进度；" +
+                    "请前往设置删除并重新下载字幕模型后重试。"
+
+            details.containsAny(AUDIO_ERROR_MARKERS) ->
+                "本地转录失败：音频读取或解码失败。已保留已完成的转录进度；" +
+                    "请确认文件完整且音频格式受当前系统支持后重试。"
+
+            details.contains("未识别到可生成字幕的日语语音") ->
+                "本地转录未识别到可生成字幕的日语语音，请确认音频包含清晰的日语语音后重试。"
+
+            details.contains("字幕在转录期间已被修改") ->
+                "字幕在转录期间已被修改，任务已停止写入，未覆盖用户版本。"
+
+            else ->
+                "本地转录失败：模型运行异常。已保留已完成的转录进度；" +
+                    "请重试，若持续失败请在设置中重新下载字幕模型。"
+        }
+    }
+
+    fun translation(error: Throwable): String {
+        val causes = error.causeChain()
+        val details = causes.joinToString(" ") { cause -> cause.message.orEmpty() }
+            .lowercase(Locale.ROOT)
+        return when {
+            causes.any { it is OutOfMemoryError } || details.containsAny(MEMORY_ERROR_MARKERS) ->
+                "字幕翻译失败：处理模型响应时内存不足。请关闭占用内存的应用后重试。"
+
+            details.contains("deepseek api key") || details.contains("api key") ->
+                "字幕翻译失败：DeepSeek API Key 未配置或已被移除，请前往设置重新配置后重试。"
+
+            else ->
+                "字幕翻译失败：发生未预期的运行错误。请重试；若持续失败，请更新应用后再试。"
+        }
+    }
+
+    fun network(error: IOException): String {
+        val causes = error.causeChain()
+        return when {
+            causes.any { it is SocketTimeoutException } ->
+                "DeepSeek 网络请求超时，请检查网络或代理设置后重试。"
+
+            causes.any { it is UnknownHostException || it is ConnectException || it is NoRouteToHostException } ->
+                "无法连接 DeepSeek 翻译服务，请检查网络或代理设置后重试。"
+
+            causes.any { it is SSLException } ->
+                "无法与 DeepSeek 建立安全连接，请检查系统时间、证书或代理设置后重试。"
+
+            else ->
+                "DeepSeek 网络请求失败，请检查网络或代理设置后重试。"
+        }
+    }
+
+    fun deepSeekHttp(statusCode: Int, serviceMessage: String?): DeepSeekHttpFailure {
+        val retryable = statusCode == 408 || statusCode == 425 || statusCode == 429 || statusCode >= 500
+        val message = when (statusCode) {
+            400, 422 -> buildHttpMessage(
+                prefix = "DeepSeek 拒绝了翻译请求（HTTP $statusCode）",
+                serviceMessage = serviceMessage,
+                action = "请更新应用或稍后重试。"
+            )
+            401 -> "DeepSeek API Key 无效或已失效，请前往设置重新配置后重试。"
+            402 -> "DeepSeek 账户余额不足，请充值后重试。"
+            403 -> "DeepSeek 拒绝访问，请检查 API Key 权限或有效状态后重试。"
+            404 -> "DeepSeek 翻译模型不可用，请更新应用后重试。"
+            408 -> "DeepSeek 请求超时，请检查网络后重试。"
+            425 -> "DeepSeek 暂时无法处理翻译请求，请稍后重试。"
+            429 -> "DeepSeek 请求过于频繁，请稍后重试。"
+            in 500..599 -> "DeepSeek 服务暂时不可用（HTTP $statusCode），请稍后重试。"
+            else -> buildHttpMessage(
+                prefix = "DeepSeek 翻译请求失败（HTTP $statusCode）",
+                serviceMessage = serviceMessage,
+                action = "请稍后重试。"
+            )
+        }
+        return DeepSeekHttpFailure(message = message, retryable = retryable)
+    }
+
+    private fun buildHttpMessage(prefix: String, serviceMessage: String?, action: String): String {
+        val detail = serviceMessage
+            ?.trim()
+            ?.replace(Regex("[\\r\\n\\t]+"), " ")
+            ?.take(MAX_SERVICE_MESSAGE_LENGTH)
+            ?.takeIf(String::isNotBlank)
+        return if (detail == null) "$prefix。$action" else "$prefix：$detail。$action"
+    }
+
+    private val MEMORY_ERROR_MARKERS = listOf(
+        "out of memory",
+        "outofmemory",
+        "failed to allocate",
+        "cannot allocate memory",
+        "memory allocation",
+        "std::bad_alloc"
+    )
+    private val RUNTIME_ERROR_MARKERS = listOf(
+        "dlopen failed",
+        "unsupported abi",
+        "当前设备不支持",
+        "no implementation found",
+        "cannot locate symbol",
+        "unsatisfiedlink"
+    )
+    private val COMPONENT_ERROR_MARKERS = listOf(
+        "字幕运行时",
+        "模型文件缺失",
+        "模型校验失败",
+        "文件校验失败",
+        "no such file",
+        "file too short",
+        "unable to open model"
+    )
+    private val AUDIO_ERROR_MARKERS = listOf(
+        "音频解码",
+        "无法读取音频",
+        "无法打开音频",
+        "mediacodec",
+        "mediaextractor"
+    )
+    private const val MAX_SERVICE_MESSAGE_LENGTH = 160
+}
+
+private fun String.containsAny(markers: List<String>): Boolean = markers.any(::contains)
+
+private fun Throwable.causeChain(): List<Throwable> {
+    val seen = Collections.newSetFromMap(IdentityHashMap<Throwable, Boolean>())
+    val causes = mutableListOf<Throwable>()
+    var current: Throwable? = this
+    while (current != null && causes.size < 12 && seen.add(current)) {
+        causes += current
+        current = current.cause
+    }
+    return causes
+}

--- a/app/src/main/java/com/asmr/player/subtitle/SubtitleTaskService.kt
+++ b/app/src/main/java/com/asmr/player/subtitle/SubtitleTaskService.kt
@@ -31,6 +31,7 @@ import com.asmr.player.data.local.db.entities.SubtitleTitleOwnerKind
 import com.asmr.player.data.local.db.entities.SubtitleTranslationSourceEntity
 import com.asmr.player.data.settings.SettingsRepository
 import com.asmr.player.di.DEEPSEEK_HTTP_CLIENT
+import com.asmr.player.util.MessageManager
 import com.google.gson.Gson
 import com.google.gson.reflect.TypeToken
 import dagger.hilt.EntryPoint
@@ -67,6 +68,7 @@ internal class SubtitleTaskService : Service() {
         fun deepSeekOkHttpClient(): OkHttpClient
         fun gson(): Gson
         fun settingsRepository(): SettingsRepository
+        fun messageManager(): MessageManager
     }
 
     private val serviceScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
@@ -77,6 +79,7 @@ internal class SubtitleTaskService : Service() {
     private lateinit var gson: Gson
     private lateinit var deepSeekOkHttpClient: OkHttpClient
     private lateinit var settingsRepository: SettingsRepository
+    private lateinit var messageManager: MessageManager
     private var transcriptionJob: Job? = null
     private var transcriptionItemId: String? = null
     private val translationJobs = ConcurrentHashMap<String, Job>()
@@ -104,6 +107,7 @@ internal class SubtitleTaskService : Service() {
         gson = entryPoint.gson()
         deepSeekOkHttpClient = entryPoint.deepSeekOkHttpClient()
         settingsRepository = entryPoint.settingsRepository()
+        messageManager = entryPoint.messageManager()
         createNotificationChannel()
         startAsForeground(buildNotification(emptyList()))
         wakeLock = getSystemService(PowerManager::class.java)
@@ -274,6 +278,13 @@ internal class SubtitleTaskService : Service() {
                     titleTranslationRetryAt.remove(taskId)
                 } catch (cancelled: CancellationException) {
                     throw cancelled
+                } catch (error: SubtitleTranslationException) {
+                    titleTranslationRetryAt[taskId] = if (error.retryable) {
+                        System.currentTimeMillis() + TITLE_TRANSLATION_RETRY_BACKOFF_MS
+                    } else {
+                        TITLE_TRANSLATION_DISABLED_RETRY_AT
+                    }
+                    Log.w(TAG, "作品显示名翻译失败 taskId=$taskId", error)
                 } catch (error: Throwable) {
                     titleTranslationRetryAt[taskId] = System.currentTimeMillis() + TITLE_TRANSLATION_RETRY_BACKOFF_MS
                     Log.w(TAG, "作品显示名翻译失败 taskId=$taskId", error)
@@ -425,7 +436,9 @@ internal class SubtitleTaskService : Service() {
             settleCancelledExecution(itemId)
             throw cancelled
         } catch (error: Throwable) {
-            failItem(itemId, error.message.orEmpty().ifBlank { "日语字幕转录失败" })
+            Log.w(TAG, "本地字幕转录失败 itemId=$itemId type=${error.javaClass.name}")
+            releaseFailedTranscriptionEngine()
+            failItem(itemId, SubtitleFailureMessages.transcription(error))
         }
     }
 
@@ -522,10 +535,15 @@ internal class SubtitleTaskService : Service() {
         } catch (error: IOException) {
             handleTranslationFailure(
                 itemId,
-                SubtitleTranslationException("网络请求失败", retryable = true, cause = error)
+                SubtitleTranslationException(
+                    SubtitleFailureMessages.network(error),
+                    retryable = true,
+                    cause = error
+                )
             )
         } catch (error: Throwable) {
-            failItem(itemId, error.message.orEmpty().ifBlank { "字幕翻译失败" })
+            Log.w(TAG, "字幕翻译运行异常 itemId=$itemId type=${error.javaClass.name}")
+            failItem(itemId, SubtitleFailureMessages.translation(error))
         }
     }
 
@@ -686,16 +704,22 @@ internal class SubtitleTaskService : Service() {
         val dao = database.subtitleTaskDao()
         val item = dao.getItem(itemId) ?: return
         if (item.state in setOf(SubtitleItemState.PAUSE_REQUESTED, SubtitleItemState.CANCEL_REQUESTED)) return
+        val userMessage = message.trim().ifBlank { "字幕任务失败，请重试。" }
         dao.updateItem(
             item.copy(
                 suspendedFromState = item.state,
                 state = SubtitleItemState.FAILED,
                 attempt = attempt ?: item.attempt,
-                errorMessage = message,
+                errorMessage = userMessage,
                 updatedAt = System.currentTimeMillis()
             )
         )
         repository.refreshTaskState(item.taskId)
+        if (SubtitleFailureMessages.isUserActionWarning(userMessage)) {
+            messageManager.showWarning(userMessage)
+        } else {
+            messageManager.showError(userMessage)
+        }
     }
 
     private suspend fun settleCancelledExecution(itemId: String) {
@@ -747,6 +771,13 @@ internal class SubtitleTaskService : Service() {
         transcriptionEngine = null
     }
 
+    private fun releaseFailedTranscriptionEngine() {
+        val engine = transcriptionEngine ?: return
+        runCatching { engine.close() }
+            .onFailure { error -> Log.w(TAG, "转录失败后释放模型失败", error) }
+        transcriptionEngine = null
+    }
+
     private suspend fun updateForegroundNotification() {
         val items = database.subtitleTaskDao().getAllItems()
         getSystemService(NotificationManager::class.java).notify(NOTIFICATION_ID, buildNotification(items))
@@ -756,7 +787,8 @@ internal class SubtitleTaskService : Service() {
         if (transcriptionJob?.isActive == true || translationJobs.values.any(Job::isActive)) return
         if (titleTranslationJobs.values.any(Job::isActive)) return
         if (database.subtitleTaskDao().countRunnableItems() > 0) return
-        if (database.subtitleTitleOwnerDao().getPendingTaskIds().isNotEmpty()) return
+        val pendingTitleTaskIds = database.subtitleTitleOwnerDao().getPendingTaskIds()
+        if (pendingTitleTaskIds.any { titleTranslationRetryAt[it] != TITLE_TRANSLATION_DISABLED_RETRY_AT }) return
         stoppingSafely = true
         stopForeground(STOP_FOREGROUND_REMOVE)
         stopSelf()
@@ -887,6 +919,7 @@ internal class SubtitleTaskService : Service() {
         private const val RETRY_JITTER_MS = 250L
         private const val SCHEDULER_TICK_MS = 500L
         private const val TITLE_TRANSLATION_RETRY_BACKOFF_MS = 60_000L
+        private const val TITLE_TRANSLATION_DISABLED_RETRY_AT = Long.MAX_VALUE
         private const val TAG = "SubtitleTaskService"
 
         fun wake(context: Context) {

--- a/app/src/main/java/com/asmr/player/subtitle/SubtitleTaskService.kt
+++ b/app/src/main/java/com/asmr/player/subtitle/SubtitleTaskService.kt
@@ -69,6 +69,7 @@ internal class SubtitleTaskService : Service() {
         fun gson(): Gson
         fun settingsRepository(): SettingsRepository
         fun messageManager(): MessageManager
+        fun deepSeekAccountRepository(): DeepSeekAccountRepository
     }
 
     private val serviceScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
@@ -80,11 +81,15 @@ internal class SubtitleTaskService : Service() {
     private lateinit var deepSeekOkHttpClient: OkHttpClient
     private lateinit var settingsRepository: SettingsRepository
     private lateinit var messageManager: MessageManager
+    private lateinit var deepSeekAccountRepository: DeepSeekAccountRepository
     private var transcriptionJob: Job? = null
     private var transcriptionItemId: String? = null
     private val translationJobs = ConcurrentHashMap<String, Job>()
     private val titleTranslationJobs = ConcurrentHashMap<String, Job>()
     private val titleTranslationRetryAt = ConcurrentHashMap<String, Long>()
+    private val balanceRefreshLock = Any()
+    private var balanceRefreshRequested = false
+    private var balanceRefreshJob: Job? = null
     private var transcriptionEngine: SubtitleTranscriptionEngine? = null
     private var stoppingSafely = false
     private var wakeLock: PowerManager.WakeLock? = null
@@ -108,6 +113,7 @@ internal class SubtitleTaskService : Service() {
         deepSeekOkHttpClient = entryPoint.deepSeekOkHttpClient()
         settingsRepository = entryPoint.settingsRepository()
         messageManager = entryPoint.messageManager()
+        deepSeekAccountRepository = entryPoint.deepSeekAccountRepository()
         createNotificationChannel()
         startAsForeground(buildNotification(emptyList()))
         wakeLock = getSystemService(PowerManager::class.java)
@@ -324,12 +330,16 @@ internal class SubtitleTaskService : Service() {
         albums.forEach { album ->
             val albumTracks = tracksByAlbum[album.id].orEmpty()
             if (albumTracks.isEmpty()) return@forEach
-            val translated = client.translateDisplayNames(
-                albumTitle = album.title,
-                circle = album.circle,
-                cv = album.cv,
-                trackTitles = albumTracks.map { it.id to it.title }
-            )
+            val translated = try {
+                client.translateDisplayNames(
+                    albumTitle = album.title,
+                    circle = album.circle,
+                    cv = album.cv,
+                    trackTitles = albumTracks.map { it.id to it.title }
+                )
+            } finally {
+                requestBalanceRefresh()
+            }
             database.withTransaction {
                 database.subtitleTaskDao().getTask(taskId) ?: return@withTransaction
                 val items = database.subtitleTaskDao().getItemsForTask(taskId)
@@ -569,17 +579,22 @@ internal class SubtitleTaskService : Service() {
         val dao = database.subtitleTaskDao()
         val sources = sourceEntities.map { it.toGeneratedSource() }
         val confirmed = dao.getCommittedCaptions(itemId).map { it.toGeneratedCaption() }
-        requireTranslationClient().translateSubtitles(
-            sources = sources,
-            allowMerging = allowMerging,
-            confirmedCaptions = confirmed
-        ) { captions ->
-            commitTranslationProgress(
-                itemId = itemId,
-                captions = captions,
-                sourceEntities = sourceEntities,
-                generated = allowMerging
-            )
+        val client = requireTranslationClient()
+        try {
+            client.translateSubtitles(
+                sources = sources,
+                allowMerging = allowMerging,
+                confirmedCaptions = confirmed
+            ) { captions ->
+                commitTranslationProgress(
+                    itemId = itemId,
+                    captions = captions,
+                    sourceEntities = sourceEntities,
+                    generated = allowMerging
+                )
+            }
+        } finally {
+            requestBalanceRefresh()
         }
         repository.finishSucceeded(itemId)
     }
@@ -786,6 +801,7 @@ internal class SubtitleTaskService : Service() {
     private suspend fun stopWhenIdle() {
         if (transcriptionJob?.isActive == true || translationJobs.values.any(Job::isActive)) return
         if (titleTranslationJobs.values.any(Job::isActive)) return
+        if (balanceRefreshJob != null) return
         if (database.subtitleTaskDao().countRunnableItems() > 0) return
         val pendingTitleTaskIds = database.subtitleTitleOwnerDao().getPendingTaskIds()
         if (pendingTitleTaskIds.any { titleTranslationRetryAt[it] != TITLE_TRANSLATION_DISABLED_RETRY_AT }) return
@@ -889,12 +905,41 @@ internal class SubtitleTaskService : Service() {
     private suspend fun requireTranslationClient(): SubtitleTranslationClient {
         val apiKey = DeepSeekApiKeyStore.get(applicationContext).read()
         check(apiKey.isNotBlank()) { "请先在设置中配置 DeepSeek API Key" }
+        deepSeekAccountRepository.bindApiKey(apiKey)
         return SubtitleTranslationClient(
             okHttpClient = deepSeekOkHttpClient,
             gson = gson,
             apiKey = apiKey,
-            settings = settingsRepository.loadDeepSeekTranslationSettings()
+            settings = settingsRepository.loadDeepSeekTranslationSettings(),
+            onTokenUsage = { totalTokens ->
+                deepSeekAccountRepository.recordTokenUsage(apiKey, totalTokens)
+            }
         )
+    }
+
+    private fun requestBalanceRefresh() {
+        val jobToStart = synchronized(balanceRefreshLock) {
+            balanceRefreshRequested = true
+            if (balanceRefreshJob != null) return@synchronized null
+            serviceScope.launch(Dispatchers.IO, start = CoroutineStart.LAZY) {
+                while (true) {
+                    val shouldRefresh = synchronized(balanceRefreshLock) {
+                        if (balanceRefreshRequested) {
+                            balanceRefreshRequested = false
+                            true
+                        } else {
+                            balanceRefreshJob = null
+                            false
+                        }
+                    }
+                    if (!shouldRefresh) break
+                    val apiKey = DeepSeekApiKeyStore.get(applicationContext).read()
+                    if (apiKey.isNotBlank()) deepSeekAccountRepository.refreshBalance(apiKey)
+                }
+                signalWake()
+            }.also { balanceRefreshJob = it }
+        }
+        jobToStart?.start()
     }
 
     companion object {

--- a/app/src/main/java/com/asmr/player/subtitle/SubtitleTranslationClient.kt
+++ b/app/src/main/java/com/asmr/player/subtitle/SubtitleTranslationClient.kt
@@ -77,7 +77,13 @@ private data class DeepSeekFunctionDefinition(
 )
 
 private data class DeepSeekChatResponse(
-    val choices: List<DeepSeekChoice> = emptyList()
+    val choices: List<DeepSeekChoice> = emptyList(),
+    val usage: DeepSeekChatUsage? = null
+)
+
+private data class DeepSeekChatUsage(
+    @SerializedName("total_tokens")
+    val totalTokens: Long = 0L
 )
 
 private data class DeepSeekChoice(
@@ -114,9 +120,13 @@ internal class SubtitleTranslationClient(
     private val gson: Gson,
     apiKey: String,
     private val settings: DeepSeekTranslationSettings = DeepSeekTranslationSettings(),
-    private val apiUrl: String = DEEPSEEK_CHAT_COMPLETIONS_URL
+    private val apiUrl: String = DEEPSEEK_CHAT_COMPLETIONS_URL,
+    private val onTokenUsage: (Long) -> Unit = {}
 ) {
-    private val authorization = "Bearer ${apiKey.trim().also { require(it.isNotEmpty()) { "请先在设置中配置 DeepSeek API Key" } }}"
+    private val normalizedApiKey = apiKey.trim().also {
+        require(it.isNotEmpty()) { "请先在设置中配置 DeepSeek API Key" }
+    }
+    private val authorization = "Bearer $normalizedApiKey"
     private val callFactory: Call.Factory = okHttpClient.newBuilder()
         .connectTimeout(20, TimeUnit.SECONDS)
         .readTimeout(5, TimeUnit.MINUTES)
@@ -336,6 +346,10 @@ internal class SubtitleTranslationClient(
                 val deepSeekResponse = runCatching {
                     gson.fromJson(raw, DeepSeekChatResponse::class.java)
                 }.getOrNull()
+                deepSeekResponse?.usage?.totalTokens?.takeIf { totalTokens -> totalTokens > 0L }?.let { totalTokens ->
+                    runCatching { onTokenUsage(totalTokens) }
+                        .onFailure { error -> Log.w(TAG, "记录 DeepSeek token 用量失败", error) }
+                }
                 val choice = deepSeekResponse?.choices?.firstOrNull()
                 val message = choice?.message ?: DeepSeekChatMessage(role = "assistant")
                 val content = message.content.orEmpty()

--- a/app/src/main/java/com/asmr/player/subtitle/SubtitleTranslationClient.kt
+++ b/app/src/main/java/com/asmr/player/subtitle/SubtitleTranslationClient.kt
@@ -314,7 +314,7 @@ internal class SubtitleTranslationClient(
             throw cancelled
         } catch (error: IOException) {
             throw SubtitleTranslationException(
-                message = "无法连接 DeepSeek 翻译服务",
+                message = SubtitleFailureMessages.network(error),
                 retryable = true,
                 cause = error
             )
@@ -323,20 +323,13 @@ internal class SubtitleTranslationClient(
             response.use {
                 val raw = it.body?.string().orEmpty()
                 if (!it.isSuccessful) {
-                    val retryable = it.code == 408 || it.code == 425 || it.code == 429 || it.code >= 500
-                    val serviceMessage = parseDeepSeekErrorMessage(raw)
+                    val failure = SubtitleFailureMessages.deepSeekHttp(
+                        statusCode = it.code,
+                        serviceMessage = parseDeepSeekErrorMessage(raw)
+                    )
                     throw SubtitleTranslationException(
-                        message = when (it.code) {
-                            401 -> "DeepSeek API Key 无效"
-                            402 -> "DeepSeek 账户余额不足"
-                            429 -> "DeepSeek 请求过于频繁"
-                            in 500..599 -> "DeepSeek 服务暂时不可用"
-                            else -> buildString {
-                                append("DeepSeek 翻译请求失败（HTTP ${it.code}）")
-                                serviceMessage?.let { message -> append("：$message") }
-                            }
-                        },
-                        retryable = retryable,
+                        message = failure.message,
+                        retryable = failure.retryable,
                         retryAfterMs = parseRetryAfterMillis(it.header("Retry-After"))
                     )
                 }

--- a/app/src/main/java/com/asmr/player/ui/downloads/DownloadsScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/downloads/DownloadsScreen.kt
@@ -1026,7 +1026,7 @@ private fun TranslationSubtitleRow(
                     ?: "${subtitle.subtitleCount} 行字幕",
                 style = MaterialTheme.typography.labelSmall,
                 color = if (task?.state == SubtitleItemState.FAILED) colors.danger else colors.textTertiary,
-                maxLines = 1,
+                maxLines = if (task?.state == SubtitleItemState.FAILED) 2 else 1,
                 overflow = TextOverflow.Ellipsis
             )
             if (task != null) {
@@ -1075,7 +1075,7 @@ private fun TranslationSubtitleRow(
         }
         if (onRetryTask != null) {
             IconButton(onClick = onRetryTask, modifier = Modifier.size(32.dp)) {
-                Icon(Icons.Rounded.Refresh, "重新翻译完整字幕", tint = colors.primary, modifier = Modifier.size(16.dp))
+                Icon(Icons.Rounded.Refresh, "重试字幕任务", tint = colors.primary, modifier = Modifier.size(16.dp))
             }
         }
         if (onCancel != null) {
@@ -1185,8 +1185,8 @@ internal fun TranslationTaskRow(
                 Text(
                     text = task.message.ifBlank { task.stage },
                     style = MaterialTheme.typography.labelSmall,
-                    color = colors.textTertiary,
-                    maxLines = 1,
+                    color = if (task.state == SubtitleItemState.FAILED) colors.danger else colors.textTertiary,
+                    maxLines = if (task.state == SubtitleItemState.FAILED) 2 else 1,
                     overflow = TextOverflow.Ellipsis
                 )
             }
@@ -1211,7 +1211,7 @@ internal fun TranslationTaskRow(
                 onClick = onRetry,
                 modifier = Modifier.size(32.dp)
             ) {
-                Icon(Icons.Rounded.Refresh, "重新翻译完整字幕", tint = colors.primary, modifier = Modifier.size(16.dp))
+                Icon(Icons.Rounded.Refresh, "重试字幕任务", tint = colors.primary, modifier = Modifier.size(16.dp))
             }
             else -> IconButton(
                 onClick = onPause,

--- a/app/src/main/java/com/asmr/player/ui/downloads/DownloadsViewModel.kt
+++ b/app/src/main/java/com/asmr/player/ui/downloads/DownloadsViewModel.kt
@@ -28,6 +28,7 @@ import java.util.UUID
 import androidx.work.workDataOf
 import javax.inject.Inject
 import com.asmr.player.util.MessageManager
+import com.asmr.player.subtitle.SubtitleFailureMessages
 import com.asmr.player.subtitle.SubtitleItemState
 import com.asmr.player.subtitle.SubtitleTaskRepository
 import com.asmr.player.subtitle.SubtitleTaskUi
@@ -599,7 +600,12 @@ class DownloadsViewModel @Inject constructor(
                     if (handle.reusedExisting) "该音频已有可继续的字幕任务" else "已加入全局翻译队列"
                 )
             }.onFailure { error ->
-                messageManager.showError(error.message?.takeIf { it.isNotBlank() } ?: "无法重新翻译字幕")
+                val message = error.message?.takeIf { it.isNotBlank() } ?: "无法重新翻译字幕"
+                if (SubtitleFailureMessages.isUserActionWarning(message)) {
+                    messageManager.showWarning(message)
+                } else {
+                    messageManager.showError(message)
+                }
             }
         }
     }

--- a/app/src/main/java/com/asmr/player/ui/library/AlbumDetailScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/AlbumDetailScreen.kt
@@ -850,7 +850,7 @@ fun AlbumDetailScreen(
                                                 onPreviewImages = { request -> imagePreviewRequest = request },
                                                 onPreviewFile = { localPreviewFile = it },
                                                 onSubtitleGenerationError = viewModel.messageManager::showError,
-                                                onSubtitleGenerationUnavailable = viewModel.messageManager::showInfo,
+                                                onSubtitleGenerationUnavailable = viewModel.messageManager::showWarning,
                                                 onSubtitleGenerationQueued = viewModel.messageManager::showInfo,
                                                 animateIntro = shouldPlayInitialAnimations
                                             )

--- a/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailLocalTab.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailLocalTab.kt
@@ -86,6 +86,7 @@ import com.asmr.player.domain.model.Album
 import com.asmr.player.domain.model.Track
 import com.asmr.player.playback.MediaItemFactory
 import com.asmr.player.subtitle.SubtitleDeviceCapability
+import com.asmr.player.subtitle.SubtitleFailureMessages
 import com.asmr.player.subtitle.SubtitleGenerationTarget
 import com.asmr.player.subtitle.SubtitleTaskRepository
 import com.asmr.player.subtitle.SubtitleModelRepository
@@ -275,7 +276,12 @@ internal fun AlbumLocalBreadcrumbTabV2(
                 } catch (cancelled: kotlinx.coroutines.CancellationException) {
                     throw cancelled
                 } catch (error: Throwable) {
-                    onSubtitleGenerationError(error.message?.takeIf { it.isNotBlank() } ?: "无法开始生成并翻译字幕")
+                    val message = error.message?.takeIf { it.isNotBlank() } ?: "无法开始生成并翻译字幕"
+                    if (SubtitleFailureMessages.isUserActionWarning(message)) {
+                        onSubtitleGenerationUnavailable(message)
+                    } else {
+                        onSubtitleGenerationError(message)
+                    }
                 }
             }
         }

--- a/app/src/main/java/com/asmr/player/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/settings/SettingsScreen.kt
@@ -58,6 +58,7 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Constraints
 import androidx.compose.ui.unit.dp
@@ -1013,31 +1014,41 @@ internal fun DeepSeekTranslationSettingsSection(
             text = DEEPSEEK_SUBTITLE_MODEL,
             style = MaterialTheme.typography.bodyMedium,
             fontWeight = FontWeight.SemiBold,
-            modifier = Modifier.weight(1f)
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+            modifier = Modifier
+                .weight(1f)
+                .testTag("deepseek_model_name")
         )
         if (state.configured) {
-            Text(
-                text = "Token ${formatDeepSeekTokenTotal(accountState.totalTokens)} · 余额 ${formatDeepSeekBalances(accountState.balances)}",
-                style = MaterialTheme.typography.bodySmall,
-                color = if (accountState.balanceAvailable == false) {
-                    MaterialTheme.colorScheme.error
-                } else {
-                    MaterialTheme.colorScheme.onSurfaceVariant
-                },
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis,
-                modifier = Modifier
-                    .widthIn(max = 190.dp)
-                    .testTag("deepseek_account_summary")
-            )
-            Icon(
-                imageVector = Icons.Rounded.CheckCircle,
-                contentDescription = "API Key 已配置",
-                tint = Color(0xFF3E9B63),
-                modifier = Modifier
-                    .size(20.dp)
-                    .testTag("deepseek_api_key_configured")
-            )
+            Row(
+                modifier = Modifier.width(if (compact) 208.dp else 248.dp),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                Text(
+                    text = "Token ${formatDeepSeekTokenTotal(accountState.totalTokens)} · 余额 ${formatDeepSeekBalances(accountState.balances)}",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = if (accountState.balanceAvailable == false) {
+                        MaterialTheme.colorScheme.error
+                    } else {
+                        MaterialTheme.colorScheme.onSurfaceVariant
+                    },
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    modifier = Modifier
+                        .weight(1f)
+                        .testTag("deepseek_account_summary")
+                )
+                Icon(
+                    imageVector = Icons.Rounded.CheckCircle,
+                    contentDescription = "API Key 已配置",
+                    tint = Color(0xFF3E9B63),
+                    modifier = Modifier
+                        .size(20.dp)
+                        .testTag("deepseek_api_key_configured")
+                )
+            }
         }
     }
     Row(
@@ -1177,12 +1188,16 @@ private fun SubtitleModelSettingsSection(
             text = model.displayName,
             style = MaterialTheme.typography.bodyMedium,
             fontWeight = FontWeight.SemiBold,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
             modifier = Modifier.weight(1f)
         )
         Text(
             text = Formatting.formatFileSize(model.artifactBytes),
             style = MaterialTheme.typography.bodySmall,
-            color = MaterialTheme.colorScheme.onSurfaceVariant
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            textAlign = TextAlign.End,
+            modifier = Modifier.widthIn(min = 72.dp)
         )
     }
 

--- a/app/src/main/java/com/asmr/player/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/settings/SettingsScreen.kt
@@ -80,6 +80,9 @@ import com.asmr.player.subtitle.SubtitleModelDownloadSource
 import com.asmr.player.subtitle.SubtitleModelState
 import com.asmr.player.subtitle.SubtitleTranscriptionModels
 import com.asmr.player.subtitle.DEEPSEEK_SUBTITLE_MODEL
+import com.asmr.player.subtitle.DeepSeekAccountState
+import com.asmr.player.subtitle.formatDeepSeekBalances
+import com.asmr.player.subtitle.formatDeepSeekTokenTotal
 import com.asmr.player.ui.library.BulkPhase
 import com.asmr.player.ui.library.LibraryViewModel
 import com.asmr.player.ui.common.AppSupportStatusSection
@@ -96,6 +99,7 @@ import com.asmr.player.ui.common.thinScrollbar
 import com.asmr.player.ui.common.withAddedBottomPadding
 import com.asmr.player.ui.common.collectAsStateWhileActive
 import com.asmr.player.ui.update.launchDownloadedApkInstall
+import com.asmr.player.util.Formatting
 import kotlin.math.abs
 import kotlin.math.roundToInt
 
@@ -134,6 +138,7 @@ fun SettingsScreen(
     val appCacheState by viewModel.appCacheState.collectAsStateWhileActive(isDataActive)
     val subtitleModelState by viewModel.subtitleModelState.collectAsStateWhileActive(isDataActive)
     val deepSeekApiKeyState by viewModel.deepSeekApiKeyState.collectAsStateWhileActive(isDataActive)
+    val deepSeekAccountState by viewModel.deepSeekAccountState.collectAsStateWhileActive(isDataActive)
     val deepSeekTranslationSettings by viewModel.deepSeekTranslationSettings.collectAsStateWhileActive(isDataActive)
     val updateState by viewModel.updateState.collectAsStateWhileActive(isDataActive)
     val autoUpdateCheckEnabled by viewModel.autoUpdateCheckEnabled.collectAsStateWhileActive(isDataActive)
@@ -775,6 +780,7 @@ fun SettingsScreen(
                         HorizontalDivider(color = MaterialTheme.colorScheme.outline.copy(alpha = 0.14f))
                         DeepSeekTranslationSettingsSection(
                             state = deepSeekApiKeyState,
+                            accountState = deepSeekAccountState,
                             settings = deepSeekTranslationSettings,
                             apiKeyInput = deepSeekApiKeyInput,
                             compact = isCompact,
@@ -985,6 +991,7 @@ fun SettingsScreen(
 @Composable
 internal fun DeepSeekTranslationSettingsSection(
     state: DeepSeekApiKeyUiState,
+    accountState: DeepSeekAccountState = DeepSeekAccountState(),
     settings: DeepSeekTranslationSettings,
     apiKeyInput: String,
     compact: Boolean,
@@ -1009,6 +1016,20 @@ internal fun DeepSeekTranslationSettingsSection(
             modifier = Modifier.weight(1f)
         )
         if (state.configured) {
+            Text(
+                text = "Token ${formatDeepSeekTokenTotal(accountState.totalTokens)} · 余额 ${formatDeepSeekBalances(accountState.balances)}",
+                style = MaterialTheme.typography.bodySmall,
+                color = if (accountState.balanceAvailable == false) {
+                    MaterialTheme.colorScheme.error
+                } else {
+                    MaterialTheme.colorScheme.onSurfaceVariant
+                },
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                modifier = Modifier
+                    .widthIn(max = 190.dp)
+                    .testTag("deepseek_account_summary")
+            )
             Icon(
                 imageVector = Icons.Rounded.CheckCircle,
                 contentDescription = "API Key 已配置",
@@ -1147,16 +1168,23 @@ private fun SubtitleModelSettingsSection(
         state is SubtitleModelState.Downloading ||
         state is SubtitleModelState.Verifying
 
-    Text(
-        text = model.displayName,
-        style = MaterialTheme.typography.bodyMedium,
-        fontWeight = FontWeight.SemiBold
-    )
-    Text(
-        text = "首次下载会同时安装约 11 MiB 的字幕运行时；删除模型后运行时会保留。",
-        style = MaterialTheme.typography.bodySmall,
-        color = MaterialTheme.colorScheme.onSurfaceVariant
-    )
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(8.dp)
+    ) {
+        Text(
+            text = model.displayName,
+            style = MaterialTheme.typography.bodyMedium,
+            fontWeight = FontWeight.SemiBold,
+            modifier = Modifier.weight(1f)
+        )
+        Text(
+            text = Formatting.formatFileSize(model.artifactBytes),
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+    }
 
     if (state !is SubtitleModelState.Available) {
         SingleChoiceSegmentedButtonRow(modifier = Modifier.fillMaxWidth()) {

--- a/app/src/main/java/com/asmr/player/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/asmr/player/ui/settings/SettingsViewModel.kt
@@ -22,6 +22,7 @@ import com.asmr.player.subtitle.SubtitleModelDownloadSource
 import com.asmr.player.subtitle.SubtitleModelRepository
 import com.asmr.player.subtitle.SubtitleModelState
 import com.asmr.player.subtitle.DeepSeekApiKeyStore
+import com.asmr.player.subtitle.DeepSeekAccountRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
 import java.io.File
@@ -89,6 +90,7 @@ class SettingsViewModel @Inject constructor(
     private val settingsDataStore: SettingsDataStore,
     private val appCacheManager: AppCacheManager,
     private val okHttpClient: OkHttpClient,
+    private val deepSeekAccountRepository: DeepSeekAccountRepository,
     @ApplicationContext private val context: Context
 ) : ViewModel() {
     private val subtitleModelRepository = SubtitleModelRepository.get(context)
@@ -165,6 +167,7 @@ class SettingsViewModel @Inject constructor(
     internal val subtitleModelState: StateFlow<SubtitleModelState> = subtitleModelRepository.state
     private val _deepSeekApiKeyState = MutableStateFlow(DeepSeekApiKeyUiState())
     internal val deepSeekApiKeyState = _deepSeekApiKeyState.asStateFlow()
+    internal val deepSeekAccountState = deepSeekAccountRepository.state
 
     private val updateClient = GitHubUpdateClient(okHttpClient)
     private val _updateState = MutableStateFlow<AppUpdateState>(AppUpdateState.Idle)
@@ -175,8 +178,13 @@ class SettingsViewModel @Inject constructor(
     init {
         appCacheManager.start()
         viewModelScope.launch(Dispatchers.IO) {
-            val configured = deepSeekApiKeyStore.isConfigured()
+            val apiKey = deepSeekApiKeyStore.read()
+            val configured = apiKey.isNotBlank()
             _deepSeekApiKeyState.value = _deepSeekApiKeyState.value.copy(configured = configured)
+            if (configured) {
+                deepSeekAccountRepository.bindApiKey(apiKey)
+                deepSeekAccountRepository.refreshBalance(apiKey)
+            }
         }
     }
 
@@ -294,22 +302,23 @@ class SettingsViewModel @Inject constructor(
                 saving = true,
                 errorMessage = null
             )
-            runCatching { deepSeekApiKeyStore.save(normalized) }
-                .onSuccess {
-                    val current = _deepSeekApiKeyState.value
-                    _deepSeekApiKeyState.value = current.copy(
-                        configured = true,
-                        saving = false,
-                        errorMessage = null,
-                        saveVersion = current.saveVersion + 1L
-                    )
-                }
-                .onFailure {
-                    _deepSeekApiKeyState.value = _deepSeekApiKeyState.value.copy(
-                        saving = false,
-                        errorMessage = "API Key 保存失败"
-                    )
-                }
+            val saved = runCatching { deepSeekApiKeyStore.save(normalized) }.isSuccess
+            if (saved) {
+                deepSeekAccountRepository.bindApiKey(normalized)
+                val current = _deepSeekApiKeyState.value
+                _deepSeekApiKeyState.value = current.copy(
+                    configured = true,
+                    saving = false,
+                    errorMessage = null,
+                    saveVersion = current.saveVersion + 1L
+                )
+                deepSeekAccountRepository.refreshBalance(normalized)
+            } else {
+                _deepSeekApiKeyState.value = _deepSeekApiKeyState.value.copy(
+                    saving = false,
+                    errorMessage = "API Key 保存失败"
+                )
+            }
         }
     }
 

--- a/app/src/main/java/com/asmr/player/util/AppErrorMessageFormatter.kt
+++ b/app/src/main/java/com/asmr/player/util/AppErrorMessageFormatter.kt
@@ -3,6 +3,17 @@ package com.asmr.player.util
 object AppErrorMessageFormatter {
     private val whitespaceRegex = Regex("""\s+""")
     private val rjSampleRegex = Regex("""[（(]\s*如\s*RJ\d{6,}\s*[)）]""", RegexOption.IGNORE_CASE)
+    private val userFacingSubtitleErrorPrefixes = listOf(
+        "本地转录失败：",
+        "本地转录未识别到",
+        "字幕在转录期间已被修改",
+        "字幕翻译失败：",
+        "字幕翻译模型返回格式错误：",
+        "DeepSeek ",
+        "无法连接 DeepSeek",
+        "无法与 DeepSeek",
+        "请先在设置中配置 DeepSeek API Key"
+    )
     private val technicalDetailRegexes = listOf(
         Regex("""\bHTTP\s*\d{3}\b""", RegexOption.IGNORE_CASE),
         Regex("""\b[A-Za-z]+Exception\b"""),
@@ -37,6 +48,7 @@ object AppErrorMessageFormatter {
 
     private fun explicitMessage(message: String): String? {
         return when {
+            userFacingSubtitleErrorPrefixes.any(message::startsWith) -> message
             message.startsWith("请输入有效 RJ 号") -> "请输入有效的作品编号"
             message.startsWith("仅支持本地库专辑手动绑定 RJ") -> "仅支持本地库专辑手动绑定作品编号"
             else -> null

--- a/app/src/test/java/com/asmr/player/subtitle/DeepSeekAccountFormattingTest.kt
+++ b/app/src/test/java/com/asmr/player/subtitle/DeepSeekAccountFormattingTest.kt
@@ -1,0 +1,30 @@
+package com.asmr.player.subtitle
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class DeepSeekAccountFormattingTest {
+    @Test
+    fun tokenTotal_usesCompactDecimalUnits() {
+        assertEquals("999", formatDeepSeekTokenTotal(999L))
+        assertEquals("1K", formatDeepSeekTokenTotal(1_000L))
+        assertEquals("12.3K", formatDeepSeekTokenTotal(12_345L))
+        assertEquals("1M", formatDeepSeekTokenTotal(1_000_000L))
+        assertEquals("2.5B", formatDeepSeekTokenTotal(2_500_000_000L))
+    }
+
+    @Test
+    fun balances_formatsKnownCurrenciesAndFallback() {
+        assertEquals(
+            "¥12.35 / $3 / JPY 90",
+            formatDeepSeekBalances(
+                listOf(
+                    DeepSeekBalance("CNY", "12.345"),
+                    DeepSeekBalance("USD", "3.00"),
+                    DeepSeekBalance("JPY", "90")
+                )
+            )
+        )
+        assertEquals("--", formatDeepSeekBalances(emptyList()))
+    }
+}

--- a/app/src/test/java/com/asmr/player/subtitle/SubtitleFailureMessagesTest.kt
+++ b/app/src/test/java/com/asmr/player/subtitle/SubtitleFailureMessagesTest.kt
@@ -1,0 +1,93 @@
+package com.asmr.player.subtitle
+
+import java.net.SocketTimeoutException
+import java.net.UnknownHostException
+import javax.net.ssl.SSLHandshakeException
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class SubtitleFailureMessagesTest {
+    @Test
+    fun userActionWarnings_includeMissingModelKeyAndBalance() {
+        assertTrue(
+            SubtitleFailureMessages.isUserActionWarning(SubtitleModelRepository.MODEL_REQUIRED_MESSAGE)
+        )
+        assertTrue(
+            SubtitleFailureMessages.isUserActionWarning("请先在设置中配置 DeepSeek API Key")
+        )
+        assertTrue(
+            SubtitleFailureMessages.isUserActionWarning("DeepSeek 账户余额不足，请充值后重试。")
+        )
+        assertFalse(
+            SubtitleFailureMessages.isUserActionWarning("DeepSeek 网络请求超时，请检查网络后重试。")
+        )
+    }
+
+    @Test
+    fun transcription_reportsNestedOomAndPreservedProgress() {
+        val message = SubtitleFailureMessages.transcription(
+            IllegalStateException("模型初始化失败", OutOfMemoryError("Failed to allocate tensor"))
+        )
+
+        assertTrue(message.contains("内存不足（OOM）"))
+        assertTrue(message.contains("已保留已完成的转录进度"))
+    }
+
+    @Test
+    fun transcription_reportsNativeRuntimeIncompatibility() {
+        val message = SubtitleFailureMessages.transcription(
+            UnsatisfiedLinkError("dlopen failed: cannot locate symbol")
+        )
+
+        assertTrue(message.contains("运行环境与当前设备不兼容"))
+        assertTrue(message.contains("arm64-v8a"))
+    }
+
+    @Test
+    fun transcription_reportsCorruptedComponentWithRecoveryAction() {
+        val message = SubtitleFailureMessages.transcription(
+            IllegalStateException("模型校验失败：model.int8.onnx")
+        )
+
+        assertTrue(message.contains("模型或运行组件缺失、损坏"))
+        assertTrue(message.contains("重新下载字幕模型"))
+    }
+
+    @Test
+    fun network_errorsProvideSpecificRecoveryActions() {
+        assertTrue(
+            SubtitleFailureMessages.network(SocketTimeoutException()).contains("请求超时")
+        )
+        assertTrue(
+            SubtitleFailureMessages.network(UnknownHostException()).contains("网络或代理设置")
+        )
+        assertTrue(
+            SubtitleFailureMessages.network(SSLHandshakeException("certificate"))
+                .contains("系统时间、证书或代理设置")
+        )
+    }
+
+    @Test
+    fun deepSeekHttp_mapsCredentialAndBalanceFailuresWithoutRetry() {
+        val invalidKey = SubtitleFailureMessages.deepSeekHttp(401, "Authentication Fails")
+        val insufficientBalance = SubtitleFailureMessages.deepSeekHttp(402, "Insufficient Balance")
+
+        assertEquals("DeepSeek API Key 无效或已失效，请前往设置重新配置后重试。", invalidKey.message)
+        assertFalse(invalidKey.retryable)
+        assertEquals("DeepSeek 账户余额不足，请充值后重试。", insufficientBalance.message)
+        assertFalse(insufficientBalance.retryable)
+    }
+
+    @Test
+    fun deepSeekHttp_retriesRateLimitAndServerFailures() {
+        val rateLimited = SubtitleFailureMessages.deepSeekHttp(429, null)
+        val unavailable = SubtitleFailureMessages.deepSeekHttp(503, null)
+
+        assertTrue(rateLimited.retryable)
+        assertTrue(rateLimited.message.contains("请求过于频繁"))
+        assertTrue(unavailable.retryable)
+        assertTrue(unavailable.message.contains("服务暂时不可用"))
+    }
+}

--- a/app/src/test/java/com/asmr/player/subtitle/SubtitleTranslationClientTest.kt
+++ b/app/src/test/java/com/asmr/player/subtitle/SubtitleTranslationClientTest.kt
@@ -69,6 +69,52 @@ class SubtitleTranslationClientTest {
     }
 
     @Test
+    fun successfulResponse_reportsTotalTokenUsage() = runBlocking {
+        val responseBody = Gson().toJson(
+            mapOf(
+                "choices" to listOf(
+                    mapOf(
+                        "finish_reason" to "stop",
+                        "message" to mapOf(
+                            "role" to "assistant",
+                            "content" to """{"work_title":"晚安","tracks":[{"track_id":13,"title":"耳语"}]}"""
+                        )
+                    )
+                ),
+                "usage" to mapOf("total_tokens" to 1_234L)
+            )
+        )
+        val httpClient = OkHttpClient.Builder()
+            .addInterceptor { chain ->
+                Response.Builder()
+                    .request(chain.request())
+                    .protocol(Protocol.HTTP_1_1)
+                    .code(200)
+                    .message("OK")
+                    .body(responseBody.toResponseBody("application/json".toMediaType()))
+                    .build()
+            }
+            .build()
+        val tokenUsage = mutableListOf<Long>()
+        val client = SubtitleTranslationClient(
+            okHttpClient = httpClient,
+            gson = Gson(),
+            apiKey = "test-key",
+            apiUrl = "https://example.test/chat",
+            onTokenUsage = tokenUsage::add
+        )
+
+        client.translateDisplayNames(
+            albumTitle = "おやすみ",
+            circle = "",
+            cv = "",
+            trackTitles = listOf(13L to "囁き")
+        )
+
+        assertEquals(listOf(1_234L), tokenUsage)
+    }
+
+    @Test
     fun manualPrompt_forbidsMergingImportedSubtitleLines() {
         val prompt = subtitleToolTranslationSystemPrompt(listOf(0, 2), allowMerging = false)
 

--- a/app/src/test/java/com/asmr/player/util/MessageManagerTest.kt
+++ b/app/src/test/java/com/asmr/player/util/MessageManagerTest.kt
@@ -1,10 +1,20 @@
 package com.asmr.player.util
 
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class MessageManagerTest {
+
+    @Test
+    fun errorFormatter_preservesActionableSubtitleFailureDetails() {
+        val oomMessage = "本地转录失败：运行模型时内存不足（OOM），请关闭占用内存的应用后重试。"
+        val keyMessage = "DeepSeek API Key 无效或已失效，请前往设置重新配置后重试。"
+
+        assertEquals(oomMessage, AppErrorMessageFormatter.sanitize(oomMessage))
+        assertEquals(keyMessage, AppErrorMessageFormatter.sanitize(keyMessage))
+    }
 
     @Test
     fun tryConsume_allowsEachMessageOnlyOnce() {


### PR DESCRIPTION
## 改动内容

- 完善本地日语转录的模型兼容、运行时、OOM、模型文件和音频解码错误提示，并统一使用 App 内消息气泡反馈。
- 完善 DeepSeek 未配置 API Key、鉴权失败、余额不足、限流及网络异常提示，保留任务错误状态并支持合理重试。
- 按当前 API Key 累计 `total_tokens`，通过 `/user/balance` 展示余额，并在每次 LLM 翻译结束后自动刷新。
- 优化翻译配置布局：显示转录模型尺寸，移除冗余下载说明；模型名称固定单行并使用省略号，右侧为用量、余额和尺寸预留稳定空间。

## 验证

- `:app:compileReleaseKotlin` 通过
- `:app:compileReleaseUnitTestKotlin` 通过
- `:app:compileReleaseAndroidTestKotlin` 通过
- `:app:installRelease` 成功安装到 Android 16 实体机和小屏模拟器

## 说明

- 既有 API Key 的历史 token 无法由 DeepSeek 反查，累计值从安装本版本后的首次成功响应开始。
- 定向 instrumentation 运行因连接设备等待未返回结果；没有收到测试断言失败，Release 测试源码编译已通过。