### PR TITLE
perf: 优化手机分身空间启动与滚动性能

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -171,6 +171,7 @@ dependencies {
     implementation("androidx.core:core-ktx:1.12.0")
     implementation("androidx.lifecycle:lifecycle-runtime:2.7.0")
     implementation("androidx.lifecycle:lifecycle-viewmodel:2.7.0")
+    implementation("androidx.lifecycle:lifecycle-runtime-compose:2.7.0")
     implementation("androidx.savedstate:savedstate:1.2.1")
     implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.7.0")
     implementation("androidx.activity:activity-compose:1.8.2")

--- a/app/src/main/java/com/asmr/player/AsmrApp.kt
+++ b/app/src/main/java/com/asmr/player/AsmrApp.kt
@@ -39,15 +39,15 @@ class AsmrApp : Application(), ImageLoaderFactory, Configuration.Provider {
         super.onCreate()
         appCacheManager.start()
         applicationScope.launch {
-            runCatching {
-                getSharedPreferences("album_detail_tree_prefs", MODE_PRIVATE).all
-            }
-        }
-        applicationScope.launch {
             runCatching { settingsRepository.clearSleepTimer() }
-            runCatching { AppDatabaseProvider.get(applicationContext) }
-            runCatching { SubtitleTaskRepository.get(applicationContext).reconcileOnAppLaunch() }
-            runCatching { DownloadQueueCoordinator.recoverDownloadsOnAppLaunch(applicationContext) }
+            val database = runCatching { AppDatabaseProvider.get(applicationContext) }.getOrNull()
+                ?: return@launch
+            if (runCatching { database.subtitleTaskDao().countAllItems() > 0 }.getOrDefault(false)) {
+                runCatching { SubtitleTaskRepository.get(applicationContext).reconcileOnAppLaunch() }
+            }
+            if (runCatching { database.downloadDao().countRecoverableItems() > 0 }.getOrDefault(false)) {
+                runCatching { DownloadQueueCoordinator.recoverDownloadsOnAppLaunch(applicationContext) }
+            }
         }
     }
 

--- a/app/src/main/java/com/asmr/player/MainActivity.kt
+++ b/app/src/main/java/com/asmr/player/MainActivity.kt
@@ -202,6 +202,7 @@ import androidx.compose.foundation.border
 import androidx.compose.foundation.BorderStroke
 import androidx.media3.common.MediaItem
 import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.asmr.player.data.settings.SettingsRepository
 import com.asmr.player.playback.AppVolume
 import com.asmr.player.ui.common.AppVolumeVerticalSlider
@@ -260,25 +261,19 @@ class MainActivity : ComponentActivity() {
             val context = LocalContext.current
             val playerViewModel: PlayerViewModel = hiltViewModel()
             val libraryViewModel: LibraryViewModel = hiltViewModel()
-            val volumeKeyTick by volumeKeyEventTick.asStateFlow().collectAsState()
-            var themeBootstrap by remember {
-                mutableStateOf(initialThemeBootstrapPreferences)
-            }
-            LaunchedEffect(settingsDataStore) {
-                settingsDataStore.themeBootstrapPreferences.collect { value ->
-                    themeBootstrap = value
-                }
-            }
+            val volumeKeyTick by volumeKeyEventTick.asStateFlow().collectAsStateWithLifecycle()
+            val themeBootstrap by settingsDataStore.themeBootstrapPreferences
+                .collectAsStateWithLifecycle(initialValue = initialThemeBootstrapPreferences)
             val themeMediaSource by remember(playerViewModel) {
                 playerViewModel.playback
                     .map { it.currentMediaItem.toThemeMediaSource() }
                     .distinctUntilChanged()
-            }.collectAsState(initial = ThemeMediaSource())
+            }.collectAsStateWithLifecycle(initialValue = ThemeMediaSource())
             val playbackRestoreResolved by remember(playerViewModel) {
                 playerViewModel.playback
                     .map { it.startupRestoreResolved }
                     .distinctUntilChanged()
-            }.collectAsState(initial = false)
+            }.collectAsStateWithLifecycle(initialValue = false)
             val systemDark = isSystemInDarkTheme()
             val themePref = themeBootstrap.theme
             val mode = resolveThemeMode(themePref = themePref, systemDark = systemDark)
@@ -299,17 +294,17 @@ class MainActivity : ComponentActivity() {
                 staticHueArgbLight = themeBootstrap.staticHueArgbLight,
                 staticHueArgbDark = themeBootstrap.staticHueArgbDark
             )
-            val coverBackgroundEnabled by settingsDataStore.coverBackgroundEnabled.collectAsState(initial = true)
-            val coverBackgroundClarity by settingsDataStore.coverBackgroundClarity.collectAsState(initial = 0.35f)
-            val coverPreviewMode by settingsDataStore.coverPreviewMode.collectAsState(initial = CoverPreviewMode.Disabled)
-            val nowPlayingHomeLayoutMode by settingsDataStore.nowPlayingHomeLayoutMode.collectAsState(
-                initial = NowPlayingHomeLayoutMode.Classic
+            val coverBackgroundEnabled by settingsDataStore.coverBackgroundEnabled.collectAsStateWithLifecycle(initialValue = true)
+            val coverBackgroundClarity by settingsDataStore.coverBackgroundClarity.collectAsStateWithLifecycle(initialValue = 0.35f)
+            val coverPreviewMode by settingsDataStore.coverPreviewMode.collectAsStateWithLifecycle(initialValue = CoverPreviewMode.Disabled)
+            val nowPlayingHomeLayoutMode by settingsDataStore.nowPlayingHomeLayoutMode.collectAsStateWithLifecycle(
+                initialValue = NowPlayingHomeLayoutMode.Classic
             )
             val nowPlayingHomeLayoutHintDismissed by produceState(initialValue = false, settingsDataStore) {
                 value = settingsDataStore.nowPlayingHomeLayoutHintDismissed.first()
             }
-            val lyricsPageSettings by settingsDataStore.lyricsPageSettings.collectAsState(initial = LyricsPageSettings())
-            val showMiniPlayerBar by settingsRepository.showMiniPlayerBar.collectAsState(initial = true)
+            val lyricsPageSettings by settingsDataStore.lyricsPageSettings.collectAsStateWithLifecycle(initialValue = LyricsPageSettings())
+            val showMiniPlayerBar by settingsRepository.showMiniPlayerBar.collectAsStateWithLifecycle(initialValue = true)
             val neutral = remember(mode) { neutralPaletteForMode(mode) }
             val cacheManager = remember(context.applicationContext) {
                 dagger.hilt.android.EntryPointAccessors.fromApplication(

--- a/app/src/main/java/com/asmr/player/benchmark/BenchmarkHarnessActivity.kt
+++ b/app/src/main/java/com/asmr/player/benchmark/BenchmarkHarnessActivity.kt
@@ -15,7 +15,7 @@ import androidx.compose.material3.windowsizeclass.ExperimentalMaterial3WindowSiz
 import androidx.compose.material3.windowsizeclass.WindowSizeClass
 import androidx.compose.material3.windowsizeclass.calculateWindowSizeClass
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
@@ -178,7 +178,7 @@ private fun BenchmarkScenarioScreen(
         BenchmarkScenario.FavoritesDetail -> {
             val items by playlistRepository
                 .observePlaylistItemsWithSubtitles(seedSummary.favoritesPlaylistId)
-                .collectAsState(initial = emptyList())
+                .collectAsStateWithLifecycle(initialValue = emptyList())
             PlaylistDetailContent(
                 windowSizeClass = windowSizeClass,
                 title = PlaylistRepository.PLAYLIST_FAVORITES,
@@ -201,7 +201,7 @@ private fun BenchmarkScenarioScreen(
         BenchmarkScenario.PlaylistDetail -> {
             val items by playlistRepository
                 .observePlaylistItemsWithSubtitles(seedSummary.detailPlaylistId)
-                .collectAsState(initial = emptyList())
+                .collectAsStateWithLifecycle(initialValue = emptyList())
             PlaylistDetailContent(
                 windowSizeClass = windowSizeClass,
                 title = seedSummary.detailPlaylistName,
@@ -247,7 +247,7 @@ private fun BenchmarkScenarioScreen(
         BenchmarkScenario.GroupDetail -> {
             val tracks by albumGroupRepository
                 .observeGroupTracks(seedSummary.detailGroupId)
-                .collectAsState(initial = emptyList())
+                .collectAsStateWithLifecycle(initialValue = emptyList())
             AlbumGroupDetailContent(
                 windowSizeClass = windowSizeClass,
                 title = seedSummary.detailGroupName,

--- a/app/src/main/java/com/asmr/player/cache/AppCacheManager.kt
+++ b/app/src/main/java/com/asmr/player/cache/AppCacheManager.kt
@@ -100,7 +100,6 @@ class AppCacheManager @Inject constructor(
             trimDirectoryToSize(previewDirectory, AppCacheLimits.previewMaxSizeBytes(sizeMb))
         }
         runCacheOperation("clear legacy Coil cache") { clearDirectoryContents(legacyCoilDirectory) }
-        refreshSizeNow()
     }
 
     private fun refreshSizeNow() {

--- a/app/src/main/java/com/asmr/player/data/local/db/dao/DownloadDao.kt
+++ b/app/src/main/java/com/asmr/player/data/local/db/dao/DownloadDao.kt
@@ -169,6 +169,9 @@ interface DownloadDao {
     @Query("SELECT * FROM download_items WHERE state = 'PAUSED' OR state IN ('RUNNING', 'ENQUEUED', 'BLOCKED', 'QUEUED')")
     suspend fun getAllActiveOrPausedItems(): List<DownloadItemEntity>
 
+    @Query("SELECT COUNT(*) FROM download_items WHERE state = 'PAUSED' OR state IN ('RUNNING', 'ENQUEUED', 'BLOCKED', 'QUEUED')")
+    suspend fun countRecoverableItems(): Int
+
     @Query("SELECT COUNT(*) FROM download_items WHERE state IN ('RUNNING', 'ENQUEUED', 'BLOCKED')")
     suspend fun countActiveItems(): Int
 

--- a/app/src/main/java/com/asmr/player/data/local/db/dao/SubtitleTaskDao.kt
+++ b/app/src/main/java/com/asmr/player/data/local/db/dao/SubtitleTaskDao.kt
@@ -47,6 +47,9 @@ interface SubtitleTaskDao {
     @Query("SELECT * FROM subtitle_task_items ORDER BY queueSequence")
     suspend fun getAllItems(): List<SubtitleTaskItemEntity>
 
+    @Query("SELECT COUNT(*) FROM subtitle_task_items")
+    suspend fun countAllItems(): Int
+
     @Query(
         "SELECT * FROM subtitle_task_items WHERE state = 'QUEUED_TRANSCRIPTION' " +
             "ORDER BY queueSequence LIMIT 1"

--- a/app/src/main/java/com/asmr/player/data/remote/download/DownloadManager.kt
+++ b/app/src/main/java/com/asmr/player/data/remote/download/DownloadManager.kt
@@ -409,29 +409,30 @@ object DownloadQueueCoordinator {
 
     suspend fun recoverDownloadsOnAppLaunch(context: Context) {
         val appContext = context.applicationContext
+        val dao = AppDatabaseProvider.get(appContext).downloadDao()
+        val recoverableItems = dao.getAllActiveOrPausedItems()
+        if (recoverableItems.isEmpty()) return
         val wm = WorkManager.getInstance(appContext)
         runCatching { wm.cancelAllWorkByTag("download") }
-        val dao = AppDatabaseProvider.get(appContext).downloadDao()
         val now = System.currentTimeMillis()
-        dao.getAllActiveOrPausedItems()
-            .forEach { item ->
-                val resolvedBytes = resolveExistingBytes(item)
-                val resolvedState = when (item.state) {
-                    WorkInfo.State.SUCCEEDED.name -> WorkInfo.State.SUCCEEDED.name
-                    "PAUSED" -> "PAUSED"
-                    else -> "PAUSED"
-                }
-                runCatching {
-                    dao.updateItemProgress(
-                        workId = item.workId,
-                        state = resolvedState,
-                        downloaded = resolvedBytes,
-                        total = item.total,
-                        speed = 0L,
-                        updatedAt = now
-                    )
-                }
+        recoverableItems.forEach { item ->
+            val resolvedBytes = resolveExistingBytes(item)
+            val resolvedState = when (item.state) {
+                WorkInfo.State.SUCCEEDED.name -> WorkInfo.State.SUCCEEDED.name
+                "PAUSED" -> "PAUSED"
+                else -> "PAUSED"
             }
+            runCatching {
+                dao.updateItemProgress(
+                    workId = item.workId,
+                    state = resolvedState,
+                    downloaded = resolvedBytes,
+                    total = item.total,
+                    speed = 0L,
+                    updatedAt = now
+                )
+            }
+        }
     }
 
     fun onTrimMemory(context: Context, level: Int) {

--- a/app/src/main/java/com/asmr/player/data/settings/SettingsRepository.kt
+++ b/app/src/main/java/com/asmr/player/data/settings/SettingsRepository.kt
@@ -269,7 +269,9 @@ class SettingsRepository private constructor(
     }
 
     suspend fun clearSleepTimer() {
-        setSleepTimerEndAtMs(0L)
+        if (sleepTimerEndAtMs.first() != 0L) {
+            setSleepTimerEndAtMs(0L)
+        }
     }
 
     suspend fun setSleepTimerLastDurationMin(minutes: Int) {

--- a/app/src/main/java/com/asmr/player/main/MainChromeUi.kt
+++ b/app/src/main/java/com/asmr/player/main/MainChromeUi.kt
@@ -1,4 +1,4 @@
-﻿package com.asmr.player
+package com.asmr.player
 
 import android.os.Bundle
 import android.view.KeyEvent
@@ -178,6 +178,7 @@ import androidx.compose.foundation.border
 import androidx.compose.foundation.BorderStroke
 import androidx.media3.common.MediaItem
 import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.asmr.player.data.settings.SettingsRepository
 import com.asmr.player.playback.AppVolume
 import com.asmr.player.ui.common.AppVolumeVerticalSlider
@@ -351,9 +352,9 @@ internal fun DrawerSiteStatusFooter(
     modifier: Modifier = Modifier
 ) {
     val colorScheme = AsmrTheme.colorScheme
-    val dlsite by viewModel.dlsite.collectAsState()
-    val asmr by viewModel.asmr.collectAsState()
-    val site by viewModel.asmrOneSite.collectAsState()
+    val dlsite by viewModel.dlsite.collectAsStateWithLifecycle()
+    val asmr by viewModel.asmr.collectAsStateWithLifecycle()
+    val site by viewModel.asmrOneSite.collectAsStateWithLifecycle()
     var expanded by remember { mutableStateOf(false) }
     Column(modifier = modifier, verticalArrangement = Arrangement.spacedBy(10.dp)) {
         DrawerSiteRow(

--- a/app/src/main/java/com/asmr/player/main/MainContainer.kt
+++ b/app/src/main/java/com/asmr/player/main/MainContainer.kt
@@ -238,6 +238,8 @@ import androidx.compose.foundation.border
 import androidx.compose.foundation.BorderStroke
 import androidx.media3.common.MediaItem
 import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.viewmodel.compose.LocalViewModelStoreOwner
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.compose.LocalLifecycleOwner
@@ -476,7 +478,7 @@ private fun AlbumDetailRouteTopBar(
     onEditRj: (String) -> Unit,
     modifier: Modifier = Modifier
 ) {
-    val detailState by viewModel.uiState.collectAsState()
+    val detailState by viewModel.uiState.collectAsStateWithLifecycle()
     val detailModel = (detailState as? AlbumDetailUiState.Success)?.model
     val showManualBind = detailModel?.localAlbum?.id?.let { it > 0L } == true
 
@@ -765,6 +767,7 @@ fun MainContainer(
     forceImmersive: Boolean,
     volumeKeyEventTick: Long
 ) {
+    val activityViewModelStoreOwner = checkNotNull(LocalViewModelStoreOwner.current)
     val navController = rememberNavController()
     val navBackStackEntry by navController.currentBackStackEntryAsState()
     val currentRoute = navBackStackEntry?.destination?.route
@@ -835,8 +838,8 @@ fun MainContainer(
         )
     }
     val bottomNavItems = remember { bottomChromeNavItems() }
-    val storedMiniPlayerDisplayMode by settingsDataStore.miniPlayerDisplayMode.collectAsState(
-        initial = MiniPlayerDisplayMode.CoverOnly.name
+    val storedMiniPlayerDisplayMode by settingsDataStore.miniPlayerDisplayMode.collectAsStateWithLifecycle(
+        initialValue = MiniPlayerDisplayMode.CoverOnly.name
     )
     var miniPlayerDisplayMode by rememberSaveable { mutableStateOf(MiniPlayerDisplayMode.CoverOnly) }
     val primaryPagerRoutes = remember(bottomNavItems) { bottomNavItems.map { it.route } }
@@ -905,19 +908,13 @@ fun MainContainer(
     var albumDetailExitInProgress by remember { mutableStateOf(false) }
     val drawerState = rememberDrawerState(initialValue = DrawerValue.Closed)
     val scope = rememberCoroutineScope()
-    val searchViewModel: SearchViewModel = hiltViewModel()
-    val playlistsViewModel: PlaylistsViewModel = hiltViewModel()
-    val albumGroupsViewModel: AlbumGroupsViewModel = hiltViewModel()
-    val downloadsViewModel: DownloadsViewModel = hiltViewModel()
-    val settingsViewModel: SettingsViewModel = hiltViewModel()
-    val dlsiteLoginViewModel: DlsiteLoginViewModel = hiltViewModel()
-    val listeningCalendarViewModel: com.asmr.player.ui.calendar.ListeningCalendarViewModel = hiltViewModel()
-    val hotListeningViewModel: HotListeningViewModel = hiltViewModel()
+    val downloadsViewModel: DownloadsViewModel = hiltViewModel(activityViewModelStoreOwner)
+    val settingsViewModel: SettingsViewModel = hiltViewModel(activityViewModelStoreOwner)
     val hasCurrentMediaItem by remember(playerViewModel) {
         playerViewModel.playback
             .map { it.currentMediaItem != null }
             .distinctUntilChanged()
-    }.collectAsState(initial = false)
+    }.collectAsStateWithLifecycle(initialValue = false)
     val sharedPlayerItem by remember(playerViewModel) {
         playerViewModel.playback
             .map { it.currentMediaItem }
@@ -926,11 +923,11 @@ fun MainContainer(
                     old?.localConfiguration?.uri == new?.localConfiguration?.uri &&
                     old?.mediaMetadata?.artworkUri == new?.mediaMetadata?.artworkUri
             }
-    }.collectAsState(initial = null)
-    val drawerStatusViewModel: DrawerStatusViewModel = hiltViewModel()
-    val bulkProgress by libraryViewModel.bulkProgress.collectAsState()
-    val cloudSyncSelectionDialogState by libraryViewModel.cloudSyncSelectionDialogState.collectAsState()
-    val appVolumePercent by playerViewModel.appVolumePercent.collectAsState()
+    }.collectAsStateWithLifecycle(initialValue = null)
+    val drawerStatusViewModel: DrawerStatusViewModel = hiltViewModel(activityViewModelStoreOwner)
+    val bulkProgress by libraryViewModel.bulkProgress.collectAsStateWithLifecycle()
+    val cloudSyncSelectionDialogState by libraryViewModel.cloudSyncSelectionDialogState.collectAsStateWithLifecycle()
+    val appVolumePercent by playerViewModel.appVolumePercent.collectAsStateWithLifecycle()
     var showManualRjDialog by remember { mutableStateOf(false) }
     var manualRjInput by remember { mutableStateOf("") }
     var showHardwareVolumeOverlay by remember { mutableStateOf(false) }
@@ -972,7 +969,7 @@ fun MainContainer(
     val isPhone = configuration.smallestScreenWidthDp < 600
     val context = LocalContext.current
     val activity = remember(context) { context.findActivity() }
-    val updateState by settingsViewModel.updateState.collectAsState()
+    val updateState by settingsViewModel.updateState.collectAsStateWithLifecycle()
     var automaticUpdateDialogDismissed by rememberSaveable { mutableStateOf(false) }
     var automaticUpdateInstallRequested by rememberSaveable { mutableStateOf(false) }
     var pendingAutomaticInstallPath by rememberSaveable { mutableStateOf<String?>(null) }
@@ -1624,7 +1621,8 @@ fun MainContainer(
             hasCurrentMediaItem &&
             !nowPlayingVisible
         val bottomChromeVisible = !nowPlayingVisible
-        val rightPanelExpandedFromStore by settingsDataStore.recentAlbumsPanelExpanded.collectAsState(initial = recentAlbumsPanelExpandedInitial)
+        val rightPanelExpandedFromStore by settingsDataStore.recentAlbumsPanelExpanded
+            .collectAsStateWithLifecycle(initialValue = recentAlbumsPanelExpandedInitial)
         val rightPanelExpandedState = remember(settingsDataStore, scope, recentAlbumsPanelExpandedInitial) {
             PersistedBooleanState(initial = recentAlbumsPanelExpandedInitial) { expanded ->
                 scope.launch { settingsDataStore.setRecentAlbumsPanelExpanded(expanded) }
@@ -1811,8 +1809,8 @@ fun MainContainer(
                                                     if (headerActionRoute != null &&
                                                         (isPrimaryRoute(headerActionRoute) || headerActionRoute == "playlist_system/{type}")
                                                     ) {
-                                                        val downloadTasks by downloadsViewModel.tasks.collectAsState()
-                                                        val activeSubtitleTaskCount by downloadsViewModel.activeSubtitleTaskCount.collectAsState()
+                                                        val downloadTasks by downloadsViewModel.tasks.collectAsStateWithLifecycle()
+                                                        val activeSubtitleTaskCount by downloadsViewModel.activeSubtitleTaskCount.collectAsStateWithLifecycle()
                                                         val activeDownloadCount = remember(downloadTasks) {
                                                             downloadTasks.sumOf { task ->
                                                                 task.items.count {
@@ -1839,7 +1837,7 @@ fun MainContainer(
                                                         }
                                                     }
                                                     if (headerActionRoute == "library") {
-                                                        val viewMode by libraryViewModel.libraryViewMode.collectAsState()
+                                                        val viewMode by libraryViewModel.libraryViewMode.collectAsStateWithLifecycle()
                                                         if (viewMode != null) {
                                                             var viewMenuExpanded by remember { mutableStateOf(false) }
                                                             Box {
@@ -1911,7 +1909,8 @@ fun MainContainer(
                                                             }
                                                         }
                                                     } else if (headerActionRoute == "search") {
-                                                        val viewMode by searchViewModel.viewMode.collectAsState()
+                                                        val searchViewModel: SearchViewModel = hiltViewModel(activityViewModelStoreOwner)
+                                                        val viewMode by searchViewModel.viewMode.collectAsStateWithLifecycle()
                                                         EaraTopBarIconButton(
                                                             onClick = { searchViewModel.setViewMode(if (viewMode == 1) 0 else 1) },
                                                             modifier = Modifier.padding(end = 4.dp)
@@ -1922,7 +1921,8 @@ fun MainContainer(
                                                             )
                                                         }
                                                     } else if (headerActionRoute == Routes.HotListening) {
-                                                        val viewMode by hotListeningViewModel.viewMode.collectAsState()
+                                                        val hotListeningViewModel: HotListeningViewModel = hiltViewModel(activityViewModelStoreOwner)
+                                                        val viewMode by hotListeningViewModel.viewMode.collectAsStateWithLifecycle()
                                                         EaraTopBarIconButton(
                                                             onClick = { hotListeningViewModel.setViewMode(if (viewMode == 1) 0 else 1) },
                                                             modifier = Modifier.padding(end = 4.dp)
@@ -1933,7 +1933,7 @@ fun MainContainer(
                                                             )
                                                         }
                                                     } else if (headerActionRoute == "downloads") {
-                                                        val tasks by downloadsViewModel.tasks.collectAsState()
+                                                        val tasks by downloadsViewModel.tasks.collectAsStateWithLifecycle()
                                                         val hasActiveDownloads = remember(tasks) {
                                                             tasks.any { task ->
                                                                 task.items.any { it.state == DownloadItemState.RUNNING || it.state == DownloadItemState.ENQUEUED }
@@ -2059,6 +2059,7 @@ fun MainContainer(
                                         }
 
                                         Routes.Search -> {
+                                            val searchViewModel: SearchViewModel = hiltViewModel(activityViewModelStoreOwner)
                                             SearchScreen(
                                                 windowSizeClass = windowSizeClass,
                                                 isActive = primaryRouteActive,
@@ -2109,6 +2110,7 @@ fun MainContainer(
                                         }
 
                                         Routes.HotListening -> {
+                                            val hotListeningViewModel: HotListeningViewModel = hiltViewModel(activityViewModelStoreOwner)
                                             HotListeningScreen(
                                                 windowSizeClass = windowSizeClass,
                                                 isActive = primaryRouteActive,
@@ -2140,6 +2142,7 @@ fun MainContainer(
                                         }
 
                                         "playlist_system/favorites" -> {
+                                            val playlistsViewModel: PlaylistsViewModel = hiltViewModel(activityViewModelStoreOwner)
                                             SystemPlaylistScreen(
                                                 windowSizeClass = windowSizeClass,
                                                 isActive = primaryRouteActive,
@@ -2154,6 +2157,7 @@ fun MainContainer(
                                         }
 
                                         "playlists" -> {
+                                            val playlistsViewModel: PlaylistsViewModel = hiltViewModel(activityViewModelStoreOwner)
                                             PlaylistsScreen(
                                                 windowSizeClass = windowSizeClass,
                                                 isActive = primaryRouteActive,
@@ -2168,6 +2172,7 @@ fun MainContainer(
                                         }
 
                                         "groups" -> {
+                                            val albumGroupsViewModel: AlbumGroupsViewModel = hiltViewModel(activityViewModelStoreOwner)
                                             com.asmr.player.ui.groups.AlbumGroupsScreen(
                                                 windowSizeClass = windowSizeClass,
                                                 isActive = primaryRouteActive,
@@ -2196,6 +2201,8 @@ fun MainContainer(
                                         }
 
                                         "listening_calendar" -> {
+                                            val listeningCalendarViewModel: com.asmr.player.ui.calendar.ListeningCalendarViewModel =
+                                                hiltViewModel(activityViewModelStoreOwner)
                                             com.asmr.player.ui.calendar.ListeningCalendarScreen(
                                                 windowSizeClass = windowSizeClass,
                                                 isActive = primaryRouteActive,
@@ -2270,37 +2277,37 @@ fun MainContainer(
                 composable("search") { backStackEntry ->
                     val submittedKeyword by backStackEntry.savedStateHandle
                         .getStateFlow(SEARCH_ASSIST_RESULT_KEY, "")
-                        .collectAsState()
+                        .collectAsStateWithLifecycle()
                     val submittedOrderName by backStackEntry.savedStateHandle
                         .getStateFlow(SEARCH_ASSIST_RESULT_ORDER_KEY, SearchAssistSearchRequest().orderName)
-                        .collectAsState()
+                        .collectAsStateWithLifecycle()
                     val submittedPurchasedOnly by backStackEntry.savedStateHandle
                         .getStateFlow(SEARCH_ASSIST_RESULT_PURCHASED_ONLY_KEY, SearchAssistSearchRequest().purchasedOnly)
-                        .collectAsState()
+                        .collectAsStateWithLifecycle()
                     val submittedPresaleOnly by backStackEntry.savedStateHandle
                         .getStateFlow(SEARCH_ASSIST_RESULT_PRESALE_ONLY_KEY, SearchAssistSearchRequest().presaleOnly)
-                        .collectAsState()
+                        .collectAsStateWithLifecycle()
                     val submittedChineseTranslatedOnly by backStackEntry.savedStateHandle
                         .getStateFlow(
                             SEARCH_ASSIST_RESULT_CHINESE_TRANSLATED_ONLY_KEY,
                             SearchAssistSearchRequest().chineseTranslatedOnly
                         )
-                        .collectAsState()
+                        .collectAsStateWithLifecycle()
                     val submittedCollectedOnly by backStackEntry.savedStateHandle
                         .getStateFlow(SEARCH_ASSIST_RESULT_COLLECTED_ONLY_KEY, SearchAssistSearchRequest().collectedOnly)
-                        .collectAsState()
+                        .collectAsStateWithLifecycle()
                     val submittedCollectedSortName by backStackEntry.savedStateHandle
                         .getStateFlow(
                             SEARCH_ASSIST_RESULT_COLLECTED_SORT_KEY,
                             SearchAssistSearchRequest().collectedSortName
                         )
-                        .collectAsState()
+                        .collectAsStateWithLifecycle()
                     val submittedLocale by backStackEntry.savedStateHandle
                         .getStateFlow(SEARCH_ASSIST_RESULT_LOCALE_KEY, SearchAssistSearchRequest().locale)
-                        .collectAsState()
+                        .collectAsStateWithLifecycle()
                     val submittedSignal by backStackEntry.savedStateHandle
                         .getStateFlow(SEARCH_ASSIST_RESULT_SIGNAL_KEY, 0L)
-                        .collectAsState()
+                        .collectAsStateWithLifecycle()
 
                     LaunchedEffect(
                         submittedSignal,
@@ -2388,6 +2395,8 @@ fun MainContainer(
                         navArgument("initialTab") { type = NavType.StringType; nullable = true; defaultValue = null }
                     )
                 ) { backStackEntry ->
+                    val playlistsViewModel: PlaylistsViewModel = hiltViewModel(activityViewModelStoreOwner)
+                    val albumGroupsViewModel: AlbumGroupsViewModel = hiltViewModel(activityViewModelStoreOwner)
                     val rj = backStackEntry.arguments?.getString("rj").orEmpty()
                     AlbumDetailRouteFrame(
                         backStackEntry = backStackEntry,
@@ -2457,6 +2466,8 @@ fun MainContainer(
                         navArgument("initialTab") { type = NavType.StringType; nullable = true; defaultValue = null }
                     )
                 ) { backStackEntry ->
+                    val playlistsViewModel: PlaylistsViewModel = hiltViewModel(activityViewModelStoreOwner)
+                    val albumGroupsViewModel: AlbumGroupsViewModel = hiltViewModel(activityViewModelStoreOwner)
                     val albumId = backStackEntry.arguments?.getLong("albumId") ?: 0L
                     val rjCode = backStackEntry.arguments?.getString("rjCode")
                     AlbumDetailRouteFrame(
@@ -2524,6 +2535,8 @@ fun MainContainer(
                     route = "album_detail_online/{rj}",
                     arguments = listOf(navArgument("rj") { defaultValue = "" })
                 ) { backStackEntry ->
+                    val playlistsViewModel: PlaylistsViewModel = hiltViewModel(activityViewModelStoreOwner)
+                    val albumGroupsViewModel: AlbumGroupsViewModel = hiltViewModel(activityViewModelStoreOwner)
                     val rj = backStackEntry.arguments?.getString("rj").orEmpty()
                     AlbumDetailRouteFrame(
                         backStackEntry = backStackEntry,
@@ -2629,6 +2642,7 @@ fun MainContainer(
                     )
                 ) { backStackEntry ->
                     val albumId = backStackEntry.arguments?.getLong("albumId") ?: 0L
+                    val albumGroupsViewModel: AlbumGroupsViewModel = hiltViewModel(activityViewModelStoreOwner)
                     SecondaryPageBackground(topPadding = secondaryPageTopPadding) {
                         com.asmr.player.ui.groups.AlbumGroupPickerScreen(
                             windowSizeClass = windowSizeClass,
@@ -2664,6 +2678,7 @@ fun MainContainer(
                     if (type == "favorites") {
                         Box(modifier = Modifier.fillMaxSize())
                     } else {
+                        val playlistsViewModel: PlaylistsViewModel = hiltViewModel(activityViewModelStoreOwner)
                         SecondaryPageBackground(topPadding = secondaryPageTopPadding) {
                             SystemPlaylistScreen(
                                 windowSizeClass = windowSizeClass,
@@ -2689,6 +2704,7 @@ fun MainContainer(
                     }
                 }
                 composable("dlsite_login") {
+                    val dlsiteLoginViewModel: DlsiteLoginViewModel = hiltViewModel(activityViewModelStoreOwner)
                     SecondaryPageBackground(topPadding = secondaryPageTopPadding) {
                         DlsiteLoginScreen(
                             windowSizeClass = windowSizeClass,
@@ -2904,6 +2920,7 @@ fun MainContainer(
                     sharedCoverDragPreviewState = sharedCoverDragPreviewState
                 )
                 nowPlayingPlaylistPickerRequest?.let { request ->
+                    val playlistsViewModel: PlaylistsViewModel = hiltViewModel(activityViewModelStoreOwner)
                     Dialog(
                         onDismissRequest = { nowPlayingPlaylistPickerRequest = null },
                         properties = DialogProperties(usePlatformDefaultWidth = false)
@@ -2931,6 +2948,7 @@ fun MainContainer(
                     }
                 }
                 albumBatchPlaylistPickerRequest?.let { request ->
+                    val playlistsViewModel: PlaylistsViewModel = hiltViewModel(activityViewModelStoreOwner)
                     Dialog(
                         onDismissRequest = { albumBatchPlaylistPickerRequest = null },
                         properties = DialogProperties(usePlatformDefaultWidth = false)
@@ -2962,6 +2980,7 @@ fun MainContainer(
 
         if (!nowPlayingVisible) {
             albumBatchPlaylistPickerRequest?.let { request ->
+                val playlistsViewModel: PlaylistsViewModel = hiltViewModel(activityViewModelStoreOwner)
                 Dialog(
                     onDismissRequest = { albumBatchPlaylistPickerRequest = null },
                     properties = DialogProperties(usePlatformDefaultWidth = false)

--- a/app/src/main/java/com/asmr/player/ui/common/AppSupportStatusSection.kt
+++ b/app/src/main/java/com/asmr/player/ui/common/AppSupportStatusSection.kt
@@ -1,4 +1,4 @@
-﻿package com.asmr.player.ui.common
+package com.asmr.player.ui.common
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.BorderStroke
@@ -33,7 +33,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableStateOf
@@ -68,9 +68,9 @@ fun SiteStatusSection(
     modifier: Modifier = Modifier
 ) {
     val colorScheme = AsmrTheme.colorScheme
-    val dlsite by viewModel.dlsite.collectAsState()
-    val asmr by viewModel.asmr.collectAsState()
-    val site by viewModel.asmrOneSite.collectAsState()
+    val dlsite by viewModel.dlsite.collectAsStateWithLifecycle()
+    val asmr by viewModel.asmr.collectAsStateWithLifecycle()
+    val site by viewModel.asmrOneSite.collectAsStateWithLifecycle()
     var expanded by remember { mutableStateOf(false) }
 
     Column(modifier = modifier, verticalArrangement = Arrangement.spacedBy(10.dp)) {

--- a/app/src/main/java/com/asmr/player/ui/dlsite/DlsiteLoginScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/dlsite/DlsiteLoginScreen.kt
@@ -1,4 +1,4 @@
-﻿package com.asmr.player.ui.dlsite
+package com.asmr.player.ui.dlsite
 
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.text.KeyboardOptions
@@ -10,6 +10,7 @@ import androidx.compose.material3.*
 import androidx.compose.material3.windowsizeclass.WindowSizeClass
 import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
 import androidx.compose.runtime.*
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -30,7 +31,7 @@ fun DlsiteLoginScreen(
     onDone: () -> Unit,
     viewModel: DlsiteLoginViewModel = hiltViewModel()
 ) {
-    val uiState by viewModel.uiState.collectAsState()
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     var loginId by remember { mutableStateOf("") }
     var password by remember { mutableStateOf("") }
     var showDlsiteCookie by remember { mutableStateOf(false) }

--- a/app/src/main/java/com/asmr/player/ui/downloads/DownloadsScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/downloads/DownloadsScreen.kt
@@ -74,7 +74,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.SideEffect
-import androidx.compose.runtime.collectAsState
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateListOf
@@ -151,10 +151,10 @@ fun DownloadsScreen(
     scrollToTopSignal: Long = 0L,
     viewModel: DownloadsViewModel = hiltViewModel()
 ) {
-    val tasks by viewModel.tasks.collectAsState()
-    val translationSubtitleGroups by viewModel.translationSubtitleGroups.collectAsState()
-    val subtitleTasks by viewModel.subtitleTasks.collectAsState()
-    val polishingRjCodes by viewModel.polishingRjCodes.collectAsState()
+    val tasks by viewModel.tasks.collectAsStateWithLifecycle()
+    val translationSubtitleGroups by viewModel.translationSubtitleGroups.collectAsStateWithLifecycle()
+    val subtitleTasks by viewModel.subtitleTasks.collectAsStateWithLifecycle()
+    val polishingRjCodes by viewModel.polishingRjCodes.collectAsStateWithLifecycle()
     val activeDownloadFileCount = remember(tasks) { countActiveDownloadFiles(tasks) }
     val activeTranslationTaskCount = remember(subtitleTasks) { countActiveSubtitleTaskItems(subtitleTasks) }
     val expandedTasks = remember { mutableStateListOf<Long>() }

--- a/app/src/main/java/com/asmr/player/ui/downloads/DownloadsViewModel.kt
+++ b/app/src/main/java/com/asmr/player/ui/downloads/DownloadsViewModel.kt
@@ -108,7 +108,7 @@ class DownloadsViewModel @Inject constructor(
     private val albumDao: AlbumDao,
     private val messageManager: MessageManager
 ) : ViewModel() {
-    private val workManager = WorkManager.getInstance(context)
+    private val workManager by lazy { WorkManager.getInstance(context) }
     private val subtitleTaskRepository = SubtitleTaskRepository.get(context)
 
     val tasks: StateFlow<List<DownloadTaskUi>> =

--- a/app/src/main/java/com/asmr/player/ui/groups/AlbumGroupDetailScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/groups/AlbumGroupDetailScreen.kt
@@ -41,7 +41,7 @@ import androidx.compose.material3.windowsizeclass.WindowSizeClass
 import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateListOf
@@ -146,7 +146,7 @@ fun AlbumGroupDetailScreen(
     LaunchedEffect(groupId) {
         viewModel.setGroupId(groupId)
     }
-    val tracks by viewModel.tracks.collectAsState()
+    val tracks by viewModel.tracks.collectAsStateWithLifecycle()
     AlbumGroupDetailContent(
         windowSizeClass = windowSizeClass,
         title = title,

--- a/app/src/main/java/com/asmr/player/ui/groups/AlbumGroupPickerScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/groups/AlbumGroupPickerScreen.kt
@@ -32,7 +32,7 @@ import androidx.compose.material3.windowsizeclass.WindowSizeClass
 import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
-import androidx.compose.runtime.collectAsState
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -58,7 +58,7 @@ fun AlbumGroupPickerScreen(
     embeddedInDialog: Boolean = false,
     viewModel: AlbumGroupsViewModel = hiltViewModel()
 ) {
-    val groups by viewModel.groups.collectAsState()
+    val groups by viewModel.groups.collectAsStateWithLifecycle()
     val colorScheme = AsmrTheme.colorScheme
     val listState = rememberLazyListState()
     val screenActive = remember { mutableStateOf(true) }

--- a/app/src/main/java/com/asmr/player/ui/library/AlbumDetailScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/AlbumDetailScreen.kt
@@ -94,6 +94,7 @@ import androidx.compose.ui.window.Dialog
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.core.net.toUri
 import androidx.media3.common.MediaItem
 import androidx.media3.exoplayer.ExoPlayer
@@ -336,8 +337,8 @@ fun AlbumDetailScreen(
     heroBlurLayerCache: AlbumHeroBlurLayerCache,
     viewModel: AlbumDetailViewModel = hiltViewModel()
 ) {
-    val uiState by viewModel.uiState.collectAsState()
-    val cloudSyncSelectionDialogState by viewModel.cloudSyncSelectionDialogState.collectAsState()
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val cloudSyncSelectionDialogState by viewModel.cloudSyncSelectionDialogState.collectAsStateWithLifecycle()
     val colorScheme = AsmrTheme.colorScheme
     val screenKey = remember(albumId, rjCode) {
         val idPart = albumId?.takeIf { it > 0 }?.toString().orEmpty()
@@ -1083,7 +1084,7 @@ fun AlbumDetailScreen(
                 }
 
                 metaActionKeyword?.let { keyword ->
-                    val searchBlockedKeywords by settingsViewModel.searchBlockedKeywords.collectAsState()
+                    val searchBlockedKeywords by settingsViewModel.searchBlockedKeywords.collectAsStateWithLifecycle()
                     AlbumMetaActionDialog(
                         keyword = keyword,
                         onDismissRequest = { metaActionKeyword = null },
@@ -1109,8 +1110,8 @@ fun AlbumDetailScreen(
 
                 val track = tagManageTrack
                 if ((track != null && track.id > 0L) || showTagManager) {
-                    val availableTags by viewModel.availableTags.collectAsState()
-                    val userTagsByTrackId by viewModel.userTagsByTrackId.collectAsState()
+                    val availableTags by viewModel.availableTags.collectAsStateWithLifecycle()
+                    val userTagsByTrackId by viewModel.userTagsByTrackId.collectAsStateWithLifecycle()
                     if (track != null && track.id > 0L) {
                         TagAssignDialog(
                             title = track.title,

--- a/app/src/main/java/com/asmr/player/ui/library/LibraryFilterSheet.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/LibraryFilterSheet.kt
@@ -42,7 +42,7 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -70,11 +70,11 @@ fun LibraryFilterScreen(
     onClose: () -> Unit,
     viewModel: LibraryViewModel
 ) {
-    val querySpec by viewModel.querySpec.collectAsState()
-    val tags by viewModel.availableTags.collectAsState()
-    val circles by viewModel.availableCircles.collectAsState()
-    val cvs by viewModel.availableCvs.collectAsState()
-    val presets by viewModel.filterPresets.collectAsState()
+    val querySpec by viewModel.querySpec.collectAsStateWithLifecycle()
+    val tags by viewModel.availableTags.collectAsStateWithLifecycle()
+    val circles by viewModel.availableCircles.collectAsStateWithLifecycle()
+    val cvs by viewModel.availableCvs.collectAsStateWithLifecycle()
+    val presets by viewModel.filterPresets.collectAsStateWithLifecycle()
     val appliedSpec = remember(querySpec) { querySpec.filterOnly() }
     var draftSpec by remember(appliedSpec) { mutableStateOf(appliedSpec) }
     var showTagManager by remember { mutableStateOf(false) }

--- a/app/src/main/java/com/asmr/player/ui/library/LibraryScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/LibraryScreen.kt
@@ -95,7 +95,7 @@ import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
-import androidx.compose.runtime.collectAsState
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.LaunchedEffect
@@ -324,7 +324,8 @@ fun LibraryScreen(
     val pagedAlbumSnapshot = pagedAlbums.itemSnapshotList
     val pagedAlbumIndices = remember(pagedAlbumSnapshot.items.size) { List(pagedAlbumSnapshot.items.size) { it } }
     val loadedTrackAlbumHeaders = pagedTrackAlbumHeaders.itemSnapshotList.items
-    val expandedAlbumTracks by (if (isTrackList) viewModel.expandedTrackAlbumTracks else flowOf(emptyMap())).collectAsState(initial = emptyMap())
+    val expandedAlbumTracks by (if (isTrackList) viewModel.expandedTrackAlbumTracks else flowOf(emptyMap()))
+        .collectAsStateWithLifecycle(initialValue = emptyMap())
     val expandedAlbumIds by viewModel.expandedTrackAlbumIds.collectAsStateWhileActive(isDataActive)
     var actionAlbum by remember { mutableStateOf<Album?>(null) }
     var showAlbumActions by remember { mutableStateOf(false) }

--- a/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailLocalTab.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailLocalTab.kt
@@ -41,6 +41,7 @@ import androidx.compose.material3.windowsizeclass.WindowSizeClass
 import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.*
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -174,7 +175,7 @@ internal fun AlbumLocalBreadcrumbTabV2(
     val scope = rememberCoroutineScope()
     val context = LocalContext.current
     val subtitleModelRepository = remember(context) { SubtitleModelRepository.get(context) }
-    val subtitleModelState by subtitleModelRepository.state.collectAsState()
+    val subtitleModelState by subtitleModelRepository.state.collectAsStateWithLifecycle()
     val subtitleDeviceCapability = remember(context) { SubtitleDeviceCapability.evaluate(context) }
     val subtitleFeatureSupported = subtitleDeviceCapability.supported
     val subtitleModelAvailable = subtitleFeatureSupported &&

--- a/app/src/main/java/com/asmr/player/ui/player/LyricsPage.kt
+++ b/app/src/main/java/com/asmr/player/ui/player/LyricsPage.kt
@@ -1,4 +1,4 @@
-﻿package com.asmr.player.ui.player
+package com.asmr.player.ui.player
 
 import androidx.compose.foundation.layout.size
 import androidx.compose.ui.text.style.TextOverflow
@@ -19,7 +19,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.collectAsState
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -50,8 +50,8 @@ internal fun LyricsPage(
     sharedCoverDragPreviewState: CoverDragPreviewState? = null,
     viewModel: LyricsViewModel = hiltViewModel()
 ) {
-    val uiState by viewModel.uiState.collectAsState()
-    val playback by playerViewModel.playback.collectAsState()
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val playback by playerViewModel.playback.collectAsStateWithLifecycle()
     val position = playback.positionMs
     val colorScheme = AsmrTheme.colorScheme
     val artwork = playback.currentMediaItem?.mediaMetadata?.artworkUri

--- a/app/src/main/java/com/asmr/player/ui/player/MiniPlayer.kt
+++ b/app/src/main/java/com/asmr/player/ui/player/MiniPlayer.kt
@@ -45,7 +45,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -126,12 +126,12 @@ fun MiniPlayer(
         viewModel.playback
             .map { it.currentMediaItem }
             .distinctUntilChanged(::sameMiniPlayerMediaItem)
-    }.collectAsState(initial = null)
+    }.collectAsStateWithLifecycle(initialValue = null)
     val isPlaying by remember(viewModel) {
         viewModel.playback
             .map { it.isPlaying }
             .distinctUntilChanged()
-    }.collectAsState(initial = false)
+    }.collectAsStateWithLifecycle(initialValue = false)
     val progressState = remember(viewModel, displayMode) {
         if (displayMode == MiniPlayerDisplayMode.Expanded) {
             viewModel.playback
@@ -140,8 +140,8 @@ fun MiniPlayer(
         } else {
             flowOf(MiniPlayerProgress())
         }
-    }.collectAsState(initial = MiniPlayerProgress())
-    val isFavorite by viewModel.isFavorite.collectAsState()
+    }.collectAsStateWithLifecycle(initialValue = MiniPlayerProgress())
+    val isFavorite by viewModel.isFavorite.collectAsStateWithLifecycle()
     val item = currentItemState ?: return
     val metadata = item.mediaMetadata
     val colorScheme = AsmrTheme.colorScheme

--- a/app/src/main/java/com/asmr/player/ui/player/NowPlayingScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/player/NowPlayingScreen.kt
@@ -34,6 +34,7 @@ import androidx.compose.material3.windowsizeclass.WindowHeightSizeClass
 import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
 import androidx.compose.material3.windowsizeclass.WindowSizeClass
 import androidx.compose.runtime.*
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.ExperimentalComposeUiApi
@@ -358,7 +359,7 @@ private fun PlaybackProgressContent(
                 NowPlayingProgressState(positionMs, snapshot.durationMs)
             }
             .distinctUntilChanged()
-    }.collectAsState(initial = initialProgressState)
+    }.collectAsStateWithLifecycle(initialValue = initialProgressState)
 
     content(progressState)
 }
@@ -1092,13 +1093,13 @@ internal fun NowPlayingScreen(
         viewModel.playback
             .map { it.toStaticPlayback() }
             .distinctUntilChanged()
-    }.collectAsState(initial = PlaybackSnapshot().toStaticPlayback())
+    }.collectAsStateWithLifecycle(initialValue = PlaybackSnapshot().toStaticPlayback())
     val playback = staticPlayback.toSnapshot(positionMs = 0L)
-    val resolvedDurationMs by viewModel.resolvedDurationMs.collectAsState()
-    val sliceUiState by viewModel.sliceUiState.collectAsState()
-    val isFavorite by viewModel.isFavorite.collectAsState()
-    val listenTogetherUiState by viewModel.listenTogetherUiState.collectAsState()
-    val lyricsState by lyricsViewModel.uiState.collectAsState()
+    val resolvedDurationMs by viewModel.resolvedDurationMs.collectAsStateWithLifecycle()
+    val sliceUiState by viewModel.sliceUiState.collectAsStateWithLifecycle()
+    val isFavorite by viewModel.isFavorite.collectAsStateWithLifecycle()
+    val listenTogetherUiState by viewModel.listenTogetherUiState.collectAsStateWithLifecycle()
+    val lyricsState by lyricsViewModel.uiState.collectAsStateWithLifecycle()
     val item = playback.currentMediaItem
     val metadata = item?.mediaMetadata
     val canBindManualLyrics = lyricsTargetContextFromMediaItem(item) != null
@@ -1116,8 +1117,8 @@ internal fun NowPlayingScreen(
     
     var showEqualizer by remember { mutableStateOf(false) }
     val tagViewModel: NowPlayingTagViewModel = hiltViewModel()
-    val tagDialog by tagViewModel.dialogState.collectAsState()
-    val availableTags by tagViewModel.availableTags.collectAsState()
+    val tagDialog by tagViewModel.dialogState.collectAsStateWithLifecycle()
+    val availableTags by tagViewModel.availableTags.collectAsStateWithLifecycle()
     val playerArtworkBackdropEnabled = coverBackgroundEnabled && !isVideo
     val playerThemeColors = rememberPlayerThemeColors(
         mediaItem = item,
@@ -2511,9 +2512,9 @@ internal fun NowPlayingScreen(
         }
 
         if (showEqualizer) {
-            val eqSettings by viewModel.sessionEqualizer.collectAsState()
-            val customPresets by viewModel.customPresets.collectAsState()
-            val appVolumePercent by viewModel.appVolumePercent.collectAsState()
+            val eqSettings by viewModel.sessionEqualizer.collectAsStateWithLifecycle()
+            val customPresets by viewModel.customPresets.collectAsStateWithLifecycle()
+            val appVolumePercent by viewModel.appVolumePercent.collectAsStateWithLifecycle()
             val equalizerFocusRequester = remember { FocusRequester() }
             var showEqualizerVolumeOverlay by remember { mutableStateOf(false) }
             var equalizerVolumeOverlayInteracting by remember { mutableStateOf(false) }

--- a/app/src/main/java/com/asmr/player/ui/player/QueueSheet.kt
+++ b/app/src/main/java/com/asmr/player/ui/player/QueueSheet.kt
@@ -30,7 +30,7 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
@@ -66,8 +66,8 @@ fun QueueSheetContent(
                 )
             }
             .distinctUntilChanged()
-    }.collectAsState(initial = QueuePlaybackPresentation())
-    val queue by viewModel.queue.collectAsState()
+    }.collectAsStateWithLifecycle(initialValue = QueuePlaybackPresentation())
+    val queue by viewModel.queue.collectAsStateWithLifecycle()
     val colorScheme = AsmrTheme.colorScheme
     val listState = rememberLazyListState()
 

--- a/app/src/main/java/com/asmr/player/ui/player/SleepTimerSheet.kt
+++ b/app/src/main/java/com/asmr/player/ui/player/SleepTimerSheet.kt
@@ -21,7 +21,7 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableLongStateOf
 import androidx.compose.runtime.mutableStateOf
@@ -47,8 +47,8 @@ fun SleepTimerSheetContent(
     modifier: Modifier = Modifier
 ) {
     val colorScheme = AsmrTheme.colorScheme
-    val endAtMs by viewModel.sleepTimerEndAtMs.collectAsState()
-    val lastMin by viewModel.sleepTimerLastDurationMin.collectAsState()
+    val endAtMs by viewModel.sleepTimerEndAtMs.collectAsStateWithLifecycle()
+    val lastMin by viewModel.sleepTimerLastDurationMin.collectAsStateWithLifecycle()
 
     var remainingMs by remember { mutableLongStateOf(0L) }
     LaunchedEffect(endAtMs) {

--- a/app/src/main/java/com/asmr/player/ui/player/nowplaying/NowPlayingControls.kt
+++ b/app/src/main/java/com/asmr/player/ui/player/nowplaying/NowPlayingControls.kt
@@ -31,6 +31,7 @@ import androidx.compose.material3.windowsizeclass.WindowHeightSizeClass
 import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
 import androidx.compose.material3.windowsizeclass.WindowSizeClass
 import androidx.compose.runtime.*
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.ExperimentalComposeUiApi
@@ -199,7 +200,7 @@ internal fun PlaybackControls(
                     )
                 }
 
-                val floatingEnabled by viewModel.floatingLyricsEnabled.collectAsState()
+                val floatingEnabled by viewModel.floatingLyricsEnabled.collectAsStateWithLifecycle()
                 IconButton(
                     onClick = { viewModel.toggleFloatingLyrics() },
                     modifier = Modifier.size(actionButtonSize)
@@ -588,7 +589,7 @@ internal fun VolumeControl(
     onExpandedChange: (Boolean) -> Unit,
     compactLayout: Boolean = false
 ) {
-    val volume by viewModel.appVolumePercent.collectAsState()
+    val volume by viewModel.appVolumePercent.collectAsStateWithLifecycle()
     var lastNonZeroVolume by remember { mutableIntStateOf(AppVolume.DefaultPercent) }
     var lastInteractionAt by remember { mutableLongStateOf(0L) }
     var hasObservedInitialHardwareVolumeEventTick by remember { mutableStateOf(false) }

--- a/app/src/main/java/com/asmr/player/ui/playlists/PlaylistPickerDialog.kt
+++ b/app/src/main/java/com/asmr/player/ui/playlists/PlaylistPickerDialog.kt
@@ -29,7 +29,7 @@ import androidx.compose.material3.windowsizeclass.WindowSizeClass
 import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
-import androidx.compose.runtime.collectAsState
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -56,7 +56,7 @@ fun PlaylistPickerScreen(
     embeddedInDialog: Boolean = false,
     viewModel: PlaylistsViewModel = hiltViewModel()
 ) {
-    val playlists by viewModel.playlists.collectAsState()
+    val playlists by viewModel.playlists.collectAsStateWithLifecycle()
     val userPlaylists = remember(playlists) { playlists.filter { it.category == "user" } }
     val colorScheme = AsmrTheme.colorScheme
     val listState = rememberLazyListState()

--- a/app/src/main/java/com/asmr/player/ui/search/SearchAssistScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/search/SearchAssistScreen.kt
@@ -34,7 +34,7 @@ import androidx.compose.material3.windowsizeclass.WindowSizeClass
 import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -111,7 +111,7 @@ fun SearchAssistScreen(
     onSubmitSearch: (SearchAssistSearchRequest) -> Unit,
     viewModel: SearchAssistViewModel = hiltViewModel()
 ) {
-    val uiState by viewModel.uiState.collectAsState()
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
 
     Surface(
         modifier = Modifier.fillMaxSize(),

--- a/app/src/main/java/com/asmr/player/ui/search/SearchScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/search/SearchScreen.kt
@@ -342,10 +342,6 @@ fun SearchScreen(
     val gridState = rememberSaveable(resultScrollKey, saver = LazyStaggeredGridState.Saver) { LazyStaggeredGridState() }
     val colorScheme = AsmrTheme.colorScheme
     val copyMeta = rememberAlbumMetaCopyAction(viewModel.messageManager)
-    val playlistsViewModel: PlaylistsViewModel = hiltViewModel()
-    val albumGroupsViewModel: AlbumGroupsViewModel = hiltViewModel()
-    val settingsViewModel: SettingsViewModel = hiltViewModel()
-    val searchBlockedKeywords by settingsViewModel.searchBlockedKeywords.collectAsStateWhileActive(isDataActive)
     val scope = rememberCoroutineScope()
     val keyboardController = LocalSoftwareKeyboardController.current
     val isCompact = windowSizeClass.widthSizeClass == WindowWidthSizeClass.Compact
@@ -363,18 +359,6 @@ fun SearchScreen(
         if (normalized.isNotBlank()) metaActionKeyword = normalized
     }
 
-    fun addMetaBlockedKeyword(value: String) {
-        val normalized = value.trim()
-        if (normalized.isBlank()) return
-        val exists = searchBlockedKeywords.any { it.equals(normalized, ignoreCase = true) }
-        settingsViewModel.addSearchBlockedKeyword(normalized)
-        if (exists) {
-            viewModel.messageManager.showInfo("屏蔽词已存在：$normalized")
-        } else {
-            viewModel.messageManager.showSuccess("已添加屏蔽词：$normalized")
-        }
-    }
-
     LaunchedEffect(Unit) {
         viewModel.bootstrap(
             initialKeyword = keyword,
@@ -383,6 +367,10 @@ fun SearchScreen(
             initialCollectedOnly = collectedOnly,
             initialCollectedSort = selectedCollectedSort
         )
+    }
+
+    LaunchedEffect(isDataActive, viewModel) {
+        if (isDataActive) viewModel.ensureHotKeywordTermsLoaded()
     }
 
     LaunchedEffect(success?.keyword) {
@@ -1333,13 +1321,28 @@ fun SearchScreen(
     }
 
     metaActionKeyword?.let { targetKeyword ->
+        val playlistsViewModel: PlaylistsViewModel = hiltViewModel()
+        val albumGroupsViewModel: AlbumGroupsViewModel = hiltViewModel()
+        val settingsViewModel: SettingsViewModel = hiltViewModel()
+        val searchBlockedKeywords by settingsViewModel.searchBlockedKeywords.collectAsStateWhileActive(isDataActive)
         AlbumMetaActionDialog(
             keyword = targetKeyword,
             onDismissRequest = { metaActionKeyword = null },
             onSearch = ::searchMetaKeyword,
             onCreatePlaylist = playlistsViewModel::createPlaylist,
             onCreateGroup = albumGroupsViewModel::createGroup,
-            onAddBlockedKeyword = ::addMetaBlockedKeyword,
+            onAddBlockedKeyword = { value ->
+                val normalized = value.trim()
+                if (normalized.isNotBlank()) {
+                    val exists = searchBlockedKeywords.any { it.equals(normalized, ignoreCase = true) }
+                    settingsViewModel.addSearchBlockedKeyword(normalized)
+                    if (exists) {
+                        viewModel.messageManager.showInfo("屏蔽词已存在：$normalized")
+                    } else {
+                        viewModel.messageManager.showSuccess("已添加屏蔽词：$normalized")
+                    }
+                }
+            },
         )
     }
 }

--- a/app/src/main/java/com/asmr/player/ui/search/SearchViewModel.kt
+++ b/app/src/main/java/com/asmr/player/ui/search/SearchViewModel.kt
@@ -79,6 +79,7 @@ class SearchViewModel @Inject constructor(
     private val asmrOneAvailabilityCache =
         BoundedLruCache<String, CachedAsmrOneAvailability>(maxEntries = 1_000)
     private val bootstrapped = AtomicBoolean(false)
+    private val hotKeywordsRequested = AtomicBoolean(false)
     private var searchResultRevision: Long = 0L
 
     private val _uiState = MutableStateFlow<SearchUiState>(SearchUiState.Idle)
@@ -94,11 +95,8 @@ class SearchViewModel @Inject constructor(
     private var currentLocale: String? = "ja_JP"
     private var lastRequestedKeyword: String = ""
 
-    init {
-        refreshHotKeywordTerms()
-    }
-
-    private fun refreshHotKeywordTerms() {
+    fun ensureHotKeywordTermsLoaded() {
+        if (!hotKeywordsRequested.compareAndSet(false, true)) return
         if (!hotListeningApi.isBackendConfigured) {
             _showHotKeywordFallback.value = true
             return

--- a/app/src/main/java/com/asmr/player/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/settings/SettingsScreen.kt
@@ -121,6 +121,9 @@ fun SettingsScreen(
     scrollToTopSignal: Long = 0L,
     onHorizontalControlInteractionChanged: (Boolean) -> Unit = {},
 ) {
+    LaunchedEffect(isDataActive, viewModel) {
+        if (isDataActive) viewModel.prepareSettingsData()
+    }
     val floatingLyricsEnabled by viewModel.floatingLyricsEnabled.collectAsStateWhileActive(isDataActive)
     val floatingSettings by viewModel.floatingLyricsSettings.collectAsStateWhileActive(isDataActive)
     val lyricsPageSettings by viewModel.lyricsPageSettings.collectAsStateWhileActive(isDataActive)

--- a/app/src/main/java/com/asmr/player/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/asmr/player/ui/settings/SettingsViewModel.kt
@@ -174,9 +174,11 @@ class SettingsViewModel @Inject constructor(
     val updateState = _updateState.asStateFlow()
     private var updateJob: Job? = null
     private var automaticCheckStarted = false
+    private var settingsDataPrepared = false
 
-    init {
-        appCacheManager.start()
+    fun prepareSettingsData() {
+        if (settingsDataPrepared) return
+        settingsDataPrepared = true
         viewModelScope.launch(Dispatchers.IO) {
             val apiKey = deepSeekApiKeyStore.read()
             val configured = apiKey.isNotBlank()

--- a/app/src/main/java/com/asmr/player/ui/sidepanel/recentalbumspanel.kt
+++ b/app/src/main/java/com/asmr/player/ui/sidepanel/recentalbumspanel.kt
@@ -1,4 +1,4 @@
-﻿package com.asmr.player.ui.sidepanel
+package com.asmr.player.ui.sidepanel
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
@@ -24,7 +24,7 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.mutableStateListOf
@@ -92,7 +92,7 @@ fun RecentAlbumsPanel(
     } else {
         hiltViewModel()
     }
-    val baseItems by resolvedViewModel.items.collectAsState()
+    val baseItems by resolvedViewModel.items.collectAsStateWithLifecycle()
     val optimisticOrderIds = remember { mutableStateListOf<Long>() }
     LaunchedEffect(baseItems) {
         val ids = baseItems.map { it.album.id }.toSet()

--- a/app/src/test/java/com/asmr/player/data/settings/SettingsRepositoryTest.kt
+++ b/app/src/test/java/com/asmr/player/data/settings/SettingsRepositoryTest.kt
@@ -107,6 +107,21 @@ class SettingsRepositoryTest {
     }
 
     @Test
+    fun clearSleepTimer_skipsDataStoreWriteWhenAlreadyCleared() = runBlocking {
+        val inMemoryDataStore = dataStore as InMemoryPreferencesDataStore
+
+        repository.clearSleepTimer()
+
+        assertEquals(0, inMemoryDataStore.updateCount)
+
+        repository.setSleepTimerEndAtMs(1_000L)
+        repository.clearSleepTimer()
+
+        assertEquals(0L, repository.sleepTimerEndAtMs.first())
+        assertEquals(2, inMemoryDataStore.updateCount)
+    }
+
+    @Test
     fun deepSeekTranslationSettings_defaultToThinkingDisabled() = runBlocking {
         val defaults = repository.loadDeepSeekTranslationSettings()
         assertFalse(defaults.thinkingEnabled)
@@ -196,12 +211,15 @@ class SettingsRepositoryTest {
     private class InMemoryPreferencesDataStore : DataStore<Preferences> {
         private val state = MutableStateFlow(emptyPreferences())
         private val updateMutex = Mutex()
+        var updateCount: Int = 0
+            private set
 
         override val data: StateFlow<Preferences> = state
 
         override suspend fun updateData(
             transform: suspend (t: Preferences) -> Preferences
         ): Preferences = updateMutex.withLock {
+            updateCount += 1
             transform(state.value).also { state.value = it }
         }
     }


### PR DESCRIPTION
## 概要

- 减少应用启动阶段的无效 IO、WorkManager、字幕任务和缓存扫描初始化
- 按实际路由与页面活跃状态延迟创建 ViewModel、搜索热词和设置数据
- 将 Compose Flow 收集统一改为生命周期感知，避免非活跃页面持续收集和重组
- 保留现有布局、动画、手势、交互和 Activity 级状态共享行为

## 问题定位

- 连接设备的主空间与隐私空间使用独立 UID/进程和应用数据
- 隐私空间中的 ProfileInstaller 运行时写入受厂商限制，但 APK 安装后全局 dexopt 仍可使用 Baseline Profile
- 冷缓存环境会放大启动期同步初始化和后台页面 Flow 收集的尾延迟

## 验证

- Release Kotlin/Java、Hilt、R8、Art Profile、APK 和 DM 打包成功
- 当前 Release APK 已安装到 user 0 与 user 10，冷启动分别为 546ms / 409ms，无崩溃
- `dumpsys package dexopt`：`speed-profile`，reason=`baseline`
- `git diff --check` 通过；改动文件均为 UTF-8 无 BOM
- 新增睡眠计时器已清除时不重复写 DataStore 的单元测试
