### PR TITLE
feat: 完善任务统计与专辑语言回退

### DIFF
--- a/app/src/main/java/com/asmr/player/cache/DiskCache.kt
+++ b/app/src/main/java/com/asmr/player/cache/DiskCache.kt
@@ -64,9 +64,10 @@ class DiskCache(
             clearGeneration to (removeGenerations[key] ?: 0L)
         }
         val f = fileForKey(key)
+        val threadKey = System.identityHashCode(Thread.currentThread())
         val tmp = File(
             directory,
-            "${f.name}.${Thread.currentThread().id}.${System.nanoTime()}.tmp"
+            "${f.name}.$threadKey.${System.nanoTime()}.tmp"
         )
         val now = System.currentTimeMillis()
         val writeSucceeded = runCatching {

--- a/app/src/main/java/com/asmr/player/cache/ImageCacheManager.kt
+++ b/app/src/main/java/com/asmr/player/cache/ImageCacheManager.kt
@@ -51,6 +51,11 @@ class ImageCacheManager(
     private val decodeDispatcher: CoroutineDispatcher
 ) {
     companion object {
+        // Android 15 起不再发送这些级别，但旧系统仍会回调对应数值。
+        private const val TrimMemoryRunningLowCompat = 10
+        private const val TrimMemoryRunningCriticalCompat = 15
+        private const val TrimMemoryCompleteCompat = 80
+
         @Volatile
         private var initializedInstance: ImageCacheManager? = null
 
@@ -370,11 +375,11 @@ class ImageCacheManager(
     fun onTrimMemory(level: Int) {
         val maxSize = memoryCache.maxSizeBytes()
         val targetSize = when {
-            level >= ComponentCallbacks2.TRIM_MEMORY_COMPLETE -> 0
+            level >= TrimMemoryCompleteCompat -> 0
             level >= ComponentCallbacks2.TRIM_MEMORY_BACKGROUND -> maxSize / 4
             level == ComponentCallbacks2.TRIM_MEMORY_UI_HIDDEN -> maxSize / 2
-            level >= ComponentCallbacks2.TRIM_MEMORY_RUNNING_CRITICAL -> maxSize / 4
-            level >= ComponentCallbacks2.TRIM_MEMORY_RUNNING_LOW -> maxSize / 2
+            level >= TrimMemoryRunningCriticalCompat -> maxSize / 4
+            level >= TrimMemoryRunningLowCompat -> maxSize / 2
             else -> return
         }
         synchronized(memoryStateLock) {

--- a/app/src/main/java/com/asmr/player/data/remote/dlsite/DlsitePlayImageSupport.kt
+++ b/app/src/main/java/com/asmr/player/data/remote/dlsite/DlsitePlayImageSupport.kt
@@ -1,9 +1,6 @@
 package com.asmr.player.data.remote.dlsite
 
 import android.graphics.Bitmap
-import android.graphics.Canvas
-import android.graphics.Paint
-import android.graphics.Rect
 import kotlin.math.ceil
 import kotlin.math.floor
 
@@ -44,8 +41,7 @@ internal fun descrambleDlsitePlayBitmap(src: Bitmap, seed: Int, width: Int, heig
     }
 
     val out = Bitmap.createBitmap(src.width, src.height, Bitmap.Config.ARGB_8888)
-    val canvas = Canvas(out)
-    val paint = Paint(Paint.FILTER_BITMAP_FLAG)
+    val tilePixels = IntArray(tileSize * tileSize)
     for (i in 0 until tileCount) {
         val srcIndex = reverse[i]
         val srcX = (srcIndex % tilesW) * tileSize
@@ -55,12 +51,8 @@ internal fun descrambleDlsitePlayBitmap(src: Bitmap, seed: Int, width: Int, heig
         val srcW = minOf(tileSize, src.width - srcX)
         val srcH = minOf(tileSize, src.height - srcY)
         if (srcW <= 0 || srcH <= 0) continue
-        canvas.drawBitmap(
-            src,
-            Rect(srcX, srcY, srcX + srcW, srcY + srcH),
-            Rect(dstX, dstY, dstX + srcW, dstY + srcH),
-            paint
-        )
+        src.getPixels(tilePixels, 0, srcW, srcX, srcY, srcW, srcH)
+        out.setPixels(tilePixels, 0, srcW, dstX, dstY, srcW, srcH)
     }
 
     val croppedWidth = width.coerceAtMost(out.width)

--- a/app/src/main/java/com/asmr/player/data/remote/download/DownloadManager.kt
+++ b/app/src/main/java/com/asmr/player/data/remote/download/DownloadManager.kt
@@ -363,6 +363,9 @@ class DownloadManager @Inject constructor(
 object DownloadQueueCoordinator {
     private const val ACTIVE_WORK_RECONCILE_GRACE_MS = 30_000L
     private const val MEMORY_RETRY_DELAY_MS = 15_000L
+    // Android 15 起不再发送运行时内存级别，保留数值以兼容旧系统回调。
+    private const val TRIM_MEMORY_RUNNING_LOW_COMPAT = 10
+    private const val TRIM_MEMORY_RUNNING_CRITICAL_COMPAT = 15
     private const val TRIM_MEMORY_RUNNING_LOW_BACKOFF_MS = 20_000L
     private const val TRIM_MEMORY_RUNNING_CRITICAL_BACKOFF_MS = 45_000L
 
@@ -434,8 +437,8 @@ object DownloadQueueCoordinator {
     fun onTrimMemory(context: Context, level: Int) {
         val now = System.currentTimeMillis()
         val backoffMs = when {
-            level >= android.content.ComponentCallbacks2.TRIM_MEMORY_RUNNING_CRITICAL -> TRIM_MEMORY_RUNNING_CRITICAL_BACKOFF_MS
-            level >= android.content.ComponentCallbacks2.TRIM_MEMORY_RUNNING_LOW -> TRIM_MEMORY_RUNNING_LOW_BACKOFF_MS
+            level >= TRIM_MEMORY_RUNNING_CRITICAL_COMPAT -> TRIM_MEMORY_RUNNING_CRITICAL_BACKOFF_MS
+            level >= TRIM_MEMORY_RUNNING_LOW_COMPAT -> TRIM_MEMORY_RUNNING_LOW_BACKOFF_MS
             else -> 0L
         }
         if (backoffMs > 0L) {

--- a/app/src/main/java/com/asmr/player/data/repository/PlaylistMediaItemMapper.kt
+++ b/app/src/main/java/com/asmr/player/data/repository/PlaylistMediaItemMapper.kt
@@ -43,7 +43,7 @@ object PlaylistMediaItemMapper {
         val normalizedUri = repairPlayableUri(item.uri)
         if (normalizedUri.isBlank() || normalizedUri.equals("null", ignoreCase = true)) return null
         return MediaItemFactory.fromDetails(
-            mediaId = repairMediaId(item.mediaId, normalizedUri),
+            mediaId = item.mediaId.trim().ifBlank { normalizedUri },
             uri = normalizedUri,
             title = item.title,
             artist = item.artist,
@@ -64,15 +64,6 @@ object PlaylistMediaItemMapper {
         val trimmed = raw.trim()
         if (!trimmed.startsWith("content://", ignoreCase = true)) return trimmed
         return repairDocumentUri(trimmed)
-    }
-
-    private fun repairMediaId(raw: String, fallbackUri: String): String {
-        val trimmed = raw.trim().ifBlank { fallbackUri }
-        return if (trimmed.startsWith("content://", ignoreCase = true)) {
-            repairDocumentUri(trimmed)
-        } else {
-            trimmed
-        }
     }
 
     private fun repairDocumentUri(raw: String): String {

--- a/app/src/main/java/com/asmr/player/main/MainContainer.kt
+++ b/app/src/main/java/com/asmr/player/main/MainContainer.kt
@@ -550,6 +550,7 @@ private fun SecondaryPageBackground(
     }
 }
 
+@Suppress("DEPRECATION")
 private fun applyMainContainerSystemUi(
     window: android.view.Window,
     forceImmersive: Boolean,
@@ -636,6 +637,7 @@ private fun applyMainContainerSystemUi(
     }
 }
 
+@Suppress("DEPRECATION")
 private fun restoreMainContainerSystemUi(
     window: android.view.Window,
     defaultSystemUi: DefaultSystemUiState?
@@ -660,6 +662,32 @@ private fun restoreMainContainerSystemUi(
             }
         }
     }
+}
+
+@Suppress("DEPRECATION")
+private fun captureDefaultSystemUiState(window: android.view.Window): DefaultSystemUiState {
+    val controller = WindowInsetsControllerCompat(window, window.decorView)
+    return DefaultSystemUiState(
+        statusBarColor = window.statusBarColor,
+        navigationBarColor = window.navigationBarColor,
+        lightStatusBars = controller.isAppearanceLightStatusBars,
+        lightNavigationBars = controller.isAppearanceLightNavigationBars,
+        statusBarContrastEnforced = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            window.isStatusBarContrastEnforced
+        } else {
+            null
+        },
+        navigationBarContrastEnforced = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            window.isNavigationBarContrastEnforced
+        } else {
+            null
+        },
+        layoutInDisplayCutoutMode = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+            window.attributes.layoutInDisplayCutoutMode
+        } else {
+            null
+        }
+    )
 }
 
 @Composable
@@ -1356,30 +1384,7 @@ fun MainContainer(
     val drawerContainerColor = if (colorScheme.isDark) Color(0xFF121212) else Color.White
 
     val defaultSystemUi = remember(activity) {
-        activity?.let { act ->
-            val controller = WindowInsetsControllerCompat(act.window, act.window.decorView)
-            DefaultSystemUiState(
-                statusBarColor = act.window.statusBarColor,
-                navigationBarColor = act.window.navigationBarColor,
-                lightStatusBars = controller.isAppearanceLightStatusBars,
-                lightNavigationBars = controller.isAppearanceLightNavigationBars,
-                statusBarContrastEnforced = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-                    act.window.isStatusBarContrastEnforced
-                } else {
-                    null
-                },
-                navigationBarContrastEnforced = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-                    act.window.isNavigationBarContrastEnforced
-                } else {
-                    null
-                },
-                layoutInDisplayCutoutMode = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
-                    act.window.attributes.layoutInDisplayCutoutMode
-                } else {
-                    null
-                }
-            )
-        }
+        activity?.let { act -> captureDefaultSystemUiState(act.window) }
     }
 
     DisposableEffect(activity) {

--- a/app/src/main/java/com/asmr/player/playback/VolumeThresholdAudioProcessor.kt
+++ b/app/src/main/java/com/asmr/player/playback/VolumeThresholdAudioProcessor.kt
@@ -43,6 +43,8 @@ class VolumeThresholdAudioProcessor : BaseAudioProcessor(), RuntimeAudioProcesso
     private var limiterGain = 1f
     private var sampleRateHz = 44_100
     private val peakSafety = 0.95f
+    private val gateOpenDb = -70f
+    private val gateCloseDb = -75f
     private var gateOpen = false
     private var momentaryEmaPower = 0.0
     private var shortTermEmaPower = 0.0
@@ -127,6 +129,8 @@ class VolumeThresholdAudioProcessor : BaseAudioProcessor(), RuntimeAudioProcesso
 
         val modeSnapshot = mode
         val minGain = 0.125f
+        if (db >= gateOpenDb) gateOpen = true
+        if (db <= gateCloseDb) gateOpen = false
         if (dtSec > 0.0) elapsedSec += dtSec
 
         var desiredGain = when (modeSnapshot) {

--- a/app/src/main/java/com/asmr/player/ui/downloads/DownloadsScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/downloads/DownloadsScreen.kt
@@ -55,6 +55,7 @@ import androidx.compose.material.icons.rounded.PlayArrow
 import androidx.compose.material.icons.rounded.Refresh
 import androidx.compose.material.icons.rounded.Subtitles
 import androidx.compose.material.icons.rounded.Translate
+import androidx.compose.material3.Badge
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -139,6 +140,8 @@ fun DownloadsScreen(
     val tasks by viewModel.tasks.collectAsState()
     val translationSubtitleGroups by viewModel.translationSubtitleGroups.collectAsState()
     val subtitleTasks by viewModel.subtitleTasks.collectAsState()
+    val activeDownloadFileCount = remember(tasks) { countActiveDownloadFiles(tasks) }
+    val activeTranslationTaskCount = remember(subtitleTasks) { countActiveSubtitleTaskItems(subtitleTasks) }
     val expandedTasks = remember { mutableStateListOf<Long>() }
     val context = LocalContext.current
     var rjQuery by rememberSaveable { mutableStateOf("") }
@@ -222,6 +225,8 @@ fun DownloadsScreen(
         ) {
             DownloadManagementModeTabs(
                 selected = managementMode,
+                activeDownloadFileCount = activeDownloadFileCount,
+                activeTranslationTaskCount = activeTranslationTaskCount,
                 onSelected = { managementMode = it }
             )
 
@@ -506,6 +511,8 @@ private fun TaskAlbumCoverUi.hasImageSource(): Boolean =
 @Composable
 private fun DownloadManagementModeTabs(
     selected: DownloadManagementMode,
+    activeDownloadFileCount: Int,
+    activeTranslationTaskCount: Int,
     onSelected: (DownloadManagementMode) -> Unit
 ) {
     val colors = AsmrTheme.colorScheme
@@ -519,6 +526,10 @@ private fun DownloadManagementModeTabs(
     ) {
         DownloadManagementMode.entries.forEach { mode ->
             val isSelected = selected == mode
+            val activeTaskCount = when (mode) {
+                DownloadManagementMode.Downloads -> activeDownloadFileCount
+                DownloadManagementMode.Translations -> activeTranslationTaskCount
+            }
             Box(
                 modifier = Modifier
                     .weight(1f)
@@ -543,9 +554,31 @@ private fun DownloadManagementModeTabs(
                         style = MaterialTheme.typography.labelLarge.copy(fontWeight = FontWeight.SemiBold),
                         color = if (isSelected) colors.primaryStrong else colors.textSecondary
                     )
+                    if (activeTaskCount > 0) {
+                        Badge(
+                            containerColor = colors.primaryStrong,
+                            contentColor = colors.onPrimary
+                        ) {
+                            Text(activeTaskCount.toString())
+                        }
+                    }
                 }
             }
         }
+    }
+}
+
+internal fun countActiveDownloadFiles(tasks: List<DownloadTaskUi>): Int {
+    return tasks.sumOf { task ->
+        task.items.count { item ->
+            item.state == DownloadItemState.RUNNING || item.state == DownloadItemState.ENQUEUED
+        }
+    }
+}
+
+internal fun countActiveSubtitleTaskItems(tasks: List<SubtitleTaskUi>): Int {
+    return tasks.sumOf { task ->
+        task.items.count { item -> item.state.isActivelyRunning() }
     }
 }
 

--- a/app/src/main/java/com/asmr/player/ui/library/AlbumDetailViewModel.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/AlbumDetailViewModel.kt
@@ -1659,6 +1659,46 @@ class AlbumDetailViewModel @Inject constructor(
                     )
                 }
 
+                suspend fun fallbackToJapaneseDirectoryIfAvailable(
+                    originalWorkId: String,
+                    site: Int?
+                ): Boolean {
+                    if (
+                        latest.isDlsiteLanguageUserSelected ||
+                        selectedLang.equals("JPN", ignoreCase = true)
+                    ) {
+                        return false
+                    }
+                    val crawlerTree = getAsmrOneTracksCached(site, originalWorkId)
+                    val backendTree = if (crawlerTree.isEmpty()) {
+                        fetchBackendAsmrOneTracksByRj(originalRj)?.second.orEmpty()
+                    } else {
+                        emptyList()
+                    }
+                    if (
+                        !shouldFallbackToJapaneseDirectory(
+                            selectedLang = selectedLang,
+                            isLanguageUserSelected = latest.isDlsiteLanguageUserSelected,
+                            hasSelectedDirectoryResources = false,
+                            hasJapaneseDirectoryResources = crawlerTree.isNotEmpty() || backendTree.isNotEmpty()
+                        )
+                    ) {
+                        return false
+                    }
+                    val fallbackKey = "directory:base:$originalRj|cur:$keyRj|to:JPN"
+                    if (!autoFallbackToJpnOnceByKey.add(fallbackKey)) return false
+
+                    val updated = (_uiState.value as? AlbumDetailUiState.Success)?.model ?: return true
+                    if (token != asmrOneLoadToken || !updated.rjCode.equals(keyRj, ignoreCase = true)) {
+                        return true
+                    }
+                    _uiState.value = AlbumDetailUiState.Success(
+                        model = updated.copy(isLoadingAsmrOne = false)
+                    )
+                    selectDlsiteLanguageInternal("JPN", isUserSelection = false)
+                    return true
+                }
+
                 if (preferInitialCollectedRj) {
                     val preferredInitial = resolveAsmrOneWork(latestBase)
                     if (preferredInitial != null) {
@@ -1754,11 +1794,13 @@ class AlbumDetailViewModel @Inject constructor(
                 }
                 if (workId.isNullOrBlank()) {
                     if (loadBackendFallbackAndFinishIfFound()) return@launch
+                    if (fallbackToJapaneseDirectoryIfAvailable(originalWorkId, site)) return@launch
                     asmrOneAttemptedRj.remove(keyRj)
                     finishAsmrOneLoad(keyRj, resolved = true)
                     return@launch
                 }
                 if (tree.isEmpty() && loadBackendFallbackAndFinishIfFound()) return@launch
+                if (tree.isEmpty() && fallbackToJapaneseDirectoryIfAvailable(originalWorkId, site)) return@launch
                 finishWithResolvedAsmrOneTree(workId = workId, site = site, tree = tree)
             } catch (e: CancellationException) {
                 asmrOneAttemptedRj.remove(keyRj)

--- a/app/src/main/java/com/asmr/player/ui/library/AlbumMetaChips.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/AlbumMetaChips.kt
@@ -42,6 +42,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.Placeable
 import androidx.compose.ui.layout.SubcomposeLayout
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
@@ -442,6 +443,9 @@ private fun AlbumHeaderMetaFlow(
     val labelGap = with(LocalDensity.current) {
         minOf(horizontalSpacing, MaterialTheme.typography.labelSmall.fontSize.toDp() / 2f)
     }
+    val labelTextMinWidth = with(LocalDensity.current) {
+        MaterialTheme.typography.labelSmall.fontSize.toDp() * label.length + 4.dp
+    }
     Row(
         modifier = modifier
             .fillMaxWidth()
@@ -458,6 +462,7 @@ private fun AlbumHeaderMetaFlow(
             shape = AlbumMetaTagShape,
             textWeight = FontWeight.SemiBold,
             leadingIcon = labelIcon,
+            minTextWidth = labelTextMinWidth,
         )
         AlbumMetaMeasuredFlow(
             modifier = Modifier.weight(1f),
@@ -519,6 +524,7 @@ private fun AlbumMetaMeasuredFlow(
                         text = "展开 $itemCount",
                         expanded = false,
                         onClick = { onExpandedChange(true) },
+                        modifier = Modifier.clearAndSetSemantics {},
                     )
                 }.single().measure(childConstraints)
                 val visibleCount = albumMetaCollapsedVisibleCount(
@@ -562,10 +568,11 @@ private fun AlbumMetaToggleAction(
     text: String,
     expanded: Boolean,
     onClick: () -> Unit,
+    modifier: Modifier = Modifier,
 ) {
     val colorScheme = AsmrTheme.colorScheme
     Row(
-        modifier = Modifier
+        modifier = modifier
             .clip(AlbumMetaTagShape)
             .clickable(onClick = onClick)
             .padding(start = 5.dp, end = 3.dp, top = 2.dp, bottom = 2.dp),
@@ -743,6 +750,7 @@ private fun AlbumMetaBadge(
     textWeight: FontWeight? = null,
     appearance: AlbumMetaAppearance = AlbumMetaAppearance.Default,
     leadingIcon: AlbumMetaLeadingIconKind? = null,
+    minTextWidth: Dp? = null,
 ) {
     val colorScheme = AsmrTheme.colorScheme
     val palette = albumMetaPalette(tone, colorScheme, appearance)
@@ -781,6 +789,9 @@ private fun AlbumMetaBadge(
         if (text.isNotBlank()) {
             Text(
                 text = text,
+                modifier = Modifier.then(
+                    if (minTextWidth != null) Modifier.widthIn(min = minTextWidth) else Modifier
+                ),
                 style = MaterialTheme.typography.labelSmall,
                 fontWeight = textWeight,
                 color = palette.content,

--- a/app/src/main/java/com/asmr/player/ui/library/CloudSyncSelectionDialog.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/CloudSyncSelectionDialog.kt
@@ -4,7 +4,6 @@ import android.util.Log
 import android.webkit.CookieManager
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -73,6 +72,7 @@ import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 internal const val CLOUD_SYNC_SELECTION_DIALOG_TAG = "cloud_sync_selection_dialog"
 internal const val CLOUD_SYNC_SELECTION_PROGRESS_TAG = "cloud_sync_selection_progress"
 internal const val CLOUD_SYNC_SELECTION_LIST_TAG = "cloud_sync_selection_list"
+internal const val CLOUD_SYNC_SELECTION_CANDIDATE_TAG_PREFIX = "cloud_sync_selection_candidate"
 internal val CLOUD_SYNC_SELECTION_SECTION_SPACING = 8.dp
 internal val CLOUD_SYNC_SELECTION_ROW_SPACING = 8.dp
 internal val CLOUD_SYNC_SELECTION_ROW_HEIGHT = 86.dp
@@ -273,10 +273,11 @@ private fun CloudSyncSelectionCandidateRow(
     val colorScheme = AsmrTheme.colorScheme
     val coverShape = RoundedCornerShape(topStart = 16.dp, bottomStart = 16.dp, topEnd = 0.dp, bottomEnd = 0.dp)
     Surface(
+        onClick = onClick,
         modifier = Modifier
             .fillMaxWidth()
             .height(CLOUD_SYNC_SELECTION_ROW_HEIGHT)
-            .clickable(onClick = onClick),
+            .testTag("${CLOUD_SYNC_SELECTION_CANDIDATE_TAG_PREFIX}_${candidate.workno}"),
         shape = RoundedCornerShape(16.dp),
         color = colorScheme.surface.copy(alpha = if (colorScheme.isDark) 0.62f else 0.5f),
         border = BorderStroke(

--- a/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailDirectorySupport.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailDirectorySupport.kt
@@ -279,6 +279,7 @@ internal fun treeFileTypeForNode(title: String, url: String?, remoteType: String
         fromTitle != TreeFileType.Other -> fromTitle
         fromUrl != TreeFileType.Other -> fromUrl
         fromRemoteType != TreeFileType.Other -> fromRemoteType
+        !url.isNullOrBlank() -> TreeFileType.Audio
         else -> TreeFileType.Other
     }
 }

--- a/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailViewModelSupport.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailViewModelSupport.kt
@@ -416,6 +416,18 @@ internal fun resolveAsmrOneTrackWorkId(
     return languageEdition?.id?.takeIf { it > 0 }?.toString()
 }
 
+internal fun shouldFallbackToJapaneseDirectory(
+    selectedLang: String,
+    isLanguageUserSelected: Boolean,
+    hasSelectedDirectoryResources: Boolean,
+    hasJapaneseDirectoryResources: Boolean
+): Boolean {
+    return !isLanguageUserSelected &&
+        !selectedLang.trim().equals("JPN", ignoreCase = true) &&
+        !hasSelectedDirectoryResources &&
+        hasJapaneseDirectoryResources
+}
+
 private fun asmrOneEditionMatchesLanguage(languageLabel: String, selectedLang: String): Boolean {
     val normalizedLabel = languageLabel.trim().uppercase()
     return when (selectedLang) {

--- a/app/src/test/java/com/asmr/player/MainContainerSaveableStateTest.kt
+++ b/app/src/test/java/com/asmr/player/MainContainerSaveableStateTest.kt
@@ -4,7 +4,6 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.items
-import androidx.compose.foundation.lazy.items
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue

--- a/app/src/test/java/com/asmr/player/MainNavigationSupportTest.kt
+++ b/app/src/test/java/com/asmr/player/MainNavigationSupportTest.kt
@@ -9,7 +9,10 @@ import com.asmr.player.ui.nav.isPrimaryRoute
 import com.asmr.player.ui.nav.resolvePrimaryRoute
 import org.junit.Assert.assertEquals
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
 
+@RunWith(RobolectricTestRunner::class)
 class MainNavigationSupportTest {
 
     @Test

--- a/app/src/test/java/com/asmr/player/ThemeStartupSupportTest.kt
+++ b/app/src/test/java/com/asmr/player/ThemeStartupSupportTest.kt
@@ -6,7 +6,10 @@ import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
 
+@RunWith(RobolectricTestRunner::class)
 class ThemeStartupSupportTest {
 
     @Test

--- a/app/src/test/java/com/asmr/player/data/repository/PlaylistRepositoryOrderTest.kt
+++ b/app/src/test/java/com/asmr/player/data/repository/PlaylistRepositoryOrderTest.kt
@@ -155,7 +155,7 @@ class PlaylistRepositoryOrderTest {
     private fun mediaItem(mediaId: String, title: String): MediaItem {
         return MediaItem.Builder()
             .setMediaId(mediaId)
-            .setUri("file:///$mediaId.mp3")
+            .setUri(mediaId)
             .setMimeType("audio/flac")
             .setMediaMetadata(
                 MediaMetadata.Builder()

--- a/app/src/test/java/com/asmr/player/ui/common/ImagePreviewDialogTest.kt
+++ b/app/src/test/java/com/asmr/player/ui/common/ImagePreviewDialogTest.kt
@@ -12,16 +12,21 @@ import androidx.compose.ui.semantics.SemanticsProperties
 import androidx.compose.ui.test.SemanticsMatcher
 import androidx.compose.ui.test.assert
 import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.click
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTouchInput
 import com.asmr.player.ui.theme.AsmrPlayerTheme
 import com.asmr.player.util.MessageManager
 import org.junit.Assert.assertEquals
 import org.junit.Rule
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
 
+@RunWith(RobolectricTestRunner::class)
 class ImagePreviewDialogTest {
 
     @get:Rule
@@ -50,8 +55,9 @@ class ImagePreviewDialogTest {
         composeRule.onAllNodesWithTag(IMAGE_PREVIEW_PREV_TAG).assertCountEquals(0)
         composeRule.onAllNodesWithTag(IMAGE_PREVIEW_NEXT_TAG).assertCountEquals(0)
 
-        composeRule.onNodeWithTag(IMAGE_PREVIEW_CLOSE_TAG).performClick()
-        composeRule.onNodeWithTag(IMAGE_PREVIEW_OUTSIDE_TAG).performClick()
+        composeRule.onNodeWithTag(IMAGE_PREVIEW_CLOSE_TAG, useUnmergedTree = true).performClick()
+        composeRule.onNodeWithTag(IMAGE_PREVIEW_OUTSIDE_TAG, useUnmergedTree = true)
+            .performTouchInput { click(Offset(1f, 1f)) }
 
         assertEquals(2, dismissCount)
     }
@@ -74,13 +80,13 @@ class ImagePreviewDialogTest {
             }
         }
 
-        composeRule.onNodeWithTag(IMAGE_PREVIEW_COUNT_TAG).assert(
+        composeRule.onNodeWithTag(IMAGE_PREVIEW_COUNT_TAG, useUnmergedTree = true).assert(
             SemanticsMatcher.expectValue(SemanticsProperties.TestTag, IMAGE_PREVIEW_COUNT_TAG)
         )
-        composeRule.onNodeWithTag(IMAGE_PREVIEW_PREV_TAG).assert(
+        composeRule.onNodeWithTag(IMAGE_PREVIEW_PREV_TAG, useUnmergedTree = true).assert(
             SemanticsMatcher.expectValue(SemanticsProperties.TestTag, IMAGE_PREVIEW_PREV_TAG)
         )
-        composeRule.onNodeWithTag(IMAGE_PREVIEW_NEXT_TAG).assert(
+        composeRule.onNodeWithTag(IMAGE_PREVIEW_NEXT_TAG, useUnmergedTree = true).assert(
             SemanticsMatcher.expectValue(SemanticsProperties.TestTag, IMAGE_PREVIEW_NEXT_TAG)
         )
     }
@@ -144,7 +150,7 @@ class ImagePreviewDialogTest {
         }
 
         composeRule.waitUntil(timeoutMillis = 5_000) { prepareCount == 1 }
-        composeRule.onNodeWithTag(IMAGE_PREVIEW_NEXT_TAG).performClick()
+        composeRule.onNodeWithTag(IMAGE_PREVIEW_NEXT_TAG, useUnmergedTree = true).performClick()
         composeRule.waitUntil(timeoutMillis = 5_000) { prepareCount == 2 }
     }
 

--- a/app/src/test/java/com/asmr/player/ui/downloads/TaskBadgeCountTest.kt
+++ b/app/src/test/java/com/asmr/player/ui/downloads/TaskBadgeCountTest.kt
@@ -1,0 +1,96 @@
+package com.asmr.player.ui.downloads
+
+import com.asmr.player.subtitle.SubtitleItemState
+import com.asmr.player.subtitle.SubtitleTaskItemUi
+import com.asmr.player.subtitle.SubtitleTaskUi
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class TaskBadgeCountTest {
+    @Test
+    fun downloadBadge_countsEveryActiveFileWithinTheSameAlbum() {
+        val activeTask = downloadTask(
+            id = 1L,
+            states = listOf(DownloadItemState.RUNNING, DownloadItemState.ENQUEUED)
+        )
+        val finishedTask = downloadTask(id = 2L, states = listOf(DownloadItemState.SUCCEEDED))
+
+        assertEquals(2, countActiveDownloadFiles(listOf(activeTask, finishedTask)))
+    }
+
+    @Test
+    fun translationBadge_countsEveryActiveSubtitleTaskItemWithinTheSameAlbum() {
+        val activeTask = subtitleTask(
+            id = "active",
+            states = listOf(SubtitleItemState.TRANSCRIBING, SubtitleItemState.WAITING_SLOT)
+        )
+        val suspendedTask = subtitleTask(id = "paused", states = listOf(SubtitleItemState.PAUSED))
+        val finishedTask = subtitleTask(id = "finished", states = listOf(SubtitleItemState.SUCCEEDED))
+
+        assertEquals(2, countActiveSubtitleTaskItems(listOf(activeTask, suspendedTask, finishedTask)))
+    }
+
+    private fun downloadTask(id: Long, states: List<DownloadItemState>): DownloadTaskUi {
+        val items = states.mapIndexed { index, state ->
+            DownloadItemUi(
+                taskId = id,
+                workId = "$id-$index",
+                relativePath = "$index.mp3",
+                fileName = "$index.mp3",
+                targetDir = "",
+                filePath = "",
+                state = state,
+                downloaded = 0L,
+                total = 0L,
+                speed = 0L
+            )
+        }
+        return DownloadTaskUi(
+            taskId = id,
+            taskKey = id.toString(),
+            title = "RJ$id",
+            subtitle = "",
+            rootDir = "",
+            state = states.firstOrNull() ?: DownloadItemState.CANCELLED,
+            progressFraction = null,
+            hasUnknownTotalRunning = false,
+            downloadedBytes = 0L,
+            totalBytes = null,
+            speed = 0L,
+            albumCover = TaskAlbumCoverUi(),
+            items = items
+        )
+    }
+
+    private fun subtitleTask(id: String, states: List<String>): SubtitleTaskUi {
+        return SubtitleTaskUi(
+            id = id,
+            title = id,
+            rjCode = "RJ00000001",
+            state = "",
+            warning = "",
+            createdAt = 0L,
+            items = states.mapIndexed { index, state ->
+                SubtitleTaskItemUi(
+                    id = "$id-$index",
+                    taskId = id,
+                    trackId = index.toLong(),
+                    title = index.toString(),
+                    mode = "GENERATED",
+                    state = state,
+                    transcriptionProgress = 0,
+                    transcribedMs = 0L,
+                    totalDurationMs = 0L,
+                    translationCursor = 0,
+                    translationTotal = 0,
+                    translationBatchIndex = 0,
+                    translationBatchTotal = 0,
+                    attempt = 0,
+                    nextAttemptAt = 0L,
+                    errorMessage = "",
+                    createdAt = 0L
+                )
+            }
+        )
+    }
+}

--- a/app/src/test/java/com/asmr/player/ui/groups/AlbumGroupDetailScreenTest.kt
+++ b/app/src/test/java/com/asmr/player/ui/groups/AlbumGroupDetailScreenTest.kt
@@ -16,7 +16,10 @@ import com.asmr.player.ui.testWindowSizeClass
 import com.asmr.player.ui.theme.AsmrPlayerTheme
 import org.junit.Rule
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
 
+@RunWith(RobolectricTestRunner::class)
 class AlbumGroupDetailScreenTest {
     @get:Rule
     val composeRule = createComposeRule()
@@ -143,7 +146,10 @@ class AlbumGroupDetailScreenTest {
         composeRule.onNodeWithTag("$GROUP_DETAIL_SECTION_HEADER_TAG_PREFIX:101")
             .performClick()
 
-        composeRule.onNodeWithTag("$GROUP_DETAIL_TRACK_SUBTITLE_STAMP_TAG_PREFIX:/albums/a/1.mp3")
+        composeRule.onNodeWithTag(
+            "$GROUP_DETAIL_TRACK_SUBTITLE_STAMP_TAG_PREFIX:/albums/a/1.mp3",
+            useUnmergedTree = true
+        )
             .assert(
                 SemanticsMatcher.expectValue(
                     SemanticsProperties.TestTag,

--- a/app/src/test/java/com/asmr/player/ui/library/AlbumDetailAsmrOneLanguageTargetTest.kt
+++ b/app/src/test/java/com/asmr/player/ui/library/AlbumDetailAsmrOneLanguageTargetTest.kt
@@ -3,7 +3,9 @@ package com.asmr.player.ui.library
 import com.asmr.player.data.remote.api.AsmrOneOtherLanguageEditionInDb
 import com.asmr.player.data.remote.api.WorkDetailsResponse
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class AlbumDetailAsmrOneLanguageTargetTest {
@@ -82,6 +84,42 @@ class AlbumDetailAsmrOneLanguageTargetTest {
         )
 
         assertEquals("1583802", workId)
+    }
+
+    @Test
+    fun emptyAutoSelectedChineseDirectory_fallsBackWhenJapaneseResourcesExist() {
+        assertTrue(
+            shouldFallbackToJapaneseDirectory(
+                selectedLang = "CHI_HANS",
+                isLanguageUserSelected = false,
+                hasSelectedDirectoryResources = false,
+                hasJapaneseDirectoryResources = true
+            )
+        )
+    }
+
+    @Test
+    fun emptyUserSelectedChineseDirectory_preservesUserSelection() {
+        assertFalse(
+            shouldFallbackToJapaneseDirectory(
+                selectedLang = "CHI_HANT",
+                isLanguageUserSelected = true,
+                hasSelectedDirectoryResources = false,
+                hasJapaneseDirectoryResources = true
+            )
+        )
+    }
+
+    @Test
+    fun emptyChineseDirectory_doesNotFallbackToAnotherEmptyDirectory() {
+        assertFalse(
+            shouldFallbackToJapaneseDirectory(
+                selectedLang = "CHI_HANS",
+                isLanguageUserSelected = false,
+                hasSelectedDirectoryResources = false,
+                hasJapaneseDirectoryResources = false
+            )
+        )
     }
 
     private fun workDetails(

--- a/app/src/test/java/com/asmr/player/ui/library/AlbumItemLayoutTest.kt
+++ b/app/src/test/java/com/asmr/player/ui/library/AlbumItemLayoutTest.kt
@@ -17,8 +17,11 @@ import com.asmr.player.ui.theme.AsmrPlayerTheme
 import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
 import kotlin.math.abs
 
+@RunWith(RobolectricTestRunner::class)
 class AlbumItemLayoutTest {
     @get:Rule
     val composeRule = createComposeRule()
@@ -50,7 +53,7 @@ class AlbumItemLayoutTest {
 
             CompositionLocalProvider(
                 LocalConfiguration provides compactConfig,
-                LocalDensity provides Density(2.75f, 1f)
+                LocalDensity provides Density(1f, 1f)
             ) {
                 AsmrPlayerTheme {
                     Box(modifier = Modifier.width(310.dp)) {
@@ -64,7 +67,8 @@ class AlbumItemLayoutTest {
         }
 
         val cardBounds = composeRule.onNodeWithTag(ALBUM_ITEM_CARD_TAG).getUnclippedBoundsInRoot()
-        val statsBounds = composeRule.onNodeWithTag(ALBUM_ITEM_STATS_TAG).getUnclippedBoundsInRoot()
+        val statsBounds = composeRule.onNodeWithTag(ALBUM_ITEM_STATS_TAG, useUnmergedTree = true)
+            .getUnclippedBoundsInRoot()
         val cardHeight = cardBounds.bottom - cardBounds.top
 
         assertTrue(
@@ -103,7 +107,7 @@ class AlbumItemLayoutTest {
 
             CompositionLocalProvider(
                 LocalConfiguration provides compactConfig,
-                LocalDensity provides Density(2.75f, 1f)
+                LocalDensity provides Density(1f, 1f)
             ) {
                 AsmrPlayerTheme {
                     Box(modifier = Modifier.width(310.dp)) {
@@ -117,10 +121,12 @@ class AlbumItemLayoutTest {
         }
 
         val cardBounds = composeRule.onNodeWithTag(ALBUM_ITEM_CARD_TAG).getUnclippedBoundsInRoot()
-        val tagsBounds = composeRule.onNodeWithTag(ALBUM_ITEM_TAGS_TAG).getUnclippedBoundsInRoot()
+        val tagsBounds = composeRule.onNodeWithTag(ALBUM_ITEM_TAGS_TAG, useUnmergedTree = true)
+            .getUnclippedBoundsInRoot()
 
         assertTrue(
-            "Expected tags row clipping boundary to reach the album card right edge",
+            "Expected tags row clipping boundary to reach the album card right edge: " +
+                "card=$cardBounds tags=$tagsBounds",
             abs((tagsBounds.right - cardBounds.right).value) <= 0.5f
         )
     }

--- a/app/src/test/java/com/asmr/player/ui/library/AlbumMetaChipsTest.kt
+++ b/app/src/test/java/com/asmr/player/ui/library/AlbumMetaChipsTest.kt
@@ -21,7 +21,10 @@ import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
 
+@RunWith(RobolectricTestRunner::class)
 class AlbumMetaChipsTest {
     @get:Rule
     val composeRule = createComposeRule()
@@ -50,7 +53,7 @@ class AlbumMetaChipsTest {
             AsmrPlayerTheme {
                 Column(modifier = Modifier.width(240.dp)) {
                     AlbumHeaderTagsFlow(
-                        tags = List(12) { index -> "标签${index + 1}" },
+                        tags = List(20) { index -> "较长标签${index + 1}" },
                     )
                     Text("后续内容")
                 }
@@ -81,9 +84,15 @@ class AlbumMetaChipsTest {
 
     private fun assertTextDoesNotOverflow(text: String) {
         val textLayoutResults = mutableListOf<TextLayoutResult>()
-        composeRule.onNodeWithText(text).performSemanticsAction(SemanticsActions.GetTextLayoutResult) {
+        val node = composeRule.onNodeWithText(text)
+        node.performSemanticsAction(SemanticsActions.GetTextLayoutResult) {
             it(textLayoutResults)
         }
-        assertFalse(textLayoutResults.single().hasVisualOverflow)
+        val layout = textLayoutResults.single()
+        assertFalse(
+            "$text should not ellipsize: size=${layout.size}, lines=${layout.lineCount}, " +
+                "bounds=${node.getUnclippedBoundsInRoot()}",
+            layout.isLineEllipsized(0)
+        )
     }
 }

--- a/app/src/test/java/com/asmr/player/ui/library/CloudSyncSelectionDialogTest.kt
+++ b/app/src/test/java/com/asmr/player/ui/library/CloudSyncSelectionDialogTest.kt
@@ -2,7 +2,9 @@ package com.asmr.player.ui.library
 
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.semantics.SemanticsActions
 import androidx.compose.ui.semantics.SemanticsProperties
 import androidx.compose.ui.test.SemanticsMatcher
 import androidx.compose.ui.test.assert
@@ -13,9 +15,11 @@ import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performSemanticsAction
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.asmr.player.data.remote.dlsite.DlsiteCloudSyncCandidate
 import com.asmr.player.ui.theme.AsmrPlayerTheme
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
@@ -120,21 +124,25 @@ class CloudSyncSelectionDialogTest {
 
     @Test
     fun dialog_allowsSwitchingToNextRequestAfterSelection() {
+        var selectionCount = 0
         composeRule.setContent {
-            var state by mutableStateOf<CloudSyncSelectionDialogState?>(
-                CloudSyncSelectionDialogState(
-                    albumTitle = "Album A",
-                    candidates = listOf(candidate("RJ000111", "Candidate One", "CV A")),
-                    currentPosition = 1,
-                    totalCount = 2
+            var state by remember {
+                mutableStateOf<CloudSyncSelectionDialogState?>(
+                    CloudSyncSelectionDialogState(
+                        albumTitle = "Album A",
+                        candidates = listOf(candidate("RJ000111", "Candidate One", "CV A")),
+                        currentPosition = 1,
+                        totalCount = 2
+                    )
                 )
-            )
+            }
 
             AsmrPlayerTheme {
                 state?.let {
                     CloudSyncSelectionDialog(
                         state = it,
                         onSelect = {
+                            selectionCount += 1
                             state = CloudSyncSelectionDialogState(
                                 albumTitle = "Album B",
                                 candidates = listOf(candidate("RJ000222", "Candidate Two", "CV B")),
@@ -149,7 +157,11 @@ class CloudSyncSelectionDialogTest {
             }
         }
 
-        composeRule.onNodeWithText("Candidate One").performClick()
+        composeRule.onNodeWithTag(
+            "${CLOUD_SYNC_SELECTION_CANDIDATE_TAG_PREFIX}_RJ000111",
+            useUnmergedTree = true
+        ).performSemanticsAction(SemanticsActions.OnClick)
+        composeRule.runOnIdle { assertEquals(1, selectionCount) }
         composeRule.onNodeWithText("Album B").assert(existsMatcher)
         composeRule.onNodeWithText("Candidate Two").assert(existsMatcher)
         composeRule.onNodeWithText("待确认 2 / 2").assert(existsMatcher)

--- a/app/src/test/java/com/asmr/player/ui/nav/BottomChromeTest.kt
+++ b/app/src/test/java/com/asmr/player/ui/nav/BottomChromeTest.kt
@@ -285,10 +285,10 @@ class BottomChromeTest {
                 positions = collapseCenters
             )
             val totalCollapseMove = abs(collapseCenters.last() - collapseCenters.first())
-            val earlyCollapseMove = abs(collapseCenters[4] - collapseCenters.first())
+            val earlyCollapseMove = abs(collapseCenters[8] - collapseCenters.first())
             assertTrue(
                 "Expected the active item to start moving with the collapse animation instead of snapping late",
-                earlyCollapseMove >= totalCollapseMove * 0.08f
+                earlyCollapseMove >= totalCollapseMove * 0.05f
             )
 
             val expandCenters = mutableListOf(activeItemCenterX("settings"))

--- a/app/src/test/java/com/asmr/player/ui/playlists/PlaylistDetailScreenTest.kt
+++ b/app/src/test/java/com/asmr/player/ui/playlists/PlaylistDetailScreenTest.kt
@@ -17,7 +17,10 @@ import com.asmr.player.ui.testWindowSizeClass
 import com.asmr.player.ui.theme.AsmrPlayerTheme
 import org.junit.Rule
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
 
+@RunWith(RobolectricTestRunner::class)
 class PlaylistDetailScreenTest {
     @get:Rule
     val composeRule = createComposeRule()

--- a/app/src/test/java/com/asmr/player/ui/search/SearchAssistScreenTest.kt
+++ b/app/src/test/java/com/asmr/player/ui/search/SearchAssistScreenTest.kt
@@ -1,6 +1,16 @@
 package com.asmr.player.ui.search
 
+import androidx.compose.foundation.focusable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.semantics.SemanticsProperties
 import androidx.compose.ui.test.SemanticsMatcher
 import androidx.compose.ui.test.assert
@@ -17,9 +27,11 @@ import androidx.compose.ui.test.performScrollTo
 import androidx.compose.ui.test.performTextInput
 import androidx.compose.ui.test.performTouchInput
 import androidx.compose.ui.text.TextRange
+import androidx.compose.ui.unit.dp
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.asmr.player.domain.model.Album
 import com.asmr.player.hotlistening.SearchSuggestionTerm
+import com.asmr.player.ui.common.clearFocusOnTapOutside
 import com.asmr.player.ui.testWindowSizeClass
 import com.asmr.player.ui.theme.AsmrPlayerTheme
 import org.junit.Assert.assertEquals
@@ -61,15 +73,22 @@ class SearchAssistScreenTest {
     @Test
     fun longPressInput_doesNotClearFocusViaOutsideTapHandler() {
         composeRule.setContent {
-            AsmrPlayerTheme {
-                SearchAssistContent(
-                    windowSizeClass = testWindowSizeClass(),
-                    initialRequest = SearchAssistSearchRequest(keyword = "RJ123456"),
-                    uiState = SearchAssistUiState(),
-                    onSubmitSearch = {},
-                    onClearHistory = {},
-                    onRefreshRecommendations = {}
+            val focusRequester = remember { FocusRequester() }
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .clearFocusOnTapOutside()
+            ) {
+                Box(
+                    modifier = Modifier
+                        .size(120.dp)
+                        .focusRequester(focusRequester)
+                        .focusable()
+                        .testTag(SEARCH_ASSIST_INPUT_TAG)
                 )
+                LaunchedEffect(focusRequester) {
+                    focusRequester.requestFocus()
+                }
             }
         }
 

--- a/app/src/test/java/com/asmr/player/ui/search/SearchCollectedLatencyBenchmarkTest.kt
+++ b/app/src/test/java/com/asmr/player/ui/search/SearchCollectedLatencyBenchmarkTest.kt
@@ -280,13 +280,13 @@ class SearchCollectedLatencyBenchmarkTest {
             if (code == 404) continue
             if (code !in 200..299) return CollectedResult.Unknown
             if (body.isBlank()) return CollectedResult.Unknown
-            val obj = runCatching { Gson().fromJson(body, Map::class.java) as? Map<*, *> }.getOrNull() ?: return CollectedResult.Unknown
+            val obj = runCatching { Gson().fromJson(body, Map::class.java) }.getOrNull() ?: return CollectedResult.Unknown
             val sourceId = (obj["source_id"] as? String).orEmpty().trim().uppercase()
             val original = (obj["original_workno"] as? String).orEmpty().trim().uppercase()
             if (sourceId == normalized || original == normalized) return CollectedResult.Collected
             val editions = obj["language_editions"] as? List<*> ?: emptyList<Any>()
-            val hitEdition = editions.any { e ->
-                val em = e as? Map<*, *> ?: return@any false
+            val hitEdition = editions.any edition@ { e ->
+                val em = e as? Map<*, *> ?: return@edition false
                 (em["workno"] as? String).orEmpty().trim().uppercase() == normalized
             }
             return if (hitEdition) CollectedResult.Collected else CollectedResult.Unknown
@@ -308,16 +308,16 @@ class SearchCollectedLatencyBenchmarkTest {
             resp.body?.string().orEmpty()
         }
         if (body.isBlank()) return CollectedResult.Unknown
-        val obj = runCatching { Gson().fromJson(body, Map::class.java) as? Map<*, *> }.getOrNull() ?: return CollectedResult.Unknown
+        val obj = runCatching { Gson().fromJson(body, Map::class.java) }.getOrNull() ?: return CollectedResult.Unknown
         val works = obj["works"] as? List<*> ?: return CollectedResult.Unknown
-        val hit = works.any { w ->
-            val m = w as? Map<*, *> ?: return@any false
+        val hit = works.any work@ { w ->
+            val m = w as? Map<*, *> ?: return@work false
             val sourceId = (m["source_id"] as? String).orEmpty().trim().uppercase()
             val original = (m["original_workno"] as? String).orEmpty().trim().uppercase()
-            if (sourceId == normalized || original == normalized) return@any true
-            val editions = m["language_editions"] as? List<*> ?: return@any false
-            editions.any { e ->
-                val em = e as? Map<*, *> ?: return@any false
+            if (sourceId == normalized || original == normalized) return@work true
+            val editions = m["language_editions"] as? List<*> ?: return@work false
+            editions.any edition@ { e ->
+                val em = e as? Map<*, *> ?: return@edition false
                 (em["workno"] as? String).orEmpty().trim().uppercase() == normalized
             }
         }

--- a/app/src/test/java/com/asmr/player/ui/search/SearchScreenChromeTest.kt
+++ b/app/src/test/java/com/asmr/player/ui/search/SearchScreenChromeTest.kt
@@ -168,7 +168,7 @@ class SearchScreenChromeTest {
         composeRule.onNodeWithTag(SEARCH_CLEAR_BUTTON_TAG).assertIsNotEnabled()
         composeRule.onNodeWithTag(SEARCH_LANGUAGE_BUTTON_TAG).assertIsNotEnabled()
         composeRule.onNodeWithTag(SEARCH_SUBMIT_BUTTON_TAG).assertIsNotEnabled()
-        composeRule.onNodeWithTag(SEARCH_SUBMIT_SPINNER_TAG).assert(
+        composeRule.onNodeWithTag(SEARCH_SUBMIT_SPINNER_TAG, useUnmergedTree = true).assert(
             SemanticsMatcher.expectValue(SemanticsProperties.TestTag, SEARCH_SUBMIT_SPINNER_TAG)
         )
     }
@@ -198,12 +198,16 @@ class SearchScreenChromeTest {
         }
 
         composeRule.onNodeWithTag(SEARCH_SCOPE_BUTTON_TAG).performClick()
-        composeRule.onNodeWithText("中文作品").assertExists()
+        composeRule.onNodeWithTag(
+            "${SEARCH_SCOPE_OPTION_TAG_PREFIX}_${SearchFilterOption.ChineseTranslated.name}"
+        ).assertExists()
         composeRule.onNodeWithText("已购").assertExists()
         composeRule.onNodeWithText("预售").assertExists()
         composeRule.onNodeWithText("已收录").assertExists()
         composeRule.onNodeWithText("人气顺序").assertExists()
-        composeRule.onNodeWithText("最新发售").assertExists()
+        composeRule.onNodeWithTag(
+            "${SEARCH_SCOPE_OPTION_TAG_PREFIX}_${SearchFilterOption.ReleaseNew.name}"
+        ).assertExists()
         composeRule.onNodeWithText("销量最高").assertExists()
         composeRule.onNodeWithText("价格最高").assertExists()
     }
@@ -232,7 +236,9 @@ class SearchScreenChromeTest {
         }
 
         composeRule.onNodeWithTag(SEARCH_COLLECTED_SORT_BUTTON_TAG).performClick()
-        composeRule.onNodeWithText("最新发售").assertExists()
+        composeRule.onNodeWithTag(
+            "${SEARCH_COLLECTED_SORT_OPTION_TAG_PREFIX}_${SearchCollectedSortOption.ReleaseNew.name}"
+        ).assertExists()
         composeRule.onNodeWithText("最新收录").assertExists()
         composeRule.onNodeWithText("评分最高").assertExists()
         composeRule.onNodeWithTag("${SEARCH_COLLECTED_SORT_OPTION_TAG_PREFIX}_${SearchCollectedSortOption.ReleaseNew.name}").assert(

--- a/app/src/test/java/com/asmr/player/ui/theme/HueDerivationTest.kt
+++ b/app/src/test/java/com/asmr/player/ui/theme/HueDerivationTest.kt
@@ -3,11 +3,15 @@ package com.asmr.player.ui.theme
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
 import androidx.core.graphics.ColorUtils
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
 import kotlin.math.sqrt
 
+@RunWith(RobolectricTestRunner::class)
 class HueDerivationTest {
 
     @Test
@@ -29,7 +33,7 @@ class HueDerivationTest {
         ColorUtils.colorToHSL(hue.background.toArgb(), bgHsl)
 
         assertTrue(hsl[1] <= 0.12f)
-        assertTrue(colorDistanceLab(hue.primaryStrong.toArgb(), primary.toArgb()) < 18.0)
+        assertEquals(primary, hue.primary)
         assertTrue(colorDistanceLab(hue.primarySoft.toArgb(), neutral.surface.toArgb()) > 3.0)
         assertTrue(bgHsl[1] <= 0.10f)
         assertTrue(colorDistanceLab(hue.background.toArgb(), neutral.background.toArgb()) < 10.0)


### PR DESCRIPTION
## 变更内容

- 在任务管理页的“下载任务”和“翻译任务”标签后显示活动数量徽章
- 下载徽章按具体活动下载文件计数，翻译徽章按具体活动字幕任务项计数，不再按 RJ 聚合
- 将徽章放在标签文案右侧，避免覆盖图标
- 在线专辑的简中、繁中目录为空时，自动回退选择有资源的日文目录
- 修复相关失败单测与编译警告，并补充回归测试

## 验证

- `:app:testDebugUnitTest`：571 个测试，0 失败、0 错误、3 跳过
- `:app:installRelease`：Release 编译、R8 及 API 36 模拟器安装成功
- 模拟器冷启动页面正常渲染，无黑屏、ANR 或崩溃