### PR TITLE
feat: 增加轻量转录模型与批量推理

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -73,6 +73,14 @@ android {
         System.getenv("SUBTITLE_MODEL_HUGGING_FACE_URL")
             ?: (project.findProperty("SUBTITLE_MODEL_HUGGING_FACE_URL") as? String)
             ?: "https://huggingface.co/csukuangfj/sherpa-onnx-nemo-parakeet-tdt_ctc-0.6b-ja-35000-int8/resolve/main/"
+    val subtitleSenseVoiceHuggingFaceUrl =
+        System.getenv("SUBTITLE_SENSEVOICE_HUGGING_FACE_URL")
+            ?: (project.findProperty("SUBTITLE_SENSEVOICE_HUGGING_FACE_URL") as? String)
+            ?: "https://huggingface.co/csukuangfj/sherpa-onnx-sense-voice-zh-en-ja-ko-yue-2024-07-17/resolve/main/"
+    val subtitleSenseVoiceGitHubUrl =
+        System.getenv("SUBTITLE_SENSEVOICE_GITHUB_URL")
+            ?: (project.findProperty("SUBTITLE_SENSEVOICE_GITHUB_URL") as? String)
+            ?: "https://github.com/eValDoll/EaraAsmrPlayer/releases/download/subtitle-model-parakeet-ja-int8/sensevoice-{fileName}"
     val subtitleRuntimeUrl =
         System.getenv("SUBTITLE_RUNTIME_URL")
             ?: (project.findProperty("SUBTITLE_RUNTIME_URL") as? String)
@@ -89,6 +97,8 @@ android {
         buildConfigField("String", "LISTEN_TOGETHER_BASE_URL", "\"$listenTogetherBaseUrl\"")
         buildConfigField("String", "SUBTITLE_MODEL_GITHUB_URL", "\"$subtitleModelGitHubUrl\"")
         buildConfigField("String", "SUBTITLE_MODEL_HUGGING_FACE_URL", "\"$subtitleModelHuggingFaceUrl\"")
+        buildConfigField("String", "SUBTITLE_SENSEVOICE_GITHUB_URL", "\"$subtitleSenseVoiceGitHubUrl\"")
+        buildConfigField("String", "SUBTITLE_SENSEVOICE_HUGGING_FACE_URL", "\"$subtitleSenseVoiceHuggingFaceUrl\"")
         buildConfigField("String", "SUBTITLE_RUNTIME_URL", "\"$subtitleRuntimeUrl\"")
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
@@ -101,6 +111,9 @@ android {
         release {
             isMinifyEnabled = true
             proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro")
+            if (project.hasProperty("releaseAndroidTest")) {
+                proguardFiles("proguard-android-test.pro")
+            }
             signingConfig = signingConfigs.getByName("earaRelease")
         }
         create("benchmark") {

--- a/app/libs/README.md
+++ b/app/libs/README.md
@@ -17,9 +17,20 @@
 Silero VAD 模型仍位于 `app/src/main/assets/subtitle/silero_vad.onnx`，SHA-256 为
 `9e2449e1087496d8d4caba907f23e0bd3f78d91fa552479bb9c23ac09cbb1fd6`。
 
-日语字幕模型使用运行时下载的
-`sherpa-onnx-nemo-parakeet-tdt_ctc-0.6b-ja-35000-int8`。原始 NVIDIA
-Parakeet 模型采用 CC-BY-4.0 许可证，应用不会把该模型打包进 APK。
-除 Hugging Face 上游下载地址外，GitHub 镜像发布在
-<https://github.com/eValDoll/EaraAsmrPlayer/releases/tag/subtitle-model-parakeet-ja-int8>，
-两个渠道下载后都会按应用内固定的文件大小和 SHA-256 摘要校验。
+应用提供两个可共存的日语转录模型，均复用上述 sherpa-onnx 1.13.2、Silero VAD、
+ONNX CPU provider 和线程策略，不会引入新的推理框架：
+
+- `sherpa-onnx-nemo-parakeet-tdt_ctc-0.6b-ja-35000-int8`：默认高精度方案，
+  模型制品共 `655,571,161` 字节。原始 NVIDIA Parakeet 模型采用 CC-BY-4.0
+  许可证。除 Hugging Face 上游地址外，GitHub 镜像发布在
+  <https://github.com/eValDoll/EaraAsmrPlayer/releases/tag/subtitle-model-parakeet-ja-int8>。
+- `SenseVoiceSmall INT8 2024-07-17`：轻量方案，来源模型名称为
+  `iic/SenseVoiceSmall`，由 FunASR/SenseVoice 作者和 sherpa-onnx 转换流程提供；
+  模型制品共 `239,549,735` 字节。应用固定以日语和 ITN 标点模式运行。除
+  Hugging Face 上游地址外，GitHub 镜像与 Parakeet 位于同一 Release，资源名为
+  `sensevoice-model.int8.onnx` 和 `sensevoice-tokens.txt`。模型权重遵循
+  FunASR Model Open Source License Agreement 1.1，见
+  `SenseVoiceSmall-MODEL-LICENSE.txt`。
+
+应用不会把任一转录模型打包进 APK。每个下载文件都会按应用内固定的文件大小和
+SHA-256 摘要校验；下载新模型不会自动改变当前模型，用户需在设置页显式切换。

--- a/app/libs/SenseVoiceSmall-MODEL-LICENSE.txt
+++ b/app/libs/SenseVoiceSmall-MODEL-LICENSE.txt
@@ -1,0 +1,99 @@
+FunASR Model Open Source License Agreement
+
+Version: 1.1
+
+Copyright (C) [2023-2028] [Alibaba Group]. All rights reserved.
+
+Thank you for choosing the FunASR open-source model. The FunASR open-source model includes a range of free and open industrial models for you to use, modify, share, and learn from.
+
+To ensure better community collaboration, we have established the following agreement, and we hope you will read and comply with its terms.
+Definitions
+In this agreement, [FunASR Software] refers to FunASR open-source model weights and their derivatives, including finetuned models; [You] refers to individuals or organizations using, modifying, sharing, and learning from [FunASR Software].
+
+2 License and Restrictions
+
+2.1 License
+
+You are free to use, copy, modify, and share [FunASR Software] under the terms of this agreement.
+
+2.2 Restrictions
+When using, copying, modifying, and sharing [FunASR Software], you must attribute the source and author information and retain relevant model names in [FunASR Software].
+
+3 Responsibility and Risk
+
+[FunASR Software] is provided for reference and learning purposes only, and Alibaba Group assumes no responsibility for any direct or indirect losses resulting from your use or modification of [FunASR Software]. You should assume all risks associated with using and modifying [FunASR Software].
+4 Community Conduct Guidelines
+
+4.1 Encouraged Behavior
+
+The community welcomes developers and users to engage in discussions about [FunASR Software]. Participants are encouraged to interact in a friendly, polite, and respectful manner to foster constructive discussion and collaboration.
+
+4.2 Prohibited Behavior
+Individual or organizational users shall not engage in unjustified denigration, malicious smearing, or baseless insults against [FunASR Software]. Such behavior is considered a violation of the spirit of community cooperation. If a user is found to be engaging in the prohibited behavior mentioned above, it will be considered an automatic forfeiture of all licenses under this agreement.
+
+5 Termination
+If you violate any terms of this agreement, your license will automatically terminate, and you must cease using, copying, modifying, and sharing [FunASR Software].
+
+6 Revisions
+
+This agreement may be updated and revised occasionally. The revised agreement will be published in the official repository of [FunASR Software] and will take effect automatically. Continuing to use, copy, modify, and share [FunASR Software] indicates your acceptance of the revised agreement.
+
+7 Miscellaneous
+This agreement is governed by the laws of [Country/Region]. If any provision is deemed illegal, invalid, or unenforceable, that provision shall be considered severed from this agreement, and the remaining provisions shall continue to be valid and binding.
+
+If you have any questions or comments regarding this agreement, please contact us.
+
+Copyright © [2023-2028] [Alibaba Group]. All rights reserved.
+
+
+FunASR 模型开源协议
+
+版本号：1.1
+
+版权所有 (C) [2023-2028] [阿里巴巴集团]。保留所有权利。
+感谢您选择 FunASR 开源模型。FunASR 开源模型包含一系列免费且开源的工业模型，让大家可以使用、修改、分享和学习该模型。
+
+为了保证更好的社区合作，我们制定了以下协议，希望您仔细阅读并遵守本协议。
+
+1 定义
+
+本协议中，[FunASR 软件]指 FunASR 开源模型权重及其衍生品，包括 Finetune 后的模型；[您]指使用、修改、分享和学习[FunASR 软件]的个人或组织。
+
+2 许可和限制
+
+2.1 许可
+
+您可以在遵守本协议的前提下，自由地使用、复制、修改和分享[FunASR 软件]。
+
+2.2 限制
+
+您在使用、复制、修改和分享[FunASR 软件]时，必须注明出处以及作者信息，并保留[FunASR 软件]中相关模型名称。
+
+3 责任和风险承担
+
+[FunASR 软件]仅作为参考和学习使用，不对您使用或修改[FunASR 软件]造成的任何直接或间接损失承担任何责任。您对[FunASR 软件]的使用和修改应该自行承担风险。
+
+4 社区行为准则
+
+4.1 欢迎交流
+
+社区欢迎开发者与用户对[FunASR 软件]进行交流讨论。交流中请注意保持友好、礼貌和文明，以促进建设性的讨论和合作。
+4.2 禁止行为
+
+个人或组织用户不得对[FunASR 软件]进行无端诋毁、恶意抹黑或凭空谩骂。此类行为被视为违反社区合作精神。如被认定从事上述禁止行为，将视为自动放弃本协议下的所有许可。
+
+5 终止
+
+如果您违反本协议的任何条款，您的许可将自动终止，您必须停止使用、复制、修改和分享[FunASR 软件]。
+
+6 修订
+
+本协议可能会不时更新和修订。修订后的协议将在[FunASR 软件]官方仓库发布，并自动生效。如果您继续使用、复制、修改和分享[FunASR 软件]，即表示您同意修订后的协议。
+
+7 其他规定
+
+本协议受到[国家/地区] 的法律管辖。如果任何条款被裁定为不合法、无效或无法执行，则该条款应被视为从本协议中删除，而其余条款应继续有效并具有约束力。
+
+如果您对本协议有任何问题或意见，请联系我们。
+
+版权所有© [2023-2028] [阿里巴巴集团]。保留所有权利。

--- a/app/proguard-android-test.pro
+++ b/app/proguard-android-test.pro
@@ -1,0 +1,5 @@
+# AndroidJUnitRunner 1.5.2 运行 Release instrumentation 时会从目标应用进程访问该类。
+-keep class androidx.tracing.Trace { *; }
+
+# AndroidX Test Platform 的 Kotlin 实现运行在目标应用的 instrumentation 进程中。
+-keep class kotlin.** { *; }

--- a/app/src/androidTest/java/com/asmr/player/data/local/db/AppDatabaseMigrationAndroidTest.kt
+++ b/app/src/androidTest/java/com/asmr/player/data/local/db/AppDatabaseMigrationAndroidTest.kt
@@ -1,0 +1,55 @@
+package com.asmr.player.data.local.db
+
+import androidx.sqlite.db.SupportSQLiteDatabase
+import androidx.sqlite.db.SupportSQLiteOpenHelper
+import androidx.sqlite.db.framework.FrameworkSQLiteOpenHelperFactory
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class AppDatabaseMigrationAndroidTest {
+    @Test
+    fun migration28To29_preservesItemAndAddsModelSnapshot() {
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        val databaseName = "migration-28-29-${System.nanoTime()}.db"
+        val helper = FrameworkSQLiteOpenHelperFactory().create(
+            SupportSQLiteOpenHelper.Configuration.builder(context)
+                .name(databaseName)
+                .callback(object : SupportSQLiteOpenHelper.Callback(28) {
+                    override fun onCreate(db: SupportSQLiteDatabase) {
+                        db.execSQL(
+                            "CREATE TABLE subtitle_task_items (" +
+                                "`id` TEXT NOT NULL PRIMARY KEY, `trackTitle` TEXT NOT NULL)"
+                        )
+                        db.execSQL("INSERT INTO subtitle_task_items VALUES('item-1','晚安音声')")
+                    }
+
+                    override fun onUpgrade(
+                        db: SupportSQLiteDatabase,
+                        oldVersion: Int,
+                        newVersion: Int
+                    ) = Unit
+                })
+                .build()
+        )
+        try {
+            val database = helper.writableDatabase
+            AppDatabaseMigrations.MIGRATION_28_29.migrate(database)
+            database.query(
+                "SELECT trackTitle, transcriptionModelId " +
+                    "FROM subtitle_task_items WHERE id = 'item-1'"
+            ).use { cursor ->
+                assertTrue(cursor.moveToFirst())
+                assertEquals("晚安音声", cursor.getString(0))
+                assertEquals("", cursor.getString(1))
+            }
+        } finally {
+            helper.close()
+            context.deleteDatabase(databaseName)
+        }
+    }
+}

--- a/app/src/androidTest/java/com/asmr/player/subtitle/SenseVoiceModelLoadingTest.kt
+++ b/app/src/androidTest/java/com/asmr/player/subtitle/SenseVoiceModelLoadingTest.kt
@@ -1,0 +1,103 @@
+package com.asmr.player.subtitle
+
+import android.os.Build
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import java.io.File
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+import org.junit.Assert.assertTrue
+import org.junit.Assume.assumeTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class SenseVoiceModelLoadingTest {
+    @Test
+    fun officialJapaneseSample_createsModelAndReturnsNonEmptyTranscription() {
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        val context = instrumentation.targetContext
+        val assets = instrumentation.context.assets
+        val runtimeRepository = SherpaOnnxRuntimeRepository.get(context)
+        val runtime = runtimeRepository.descriptor
+        val model = SubtitleTranscriptionModels.SENSE_VOICE_SMALL_INT8
+        assumeTrue(Build.SUPPORTED_ABIS.any { it == runtime.abi })
+        assumeTrue(
+            assets.list(ASSET_DIRECTORY).orEmpty().toList().containsAll(REQUIRED_MODEL_ASSETS)
+        )
+        assumeTrue(assets.list("").orEmpty().contains(runtime.archiveFileName))
+
+        val modelDirectory = File(context.cacheDir, "sensevoice-instrumentation-model")
+        modelDirectory.deleteRecursively()
+        assertTrue(modelDirectory.mkdirs())
+        try {
+            if (!runtimeRepository.isInstalled()) {
+                assets.open(runtime.archiveFileName).use { input ->
+                    runtimeRepository.partialArchiveFile().outputStream().use(input::copyTo)
+                }
+                runtimeRepository.installDownloadedArchive()
+            }
+            model.artifacts.forEach { artifact ->
+                assets.open("$ASSET_DIRECTORY/${artifact.fileName}").use { input ->
+                    File(modelDirectory, artifact.fileName).outputStream().use(input::copyTo)
+                }
+            }
+            val samples = assets.open("$ASSET_DIRECTORY/$JAPANESE_WAV").use { input ->
+                decodeMono16BitWav(input.readBytes())
+            }
+            SherpaOnnxTranscriptionEngine(context, modelDirectory, model).use { engine ->
+                val result = engine.transcribe(
+                    channelSamples = listOf(samples),
+                    isCancelled = { false },
+                    onProgress = {}
+                )
+                assertTrue(result.joinToString("") { it.text }.isNotBlank())
+                assertTrue(result.flatMap { it.tokens }.isNotEmpty())
+            }
+        } finally {
+            modelDirectory.deleteRecursively()
+        }
+    }
+
+    private fun decodeMono16BitWav(bytes: ByteArray): FloatArray {
+        require(bytes.size >= 44 && bytes.copyOfRange(0, 4).decodeToString() == "RIFF")
+        var offset = 12
+        var channelCount = 0
+        var bitsPerSample = 0
+        var dataOffset = -1
+        var dataSize = 0
+        while (offset + 8 <= bytes.size) {
+            val chunkName = bytes.copyOfRange(offset, offset + 4).decodeToString()
+            val chunkSize = ByteBuffer.wrap(bytes, offset + 4, 4)
+                .order(ByteOrder.LITTLE_ENDIAN)
+                .int
+            val chunkData = offset + 8
+            when (chunkName) {
+                "fmt " -> {
+                    val format = ByteBuffer.wrap(bytes, chunkData, chunkSize)
+                        .order(ByteOrder.LITTLE_ENDIAN)
+                    require(format.short.toInt() == 1) { "测试音频必须是 PCM" }
+                    channelCount = format.short.toInt()
+                    format.int
+                    format.int
+                    format.short
+                    bitsPerSample = format.short.toInt()
+                }
+                "data" -> {
+                    dataOffset = chunkData
+                    dataSize = chunkSize.coerceAtMost(bytes.size - chunkData)
+                }
+            }
+            offset = chunkData + chunkSize + (chunkSize and 1)
+        }
+        require(channelCount == 1 && bitsPerSample == 16 && dataOffset >= 0)
+        val pcm = ByteBuffer.wrap(bytes, dataOffset, dataSize).order(ByteOrder.LITTLE_ENDIAN)
+        return FloatArray(dataSize / 2) { pcm.short / 32_768f }
+    }
+
+    private companion object {
+        const val ASSET_DIRECTORY = "sensevoice"
+        const val JAPANESE_WAV = "ja.wav"
+        val REQUIRED_MODEL_ASSETS = listOf("model.int8.onnx", "tokens.txt", JAPANESE_WAV)
+    }
+}

--- a/app/src/androidTest/java/com/asmr/player/subtitle/SenseVoiceModelLoadingTest.kt
+++ b/app/src/androidTest/java/com/asmr/player/subtitle/SenseVoiceModelLoadingTest.kt
@@ -45,12 +45,14 @@ class SenseVoiceModelLoadingTest {
             val samples = assets.open("$ASSET_DIRECTORY/$JAPANESE_WAV").use { input ->
                 decodeMono16BitWav(input.readBytes())
             }
+            val batchedSamples = samples + FloatArray(model.inputSampleRateHz) + samples
             SherpaOnnxTranscriptionEngine(context, modelDirectory, model).use { engine ->
                 val result = engine.transcribe(
-                    channelSamples = listOf(samples),
+                    channelSamples = listOf(batchedSamples),
                     isCancelled = { false },
                     onProgress = {}
                 )
+                assertTrue(result.size >= model.inferenceBatchSize)
                 assertTrue(result.joinToString("") { it.text }.isNotBlank())
                 assertTrue(result.flatMap { it.tokens }.isNotEmpty())
             }

--- a/app/src/androidTest/java/com/asmr/player/ui/settings/SubtitleModelSettingsSectionTest.kt
+++ b/app/src/androidTest/java/com/asmr/player/ui/settings/SubtitleModelSettingsSectionTest.kt
@@ -1,0 +1,131 @@
+package com.asmr.player.ui.settings
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.SegmentedButtonDefaults
+import androidx.compose.ui.test.assertIsEnabled
+import androidx.compose.ui.test.assertIsNotEnabled
+import androidx.compose.ui.test.assertIsSelected
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.asmr.player.subtitle.SubtitleModelDownloadSource
+import com.asmr.player.subtitle.SubtitleModelInstallStage
+import com.asmr.player.subtitle.SubtitleModelInstallationState
+import com.asmr.player.subtitle.SubtitleModelOperation
+import com.asmr.player.subtitle.SubtitleModelState
+import com.asmr.player.subtitle.SubtitleTranscriptionModels
+import com.asmr.player.ui.theme.AsmrPlayerTheme
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+@OptIn(ExperimentalMaterial3Api::class)
+class SubtitleModelSettingsSectionTest {
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    @Test
+    fun installedModels_defaultToLightweightAndShowCurrentState() {
+        val parakeet = SubtitleTranscriptionModels.PARAKEET_TDT_CTC_06B_JA_INT8
+        val senseVoice = SubtitleTranscriptionModels.SENSE_VOICE_SMALL_INT8
+        setContent(
+            SubtitleModelState(
+                activeModelId = parakeet.id,
+                installations = mapOf(
+                    parakeet.id to SubtitleModelInstallationState.Available(
+                        SubtitleModelDownloadSource.HuggingFace
+                    ),
+                    senseVoice.id to SubtitleModelInstallationState.Available(
+                        SubtitleModelDownloadSource.HuggingFace
+                    )
+                )
+            )
+        )
+
+        composeRule.onNodeWithText("高精度 · 当前").assertExists()
+        composeRule.onNodeWithTag("subtitle_model_choice_${senseVoice.id}").assertIsSelected()
+        composeRule.onNodeWithText("已安装").assertExists()
+        composeRule.onNodeWithText("转录模型可同时安装", substring = true).assertDoesNotExist()
+        composeRule.onNodeWithText("日语专用", substring = true).assertDoesNotExist()
+        composeRule.onNodeWithText("安装来源", substring = true).assertDoesNotExist()
+        composeRule.onNodeWithText("体积更小", substring = true).assertDoesNotExist()
+        composeRule.onNodeWithText("下载来源", substring = true).assertDoesNotExist()
+        composeRule.onNodeWithTag("subtitle_model_select_${senseVoice.id}").assertIsEnabled()
+    }
+
+    @Test
+    fun downloadingOneModel_disablesOtherModelDownload() {
+        val parakeet = SubtitleTranscriptionModels.PARAKEET_TDT_CTC_06B_JA_INT8
+        val senseVoice = SubtitleTranscriptionModels.SENSE_VOICE_SMALL_INT8
+        setContent(
+            SubtitleModelState(
+                activeModelId = parakeet.id,
+                installations = emptyMap(),
+                operation = SubtitleModelOperation.Downloading(
+                    modelId = parakeet.id,
+                    source = SubtitleModelDownloadSource.HuggingFace,
+                    stage = SubtitleModelInstallStage.Model,
+                    downloadedBytes = 100L,
+                    totalBytes = 1_000L
+                )
+            )
+        )
+
+        composeRule.onNodeWithText(SubtitleModelInstallStage.Model.displayName).assertExists()
+        composeRule.onNodeWithText("取消下载").assertExists()
+        composeRule.onNodeWithTag("subtitle_model_choice_${senseVoice.id}").performClick()
+        composeRule.onNodeWithText("其他模型正在下载").assertExists()
+        composeRule.onNodeWithTag("subtitle_model_download_${senseVoice.id}").assertIsNotEnabled()
+    }
+
+    @Test
+    fun failedSenseVoice_keepsParakeetCurrentAndOffersRetry() {
+        val parakeet = SubtitleTranscriptionModels.PARAKEET_TDT_CTC_06B_JA_INT8
+        val senseVoice = SubtitleTranscriptionModels.SENSE_VOICE_SMALL_INT8
+        setContent(
+            SubtitleModelState(
+                activeModelId = parakeet.id,
+                installations = mapOf(
+                    parakeet.id to SubtitleModelInstallationState.Available(null)
+                ),
+                operation = SubtitleModelOperation.Failed(
+                    modelId = senseVoice.id,
+                    source = SubtitleModelDownloadSource.HuggingFace,
+                    message = "模型校验失败"
+                )
+            )
+        )
+
+        composeRule.onNodeWithText("高精度 · 当前").assertExists()
+        composeRule.onNodeWithText("模型校验失败").assertExists()
+        composeRule.onNodeWithText(SubtitleModelDownloadSource.GitHub.displayName).assertExists()
+        composeRule.onNodeWithText("重新下载").assertIsEnabled()
+    }
+
+    private fun setContent(state: SubtitleModelState) {
+        composeRule.setContent {
+            AsmrPlayerTheme {
+                Column {
+                    SubtitleModelSettingsSection(
+                        state = state,
+                        selectedSourceIds = SubtitleTranscriptionModels.all.associate {
+                            it.id to SubtitleModelDownloadSource.HuggingFace.id
+                        },
+                        deviceSupported = true,
+                        segmentedButtonColors = SegmentedButtonDefaults.colors(),
+                        onSourceSelected = { _, _ -> },
+                        onDownload = { _, _ -> },
+                        onCancelDownload = {},
+                        onSelect = {},
+                        onDelete = {},
+                        onClearFailure = {}
+                    )
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/asmr/player/benchmark/BenchmarkDataSeeder.kt
+++ b/app/src/main/java/com/asmr/player/benchmark/BenchmarkDataSeeder.kt
@@ -22,6 +22,7 @@ import com.asmr.player.domain.model.Track
 import com.asmr.player.playback.MediaItemFactory
 import com.asmr.player.playback.PlayerConnection
 import com.asmr.player.subtitle.SubtitleItemState
+import com.asmr.player.subtitle.SubtitleTranscriptionModels
 import com.asmr.player.subtitle.SubtitleTaskMode
 import com.asmr.player.subtitle.SubtitleTaskOrigin
 import com.asmr.player.subtitle.SubtitleTaskState
@@ -372,6 +373,7 @@ class BenchmarkDataSeeder @Inject constructor(
                         },
                         transcriptionChunkCursor = if (translationReady) 6 else 3,
                         transcriptionProgress = if (translationReady) 100 else 42,
+                        transcriptionModelId = SubtitleTranscriptionModels.default.id,
                         transcribedMs = if (translationReady) {
                             (track.duration * 1_000.0).toLong()
                         } else {

--- a/app/src/main/java/com/asmr/player/data/local/db/AppDatabaseMigrations.kt
+++ b/app/src/main/java/com/asmr/player/data/local/db/AppDatabaseMigrations.kt
@@ -546,6 +546,15 @@ object AppDatabaseMigrations {
         }
     }
 
+    val MIGRATION_28_29: Migration = object : Migration(28, 29) {
+        override fun migrate(db: SupportSQLiteDatabase) {
+            db.execSQL(
+                "ALTER TABLE subtitle_task_items " +
+                    "ADD COLUMN `transcriptionModelId` TEXT NOT NULL DEFAULT ''"
+            )
+        }
+    }
+
     private fun createItemChildTable(
         db: SupportSQLiteDatabase,
         table: String,

--- a/app/src/main/java/com/asmr/player/data/local/db/AppDatabaseProvider.kt
+++ b/app/src/main/java/com/asmr/player/data/local/db/AppDatabaseProvider.kt
@@ -43,7 +43,8 @@ object AppDatabaseProvider {
                 AppDatabaseMigrations.MIGRATION_24_25,
                 AppDatabaseMigrations.MIGRATION_25_26,
                 AppDatabaseMigrations.MIGRATION_26_27,
-                AppDatabaseMigrations.MIGRATION_27_28
+                AppDatabaseMigrations.MIGRATION_27_28,
+                AppDatabaseMigrations.MIGRATION_28_29
             )
             // Never wipe the local database during app upgrades.
             // If a migration is missing, fail loudly so user data can still be recovered.

--- a/app/src/main/java/com/asmr/player/data/local/db/appdatabase.kt
+++ b/app/src/main/java/com/asmr/player/data/local/db/appdatabase.kt
@@ -89,7 +89,7 @@ import com.asmr.player.data.local.db.entities.TrackPlaybackProgressEntity
         SubtitleCommittedCaptionEntity::class,
         SubtitleTitleOwnerEntity::class
     ],
-    version = 28,
+    version = 29,
     exportSchema = false
 )
 abstract class AppDatabase : RoomDatabase() {

--- a/app/src/main/java/com/asmr/player/data/local/db/entities/SubtitleTaskEntities.kt
+++ b/app/src/main/java/com/asmr/player/data/local/db/entities/SubtitleTaskEntities.kt
@@ -52,6 +52,7 @@ data class SubtitleTaskItemEntity(
     val suspendedFromState: String,
     val transcriptionChunkCursor: Int,
     val transcriptionProgress: Int,
+    val transcriptionModelId: String,
     val transcribedMs: Long,
     val totalDurationMs: Long,
     val translationCursor: Int,

--- a/app/src/main/java/com/asmr/player/subtitle/ParakeetEngine.kt
+++ b/app/src/main/java/com/asmr/player/subtitle/ParakeetEngine.kt
@@ -5,6 +5,7 @@ import com.k2fsa.sherpa.onnx.OfflineModelConfig
 import com.k2fsa.sherpa.onnx.OfflineNemoEncDecCtcModelConfig
 import com.k2fsa.sherpa.onnx.OfflineRecognizer
 import com.k2fsa.sherpa.onnx.OfflineRecognizerConfig
+import com.k2fsa.sherpa.onnx.OfflineSenseVoiceModelConfig
 import com.k2fsa.sherpa.onnx.SileroVadModelConfig
 import com.k2fsa.sherpa.onnx.Vad
 import com.k2fsa.sherpa.onnx.VadModelConfig
@@ -18,7 +19,7 @@ internal data class SpeechRegion(
     val endSample: Int
 )
 
-internal class ParakeetEngine(
+internal class SherpaOnnxTranscriptionEngine(
     context: Context,
     modelDirectory: File,
     override val model: SubtitleTranscriptionModel
@@ -93,7 +94,7 @@ internal class ParakeetEngine(
                     activeRecognizer.decode(stream)
                     if (isCancelled()) return emptyList()
                     val result = activeRecognizer.getResult(stream)
-                    val text = cleanParakeetText(result.text)
+                    val text = cleanRecognizerText(result.text)
                     if (text.isNotEmpty()) {
                         val regionDurationMs =
                             (region.endSample - region.startSample) * 1_000L /
@@ -103,7 +104,7 @@ internal class ParakeetEngine(
                                 startMs = region.startSample * 1_000L / model.inputSampleRateHz,
                                 endMs = region.endSample * 1_000L / model.inputSampleRateHz,
                                 text = text,
-                                tokens = buildParakeetTokenTimeline(
+                                tokens = buildRecognizerTokenTimeline(
                                     tokens = result.tokens.toList(),
                                     timestampsSeconds = result.timestamps.toList(),
                                     durationsSeconds = result.durations.toList(),
@@ -139,18 +140,10 @@ internal class ParakeetEngine(
             }
         }
         return OfflineRecognizer(
-            config = OfflineRecognizerConfig(
-                modelConfig = OfflineModelConfig(
-                    nemo = OfflineNemoEncDecCtcModelConfig(
-                        model = artifacts.getValue(MODEL_FILE_NAME).absolutePath
-                    ),
-                    numThreads = preferredThreadCount(),
-                    debug = false,
-                    provider = "cpu",
-                    tokens = artifacts.getValue(TOKENS_FILE_NAME).absolutePath
-                ),
-                decodingMethod = "greedy_search",
-                maxActivePaths = 4
+            config = buildOfflineRecognizerConfig(
+                model = model,
+                artifactPaths = artifacts.mapValues { it.value.absolutePath },
+                numThreads = preferredThreadCount()
             )
         )
     }
@@ -218,12 +211,12 @@ internal class ParakeetEngine(
     }
 }
 
-internal class ParakeetEngineFactory(
+internal class SherpaOnnxTranscriptionEngineFactory(
     private val context: Context,
     private val modelDirectory: File,
     override val model: SubtitleTranscriptionModel
 ) : SubtitleTranscriptionEngineFactory {
-    override fun create(): SubtitleTranscriptionEngine = ParakeetEngine(
+    override fun create(): SubtitleTranscriptionEngine = SherpaOnnxTranscriptionEngine(
         context = context,
         modelDirectory = modelDirectory,
         model = model
@@ -383,7 +376,7 @@ private fun selectSpeechChannel(
 private fun squareEnergy(samples: FloatArray): Double =
     samples.sumOf { sample -> sample.toDouble() * sample }
 
-internal fun buildParakeetTokenTimeline(
+internal fun buildRecognizerTokenTimeline(
     tokens: List<String>,
     timestampsSeconds: List<Float>,
     durationsSeconds: List<Float> = emptyList(),
@@ -400,7 +393,7 @@ internal fun buildParakeetTokenTimeline(
             ?.coerceAtMost(segmentDurationMs)
     }
     return tokens.mapIndexedNotNull { index, rawToken ->
-        val text = cleanParakeetToken(rawToken)
+        val text = cleanRecognizerToken(rawToken)
         val startMs = starts[index]
         if (text.isEmpty() || startMs == null || startMs >= segmentDurationMs) {
             return@mapIndexedNotNull null
@@ -422,11 +415,43 @@ internal fun buildParakeetTokenTimeline(
 
 private const val MAX_TOKEN_DURATION_MS = 400L
 
-private fun cleanParakeetToken(text: String): String = text
+internal fun buildOfflineRecognizerConfig(
+    model: SubtitleTranscriptionModel,
+    artifactPaths: Map<String, String>,
+    numThreads: Int
+): OfflineRecognizerConfig {
+    val modelFile = artifactPaths.getValue("model.int8.onnx")
+    val modelConfig = OfflineModelConfig(
+        numThreads = numThreads,
+        debug = false,
+        provider = "cpu",
+        tokens = artifactPaths.getValue("tokens.txt")
+    )
+    when (model.type) {
+        SubtitleTranscriptionModelType.NEMO_CTC -> {
+            modelConfig.nemo = OfflineNemoEncDecCtcModelConfig(model = modelFile)
+        }
+
+        SubtitleTranscriptionModelType.SENSE_VOICE -> {
+            modelConfig.senseVoice = OfflineSenseVoiceModelConfig(
+                model = modelFile,
+                language = "ja",
+                useInverseTextNormalization = true
+            )
+        }
+    }
+    return OfflineRecognizerConfig(
+        modelConfig = modelConfig,
+        decodingMethod = "greedy_search",
+        maxActivePaths = 4
+    )
+}
+
+private fun cleanRecognizerToken(text: String): String = text
     .replace('▁', ' ')
     .replace(Regex("[\\t\\r\\n ]+"), " ")
     .trim()
 
-private fun cleanParakeetText(text: String): String = text
+private fun cleanRecognizerText(text: String): String = text
     .replace(Regex("[\\t\\r\\n ]+"), " ")
     .trim()

--- a/app/src/main/java/com/asmr/player/subtitle/ParakeetEngine.kt
+++ b/app/src/main/java/com/asmr/player/subtitle/ParakeetEngine.kt
@@ -6,6 +6,7 @@ import com.k2fsa.sherpa.onnx.OfflineNemoEncDecCtcModelConfig
 import com.k2fsa.sherpa.onnx.OfflineRecognizer
 import com.k2fsa.sherpa.onnx.OfflineRecognizerConfig
 import com.k2fsa.sherpa.onnx.OfflineSenseVoiceModelConfig
+import com.k2fsa.sherpa.onnx.OfflineStream
 import com.k2fsa.sherpa.onnx.SileroVadModelConfig
 import com.k2fsa.sherpa.onnx.Vad
 import com.k2fsa.sherpa.onnx.VadModelConfig
@@ -80,48 +81,54 @@ internal class SherpaOnnxTranscriptionEngine(
         onProgress(VAD_PROGRESS_PERCENT)
         if (regions.isEmpty()) return emptyList()
 
-        return buildList(regions.size) {
-            regions.forEachIndexed { index, region ->
-                if (isCancelled()) return emptyList()
-                val speech = selectSpeechChannel(filteredChannels, region)
-                val prepared = SpeechAudioPreprocessor.normalizeSpeechSegment(
-                    speech,
-                    model.inputSampleRateHz
-                )
-                val stream = activeRecognizer.createStream()
-                try {
+        val segments = mutableListOf<SubtitleTranscriptionSegment>()
+        var completedRegionCount = 0
+        regions.chunked(model.inferenceBatchSize).forEach { batch ->
+            if (isCancelled()) return emptyList()
+            val pending = mutableListOf<Pair<SpeechRegion, OfflineStream>>()
+            try {
+                batch.forEach { region ->
+                    val speech = selectSpeechChannel(filteredChannels, region)
+                    val prepared = SpeechAudioPreprocessor.normalizeSpeechSegment(
+                        speech,
+                        model.inputSampleRateHz
+                    )
+                    val stream = activeRecognizer.createStream()
+                    pending += region to stream
                     stream.acceptWaveform(prepared, model.inputSampleRateHz)
-                    activeRecognizer.decode(stream)
-                    if (isCancelled()) return emptyList()
+                }
+                activeRecognizer.decode(pending.map { it.second })
+                if (isCancelled()) return emptyList()
+                pending.forEach { (region, stream) ->
                     val result = activeRecognizer.getResult(stream)
                     val text = cleanRecognizerText(result.text)
                     if (text.isNotEmpty()) {
                         val regionDurationMs =
                             (region.endSample - region.startSample) * 1_000L /
                                 model.inputSampleRateHz
-                        add(
-                            SubtitleTranscriptionSegment(
-                                startMs = region.startSample * 1_000L / model.inputSampleRateHz,
-                                endMs = region.endSample * 1_000L / model.inputSampleRateHz,
-                                text = text,
-                                tokens = buildRecognizerTokenTimeline(
-                                    tokens = result.tokens.toList(),
-                                    timestampsSeconds = result.timestamps.toList(),
-                                    durationsSeconds = result.durations.toList(),
-                                    segmentDurationMs = regionDurationMs
-                                )
+                        segments += SubtitleTranscriptionSegment(
+                            startMs = region.startSample * 1_000L / model.inputSampleRateHz,
+                            endMs = region.endSample * 1_000L / model.inputSampleRateHz,
+                            text = text,
+                            tokens = buildRecognizerTokenTimeline(
+                                tokens = result.tokens.toList(),
+                                timestampsSeconds = result.timestamps.toList(),
+                                durationsSeconds = result.durations.toList(),
+                                segmentDurationMs = regionDurationMs
                             )
                         )
                     }
-                } finally {
-                    stream.release()
+                    completedRegionCount += 1
+                    onProgress(
+                        VAD_PROGRESS_PERCENT +
+                            (completedRegionCount * (100 - VAD_PROGRESS_PERCENT) / regions.size)
+                    )
                 }
-                onProgress(
-                    VAD_PROGRESS_PERCENT +
-                        ((index + 1) * (100 - VAD_PROGRESS_PERCENT) / regions.size)
-                )
+            } finally {
+                pending.forEach { (_, stream) -> stream.release() }
             }
         }
+        return segments
     }
 
     override fun close() {

--- a/app/src/main/java/com/asmr/player/subtitle/SubtitleModelDownloadWorker.kt
+++ b/app/src/main/java/com/asmr/player/subtitle/SubtitleModelDownloadWorker.kt
@@ -38,6 +38,8 @@ internal class SubtitleModelDownloadWorker(
     }
 
     override suspend fun doWork(): Result = withContext(Dispatchers.IO) {
+        val model = SubtitleTranscriptionModels.fromId(inputData.getString(KEY_MODEL_ID))
+            ?: return@withContext Result.failure()
         val source = SubtitleModelDownloadSource.fromId(inputData.getString(KEY_SOURCE))
             ?: return@withContext Result.failure()
         val baseUrl = inputData.getString(KEY_URL).orEmpty()
@@ -47,18 +49,17 @@ internal class SubtitleModelDownloadWorker(
         val runtimeRepository = SherpaOnnxRuntimeRepository.get(applicationContext)
         val runtime = runtimeRepository.descriptor
         if (!runtime.url.startsWith("https://")) return@withContext Result.failure()
-        val model = SubtitleTranscriptionModels.PARAKEET_TDT_CTC_06B_JA_INT8
-        val totalBytes = repository.installationBytes()
+        val totalBytes = repository.installationBytes(model)
         var activeStage = SubtitleModelInstallStage.Runtime
         try {
-            val modelDirectory = repository.ensureModelDirectory()
-            if (repository.isModelAvailable()) {
-                repository.updateAvailable(source)
+            val modelDirectory = repository.ensureModelDirectory(model)
+            if (repository.isModelAvailable(model.id)) {
+                repository.updateAvailable(model.id, source)
                 return@withContext Result.success()
             }
             setForeground(
                 createForegroundInfo(
-                    repository.downloadedInstallationBytes(),
+                    repository.downloadedInstallationBytes(model),
                     totalBytes,
                     "准备下载字幕组件"
                 )
@@ -83,15 +84,17 @@ internal class SubtitleModelDownloadWorker(
                     stage = SubtitleModelInstallStage.Runtime,
                     destination = partialRuntime,
                     expectedBytes = runtime.archiveBytes,
-                    completedBefore = repository.downloadedModelBytes(),
+                    completedBefore = repository.downloadedModelBytes(model),
                     totalBytes = totalBytes,
+                    modelId = model.id,
                     repository = repository
                 )
                 activeStage = SubtitleModelInstallStage.RuntimeVerification
-                repository.updateVerifying(source, activeStage)
+                repository.updateVerifying(model.id, source, activeStage)
                 publishStage(
+                    modelId = model.id,
                     stage = activeStage,
-                    downloadedBytes = runtime.archiveBytes + repository.downloadedModelBytes(),
+                    downloadedBytes = runtime.archiveBytes + repository.downloadedModelBytes(model),
                     totalBytes = totalBytes
                 )
                 runtimeRepository.installDownloadedArchive()
@@ -101,16 +104,16 @@ internal class SubtitleModelDownloadWorker(
             ensureFreeSpace(
                 destinationDirectory = modelDirectory,
                 expectedBytes = model.artifactBytes,
-                existingBytes = repository.downloadedModelBytes()
+                existingBytes = repository.downloadedModelBytes(model)
             )
             model.artifacts.forEach { artifact ->
-                if (isInstalledSubtitleModelArtifact(repository.artifactFile(artifact), artifact.bytes)) {
+                if (isInstalledSubtitleModelArtifact(repository.artifactFile(model, artifact), artifact.bytes)) {
                     return@forEach
                 }
-                val partialFile = repository.partialArtifactFile(artifact)
+                val partialFile = repository.partialArtifactFile(model, artifact)
                 val currentPartialBytes = partialFile.length().coerceIn(0L, artifact.bytes)
                 val completedBefore = runtime.archiveBytes +
-                    repository.downloadedModelBytes() - currentPartialBytes
+                    repository.downloadedModelBytes(model) - currentPartialBytes
                 download(
                     client = client,
                     url = buildSubtitleModelArtifactUrl(baseUrl, artifact.fileName),
@@ -120,17 +123,18 @@ internal class SubtitleModelDownloadWorker(
                     expectedBytes = artifact.bytes,
                     completedBefore = completedBefore,
                     totalBytes = totalBytes,
+                    modelId = model.id,
                     repository = repository
                 )
             }
             activeStage = SubtitleModelInstallStage.ModelVerification
-            repository.updateVerifying(source, activeStage)
-            publishStage(activeStage, totalBytes, totalBytes)
+            repository.updateVerifying(model.id, source, activeStage)
+            publishStage(model.id, activeStage, totalBytes, totalBytes)
             model.artifacts.forEach { artifact ->
-                val targetFile = repository.artifactFile(artifact)
+                val targetFile = repository.artifactFile(model, artifact)
                 if (isInstalledSubtitleModelArtifact(targetFile, artifact.bytes)) return@forEach
 
-                val partialFile = repository.partialArtifactFile(artifact)
+                val partialFile = repository.partialArtifactFile(model, artifact)
                 val actualHash = sha256(partialFile)
                 check(actualHash.equals(artifact.sha256, ignoreCase = true)) {
                     partialFile.delete()
@@ -139,29 +143,36 @@ internal class SubtitleModelDownloadWorker(
                 if (targetFile.exists()) check(targetFile.delete()) { "无法替换旧模型文件" }
                 check(partialFile.renameTo(targetFile)) { "无法保存日语字幕模型" }
             }
-            repository.updateAvailable(source)
+            repository.updateAvailable(model.id, source)
             Result.success(
                 workDataOf(
+                    KEY_MODEL_ID to model.id,
                     KEY_DOWNLOADED_BYTES to totalBytes,
                     KEY_TOTAL_BYTES to totalBytes
                 )
             )
         } catch (cancelled: CancellationException) {
-            repository.updateMissing()
+            repository.updateMissing(model.id)
             throw cancelled
         } catch (error: Throwable) {
             val message = error.message?.trim().orEmpty().ifBlank { "字幕组件下载失败" }
             if (runAttemptCount < MAX_RETRY_COUNT && error is IOException) {
                 repository.updateDownloading(
+                    model.id,
                     source,
                     activeStage,
-                    repository.downloadedInstallationBytes(),
+                    repository.downloadedInstallationBytes(model),
                     totalBytes
                 )
                 Result.retry()
             } else {
-                repository.updateFailure(source, message)
-                Result.failure(workDataOf(KEY_ERROR_MESSAGE to message))
+                repository.updateFailure(model.id, source, message)
+                Result.failure(
+                    workDataOf(
+                        KEY_MODEL_ID to model.id,
+                        KEY_ERROR_MESSAGE to message
+                    )
+                )
             }
         }
     }
@@ -175,6 +186,7 @@ internal class SubtitleModelDownloadWorker(
         expectedBytes: Long,
         completedBefore: Long,
         totalBytes: Long,
+        modelId: String,
         repository: SubtitleModelRepository
     ) {
         SubtitleArtifactDownloader.download(
@@ -184,6 +196,7 @@ internal class SubtitleModelDownloadWorker(
             expectedBytes = expectedBytes
         ) { downloadedBytes ->
             publishProgress(
+                modelId,
                 source,
                 stage,
                 repository,
@@ -194,15 +207,17 @@ internal class SubtitleModelDownloadWorker(
     }
 
     private suspend fun publishProgress(
+        modelId: String,
         source: SubtitleModelDownloadSource,
         stage: SubtitleModelInstallStage,
         repository: SubtitleModelRepository,
         downloadedBytes: Long,
         totalBytes: Long
     ) {
-        repository.updateDownloading(source, stage, downloadedBytes, totalBytes)
+        repository.updateDownloading(modelId, source, stage, downloadedBytes, totalBytes)
         setProgress(
             workDataOf(
+                KEY_MODEL_ID to modelId,
                 KEY_STAGE to stage.name,
                 KEY_DOWNLOADED_BYTES to downloadedBytes,
                 KEY_TOTAL_BYTES to totalBytes
@@ -212,12 +227,14 @@ internal class SubtitleModelDownloadWorker(
     }
 
     private suspend fun publishStage(
+        modelId: String,
         stage: SubtitleModelInstallStage,
         downloadedBytes: Long,
         totalBytes: Long
     ) {
         setProgress(
             workDataOf(
+                KEY_MODEL_ID to modelId,
                 KEY_STAGE to stage.name,
                 KEY_DOWNLOADED_BYTES to downloadedBytes,
                 KEY_TOTAL_BYTES to totalBytes
@@ -288,6 +305,7 @@ internal class SubtitleModelDownloadWorker(
 
     companion object {
         const val UNIQUE_WORK_NAME = "subtitle_model_download"
+        const val KEY_MODEL_ID = "modelId"
         const val KEY_SOURCE = "source"
         const val KEY_URL = "url"
         const val KEY_STAGE = "stage"

--- a/app/src/main/java/com/asmr/player/subtitle/SubtitleModelRepository.kt
+++ b/app/src/main/java/com/asmr/player/subtitle/SubtitleModelRepository.kt
@@ -1,6 +1,7 @@
 package com.asmr.player.subtitle
 
 import android.content.Context
+import android.content.SharedPreferences
 import androidx.work.BackoffPolicy
 import androidx.work.Constraints
 import androidx.work.ExistingWorkPolicy
@@ -26,57 +27,89 @@ internal enum class SubtitleModelDownloadSource(
     GitHub("github", "GitHub"),
     HuggingFace("hugging_face", "Hugging Face");
 
-    fun downloadBaseUrl(): String = when (this) {
-        GitHub -> BuildConfig.SUBTITLE_MODEL_GITHUB_URL
-        HuggingFace -> BuildConfig.SUBTITLE_MODEL_HUGGING_FACE_URL
-    }
-
-    fun artifactUrl(fileName: String): String = buildSubtitleModelArtifactUrl(
-        baseUrl = downloadBaseUrl(),
-        fileName = fileName
-    )
-
-    fun isConfigured(): Boolean = downloadBaseUrl().trim().startsWith("https://")
-
     companion object {
         fun fromId(id: String?): SubtitleModelDownloadSource? = entries.firstOrNull { it.id == id }
     }
 }
 
-internal sealed interface SubtitleModelState {
-    data object Missing : SubtitleModelState
-
-    data class Queued(
-        val source: SubtitleModelDownloadSource
-    ) : SubtitleModelState
-
-    data class Downloading(
-        val source: SubtitleModelDownloadSource,
-        val stage: SubtitleModelInstallStage,
-        val downloadedBytes: Long,
-        val totalBytes: Long
-    ) : SubtitleModelState
-
-    data class Verifying(
-        val source: SubtitleModelDownloadSource,
-        val stage: SubtitleModelInstallStage
-    ) : SubtitleModelState
+internal sealed interface SubtitleModelInstallationState {
+    data object Missing : SubtitleModelInstallationState
 
     data class Available(
         val source: SubtitleModelDownloadSource?
-    ) : SubtitleModelState
+    ) : SubtitleModelInstallationState
+}
+
+internal sealed interface SubtitleModelOperation {
+    val modelId: String
+    val source: SubtitleModelDownloadSource
+
+    data class Queued(
+        override val modelId: String,
+        override val source: SubtitleModelDownloadSource
+    ) : SubtitleModelOperation
+
+    data class Downloading(
+        override val modelId: String,
+        override val source: SubtitleModelDownloadSource,
+        val stage: SubtitleModelInstallStage,
+        val downloadedBytes: Long,
+        val totalBytes: Long
+    ) : SubtitleModelOperation
+
+    data class Verifying(
+        override val modelId: String,
+        override val source: SubtitleModelDownloadSource,
+        val stage: SubtitleModelInstallStage
+    ) : SubtitleModelOperation
 
     data class Failed(
-        val source: SubtitleModelDownloadSource,
+        override val modelId: String,
+        override val source: SubtitleModelDownloadSource,
         val message: String
-    ) : SubtitleModelState
+    ) : SubtitleModelOperation
 }
+
+internal data class SubtitleModelState(
+    val activeModelId: String,
+    val installations: Map<String, SubtitleModelInstallationState>,
+    val operation: SubtitleModelOperation? = null
+) {
+    fun installation(modelId: String): SubtitleModelInstallationState =
+        installations[modelId] ?: SubtitleModelInstallationState.Missing
+}
+
+internal data class InstalledSubtitleModel(
+    val model: SubtitleTranscriptionModel,
+    val directory: File
+)
 
 internal enum class SubtitleModelInstallStage(val displayName: String) {
     Runtime("正在下载字幕运行时"),
     RuntimeVerification("正在校验并安装字幕运行时"),
     Model("正在下载日语字幕模型"),
     ModelVerification("正在校验日语字幕模型")
+}
+
+internal fun subtitleModelDownloadBaseUrl(
+    model: SubtitleTranscriptionModel,
+    source: SubtitleModelDownloadSource
+): String = when (model.id) {
+    SubtitleTranscriptionModels.PARAKEET_TDT_CTC_06B_JA_INT8.id -> when (source) {
+        SubtitleModelDownloadSource.GitHub -> BuildConfig.SUBTITLE_MODEL_GITHUB_URL
+        SubtitleModelDownloadSource.HuggingFace -> BuildConfig.SUBTITLE_MODEL_HUGGING_FACE_URL
+    }
+    SubtitleTranscriptionModels.SENSE_VOICE_SMALL_INT8.id -> when (source) {
+        SubtitleModelDownloadSource.GitHub -> BuildConfig.SUBTITLE_SENSEVOICE_GITHUB_URL
+        SubtitleModelDownloadSource.HuggingFace -> BuildConfig.SUBTITLE_SENSEVOICE_HUGGING_FACE_URL
+    }
+    else -> ""
+}
+
+internal fun configuredSubtitleModelDownloadSources(
+    model: SubtitleTranscriptionModel
+): List<SubtitleModelDownloadSource> = SubtitleModelDownloadSource.entries.filter { source ->
+    subtitleModelDownloadBaseUrl(model, source).trim().startsWith("https://")
 }
 
 internal fun buildSubtitleModelArtifactUrl(baseUrl: String, fileName: String): String {
@@ -95,34 +128,57 @@ internal fun isInstalledSubtitleModelArtifact(
 
 internal class SubtitleModelRepository private constructor(context: Context) {
     private val appContext = context.applicationContext
-    private val model = SubtitleTranscriptionModels.PARAKEET_TDT_CTC_06B_JA_INT8
     private val runtimeRepository = SherpaOnnxRuntimeRepository.get(appContext)
     private val preferences = appContext.getSharedPreferences(PREFERENCES_NAME, Context.MODE_PRIVATE)
-    private val _state = MutableStateFlow(initialState())
-    val state: StateFlow<SubtitleModelState> = _state.asStateFlow()
+    private val _state: MutableStateFlow<SubtitleModelState>
+    val state: StateFlow<SubtitleModelState>
 
-    fun isModelAvailable(): Boolean =
-        runtimeRepository.isInstalled() && installedModelDirectoryOrNull() != null
-
-    fun requireInstalledModelDirectory(): File {
-        return installedModelDirectoryOrNull()
-            ?: throw IllegalStateException(MODEL_REQUIRED_MESSAGE)
+    init {
+        migrateLegacyPreferences(preferences)
+        _state = MutableStateFlow(buildState())
+        state = _state.asStateFlow()
     }
 
-    fun enqueueDownload(source: SubtitleModelDownloadSource) {
-        if (isModelAvailable()) {
-            refreshInstalledState()
+    fun activeModel(): SubtitleTranscriptionModel =
+        SubtitleTranscriptionModels.fromId(preferences.getString(KEY_ACTIVE_MODEL_ID, null))
+            ?: SubtitleTranscriptionModels.default
+
+    fun isModelAvailable(modelId: String = activeModel().id): Boolean {
+        val model = SubtitleTranscriptionModels.fromId(modelId) ?: return false
+        return runtimeRepository.isInstalled() && installedModelDirectoryOrNull(model) != null
+    }
+
+    fun requireInstalledModel(modelId: String = activeModel().id): InstalledSubtitleModel {
+        val model = SubtitleTranscriptionModels.fromId(modelId)
+            ?: throw IllegalStateException(MODEL_REQUIRED_MESSAGE)
+        val directory = installedModelDirectoryOrNull(model)
+            ?.takeIf { runtimeRepository.isInstalled() }
+            ?: throw IllegalStateException(MODEL_REQUIRED_MESSAGE)
+        return InstalledSubtitleModel(model, directory)
+    }
+
+    fun selectModel(modelId: String) {
+        require(isModelAvailable(modelId)) { "请先下载该日语字幕模型" }
+        preferences.edit().putString(KEY_ACTIVE_MODEL_ID, modelId).apply()
+        refreshState()
+    }
+
+    fun enqueueDownload(modelId: String, source: SubtitleModelDownloadSource) {
+        val model = requireNotNull(SubtitleTranscriptionModels.fromId(modelId)) { "未知的字幕模型" }
+        if (isModelAvailable(model.id)) {
+            refreshState()
             return
         }
-        val baseUrl = source.downloadBaseUrl().trim()
+        val baseUrl = subtitleModelDownloadBaseUrl(model, source).trim()
         require(baseUrl.startsWith("https://")) { "模型下载地址未配置" }
         require(runtimeRepository.descriptor.url.trim().startsWith("https://")) {
             "字幕运行时下载地址未配置"
         }
-        _state.value = SubtitleModelState.Queued(source)
+        refreshState(SubtitleModelOperation.Queued(model.id, source))
         val request = OneTimeWorkRequestBuilder<SubtitleModelDownloadWorker>()
             .setInputData(
                 workDataOf(
+                    SubtitleModelDownloadWorker.KEY_MODEL_ID to model.id,
                     SubtitleModelDownloadWorker.KEY_SOURCE to source.id,
                     SubtitleModelDownloadWorker.KEY_URL to baseUrl
                 )
@@ -142,133 +198,183 @@ internal class SubtitleModelRepository private constructor(context: Context) {
         )
     }
 
-    fun clearFailure() {
-        if (_state.value is SubtitleModelState.Failed) {
-            _state.value = SubtitleModelState.Missing
-        }
+    fun clearFailure(modelId: String) {
+        val failure = _state.value.operation as? SubtitleModelOperation.Failed ?: return
+        if (failure.modelId == modelId) refreshState(operation = null)
     }
 
     suspend fun cancelDownload() = withContext(Dispatchers.IO) {
+        val model = _state.value.operation?.modelId?.let(SubtitleTranscriptionModels::fromId)
         WorkManager.getInstance(appContext)
             .cancelUniqueWork(SubtitleModelDownloadWorker.UNIQUE_WORK_NAME)
             .result
             .get()
-        deletePartialModelFiles()
+        model?.let(::deletePartialModelFiles)
         runtimeRepository.deletePartialArchive()
-        _state.value = initialState()
+        refreshState(operation = null)
     }
 
-    suspend fun deleteModel() = withContext(Dispatchers.IO) {
-        WorkManager.getInstance(appContext)
-            .cancelUniqueWork(SubtitleModelDownloadWorker.UNIQUE_WORK_NAME)
-            .result
-            .get()
+    suspend fun deleteModel(modelId: String) = withContext(Dispatchers.IO) {
+        val model = requireNotNull(SubtitleTranscriptionModels.fromId(modelId)) { "未知的字幕模型" }
+        val operation = _state.value.operation
+        if (operation?.modelId == model.id) {
+            WorkManager.getInstance(appContext)
+                .cancelUniqueWork(SubtitleModelDownloadWorker.UNIQUE_WORK_NAME)
+                .result
+                .get()
+        }
         val deletedModel = model.artifacts.all { artifact ->
-            deleteIfPresent(artifactFile(artifact)) && deleteIfPresent(partialArtifactFile(artifact))
+            deleteIfPresent(artifactFile(model, artifact)) &&
+                deleteIfPresent(partialArtifactFile(model, artifact))
         }
         check(deletedModel) { "无法删除日语字幕模型" }
-        modelDirectory().takeIf { it.isDirectory && it.list().isNullOrEmpty() }?.delete()
-        preferences.edit().remove(KEY_INSTALLED_SOURCE).apply()
-        _state.value = SubtitleModelState.Missing
+        modelDirectory(model).takeIf { it.isDirectory && it.list().isNullOrEmpty() }?.delete()
+
+        val editor = preferences.edit().remove(installedSourceKey(model.id))
+        if (activeModel().id == model.id) {
+            val availableModelIds = SubtitleTranscriptionModels.all
+                .filter { candidate -> candidate.id != model.id && isModelAvailable(candidate.id) }
+                .mapTo(mutableSetOf(), SubtitleTranscriptionModel::id)
+            editor.putString(
+                KEY_ACTIVE_MODEL_ID,
+                fallbackSubtitleModelId(model.id, availableModelIds)
+            )
+        }
+        editor.apply()
+        refreshState(operation = operation?.takeUnless { it.modelId == model.id })
     }
 
     internal fun updateDownloading(
+        modelId: String,
         source: SubtitleModelDownloadSource,
         stage: SubtitleModelInstallStage,
         downloadedBytes: Long,
         totalBytes: Long
     ) {
-        _state.value = SubtitleModelState.Downloading(
-            source = source,
-            stage = stage,
-            downloadedBytes = downloadedBytes.coerceAtLeast(0L),
-            totalBytes = totalBytes.coerceAtLeast(0L)
+        refreshState(
+            SubtitleModelOperation.Downloading(
+                modelId = modelId,
+                source = source,
+                stage = stage,
+                downloadedBytes = downloadedBytes.coerceAtLeast(0L),
+                totalBytes = totalBytes.coerceAtLeast(0L)
+            )
         )
     }
 
     internal fun updateVerifying(
+        modelId: String,
         source: SubtitleModelDownloadSource,
         stage: SubtitleModelInstallStage
     ) {
-        _state.value = SubtitleModelState.Verifying(source, stage)
+        refreshState(SubtitleModelOperation.Verifying(modelId, source, stage))
     }
 
-    internal fun updateAvailable(source: SubtitleModelDownloadSource) {
-        preferences.edit().putString(KEY_INSTALLED_SOURCE, source.id).apply()
-        _state.value = SubtitleModelState.Available(source)
+    internal fun updateAvailable(modelId: String, source: SubtitleModelDownloadSource) {
+        preferences.edit().putString(installedSourceKey(modelId), source.id).apply()
+        refreshState(operation = null)
     }
 
-    internal fun updateFailure(source: SubtitleModelDownloadSource, message: String) {
-        _state.value = SubtitleModelState.Failed(
-            source = source,
-            message = message.trim().ifBlank { "模型下载失败" }
+    internal fun updateFailure(
+        modelId: String,
+        source: SubtitleModelDownloadSource,
+        message: String
+    ) {
+        refreshState(
+            SubtitleModelOperation.Failed(
+                modelId = modelId,
+                source = source,
+                message = message.trim().ifBlank { "模型下载失败" }
+            )
         )
     }
 
-    internal fun updateMissing() {
-        _state.value = initialState()
+    internal fun updateMissing(modelId: String) {
+        val operation = _state.value.operation
+        refreshState(operation = operation?.takeUnless { it.modelId == modelId })
     }
 
-    internal fun artifactFile(artifact: SubtitleModelArtifact): File =
-        File(modelDirectory(), artifact.fileName)
+    internal fun artifactFile(
+        model: SubtitleTranscriptionModel,
+        artifact: SubtitleModelArtifact
+    ): File = File(modelDirectory(model), artifact.fileName)
 
-    internal fun partialArtifactFile(artifact: SubtitleModelArtifact): File =
-        File(modelDirectory(), "${artifact.fileName}.part")
+    internal fun partialArtifactFile(
+        model: SubtitleTranscriptionModel,
+        artifact: SubtitleModelArtifact
+    ): File = File(modelDirectory(model), "${artifact.fileName}.part")
 
-    internal fun downloadedModelBytes(): Long = model.artifacts.sumOf { artifact ->
-        val installed = artifactFile(artifact)
-        if (isInstalledSubtitleModelArtifact(installed, artifact.bytes)) {
-            artifact.bytes
-        } else {
-            partialArtifactFile(artifact).length().coerceIn(0L, artifact.bytes)
+    internal fun downloadedModelBytes(model: SubtitleTranscriptionModel): Long =
+        model.artifacts.sumOf { artifact ->
+            val installed = artifactFile(model, artifact)
+            if (isInstalledSubtitleModelArtifact(installed, artifact.bytes)) {
+                artifact.bytes
+            } else {
+                partialArtifactFile(model, artifact).length().coerceIn(0L, artifact.bytes)
+            }
         }
-    }
 
-    internal fun downloadedInstallationBytes(): Long {
+    internal fun downloadedInstallationBytes(model: SubtitleTranscriptionModel): Long {
         val runtimeBytes = if (runtimeRepository.isInstalled()) {
             runtimeRepository.descriptor.archiveBytes
         } else {
             runtimeRepository.downloadedArchiveBytes()
         }
-        return runtimeBytes + downloadedModelBytes()
+        return runtimeBytes + downloadedModelBytes(model)
     }
 
-    internal fun installationBytes(): Long =
+    internal fun installationBytes(model: SubtitleTranscriptionModel): Long =
         runtimeRepository.descriptor.archiveBytes + model.artifactBytes
 
-    internal fun deletePartialModelFiles(): Boolean = model.artifacts.all { artifact ->
-        deleteIfPresent(partialArtifactFile(artifact))
+    internal fun deletePartialModelFiles(model: SubtitleTranscriptionModel): Boolean =
+        model.artifacts.all { artifact -> deleteIfPresent(partialArtifactFile(model, artifact)) }
+
+    internal fun ensureModelDirectory(model: SubtitleTranscriptionModel): File =
+        modelDirectory(model).apply {
+            check(exists() || mkdirs()) { "无法创建模型目录" }
+        }
+
+    private fun refreshState(operation: SubtitleModelOperation? = _state.value.operation) {
+        _state.value = buildState(operation)
     }
 
-    internal fun ensureModelDirectory(): File = modelDirectory().apply {
-        check(exists() || mkdirs()) { "无法创建模型目录" }
+    private fun buildState(operation: SubtitleModelOperation? = null): SubtitleModelState {
+        val installations = SubtitleTranscriptionModels.all.associate { model ->
+            val installation = if (
+                runtimeRepository.isInstalled() && installedModelDirectoryOrNull(model) != null
+            ) {
+                SubtitleModelInstallationState.Available(
+                    SubtitleModelDownloadSource.fromId(
+                        preferences.getString(installedSourceKey(model.id), null)
+                    )
+                )
+            } else {
+                SubtitleModelInstallationState.Missing
+            }
+            model.id to installation
+        }
+        return SubtitleModelState(
+            activeModelId = activeModel().id,
+            installations = installations,
+            operation = operation
+        )
     }
 
-    private fun refreshInstalledState() {
-        _state.value = initialState()
-    }
-
-    private fun installedModelDirectoryOrNull(): File? {
-        val directory = modelDirectory()
+    private fun installedModelDirectoryOrNull(model: SubtitleTranscriptionModel): File? {
+        val directory = modelDirectory(model)
         return directory.takeIf {
             it.isDirectory && model.artifacts.all { artifact ->
-                isInstalledSubtitleModelArtifact(artifactFile(artifact), artifact.bytes)
+                isInstalledSubtitleModelArtifact(artifactFile(model, artifact), artifact.bytes)
             }
         }
     }
 
-    private fun initialState(): SubtitleModelState {
-        if (!runtimeRepository.isInstalled()) return SubtitleModelState.Missing
-        installedModelDirectoryOrNull() ?: return SubtitleModelState.Missing
-        val source = SubtitleModelDownloadSource.fromId(
-            preferences.getString(KEY_INSTALLED_SOURCE, null)
-        )
-        return SubtitleModelState.Available(source)
-    }
-
-    private fun modelDirectory(): File = File(modelRootDirectory(), model.id)
+    private fun modelDirectory(model: SubtitleTranscriptionModel): File =
+        File(modelRootDirectory(), model.id)
 
     private fun modelRootDirectory(): File = File(appContext.filesDir, MODEL_ROOT_DIRECTORY_NAME)
+
+    private fun installedSourceKey(modelId: String): String = "$KEY_INSTALLED_SOURCE_PREFIX$modelId"
 
     private fun deleteIfPresent(file: File): Boolean = !file.exists() || file.delete()
 
@@ -277,7 +383,10 @@ internal class SubtitleModelRepository private constructor(context: Context) {
 
         private const val MODEL_ROOT_DIRECTORY_NAME = "subtitle-models"
         private const val PREFERENCES_NAME = "subtitle_model_preferences"
-        private const val KEY_INSTALLED_SOURCE = "installed_source"
+        private const val KEY_ACTIVE_MODEL_ID = "active_model_id"
+        private const val KEY_INSTALLED_SOURCE_PREFIX = "installed_source:"
+        private const val KEY_LEGACY_INSTALLED_SOURCE = "installed_source"
+
         @Volatile
         private var instance: SubtitleModelRepository? = null
 
@@ -286,5 +395,20 @@ internal class SubtitleModelRepository private constructor(context: Context) {
                 instance ?: SubtitleModelRepository(context).also { instance = it }
             }
         }
+
+        internal fun migrateLegacyPreferences(preferences: SharedPreferences) {
+            val legacySource = preferences.getString(KEY_LEGACY_INSTALLED_SOURCE, null) ?: return
+            val parakeetKey = "$KEY_INSTALLED_SOURCE_PREFIX${SubtitleTranscriptionModels.default.id}"
+            val editor = preferences.edit()
+            if (!preferences.contains(parakeetKey)) editor.putString(parakeetKey, legacySource)
+            editor.remove(KEY_LEGACY_INSTALLED_SOURCE).apply()
+        }
     }
 }
+
+internal fun fallbackSubtitleModelId(
+    deletedModelId: String,
+    availableModelIds: Set<String>
+): String = SubtitleTranscriptionModels.all.firstOrNull { model ->
+    model.id != deletedModelId && model.id in availableModelIds
+}?.id ?: SubtitleTranscriptionModels.default.id

--- a/app/src/main/java/com/asmr/player/subtitle/SubtitleTaskRepository.kt
+++ b/app/src/main/java/com/asmr/player/subtitle/SubtitleTaskRepository.kt
@@ -131,6 +131,7 @@ internal class SubtitleTaskRepository private constructor(context: Context) {
                     suspendedFromState = "",
                     transcriptionChunkCursor = 0,
                     transcriptionProgress = if (mode == SubtitleTaskMode.MANUAL) 100 else 0,
+                    transcriptionModelId = "",
                     transcribedMs = 0L,
                     totalDurationMs = (track.duration * 1_000.0).toLong().coerceAtLeast(0L),
                     translationCursor = 0,

--- a/app/src/main/java/com/asmr/player/subtitle/SubtitleTaskService.kt
+++ b/app/src/main/java/com/asmr/player/subtitle/SubtitleTaskService.kt
@@ -365,23 +365,24 @@ internal class SubtitleTaskService : Service() {
         val dao = database.subtitleTaskDao()
         val initial = dao.getItem(itemId) ?: return
         if (initial.state != SubtitleItemState.QUEUED_TRANSCRIPTION) return
-        dao.updateItem(
-            initial.copy(
-                state = SubtitleItemState.TRANSCRIBING,
-                errorMessage = "",
-                updatedAt = System.currentTimeMillis()
-            )
+        val modelId = resolveTranscriptionModelId(
+            persistedModelId = initial.transcriptionModelId,
+            activeModelId = SubtitleModelRepository.get(applicationContext).activeModel().id
         )
-        repository.refreshTaskState(initial.taskId)
+        val activeItem = initial.copy(
+            state = SubtitleItemState.TRANSCRIBING,
+            transcriptionModelId = modelId,
+            errorMessage = "",
+            updatedAt = System.currentTimeMillis()
+        )
+        dao.updateItem(activeItem)
+        repository.refreshTaskState(activeItem.taskId)
         try {
-            val engine = transcriptionEngine ?: SubtitleTranscriptionEngineRegistry
-                .defaultFactory(applicationContext)
-                .create()
-                .also { transcriptionEngine = it }
+            val engine = requireTranscriptionEngine(modelId)
             val existingChunks = dao.getChunks(itemId)
             val resumeAtMs = existingChunks.lastOrNull()?.endMs ?: 0L
             LocalAudioDecoder(applicationContext, engine.model.inputSampleRateHz).decode(
-                path = initial.trackPath,
+                path = activeItem.trackPath,
                 startAtMs = resumeAtMs
             ) { chunk ->
                 coroutineContext.ensureActive()
@@ -791,6 +792,18 @@ internal class SubtitleTaskService : Service() {
         runCatching { engine.close() }
             .onFailure { error -> Log.w(TAG, "转录失败后释放模型失败", error) }
         transcriptionEngine = null
+    }
+
+    private fun requireTranscriptionEngine(modelId: String): SubtitleTranscriptionEngine {
+        transcriptionEngine?.takeIf { it.model.id == modelId }?.let { return it }
+        transcriptionEngine?.let { staleEngine ->
+            runCatching { staleEngine.close() }
+                .onFailure { error -> Log.w(TAG, "切换转录模型时释放旧模型失败", error) }
+        }
+        transcriptionEngine = null
+        return SubtitleTranscriptionEngineRegistry.factory(applicationContext, modelId)
+            .create()
+            .also { transcriptionEngine = it }
     }
 
     private suspend fun updateForegroundNotification() {

--- a/app/src/main/java/com/asmr/player/subtitle/SubtitleTranscriptionEngine.kt
+++ b/app/src/main/java/com/asmr/player/subtitle/SubtitleTranscriptionEngine.kt
@@ -10,9 +10,16 @@ internal data class SubtitleModelArtifact(
     val sha256: String
 )
 
+internal enum class SubtitleTranscriptionModelType {
+    NEMO_CTC,
+    SENSE_VOICE
+}
+
 internal data class SubtitleTranscriptionModel(
     val id: String,
     val displayName: String,
+    val optionName: String,
+    val type: SubtitleTranscriptionModelType,
     val artifacts: List<SubtitleModelArtifact>,
     val inputSampleRateHz: Int
 ) {
@@ -49,12 +56,13 @@ internal interface SubtitleTranscriptionEngineFactory {
 }
 
 internal object SubtitleTranscriptionEngineRegistry {
-    fun defaultFactory(context: Context): SubtitleTranscriptionEngineFactory {
+    fun factory(context: Context, modelId: String? = null): SubtitleTranscriptionEngineFactory {
         val repository = SubtitleModelRepository.get(context)
-        return ParakeetEngineFactory(
+        val installed = repository.requireInstalledModel(modelId ?: repository.activeModel().id)
+        return SherpaOnnxTranscriptionEngineFactory(
             context = context.applicationContext,
-            modelDirectory = repository.requireInstalledModelDirectory(),
-            model = SubtitleTranscriptionModels.PARAKEET_TDT_CTC_06B_JA_INT8
+            modelDirectory = installed.directory,
+            model = installed.model
         )
     }
 }
@@ -63,6 +71,8 @@ internal object SubtitleTranscriptionModels {
     val PARAKEET_TDT_CTC_06B_JA_INT8 = SubtitleTranscriptionModel(
         id = "parakeet-tdt-ctc-0.6b-ja-35000-int8",
         displayName = "Parakeet TDT-CTC 0.6B Japanese INT8",
+        optionName = "高精度",
+        type = SubtitleTranscriptionModelType.NEMO_CTC,
         artifacts = listOf(
             SubtitleModelArtifact(
                 fileName = "model.int8.onnx",
@@ -77,4 +87,38 @@ internal object SubtitleTranscriptionModels {
         ),
         inputSampleRateHz = 16_000
     )
+
+    val SENSE_VOICE_SMALL_INT8 = SubtitleTranscriptionModel(
+        id = "sense-voice-small-zh-en-ja-ko-yue-int8-2024-07-17",
+        displayName = "SenseVoiceSmall INT8",
+        optionName = "轻量快速",
+        type = SubtitleTranscriptionModelType.SENSE_VOICE,
+        artifacts = listOf(
+            SubtitleModelArtifact(
+                fileName = "model.int8.onnx",
+                bytes = 239_233_841L,
+                sha256 = "c71f0ce00bec95b07744e116345e33d8cbbe08cef896382cf907bf4b51a2cd51"
+            ),
+            SubtitleModelArtifact(
+                fileName = "tokens.txt",
+                bytes = 315_894L,
+                sha256 = "f449eb28dc567533d7fa59be34e2abca8784f771850c78a47fb731a31429a1dc"
+            )
+        ),
+        inputSampleRateHz = 16_000
+    )
+
+    val all: List<SubtitleTranscriptionModel> = listOf(
+        PARAKEET_TDT_CTC_06B_JA_INT8,
+        SENSE_VOICE_SMALL_INT8
+    )
+
+    val default: SubtitleTranscriptionModel = PARAKEET_TDT_CTC_06B_JA_INT8
+
+    fun fromId(id: String?): SubtitleTranscriptionModel? = all.firstOrNull { it.id == id }
 }
+
+internal fun resolveTranscriptionModelId(
+    persistedModelId: String,
+    activeModelId: String
+): String = persistedModelId.ifBlank { activeModelId }

--- a/app/src/main/java/com/asmr/player/subtitle/SubtitleTranscriptionEngine.kt
+++ b/app/src/main/java/com/asmr/player/subtitle/SubtitleTranscriptionEngine.kt
@@ -21,8 +21,13 @@ internal data class SubtitleTranscriptionModel(
     val optionName: String,
     val type: SubtitleTranscriptionModelType,
     val artifacts: List<SubtitleModelArtifact>,
-    val inputSampleRateHz: Int
+    val inputSampleRateHz: Int,
+    val inferenceBatchSize: Int = 1
 ) {
+    init {
+        require(inferenceBatchSize > 0)
+    }
+
     val artifactBytes: Long = artifacts.sumOf(SubtitleModelArtifact::bytes)
 }
 
@@ -105,7 +110,8 @@ internal object SubtitleTranscriptionModels {
                 sha256 = "f449eb28dc567533d7fa59be34e2abca8784f771850c78a47fb731a31429a1dc"
             )
         ),
-        inputSampleRateHz = 16_000
+        inputSampleRateHz = 16_000,
+        inferenceBatchSize = 2
     )
 
     val all: List<SubtitleTranscriptionModel> = listOf(

--- a/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailLocalTab.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailLocalTab.kt
@@ -90,7 +90,7 @@ import com.asmr.player.subtitle.SubtitleFailureMessages
 import com.asmr.player.subtitle.SubtitleGenerationTarget
 import com.asmr.player.subtitle.SubtitleTaskRepository
 import com.asmr.player.subtitle.SubtitleModelRepository
-import com.asmr.player.subtitle.SubtitleModelState
+import com.asmr.player.subtitle.SubtitleModelInstallationState
 import com.asmr.player.data.remote.NetworkHeaders
 import com.asmr.player.cache.CacheImageModel
 import com.asmr.player.data.remote.dlsite.DlsiteLanguageEdition
@@ -177,7 +177,9 @@ internal fun AlbumLocalBreadcrumbTabV2(
     val subtitleModelState by subtitleModelRepository.state.collectAsState()
     val subtitleDeviceCapability = remember(context) { SubtitleDeviceCapability.evaluate(context) }
     val subtitleFeatureSupported = subtitleDeviceCapability.supported
-    val subtitleModelAvailable = subtitleFeatureSupported && subtitleModelState is SubtitleModelState.Available
+    val subtitleModelAvailable = subtitleFeatureSupported &&
+        subtitleModelState.installation(subtitleModelState.activeModelId) is
+        SubtitleModelInstallationState.Available
     val allPaths = remember(album) { album.getAllLocalPaths() }
     var currentPath by rememberSaveable(stateKey) { mutableStateOf(initialCurrentPath.trim().trim('/')) }
 

--- a/app/src/main/java/com/asmr/player/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/settings/SettingsScreen.kt
@@ -78,8 +78,11 @@ import com.asmr.player.data.settings.FloatingLyricsSettings
 import com.asmr.player.data.settings.LyricsPageSettings
 import com.asmr.player.subtitle.SubtitleDeviceCapability
 import com.asmr.player.subtitle.SubtitleModelDownloadSource
+import com.asmr.player.subtitle.SubtitleModelInstallationState
+import com.asmr.player.subtitle.SubtitleModelOperation
 import com.asmr.player.subtitle.SubtitleModelState
 import com.asmr.player.subtitle.SubtitleTranscriptionModels
+import com.asmr.player.subtitle.configuredSubtitleModelDownloadSources
 import com.asmr.player.subtitle.DEEPSEEK_SUBTITLE_MODEL
 import com.asmr.player.subtitle.DeepSeekAccountState
 import com.asmr.player.subtitle.formatDeepSeekBalances
@@ -172,9 +175,13 @@ fun SettingsScreen(
     var activeTipKey by remember { mutableStateOf<String?>(null) }
     var searchBlockedKeywordInput by rememberSaveable { mutableStateOf("") }
     var showClearAppCacheConfirmation by remember { mutableStateOf(false) }
-    var showDeleteSubtitleModelConfirmation by remember { mutableStateOf(false) }
-    var subtitleModelSourceId by rememberSaveable {
-        mutableStateOf(SubtitleModelDownloadSource.HuggingFace.id)
+    var pendingDeleteSubtitleModelId by remember { mutableStateOf<String?>(null) }
+    val subtitleModelSourceIds = remember {
+        mutableStateMapOf<String, String>().apply {
+            SubtitleTranscriptionModels.all.forEach { model ->
+                this[model.id] = SubtitleModelDownloadSource.HuggingFace.id
+            }
+        }
     }
     var deepSeekApiKeyInput by remember { mutableStateOf("") }
     LaunchedEffect(deepSeekApiKeyState.saveVersion) {
@@ -766,16 +773,18 @@ fun SettingsScreen(
                     SettingsGroup(title = "翻译配置") {
                         SubtitleModelSettingsSection(
                             state = subtitleModelState,
-                            selectedSource = SubtitleModelDownloadSource.fromId(subtitleModelSourceId)
-                                ?: SubtitleModelDownloadSource.HuggingFace,
+                            selectedSourceIds = subtitleModelSourceIds,
                             deviceSupported = remember(context) {
                                 SubtitleDeviceCapability.evaluate(context).supported
                             },
                             segmentedButtonColors = segmentedButtonColors,
-                            onSourceSelected = { source -> subtitleModelSourceId = source.id },
+                            onSourceSelected = { modelId, source ->
+                                subtitleModelSourceIds[modelId] = source.id
+                            },
                             onDownload = viewModel::downloadSubtitleModel,
                             onCancelDownload = viewModel::cancelSubtitleModelDownload,
-                            onDelete = { showDeleteSubtitleModelConfirmation = true },
+                            onSelect = viewModel::selectSubtitleModel,
+                            onDelete = { modelId -> pendingDeleteSubtitleModelId = modelId },
                             onClearFailure = viewModel::clearSubtitleModelFailure
                         )
                         HorizontalDivider(color = MaterialTheme.colorScheme.outline.copy(alpha = 0.14f))
@@ -969,18 +978,19 @@ fun SettingsScreen(
             )
         )
     }
-    if (showDeleteSubtitleModelConfirmation) {
+    pendingDeleteSubtitleModelId?.let { modelId ->
+        val modelName = SubtitleTranscriptionModels.fromId(modelId)?.optionName ?: "字幕"
         FlatActionDialog(
-            onDismissRequest = { showDeleteSubtitleModelConfirmation = false },
-            message = "确定删除字幕模型？约 29 MiB 的字幕运行时会保留，之后重新下载模型时无需重复安装。",
+            onDismissRequest = { pendingDeleteSubtitleModelId = null },
+            message = "确定删除“$modelName”模型？约 29 MiB 的公共运行时会保留，之后下载任一模型时无需重复安装。",
             actions = listOf(
-                FlatDialogAction("取消", onClick = { showDeleteSubtitleModelConfirmation = false }),
+                FlatDialogAction("取消", onClick = { pendingDeleteSubtitleModelId = null }),
                 FlatDialogAction(
                     text = "删除模型",
                     tone = FlatDialogActionTone.Danger,
                     onClick = {
-                        showDeleteSubtitleModelConfirmation = false
-                        viewModel.deleteSubtitleModel()
+                        pendingDeleteSubtitleModelId = null
+                        viewModel.deleteSubtitleModel(modelId)
                     }
                 )
             )
@@ -1153,163 +1163,222 @@ internal fun DeepSeekTranslationSettingsSection(
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-private fun SubtitleModelSettingsSection(
+internal fun SubtitleModelSettingsSection(
     state: SubtitleModelState,
-    selectedSource: SubtitleModelDownloadSource,
+    selectedSourceIds: Map<String, String>,
     deviceSupported: Boolean,
     segmentedButtonColors: SegmentedButtonColors,
-    onSourceSelected: (SubtitleModelDownloadSource) -> Unit,
-    onDownload: (SubtitleModelDownloadSource) -> Unit,
+    onSourceSelected: (String, SubtitleModelDownloadSource) -> Unit,
+    onDownload: (String, SubtitleModelDownloadSource) -> Unit,
     onCancelDownload: () -> Unit,
-    onDelete: () -> Unit,
-    onClearFailure: () -> Unit
+    onSelect: (String) -> Unit,
+    onDelete: (String) -> Unit,
+    onClearFailure: (String) -> Unit
 ) {
-    val actionButtonColors = settingsPrimaryTonalButtonColors()
-    val model = SubtitleTranscriptionModels.PARAKEET_TDT_CTC_06B_JA_INT8
-    val effectiveSource = when (state) {
-        is SubtitleModelState.Queued -> state.source
-        is SubtitleModelState.Downloading -> state.source
-        is SubtitleModelState.Verifying -> state.source
-        is SubtitleModelState.Failed -> state.source
-        is SubtitleModelState.Available -> state.source ?: selectedSource
-        SubtitleModelState.Missing -> selectedSource
-    }
-    val sourceConfigured = effectiveSource.isConfigured()
-    val isDownloading = state is SubtitleModelState.Queued ||
-        state is SubtitleModelState.Downloading ||
-        state is SubtitleModelState.Verifying
-
-    Row(
-        modifier = Modifier.fillMaxWidth(),
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.spacedBy(8.dp)
-    ) {
-        Text(
-            text = model.displayName,
-            style = MaterialTheme.typography.bodyMedium,
-            fontWeight = FontWeight.SemiBold,
-            maxLines = 1,
-            overflow = TextOverflow.Ellipsis,
-            modifier = Modifier.weight(1f)
-        )
-        Text(
-            text = Formatting.formatFileSize(model.artifactBytes),
-            style = MaterialTheme.typography.bodySmall,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-            textAlign = TextAlign.End,
-            modifier = Modifier.widthIn(min = 72.dp)
+    var selectedModelId by rememberSaveable {
+        mutableStateOf(
+            state.operation?.modelId ?: SubtitleTranscriptionModels.SENSE_VOICE_SMALL_INT8.id
         )
     }
+    LaunchedEffect(state.operation?.modelId) {
+        state.operation?.modelId?.let { selectedModelId = it }
+    }
+    val model = SubtitleTranscriptionModels.fromId(selectedModelId)
+        ?: SubtitleTranscriptionModels.default
+    val installation = state.installation(model.id)
+    val installed = installation is SubtitleModelInstallationState.Available
+    val isActive = state.activeModelId == model.id
+    val operation = state.operation?.takeIf { it.modelId == model.id }
+    val running = operation is SubtitleModelOperation.Queued ||
+        operation is SubtitleModelOperation.Downloading ||
+        operation is SubtitleModelOperation.Verifying
+    val anotherOperationRunning = state.operation != null &&
+        state.operation.modelId != model.id &&
+        state.operation !is SubtitleModelOperation.Failed
+    val availableSources = configuredSubtitleModelDownloadSources(model)
+    val selectedSource = operation?.source
+        ?: SubtitleModelDownloadSource.fromId(selectedSourceIds[model.id])
+        ?: availableSources.firstOrNull()
+        ?: SubtitleModelDownloadSource.HuggingFace
+    val colors = AsmrTheme.colorScheme
 
-    if (state !is SubtitleModelState.Available) {
+    Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
         SingleChoiceSegmentedButtonRow(modifier = Modifier.fillMaxWidth()) {
-            SubtitleModelDownloadSource.entries.forEachIndexed { index, source ->
+            SubtitleTranscriptionModels.all.forEachIndexed { index, candidate ->
                 SegmentedButton(
-                    selected = effectiveSource == source,
-                    onClick = {
-                        onClearFailure()
-                        onSourceSelected(source)
-                    },
-                    enabled = !isDownloading,
+                    selected = model.id == candidate.id,
+                    onClick = { selectedModelId = candidate.id },
                     shape = SegmentedButtonDefaults.itemShape(
                         index = index,
-                        count = SubtitleModelDownloadSource.entries.size
+                        count = SubtitleTranscriptionModels.all.size
                     ),
                     colors = segmentedButtonColors,
                     icon = {},
-                    label = { Text(source.displayName) }
+                    modifier = Modifier.testTag("subtitle_model_choice_${candidate.id}"),
+                    label = {
+                        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                            Text(
+                                text = if (state.activeModelId == candidate.id) {
+                                    "${candidate.optionName} · 当前"
+                                } else {
+                                    candidate.optionName
+                                },
+                                maxLines = 1
+                            )
+                            Text(
+                                text = Formatting.formatFileSize(candidate.artifactBytes),
+                                style = MaterialTheme.typography.labelSmall,
+                                maxLines = 1
+                            )
+                        }
+                    }
                 )
             }
         }
-    }
 
-    when (state) {
-        SubtitleModelState.Missing -> Unit
-        is SubtitleModelState.Queued -> {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.Top,
+            horizontalArrangement = Arrangement.spacedBy(10.dp)
+        ) {
             Text(
-                text = "等待下载字幕组件",
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant
+                text = model.displayName,
+                style = MaterialTheme.typography.bodyMedium,
+                fontWeight = FontWeight.SemiBold,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                modifier = Modifier.weight(1f)
             )
-            LinearProgressIndicator(modifier = Modifier.fillMaxWidth())
+            Text(
+                text = when {
+                    isActive && installed -> "当前使用"
+                    isActive -> "当前（未安装）"
+                    installed -> "已安装"
+                    else -> "未安装"
+                },
+                style = MaterialTheme.typography.labelMedium,
+                color = if (isActive) colors.primaryStrong else colors.textSecondary,
+                modifier = Modifier.testTag("subtitle_model_status_${model.id}")
+            )
         }
-        is SubtitleModelState.Downloading -> {
-            Text(
-                text = state.stage.displayName,
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant
-            )
-            val progress = if (state.totalBytes > 0L) {
-                (state.downloadedBytes.toFloat() / state.totalBytes.toFloat()).coerceIn(0f, 1f)
-            } else {
-                null
+
+        if (!installed && availableSources.size > 1) {
+            SingleChoiceSegmentedButtonRow(modifier = Modifier.fillMaxWidth()) {
+                availableSources.forEachIndexed { index, source ->
+                    SegmentedButton(
+                        selected = selectedSource == source,
+                        onClick = {
+                            onClearFailure(model.id)
+                            onSourceSelected(model.id, source)
+                        },
+                        enabled = !running && !anotherOperationRunning,
+                        shape = SegmentedButtonDefaults.itemShape(index, availableSources.size),
+                        colors = segmentedButtonColors,
+                        icon = {},
+                        label = { Text(source.displayName) }
+                    )
+                }
             }
-            if (progress != null) {
-                LinearProgressIndicator(progress = { progress }, modifier = Modifier.fillMaxWidth())
-            } else {
+        }
+
+        when (operation) {
+            null -> Unit
+            is SubtitleModelOperation.Queued -> {
+                Text("等待下载字幕组件", style = MaterialTheme.typography.bodySmall)
                 LinearProgressIndicator(modifier = Modifier.fillMaxWidth())
             }
-        }
-        is SubtitleModelState.Verifying -> {
-            Text(
-                text = state.stage.displayName,
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant
-            )
-            LinearProgressIndicator(modifier = Modifier.fillMaxWidth())
-        }
-        is SubtitleModelState.Available -> Unit
-        is SubtitleModelState.Failed -> {
-            Text(
-                text = state.message,
+            is SubtitleModelOperation.Downloading -> {
+                Text(operation.stage.displayName, style = MaterialTheme.typography.bodySmall)
+                if (operation.totalBytes > 0L) {
+                    val progress = (operation.downloadedBytes.toFloat() / operation.totalBytes)
+                        .coerceIn(0f, 1f)
+                    LinearProgressIndicator(
+                        progress = { progress },
+                        modifier = Modifier.fillMaxWidth()
+                    )
+                } else {
+                    LinearProgressIndicator(modifier = Modifier.fillMaxWidth())
+                }
+            }
+            is SubtitleModelOperation.Verifying -> {
+                Text(operation.stage.displayName, style = MaterialTheme.typography.bodySmall)
+                LinearProgressIndicator(modifier = Modifier.fillMaxWidth())
+            }
+            is SubtitleModelOperation.Failed -> Text(
+                text = operation.message,
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.error
             )
         }
-    }
 
-    when {
-        state is SubtitleModelState.Available -> {
-            FilledTonalButton(
-                onClick = onDelete,
+        when {
+            running -> FilledTonalButton(
+                onClick = onCancelDownload,
                 modifier = Modifier.fillMaxWidth(),
-                colors = ButtonDefaults.filledTonalButtonColors(
-                    containerColor = MaterialTheme.colorScheme.errorContainer,
-                    contentColor = MaterialTheme.colorScheme.onErrorContainer
-                )
+                colors = settingsPrimaryTonalButtonColors()
+            ) {
+                Text("取消下载")
+            }
+            installed && !isActive -> Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                FilledTonalButton(
+                    onClick = { onSelect(model.id) },
+                    modifier = Modifier
+                        .weight(1f)
+                        .testTag("subtitle_model_select_${model.id}"),
+                    colors = settingsPrimaryTonalButtonColors()
+                ) {
+                    Text("设为当前")
+                }
+                FilledTonalButton(
+                    onClick = { onDelete(model.id) },
+                    colors = subtitleModelDeleteButtonColors()
+                ) {
+                    Icon(Icons.Rounded.Delete, contentDescription = "删除模型")
+                }
+            }
+            installed -> FilledTonalButton(
+                onClick = { onDelete(model.id) },
+                modifier = Modifier.fillMaxWidth(),
+                colors = subtitleModelDeleteButtonColors()
             ) {
                 Icon(Icons.Rounded.Delete, contentDescription = null)
                 Spacer(modifier = Modifier.width(8.dp))
                 Text("删除模型")
             }
-        }
-        isDownloading -> {
-            FilledTonalButton(
-                onClick = onCancelDownload,
-                modifier = Modifier.fillMaxWidth(),
-                colors = actionButtonColors
-            ) {
-                Text("取消下载")
-            }
-        }
-        else -> {
-            FilledTonalButton(
-                onClick = { onDownload(effectiveSource) },
-                modifier = Modifier.fillMaxWidth(),
-                enabled = deviceSupported && sourceConfigured,
-                colors = actionButtonColors
+            else -> FilledTonalButton(
+                onClick = { onDownload(model.id, selectedSource) },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .testTag("subtitle_model_download_${model.id}"),
+                enabled = deviceSupported && availableSources.contains(selectedSource) &&
+                    !anotherOperationRunning,
+                colors = settingsPrimaryTonalButtonColors()
             ) {
                 Text(
                     when {
                         !deviceSupported -> "设备不支持"
-                        !sourceConfigured -> "来源不可用"
-                        else -> "下载字幕组件"
+                        availableSources.isEmpty() -> "来源不可用"
+                        anotherOperationRunning -> "其他模型正在下载"
+                        operation is SubtitleModelOperation.Failed -> "重新下载"
+                        else -> "下载模型"
                     }
                 )
             }
         }
     }
 }
+
+@Composable
+private fun subtitleModelDeleteButtonColors(): ButtonColors =
+    ButtonDefaults.filledTonalButtonColors(
+        containerColor = MaterialTheme.colorScheme.errorContainer,
+        contentColor = MaterialTheme.colorScheme.onErrorContainer,
+        disabledContainerColor = MaterialTheme.colorScheme.errorContainer.copy(alpha = 0.48f),
+        disabledContentColor = MaterialTheme.colorScheme.onErrorContainer.copy(alpha = 0.48f)
+    )
 
 @Composable
 private fun settingsPrimaryTonalButtonColors(): ButtonColors {

--- a/app/src/main/java/com/asmr/player/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/asmr/player/ui/settings/SettingsViewModel.kt
@@ -272,10 +272,14 @@ class SettingsViewModel @Inject constructor(
         appCacheManager.clearCache()
     }
 
-    internal fun downloadSubtitleModel(source: SubtitleModelDownloadSource) {
-        runCatching { subtitleModelRepository.enqueueDownload(source) }
+    internal fun downloadSubtitleModel(
+        modelId: String,
+        source: SubtitleModelDownloadSource
+    ) {
+        runCatching { subtitleModelRepository.enqueueDownload(modelId, source) }
             .onFailure { error ->
                 subtitleModelRepository.updateFailure(
+                    modelId,
                     source,
                     error.message?.takeIf { it.isNotBlank() } ?: "无法开始模型下载"
                 )
@@ -286,12 +290,16 @@ class SettingsViewModel @Inject constructor(
         viewModelScope.launch { subtitleModelRepository.cancelDownload() }
     }
 
-    fun deleteSubtitleModel() {
-        viewModelScope.launch { subtitleModelRepository.deleteModel() }
+    fun selectSubtitleModel(modelId: String) {
+        subtitleModelRepository.selectModel(modelId)
     }
 
-    fun clearSubtitleModelFailure() {
-        subtitleModelRepository.clearFailure()
+    fun deleteSubtitleModel(modelId: String) {
+        viewModelScope.launch { subtitleModelRepository.deleteModel(modelId) }
+    }
+
+    fun clearSubtitleModelFailure(modelId: String) {
+        subtitleModelRepository.clearFailure(modelId)
     }
 
     internal fun saveDeepSeekApiKey(apiKey: String) {

--- a/app/src/main/java/com/k2fsa/sherpa/onnx/OfflineRecognizer.kt
+++ b/app/src/main/java/com/k2fsa/sherpa/onnx/OfflineRecognizer.kt
@@ -196,6 +196,15 @@ class OfflineRecognizer(
 
     fun decode(stream: OfflineStream) = decode(ptr, stream.ptr)
 
+    fun decode(streams: List<OfflineStream>) {
+        require(streams.isNotEmpty())
+        if (streams.size == 1) {
+            decode(streams.single())
+        } else {
+            decodeStreams(ptr, streams.map(OfflineStream::ptr).toLongArray())
+        }
+    }
+
     fun setConfig(config: OfflineRecognizerConfig) = setConfig(ptr, config)
 
     private external fun delete(ptr: Long)
@@ -208,5 +217,6 @@ class OfflineRecognizer(
     ): Long
     private external fun newFromFile(config: OfflineRecognizerConfig): Long
     private external fun decode(ptr: Long, streamPtr: Long)
+    private external fun decodeStreams(ptr: Long, streamPtrs: LongArray)
     private external fun getResult(streamPtr: Long): OfflineRecognizerResult
 }

--- a/app/src/test/java/com/asmr/player/data/local/db/AppDatabaseMigrationsTest.kt
+++ b/app/src/test/java/com/asmr/player/data/local/db/AppDatabaseMigrationsTest.kt
@@ -15,6 +15,57 @@ import java.io.File
 @Config(application = Application::class, sdk = [34])
 class AppDatabaseMigrationsTest {
     @Test
+    fun migration28To29_preservesTaskItemAndAddsEmptyModelSnapshot() {
+        val context = RuntimeEnvironment.getApplication()
+        val dbName = "migration-test-${System.nanoTime()}.db"
+        val dbFile = context.getDatabasePath(dbName)
+        dbFile.parentFile?.mkdirs()
+        if (dbFile.exists()) dbFile.delete()
+        val helper = FrameworkSQLiteOpenHelperFactory().create(
+            androidx.sqlite.db.SupportSQLiteOpenHelper.Configuration.builder(context)
+                .name(dbName)
+                .callback(object : androidx.sqlite.db.SupportSQLiteOpenHelper.Callback(28) {
+                    override fun onCreate(db: androidx.sqlite.db.SupportSQLiteDatabase) {
+                        db.execSQL(
+                            "CREATE TABLE subtitle_task_items (" +
+                                "`id` TEXT NOT NULL PRIMARY KEY, `trackTitle` TEXT NOT NULL, " +
+                                "`transcriptionProgress` INTEGER NOT NULL)"
+                        )
+                        db.execSQL(
+                            "INSERT INTO subtitle_task_items VALUES('item-1','晚安音声',37)"
+                        )
+                    }
+
+                    override fun onUpgrade(
+                        db: androidx.sqlite.db.SupportSQLiteDatabase,
+                        oldVersion: Int,
+                        newVersion: Int
+                    ) = Unit
+                })
+                .build()
+        )
+        val db = helper.writableDatabase
+
+        AppDatabaseMigrations.MIGRATION_28_29.migrate(db)
+
+        db.query(
+            "SELECT trackTitle, transcriptionProgress, transcriptionModelId " +
+                "FROM subtitle_task_items WHERE id = 'item-1'"
+        ).use { cursor ->
+            assertTrue(cursor.moveToFirst())
+            assertEquals("晚安音声", cursor.getString(0))
+            assertEquals(37, cursor.getInt(1))
+            assertEquals("", cursor.getString(2))
+        }
+
+        db.close()
+        helper.close()
+        File(dbFile.absolutePath).delete()
+        File(dbFile.absolutePath + "-wal").delete()
+        File(dbFile.absolutePath + "-shm").delete()
+    }
+
+    @Test
     fun migration27To28_preservesChineseAndAddsHiddenJapaneseText() {
         val context = RuntimeEnvironment.getApplication()
         val dbName = "migration-test-${System.nanoTime()}.db"

--- a/app/src/test/java/com/asmr/player/subtitle/ParakeetTokenTimelineTest.kt
+++ b/app/src/test/java/com/asmr/player/subtitle/ParakeetTokenTimelineTest.kt
@@ -7,7 +7,7 @@ import org.junit.Test
 class ParakeetTokenTimelineTest {
     @Test
     fun `token timestamps become bounded millisecond segments`() {
-        val result = buildParakeetTokenTimeline(
+        val result = buildRecognizerTokenTimeline(
             tokens = listOf(" ", "日本", "語", "?", "って"),
             timestampsSeconds = listOf(0f, 1.04f, 1.36f, 4.72f, 4.96f),
             segmentDurationMs = 5_500L
@@ -25,7 +25,7 @@ class ParakeetTokenTimelineTest {
 
     @Test
     fun `reported token duration takes precedence when available`() {
-        val result = buildParakeetTokenTimeline(
+        val result = buildRecognizerTokenTimeline(
             tokens = listOf("▁おやすみ"),
             timestampsSeconds = listOf(0.25f),
             durationsSeconds = listOf(0.12f),
@@ -40,7 +40,7 @@ class ParakeetTokenTimelineTest {
 
     @Test
     fun `mismatched token timestamps are rejected for safe fallback`() {
-        val result = buildParakeetTokenTimeline(
+        val result = buildRecognizerTokenTimeline(
             tokens = listOf("今日", "は"),
             timestampsSeconds = listOf(0f),
             segmentDurationMs = 1_000L

--- a/app/src/test/java/com/asmr/player/subtitle/SherpaOnnxRecognizerConfigTest.kt
+++ b/app/src/test/java/com/asmr/player/subtitle/SherpaOnnxRecognizerConfigTest.kt
@@ -1,0 +1,44 @@
+package com.asmr.player.subtitle
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class SherpaOnnxRecognizerConfigTest {
+    private val artifacts = mapOf(
+        "model.int8.onnx" to "/models/model.int8.onnx",
+        "tokens.txt" to "/models/tokens.txt"
+    )
+
+    @Test
+    fun parakeet_usesNemoCtcOnCpu() {
+        val config = buildOfflineRecognizerConfig(
+            model = SubtitleTranscriptionModels.PARAKEET_TDT_CTC_06B_JA_INT8,
+            artifactPaths = artifacts,
+            numThreads = 3
+        )
+
+        assertEquals(artifacts.getValue("model.int8.onnx"), config.modelConfig.nemo.model)
+        assertTrue(config.modelConfig.senseVoice.model.isEmpty())
+        assertEquals("cpu", config.modelConfig.provider)
+        assertEquals(3, config.modelConfig.numThreads)
+        assertEquals(artifacts.getValue("tokens.txt"), config.modelConfig.tokens)
+    }
+
+    @Test
+    fun senseVoice_usesJapaneseItnOnSameCpuRuntime() {
+        val config = buildOfflineRecognizerConfig(
+            model = SubtitleTranscriptionModels.SENSE_VOICE_SMALL_INT8,
+            artifactPaths = artifacts,
+            numThreads = 2
+        )
+
+        assertEquals(artifacts.getValue("model.int8.onnx"), config.modelConfig.senseVoice.model)
+        assertEquals("ja", config.modelConfig.senseVoice.language)
+        assertTrue(config.modelConfig.senseVoice.useInverseTextNormalization)
+        assertTrue(config.modelConfig.nemo.model.isEmpty())
+        assertEquals("cpu", config.modelConfig.provider)
+        assertFalse(config.modelConfig.tokens.isEmpty())
+    }
+}

--- a/app/src/test/java/com/asmr/player/subtitle/SherpaOnnxRecognizerConfigTest.kt
+++ b/app/src/test/java/com/asmr/player/subtitle/SherpaOnnxRecognizerConfigTest.kt
@@ -12,6 +12,18 @@ class SherpaOnnxRecognizerConfigTest {
     )
 
     @Test
+    fun modelBatchSizes_matchMeasuredDefaults() {
+        assertEquals(
+            1,
+            SubtitleTranscriptionModels.PARAKEET_TDT_CTC_06B_JA_INT8.inferenceBatchSize
+        )
+        assertEquals(
+            2,
+            SubtitleTranscriptionModels.SENSE_VOICE_SMALL_INT8.inferenceBatchSize
+        )
+    }
+
+    @Test
     fun parakeet_usesNemoCtcOnCpu() {
         val config = buildOfflineRecognizerConfig(
             model = SubtitleTranscriptionModels.PARAKEET_TDT_CTC_06B_JA_INT8,

--- a/app/src/test/java/com/asmr/player/subtitle/SubtitleModelRepositoryTest.kt
+++ b/app/src/test/java/com/asmr/player/subtitle/SubtitleModelRepositoryTest.kt
@@ -1,5 +1,7 @@
 package com.asmr.player.subtitle
 
+import android.app.Application
+import android.content.Context
 import java.io.File
 import java.nio.file.Files
 import org.junit.Assert.assertEquals
@@ -7,18 +9,46 @@ import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.annotation.Config
 
+@RunWith(RobolectricTestRunner::class)
+@Config(application = Application::class, sdk = [34])
 class SubtitleModelRepositoryTest {
     @Test
     fun downloadSource_roundTripsStableIds() {
         SubtitleModelDownloadSource.entries.forEach { source ->
             assertEquals(source, SubtitleModelDownloadSource.fromId(source.id))
-            assertEquals(
-                source.downloadBaseUrl().trim().startsWith("https://"),
-                source.isConfigured()
-            )
         }
         assertNull(SubtitleModelDownloadSource.fromId("unknown"))
+        assertEquals(
+            listOf(
+                SubtitleModelDownloadSource.GitHub,
+                SubtitleModelDownloadSource.HuggingFace
+            ),
+            configuredSubtitleModelDownloadSources(SubtitleTranscriptionModels.SENSE_VOICE_SMALL_INT8)
+        )
+    }
+
+    @Test
+    fun senseVoiceGitHubSource_mapsLocalArtifactNamesToReleaseAssets() {
+        val baseUrl = subtitleModelDownloadBaseUrl(
+            SubtitleTranscriptionModels.SENSE_VOICE_SMALL_INT8,
+            SubtitleModelDownloadSource.GitHub
+        )
+
+        assertEquals(
+            "https://github.com/eValDoll/EaraAsmrPlayer/releases/download/" +
+                "subtitle-model-parakeet-ja-int8/sensevoice-model.int8.onnx",
+            buildSubtitleModelArtifactUrl(baseUrl, "model.int8.onnx")
+        )
+        assertEquals(
+            "https://github.com/eValDoll/EaraAsmrPlayer/releases/download/" +
+                "subtitle-model-parakeet-ja-int8/sensevoice-tokens.txt",
+            buildSubtitleModelArtifactUrl(baseUrl, "tokens.txt")
+        )
     }
 
     @Test
@@ -59,5 +89,82 @@ class SubtitleModelRepositoryTest {
         assertEquals(655_571_161L, model.artifactBytes)
         assertEquals(2, model.artifacts.size)
         assertTrue(model.artifacts.all { it.sha256.length == 64 })
+    }
+
+    @Test
+    fun senseVoiceModel_usesVerifiedOfficialArtifacts() {
+        val model = SubtitleTranscriptionModels.SENSE_VOICE_SMALL_INT8
+
+        assertEquals("sense-voice-small-zh-en-ja-ko-yue-int8-2024-07-17", model.id)
+        assertEquals(239_549_735L, model.artifactBytes)
+        assertEquals(
+            "c71f0ce00bec95b07744e116345e33d8cbbe08cef896382cf907bf4b51a2cd51",
+            model.artifacts.single { it.fileName == "model.int8.onnx" }.sha256
+        )
+        assertEquals(
+            "f449eb28dc567533d7fa59be34e2abca8784f771850c78a47fb731a31429a1dc",
+            model.artifacts.single { it.fileName == "tokens.txt" }.sha256
+        )
+        assertEquals(model, SubtitleTranscriptionModels.fromId(model.id))
+    }
+
+    @Test
+    fun legacyInstalledSource_migratesToParakeetWithoutOverwritingNewValue() {
+        val preferences = RuntimeEnvironment.getApplication()
+            .getSharedPreferences("subtitle-model-migration-test", Context.MODE_PRIVATE)
+        preferences.edit()
+            .clear()
+            .putString("installed_source", SubtitleModelDownloadSource.GitHub.id)
+            .commit()
+
+        SubtitleModelRepository.migrateLegacyPreferences(preferences)
+
+        val parakeetKey = "installed_source:${SubtitleTranscriptionModels.default.id}"
+        assertEquals(SubtitleModelDownloadSource.GitHub.id, preferences.getString(parakeetKey, null))
+        assertFalse(preferences.contains("installed_source"))
+
+        preferences.edit()
+            .putString("installed_source", SubtitleModelDownloadSource.GitHub.id)
+            .putString(parakeetKey, SubtitleModelDownloadSource.HuggingFace.id)
+            .commit()
+        SubtitleModelRepository.migrateLegacyPreferences(preferences)
+        assertEquals(
+            SubtitleModelDownloadSource.HuggingFace.id,
+            preferences.getString(parakeetKey, null)
+        )
+        preferences.edit().clear().commit()
+    }
+
+    @Test
+    fun deletingCurrentModel_fallsBackToInstalledAlternativeOrDefault() {
+        val parakeet = SubtitleTranscriptionModels.PARAKEET_TDT_CTC_06B_JA_INT8.id
+        val senseVoice = SubtitleTranscriptionModels.SENSE_VOICE_SMALL_INT8.id
+
+        assertEquals(senseVoice, fallbackSubtitleModelId(parakeet, setOf(senseVoice)))
+        assertEquals(parakeet, fallbackSubtitleModelId(senseVoice, emptySet()))
+    }
+
+    @Test
+    fun state_tracksCoexistingModelsAndStableFailureTarget() {
+        val parakeet = SubtitleTranscriptionModels.PARAKEET_TDT_CTC_06B_JA_INT8.id
+        val senseVoice = SubtitleTranscriptionModels.SENSE_VOICE_SMALL_INT8.id
+        val failure = SubtitleModelOperation.Failed(
+            modelId = senseVoice,
+            source = SubtitleModelDownloadSource.HuggingFace,
+            message = "校验失败"
+        )
+        val state = SubtitleModelState(
+            activeModelId = parakeet,
+            installations = mapOf(
+                parakeet to SubtitleModelInstallationState.Available(null),
+                senseVoice to SubtitleModelInstallationState.Missing
+            ),
+            operation = failure
+        )
+
+        assertTrue(state.installation(parakeet) is SubtitleModelInstallationState.Available)
+        assertEquals(SubtitleModelInstallationState.Missing, state.installation(senseVoice))
+        assertEquals(senseVoice, state.operation?.modelId)
+        assertEquals(parakeet, state.activeModelId)
     }
 }

--- a/app/src/test/java/com/asmr/player/subtitle/SubtitleTaskDaoTest.kt
+++ b/app/src/test/java/com/asmr/player/subtitle/SubtitleTaskDaoTest.kt
@@ -116,6 +116,7 @@ class SubtitleTaskDaoTest {
             suspendedFromState = "",
             transcriptionChunkCursor = 0,
             transcriptionProgress = 0,
+            transcriptionModelId = "",
             transcribedMs = 0L,
             totalDurationMs = 0L,
             translationCursor = 0,

--- a/app/src/test/java/com/asmr/player/subtitle/SubtitleTaskStateMachineTest.kt
+++ b/app/src/test/java/com/asmr/player/subtitle/SubtitleTaskStateMachineTest.kt
@@ -92,4 +92,13 @@ class SubtitleTaskStateMachineTest {
             SubtitleItemState.requireTransition(SubtitleItemState.SUCCEEDED, SubtitleItemState.CANCEL_REQUESTED)
         }
     }
+
+    @Test
+    fun transcriptionModel_isCapturedOnceAndKeptAcrossResume() {
+        val parakeet = SubtitleTranscriptionModels.PARAKEET_TDT_CTC_06B_JA_INT8.id
+        val senseVoice = SubtitleTranscriptionModels.SENSE_VOICE_SMALL_INT8.id
+
+        assertEquals(senseVoice, resolveTranscriptionModelId("", senseVoice))
+        assertEquals(parakeet, resolveTranscriptionModelId(parakeet, senseVoice))
+    }
 }


### PR DESCRIPTION
## 变更内容

- 保留 Parakeet TDT-CTC 0.6B Japanese INT8 作为高精度方案，新增 SenseVoiceSmall INT8 轻量快速方案，共用现有 sherpa-onnx、Silero VAD、ONNX CPU 与线程策略。
- 两个模型可共存，支持统一下载来源、下载、启用和删除操作；SenseVoice 制品同时提供 GitHub Release 与 Hugging Face 地址。
- 将转录引擎统一为 sherpa-onnx 引擎，根据模型类型创建 NeMo CTC 或 SenseVoice recognizer。
- 数据库升级至 29，任务音频项固化 `transcriptionModelId`，暂停、恢复和进程重启不会在同一音频内混用模型。
- 设置页使用紧凑的共享模型选择与操作区域，不增加描述性文案。
- 接入 sherpa-onnx `decodeStreams`：单个 recognizer 一次提交多个语音分片。根据实测，SenseVoice 默认 batch=2，Parakeet 保持 batch=1。

## 实机测试环境

- 设备：CPU 8gen3、天机9200+，Android 16，arm64，Release 构建
- 样本：官方 `ja.wav`，时长 7.2 秒
- 推理：ONNX CPU，4 个推理线程；计时不包含模型加载、stream 创建和波形写入
- 每个 batch 档位交错执行 8 次，测试期间 Thermal Status 为 0

### 单分片推理速度

| 模型 | 中位耗时 | 测量范围 | 实时倍率 |
|---|---:|---:|---:|
| SenseVoiceSmall INT8 | 177.3 ms | 162.3–189.7 ms | 40.6× |
| Parakeet TDT-CTC 0.6B INT8 | 325.3 ms | 292.0–380.5 ms | 22.1× |

SenseVoice 单分片延迟降低约 45.5%，吞吐约为 Parakeet 的 1.83 倍。

### 单实例峰值 PSS

| 模型 | 进程峰值 PSS | 扣除空进程基线后的增量 |
|---|---:|---:|
| SenseVoiceSmall INT8 | 445.7 MiB | 339.9 MiB |
| Parakeet TDT-CTC 0.6B INT8 | 860.3 MiB | 753.5 MiB |

### 多分片 batch 推理

| 模型 | Batch | 整批中位耗时 | 单分片摊销 | 吞吐 | 相对 batch=1 |
|---|---:|---:|---:|---:|---:|
| SenseVoiceSmall INT8 | 1 | 176.8 ms | 176.8 ms | 5.658 items/s | 基准 |
| SenseVoiceSmall INT8 | 2 | 269.1 ms | 134.5 ms | 7.432 items/s | +31.4% |
| SenseVoiceSmall INT8 | 4 | 530.5 ms | 132.6 ms | 7.540 items/s | +33.3% |
| SenseVoiceSmall INT8 | 8 | 1025.3 ms | 128.2 ms | 7.802 items/s | +37.9% |
| Parakeet TDT-CTC 0.6B INT8 | 1 | 387.4 ms | 387.4 ms | 2.581 items/s | 基准 |
| Parakeet TDT-CTC 0.6B INT8 | 2 | 899.7 ms | 449.9 ms | 2.223 items/s | -13.9% |
| Parakeet TDT-CTC 0.6B INT8 | 4 | 1715.9 ms | 429.0 ms | 2.331 items/s | -9.7% |
| Parakeet TDT-CTC 0.6B INT8 | 8 | 3373.2 ms | 421.6 ms | 2.372 items/s | -8.1% |

SenseVoice 的 batch=2 已获得大部分吞吐收益；batch=4 相比 batch=2 只再提升约 1.5%，因此默认采用 2。Parakeet 所有多 batch 档位均低于 batch=1，因此保持单分片推理。

## 验证

- `SherpaOnnxRecognizerConfigTest`：通过，覆盖两类 recognizer 配置与模型默认 batch。
- Release 实体机：两个模型的 batch=1/2/4/8 均完成非空日语转录，JNI 批量入口正常。
- `./gradlew-local.bat :app:installRelease`：成功安装到实体机，清理测速入口后冷启动正常。
- 完整 `:app:testReleaseUnitTest` 