### PR TITLE
fix: 修复详情页一起听人数与语言版本识别

### DIFF
--- a/app/src/main/java/com/asmr/player/data/remote/dlsite/DlsiteProductInfoClient.kt
+++ b/app/src/main/java/com/asmr/player/data/remote/dlsite/DlsiteProductInfoClient.kt
@@ -36,9 +36,9 @@ class DlsiteProductInfoClient @Inject constructor(
                 (k as? String)?.trim()?.equals(clean, ignoreCase = true) == true
             }?.value as? Map<*, *>)
             ?: return emptyList()
-        val rawItems = workObj["dl_count_items"] as? List<*> ?: return emptyList()
+        val rawItems = workObj["dl_count_items"] as? List<*> ?: emptyList<Any?>()
 
-        return rawItems.mapNotNull { it as? Map<*, *> }
+        val listedEditions = rawItems.mapNotNull { it as? Map<*, *> }
             .mapNotNull { item ->
                 val editionType = (item["edition_type"] as? String).orEmpty().trim()
                 if (editionType != "language") return@mapNotNull null
@@ -49,10 +49,46 @@ class DlsiteProductInfoClient @Inject constructor(
                 }
                 val order = (item["display_order"] as? Number)?.toInt() ?: 0
                 if (lang.isBlank() || workno.isBlank()) return@mapNotNull null
-                if (lang !in setOf("JPN", "CHI_HANS", "CHI_HANT")) return@mapNotNull null
+                if (lang !in SUPPORTED_LANGUAGES) return@mapNotNull null
                 DlsiteLanguageEdition(workno = workno, lang = lang, label = label, displayOrder = order)
             }
+
+        val translationInfo = workObj["translation_info"] as? Map<*, *>
+        val currentLang = (translationInfo?.get("lang") as? String).orEmpty().trim()
+        val currentEdition = currentLang
+            .takeIf { it in SUPPORTED_LANGUAGES }
+            ?.let { lang ->
+                listedEditions.firstOrNull { it.lang == lang }
+                    ?.copy(workno = clean)
+                    ?: DlsiteLanguageEdition(
+                        workno = clean,
+                        lang = lang,
+                        label = defaultLanguageLabel(lang),
+                        displayOrder = defaultLanguageOrder(lang)
+                    )
+            }
+
+        return buildList {
+            if (currentEdition != null) add(currentEdition)
+            addAll(listedEditions.filterNot { it.lang == currentLang })
+        }
             .sortedWith(compareBy({ it.displayOrder }, { it.lang }))
+    }
+
+    private fun defaultLanguageLabel(lang: String): String {
+        return when (lang) {
+            "CHI_HANS" -> "简体中文"
+            "CHI_HANT" -> "繁体中文"
+            else -> "日本語"
+        }
+    }
+
+    private fun defaultLanguageOrder(lang: String): Int {
+        return when (lang) {
+            "CHI_HANS" -> 5
+            "CHI_HANT" -> 7
+            else -> 1
+        }
     }
 
     suspend fun fetchLanguageEditions(productId: String): List<DlsiteLanguageEdition> = withContext(Dispatchers.IO) {
@@ -79,5 +115,9 @@ class DlsiteProductInfoClient @Inject constructor(
             if (!resp.isSuccessful || body.isBlank()) return@withContext emptyList()
             parseLanguageEditions(clean, body)
         }
+    }
+
+    private companion object {
+        val SUPPORTED_LANGUAGES = setOf("JPN", "CHI_HANS", "CHI_HANT")
     }
 }

--- a/app/src/main/java/com/asmr/player/ui/library/AlbumDetailViewModel.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/AlbumDetailViewModel.kt
@@ -35,7 +35,6 @@ import com.asmr.player.data.remote.NetworkHeaders
 import com.asmr.player.data.remote.ONLINE_DIRECTORY_REQUEST_TIMEOUT_MS
 import com.asmr.player.data.remote.api.AsmrOneAvailabilityApi
 import com.asmr.player.data.remote.api.AsmrOneEndpoint
-import com.asmr.player.data.remote.api.AsmrOneOtherLanguageEditionInDb
 import com.asmr.player.data.remote.api.AsmrOneTrackNodeResponse
 import com.asmr.player.data.remote.auth.DlsiteAuthStore
 import com.asmr.player.data.remote.auth.buildDlsiteCookieHeader
@@ -210,7 +209,6 @@ class AlbumDetailViewModel @Inject constructor(
     private val asmrOneResolvedCache = linkedMapOf<String, Pair<Long, Pair<String, Int?>?>>()
     private val asmrOneResolutionInFlight = mutableMapOf<String, Deferred<Pair<String, Int?>?>>()
     private val asmrOneTracksCache = linkedMapOf<String, Pair<Long, AsmrOneTracksResult>>()
-    private val autoFallbackToJpnOnceByKey = linkedSetOf<String>()
 
     private val treeExpandedByKey = linkedMapOf<String, List<String>>()
     private val treeInitializedKeys = linkedSetOf<String>()
@@ -228,7 +226,7 @@ class AlbumDetailViewModel @Inject constructor(
         viewModelScope.launch {
             combine(
                 uiState.map {
-                    (it as? AlbumDetailUiState.Success)?.model?.rjCode?.trim().orEmpty().uppercase()
+                    (it as? AlbumDetailUiState.Success)?.model?.listenTogetherSummaryRj().orEmpty()
                 },
                 listenTogetherRjSummaryPollingEnabled,
             ) { rj, enabled ->
@@ -269,7 +267,7 @@ class AlbumDetailViewModel @Inject constructor(
             }.getOrNull() ?: return
             val listenerCount = summary.listenerCount.coerceAtLeast(0)
             val current = _uiState.value as? AlbumDetailUiState.Success ?: return
-            if (!current.model.rjCode.trim().uppercase().equals(normalizedRj, ignoreCase = true)) return
+            if (!current.model.listenTogetherSummaryRj().equals(normalizedRj, ignoreCase = true)) return
             if (current.model.listenTogetherRjListenerCount == listenerCount) return
             _uiState.value = AlbumDetailUiState.Success(
                 model = current.model.copy(listenTogetherRjListenerCount = listenerCount)
@@ -713,7 +711,7 @@ class AlbumDetailViewModel @Inject constructor(
                 // 种入列表点击时记录的封面与元信息：让 hero 与列表卡片使用相同图片 model，
                 // 在网络解析完成前即可命中跨尺寸内存缓存，避免重复请求封面。
                 val displayAlbum = if (hint != null) hintAlbum else localAlbum ?: hintAlbum
-                val loadedModel = createInitialAlbumDetailModel(
+                val initialLoadedModel = createInitialAlbumDetailModel(
                     rj = rj,
                     displayAlbum = displayAlbum,
                     localAlbum = localAlbum,
@@ -721,6 +719,7 @@ class AlbumDetailViewModel @Inject constructor(
                     preserveHeaderAlbumMetadata = preserveHeaderAlbumMetadata
                 )
                 val currentModel = (_uiState.value as? AlbumDetailUiState.Success)?.model
+                val loadedModel = initialLoadedModel.withPreservedListenTogetherListenerCount(currentModel)
                 if (loadedModel != currentModel) {
                     _uiState.value = AlbumDetailUiState.Success(
                         model = loadedModel
@@ -996,155 +995,6 @@ class AlbumDetailViewModel @Inject constructor(
         if (refs.isNotEmpty()) tagDao.insertAlbumTags(refs)
     }
 
-    private fun defaultDlsiteEditions(rj: String): List<DlsiteLanguageEdition> {
-        val clean = rj.trim().uppercase()
-        if (clean.isBlank()) return emptyList()
-        return listOf(DlsiteLanguageEdition(workno = clean, lang = "JPN", label = "日本語", displayOrder = 1))
-    }
-
-    private fun fetchDlsiteEditions(baseRj: String) {
-        val clean = baseRj.trim().uppercase()
-        if (clean.isBlank()) return
-        viewModelScope.launch {
-            val editions = runCatching { dlsiteProductInfoClient.fetchLanguageEditions(clean) }.getOrDefault(emptyList())
-            val merged = buildList {
-                val hasJpn = editions.any { it.lang == "JPN" }
-                if (!hasJpn) addAll(defaultDlsiteEditions(clean))
-                addAll(editions)
-            }.distinctBy { it.lang }.sortedWith(compareBy({ it.displayOrder }, { it.lang }))
-
-            val current = _uiState.value as? AlbumDetailUiState.Success ?: return@launch
-            if (!current.model.baseRjCode.equals(clean, ignoreCase = true)) return@launch
-
-            val isFirstLangFetch = current.model.dlsiteEditions.size <= 1
-            val currentSelectedLang = current.model.dlsiteSelectedLang.trim().uppercase().ifBlank { "JPN" }
-            if (isFirstLangFetch && currentSelectedLang == "JPN") {
-                _uiState.value = AlbumDetailUiState.Success(model = current.model.copy(dlsiteEditions = merged))
-                val hasHansEdition = merged.any { it.lang.equals("CHI_HANS", ignoreCase = true) }
-                val hasHantEdition = merged.any { it.lang.equals("CHI_HANT", ignoreCase = true) }
-                val jpnWorkno = merged.firstOrNull { it.lang.equals("JPN", ignoreCase = true) }
-                    ?.workno
-                    ?.trim()
-                    ?.uppercase()
-                    .orEmpty()
-                    .ifBlank { clean }
-
-                val resolved = resolveAsmrOneWork(jpnWorkno, timeoutMs = 1_200L) ?: resolveAsmrOneWork(clean, timeoutMs = 1_200L)
-                val picked = if (resolved != null) {
-                    val workId = resolved.first
-                    val details = withTimeoutOrNull(1_500L) {
-                        asmrOneCrawler.getDetails(workId)
-                    }
-                    val other = details?.other_language_editions_in_db.orEmpty()
-                    val hasHans = other.any { it.lang.orEmpty().contains("简体") || it.lang.orEmpty().contains("簡体") }
-                    val hasHant = other.any { it.lang.orEmpty().contains("繁体") || it.lang.orEmpty().contains("繁體") }
-                    when {
-                        hasHansEdition && hasHans -> "CHI_HANS"
-                        hasHantEdition && hasHant -> "CHI_HANT"
-                        else -> "JPN"
-                    }
-                } else {
-                    when {
-                        hasHansEdition -> "CHI_HANS"
-                        hasHantEdition -> "CHI_HANT"
-                        else -> "JPN"
-                    }
-                }
-                if (picked != "JPN") {
-                    selectDlsiteLanguage(picked)
-                }
-                return@launch
-            }
-
-            val selectedByWorkno = merged.firstOrNull { it.workno.trim().equals(clean, ignoreCase = true) }
-            val selectedLang = current.model.dlsiteSelectedLang.trim().uppercase().ifBlank { "JPN" }
-            val selected = selectedByWorkno
-                ?: merged.firstOrNull { it.lang == selectedLang }
-                ?: merged.firstOrNull { it.lang == "JPN" }
-                ?: merged.firstOrNull()
-            val selectedWorkno = selected?.workno?.trim()?.uppercase().orEmpty().ifBlank { clean }
-            _uiState.value = AlbumDetailUiState.Success(
-                model = current.model.copy(
-                    dlsiteEditions = merged,
-                    dlsiteSelectedLang = selected?.lang ?: "JPN",
-                    dlsiteWorkno = selectedWorkno
-                )
-            )
-        }
-    }
-
-    private fun matchesAsmrOneChineseEdition(
-        edition: AsmrOneOtherLanguageEditionInDb,
-        workno: String,
-        langCode: String,
-        titleKeywords: List<String>
-    ): Boolean {
-        val normalizedWorkno = workno.trim().uppercase()
-        val normalizedLang = edition.lang.orEmpty().trim().uppercase()
-        val normalizedTitle = edition.title.orEmpty().trim()
-        val normalizedSourceId = edition.source_id.orEmpty().trim().uppercase()
-        return (normalizedWorkno.isNotBlank() && normalizedSourceId == normalizedWorkno) ||
-            normalizedLang.contains(langCode) ||
-            titleKeywords.any { keyword ->
-                normalizedLang.contains(keyword, ignoreCase = true) ||
-                    normalizedTitle.contains(keyword, ignoreCase = true)
-            }
-    }
-
-    private suspend fun resolveInitialDlsiteChinesePreference(
-        baseRj: String,
-        editions: List<DlsiteLanguageEdition>
-    ): DlsiteChinesePreference {
-        val clean = baseRj.trim().uppercase()
-        if (clean.isBlank()) return DlsiteChinesePreference.None
-        val hasHansEdition = editions.any { it.lang.equals("CHI_HANS", ignoreCase = true) }
-        val hasHantEdition = editions.any { it.lang.equals("CHI_HANT", ignoreCase = true) }
-        if (!hasHansEdition && !hasHantEdition) return DlsiteChinesePreference.None
-
-        val jpnWorkno = editions.firstOrNull { it.lang.equals("JPN", ignoreCase = true) }
-            ?.workno
-            ?.trim()
-            ?.uppercase()
-            .orEmpty()
-            .ifBlank { clean }
-        val resolved = resolveAsmrOneWork(jpnWorkno, timeoutMs = 1_200L)
-            ?: resolveAsmrOneWork(clean, timeoutMs = 1_200L)
-            ?: return DlsiteChinesePreference.None
-        val workId = resolved.first
-        val details = withTimeoutOrNull(1_500L) {
-            asmrOneCrawler.getDetails(workId)
-        } ?: return DlsiteChinesePreference.None
-        val otherEditions = details.other_language_editions_in_db.orEmpty()
-        val hansWorkno = editions.firstOrNull { it.lang.equals("CHI_HANS", ignoreCase = true) }
-            ?.workno
-            .orEmpty()
-        val hantWorkno = editions.firstOrNull { it.lang.equals("CHI_HANT", ignoreCase = true) }
-            ?.workno
-            .orEmpty()
-
-        return when {
-            hasHansEdition && otherEditions.any {
-                matchesAsmrOneChineseEdition(
-                    edition = it,
-                    workno = hansWorkno,
-                    langCode = "CHI_HANS",
-                    titleKeywords = listOf("简", "簡")
-                )
-            } -> DlsiteChinesePreference.Hans
-
-            hasHantEdition && otherEditions.any {
-                matchesAsmrOneChineseEdition(
-                    edition = it,
-                    workno = hantWorkno,
-                    langCode = "CHI_HANT",
-                    titleKeywords = listOf("繁")
-                )
-            } -> DlsiteChinesePreference.Hant
-
-            else -> DlsiteChinesePreference.None
-        }
-    }
-
     private suspend fun resolveInitialDlsiteLoadTarget(
         model: AlbumDetailModel
     ): ResolvedDlsiteLoadTarget {
@@ -1158,14 +1008,9 @@ class AlbumDetailViewModel @Inject constructor(
         }
         val editions = runCatching { dlsiteProductInfoClient.fetchLanguageEditions(clean) }
             .getOrDefault(emptyList())
-        val merged = mergeDlsiteEditions(clean, editions)
-        val chinesePreference = resolveInitialDlsiteChinesePreference(clean, merged)
         return resolveInitialDlsiteLoadTarget(
-            baseRj = clean,
-            editions = merged,
-            currentSelectedLang = model.dlsiteSelectedLang,
-            preserveCurrentSelection = model.isDlsiteLanguageUserSelected,
-            chinesePreference = chinesePreference
+            entryRjCode = clean,
+            editions = editions
         )
     }
 
@@ -1406,10 +1251,6 @@ class AlbumDetailViewModel @Inject constructor(
     }
 
     fun selectDlsiteLanguage(lang: String) {
-        selectDlsiteLanguageInternal(lang, isUserSelection = true)
-    }
-
-    private fun selectDlsiteLanguageInternal(lang: String, isUserSelection: Boolean) {
         val current = _uiState.value as? AlbumDetailUiState.Success ?: return
         val normalized = lang.trim().uppercase()
         if (normalized.isBlank()) return
@@ -1453,7 +1294,7 @@ class AlbumDetailViewModel @Inject constructor(
                 hasLoadedInitialDlsiteContent = false,
                 hasResolvedAsmrOneContent = false,
                 hasResolvedDlsitePlayContent = false,
-                isDlsiteLanguageUserSelected = current.model.isDlsiteLanguageUserSelected || isUserSelection,
+                isDlsiteLanguageUserSelected = true,
                 asmrOneWorkId = null,
                 asmrOneSite = null,
                 asmrOneTree = emptyList(),
@@ -1468,11 +1309,7 @@ class AlbumDetailViewModel @Inject constructor(
         clearTreeState("tree:dlsitePlay:$workno")
         clearTreeState("localTree:rj:$workno")
         viewModelScope.launch {
-            val local = if (isUserSelection) {
-                runCatching { loadLocalAlbumByRj(workno) }.getOrNull() ?: current.model.localAlbum
-            } else {
-                current.model.localAlbum
-            }
+            val local = runCatching { loadLocalAlbumByRj(workno) }.getOrNull() ?: current.model.localAlbum
             val updated = (_uiState.value as? AlbumDetailUiState.Success)?.model ?: return@launch
             if (!updated.rjCode.equals(workno, ignoreCase = true)) return@launch
             val displayAlbum = mergeDetailHeaderAlbum(
@@ -1678,40 +1515,6 @@ class AlbumDetailViewModel @Inject constructor(
                     return@launch
                 }
 
-                suspend fun fallbackToJapaneseDirectoryIfAvailable(
-                    originalWorkId: String
-                ): Boolean {
-                    if (
-                        latest.isDlsiteLanguageUserSelected ||
-                        selectedLang.equals("JPN", ignoreCase = true)
-                    ) {
-                        return false
-                    }
-                    val crawlerResult = getAsmrOneTracksCached(originalWorkId)
-                    if (
-                        !shouldFallbackToJapaneseDirectory(
-                            selectedLang = selectedLang,
-                            isLanguageUserSelected = latest.isDlsiteLanguageUserSelected,
-                            hasSelectedDirectoryResources = false,
-                            hasJapaneseDirectoryResources = crawlerResult.tree.isNotEmpty()
-                        )
-                    ) {
-                        return false
-                    }
-                    val fallbackKey = "directory:base:$originalRj|cur:$keyRj|to:JPN"
-                    if (!autoFallbackToJpnOnceByKey.add(fallbackKey)) return false
-
-                    val updated = (_uiState.value as? AlbumDetailUiState.Success)?.model ?: return true
-                    if (token != asmrOneLoadToken || !updated.rjCode.equals(keyRj, ignoreCase = true)) {
-                        return true
-                    }
-                    _uiState.value = AlbumDetailUiState.Success(
-                        model = updated.copy(isLoadingAsmrOne = false)
-                    )
-                    selectDlsiteLanguageInternal("JPN", isUserSelection = false)
-                    return true
-                }
-
                 var preferredInitialResolution: Pair<String, Int?>? = null
                 if (preferInitialRj) {
                     val preferredInitial = resolveAsmrOneWork(latestBase)
@@ -1727,47 +1530,6 @@ class AlbumDetailViewModel @Inject constructor(
                             )
                             return@launch
                         }
-                    }
-                }
-
-                val collected = isAsmrOneCollected(originalRj, timeoutMs = 1_200L)
-                if (collected == false) {
-                    val baseKey = originalRj
-                    val preferred = listOf("CHI_HANS", "CHI_HANT", "JPN")
-                    val candidates = preferred.mapNotNull { lang ->
-                        val workno = latest.dlsiteEditions.firstOrNull { it.lang.equals(lang, ignoreCase = true) }
-                            ?.workno
-                            ?.trim()
-                            ?.uppercase()
-                            .orEmpty()
-                            .ifBlank {
-                                if (lang == "JPN") baseKey else ""
-                            }
-                        if (workno.isBlank() || workno.equals(keyRj, ignoreCase = true)) return@mapNotNull null
-                        lang to workno
-                    }
-                    val results = coroutineScope {
-                        candidates.map { (lang, workno) ->
-                            async {
-                                lang to isAsmrOneCollected(workno, timeoutMs = 1_200L)
-                            }
-                        }.mapNotNull { runCatching { it.await() }.getOrNull() }.toMap()
-                    }
-                    val fallbackLang = preferred.firstOrNull { lang -> results[lang] == true }
-                    val fallbackKey = "base:$baseKey|cur:$keyRj|to:${fallbackLang.orEmpty()}"
-                    if (
-                        !latest.isDlsiteLanguageUserSelected &&
-                        !fallbackLang.isNullOrBlank() &&
-                        !autoFallbackToJpnOnceByKey.contains(fallbackKey)
-                    ) {
-                        autoFallbackToJpnOnceByKey.add(fallbackKey)
-                        val updated0 = (_uiState.value as? AlbumDetailUiState.Success)?.model ?: return@launch
-                        val updatedKey0 = updated0.rjCode.trim().uppercase()
-                        if (updatedKey0.equals(keyRj, ignoreCase = true) && updated0.isLoadingAsmrOne) {
-                            _uiState.value = AlbumDetailUiState.Success(model = updated0.copy(isLoadingAsmrOne = false))
-                        }
-                        selectDlsiteLanguageInternal(fallbackLang, isUserSelection = false)
-                        return@launch
                     }
                 }
 
@@ -1816,12 +1578,8 @@ class AlbumDetailViewModel @Inject constructor(
                     return@launch
                 }
                 if (workId.isNullOrBlank()) {
-                    if (fallbackToJapaneseDirectoryIfAvailable(originalWorkId)) return@launch
                     asmrOneAttemptedRj.remove(keyRj)
                     finishAsmrOneLoad(keyRj, resolved = true)
-                    return@launch
-                }
-                if (trackResult.tree.isEmpty() && fallbackToJapaneseDirectoryIfAvailable(originalWorkId)) {
                     return@launch
                 }
                 finishWithResolvedAsmrOneTree(

--- a/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailViewModelSupport.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailViewModelSupport.kt
@@ -178,6 +178,19 @@ data class AlbumDetailModel(
     val isLoadingDlsitePlay: Boolean
 )
 
+internal fun AlbumDetailModel.listenTogetherSummaryRj(): String {
+    return baseRjCode.trim().uppercase().ifBlank { rjCode.trim().uppercase() }
+}
+
+internal fun AlbumDetailModel.withPreservedListenTogetherListenerCount(
+    previous: AlbumDetailModel?
+): AlbumDetailModel {
+    if (previous == null || listenTogetherSummaryRj() != previous.listenTogetherSummaryRj()) {
+        return this
+    }
+    return copy(listenTogetherRjListenerCount = previous.listenTogetherRjListenerCount)
+}
+
 internal fun AlbumDetailModel.withUpdatedLocalCover(
     albumId: Long,
     coverPath: String,
@@ -281,12 +294,6 @@ internal fun shouldPreserveHeaderAlbumMetadata(hint: AlbumCoverHint?): Boolean {
     return hint?.hasResolvedDlsiteInfo == true
 }
 
-internal enum class DlsiteChinesePreference {
-    None,
-    Hans,
-    Hant
-}
-
 internal data class ResolvedDlsiteLoadTarget(
     val editions: List<DlsiteLanguageEdition>,
     val selectedLang: String,
@@ -314,20 +321,20 @@ internal fun mergeDlsiteEditions(
     if (clean.isBlank()) return emptyList()
     return buildList {
         val hasJpn = editions.any { it.lang.equals("JPN", ignoreCase = true) }
-        if (!hasJpn) addAll(defaultDlsiteEditions(clean))
+        val hasEntryEdition = editions.any {
+            it.workno.trim().equals(clean, ignoreCase = true)
+        }
+        if (!hasJpn && !hasEntryEdition) addAll(defaultDlsiteEditions(clean))
         addAll(editions)
     }.distinctBy { it.lang.trim().uppercase() }
         .sortedWith(compareBy({ it.displayOrder }, { it.lang }))
 }
 
 internal fun resolveInitialDlsiteLoadTarget(
-    baseRj: String,
-    editions: List<DlsiteLanguageEdition>,
-    currentSelectedLang: String = "JPN",
-    preserveCurrentSelection: Boolean = false,
-    chinesePreference: DlsiteChinesePreference = DlsiteChinesePreference.None
+    entryRjCode: String,
+    editions: List<DlsiteLanguageEdition>
 ): ResolvedDlsiteLoadTarget {
-    val clean = baseRj.trim().uppercase()
+    val clean = entryRjCode.trim().uppercase()
     if (clean.isBlank()) {
         return ResolvedDlsiteLoadTarget(
             editions = emptyList(),
@@ -336,32 +343,14 @@ internal fun resolveInitialDlsiteLoadTarget(
         )
     }
     val merged = mergeDlsiteEditions(clean, editions)
-    val normalizedCurrentLang = currentSelectedLang.trim().uppercase().ifBlank { "JPN" }
-    val hasHans = merged.any { it.lang.equals("CHI_HANS", ignoreCase = true) }
-    val hasHant = merged.any { it.lang.equals("CHI_HANT", ignoreCase = true) }
-    val preservedTarget = if (preserveCurrentSelection) {
-        merged.firstOrNull { it.lang.equals(normalizedCurrentLang, ignoreCase = true) }
-    } else {
-        null
+    val entryEdition = merged.firstOrNull {
+        it.workno.trim().equals(clean, ignoreCase = true)
     }
-    val preferredLang = when {
-        preservedTarget != null -> preservedTarget.lang
-        chinesePreference == DlsiteChinesePreference.Hans && hasHans -> "CHI_HANS"
-        chinesePreference == DlsiteChinesePreference.Hant && hasHant -> "CHI_HANT"
-        hasHans -> "CHI_HANS"
-        hasHant -> "CHI_HANT"
-        else -> "JPN"
-    }
-    val selected = preservedTarget
-        ?: merged.firstOrNull { it.lang.equals(preferredLang, ignoreCase = true) }
-        ?: merged.firstOrNull { it.lang.equals("JPN", ignoreCase = true) }
-        ?: merged.firstOrNull()
-    val selectedLang = selected?.lang?.trim().orEmpty().ifBlank { preferredLang }
-    val selectedWorkno = selected?.workno?.trim()?.uppercase().orEmpty().ifBlank { clean }
+    val selectedLang = entryEdition?.lang?.trim().orEmpty().ifBlank { "JPN" }
     return ResolvedDlsiteLoadTarget(
         editions = merged,
         selectedLang = selectedLang,
-        workno = selectedWorkno
+        workno = clean
     )
 }
 
@@ -414,18 +403,6 @@ internal fun resolveAsmrOneTrackWorkId(
         asmrOneEditionMatchesLanguage(edition.lang.orEmpty(), normalizedLang)
     }
     return languageEdition?.id?.takeIf { it > 0 }?.toString()
-}
-
-internal fun shouldFallbackToJapaneseDirectory(
-    selectedLang: String,
-    isLanguageUserSelected: Boolean,
-    hasSelectedDirectoryResources: Boolean,
-    hasJapaneseDirectoryResources: Boolean
-): Boolean {
-    return !isLanguageUserSelected &&
-        !selectedLang.trim().equals("JPN", ignoreCase = true) &&
-        !hasSelectedDirectoryResources &&
-        hasJapaneseDirectoryResources
 }
 
 private fun asmrOneEditionMatchesLanguage(languageLabel: String, selectedLang: String): Boolean {

--- a/app/src/test/java/com/asmr/player/data/remote/dlsite/DlsiteProductInfoClientTest.kt
+++ b/app/src/test/java/com/asmr/player/data/remote/dlsite/DlsiteProductInfoClientTest.kt
@@ -79,5 +79,74 @@ class DlsiteProductInfoClientTest {
 
         assertEquals(emptyList<DlsiteLanguageEdition>(), editions)
     }
+
+    @Test
+    fun parseLanguageEditions_usesCurrentTranslatedChildInsteadOfParentEdition() {
+        val json = """
+            {
+              "RJ01189945": {
+                "translation_info": {
+                  "is_original": false,
+                  "original_workno": "RJ365382",
+                  "parent_workno": "RJ01189944",
+                  "lang": "CHI_HANS"
+                },
+                "dl_count_items": [
+                  {
+                    "workno": "RJ365382",
+                    "edition_type": "language",
+                    "display_order": 1,
+                    "label": "日本語",
+                    "lang": "JPN",
+                    "display_label": "日本語"
+                  },
+                  {
+                    "workno": "RJ01189944",
+                    "edition_type": "language",
+                    "display_order": 5,
+                    "label": "簡体中文",
+                    "lang": "CHI_HANS",
+                    "display_label": "簡体中文"
+                  }
+                ]
+              }
+            }
+        """.trimIndent()
+
+        val client = DlsiteProductInfoClient(OkHttpClient())
+        val editions = client.parseLanguageEditions("RJ01189945", json)
+
+        assertEquals("RJ365382", editions.single { it.lang == "JPN" }.workno)
+        assertEquals("RJ01189945", editions.single { it.lang == "CHI_HANS" }.workno)
+        assertTrue(editions.none { it.workno == "RJ01189944" })
+    }
+
+    @Test
+    fun parseLanguageEditions_keepsCurrentTranslationWithoutEditionItems() {
+        val json = """
+            {
+              "RJ01189945": {
+                "translation_info": {
+                  "lang": "CHI_HANS"
+                }
+              }
+            }
+        """.trimIndent()
+
+        val client = DlsiteProductInfoClient(OkHttpClient())
+        val editions = client.parseLanguageEditions("RJ01189945", json)
+
+        assertEquals(
+            listOf(
+                DlsiteLanguageEdition(
+                    workno = "RJ01189945",
+                    lang = "CHI_HANS",
+                    label = "简体中文",
+                    displayOrder = 5
+                )
+            ),
+            editions
+        )
+    }
 }
 

--- a/app/src/test/java/com/asmr/player/ui/library/AlbumDetailAsmrOneLanguageTargetTest.kt
+++ b/app/src/test/java/com/asmr/player/ui/library/AlbumDetailAsmrOneLanguageTargetTest.kt
@@ -3,9 +3,7 @@ package com.asmr.player.ui.library
 import com.asmr.player.data.remote.api.AsmrOneOtherLanguageEditionInDb
 import com.asmr.player.data.remote.api.WorkDetailsResponse
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
-import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class AlbumDetailAsmrOneLanguageTargetTest {
@@ -84,42 +82,6 @@ class AlbumDetailAsmrOneLanguageTargetTest {
         )
 
         assertEquals("1583802", workId)
-    }
-
-    @Test
-    fun emptyAutoSelectedChineseDirectory_fallsBackWhenJapaneseResourcesExist() {
-        assertTrue(
-            shouldFallbackToJapaneseDirectory(
-                selectedLang = "CHI_HANS",
-                isLanguageUserSelected = false,
-                hasSelectedDirectoryResources = false,
-                hasJapaneseDirectoryResources = true
-            )
-        )
-    }
-
-    @Test
-    fun emptyUserSelectedChineseDirectory_preservesUserSelection() {
-        assertFalse(
-            shouldFallbackToJapaneseDirectory(
-                selectedLang = "CHI_HANT",
-                isLanguageUserSelected = true,
-                hasSelectedDirectoryResources = false,
-                hasJapaneseDirectoryResources = true
-            )
-        )
-    }
-
-    @Test
-    fun emptyChineseDirectory_doesNotFallbackToAnotherEmptyDirectory() {
-        assertFalse(
-            shouldFallbackToJapaneseDirectory(
-                selectedLang = "CHI_HANS",
-                isLanguageUserSelected = false,
-                hasSelectedDirectoryResources = false,
-                hasJapaneseDirectoryResources = false
-            )
-        )
     }
 
     private fun workDetails(

--- a/app/src/test/java/com/asmr/player/ui/library/AlbumDetailDlsiteInitialTargetTest.kt
+++ b/app/src/test/java/com/asmr/player/ui/library/AlbumDetailDlsiteInitialTargetTest.kt
@@ -7,44 +7,59 @@ import org.junit.Test
 class AlbumDetailDlsiteInitialTargetTest {
 
     @Test
-    fun resolveInitialDlsiteLoadTarget_prefersHansWhenAvailable() {
+    fun resolveInitialDlsiteLoadTarget_keepsJapaneseEntryWhenChineseEditionsExist() {
         val result = resolveInitialDlsiteLoadTarget(
-            baseRj = "RJ000001",
+            entryRjCode = "RJ000001",
             editions = listOf(
                 DlsiteLanguageEdition(workno = "RJ000001", lang = "JPN", label = "jp", displayOrder = 3),
                 DlsiteLanguageEdition(workno = "RJ000010", lang = "CHI_HANS", label = "zh-cn", displayOrder = 1),
                 DlsiteLanguageEdition(workno = "RJ000011", lang = "CHI_HANT", label = "zh-tw", displayOrder = 2)
-            ),
-            chinesePreference = DlsiteChinesePreference.None
+            )
         )
 
-        assertEquals("CHI_HANS", result.selectedLang)
-        assertEquals("RJ000010", result.workno)
+        assertEquals("JPN", result.selectedLang)
+        assertEquals("RJ000001", result.workno)
     }
 
     @Test
-    fun resolveInitialDlsiteLoadTarget_fallsBackToHantWhenHansMissing() {
+    fun resolveInitialDlsiteLoadTarget_keepsChineseEntryWhenJapaneseEditionExists() {
         val result = resolveInitialDlsiteLoadTarget(
-            baseRj = "RJ000002",
+            entryRjCode = "RJ01189945",
             editions = listOf(
-                DlsiteLanguageEdition(workno = "RJ000002", lang = "JPN", label = "jp", displayOrder = 2),
-                DlsiteLanguageEdition(workno = "RJ000020", lang = "CHI_HANT", label = "zh-tw", displayOrder = 1)
-            ),
-            chinesePreference = DlsiteChinesePreference.None
+                DlsiteLanguageEdition(workno = "RJ365382", lang = "JPN", label = "jp", displayOrder = 1),
+                DlsiteLanguageEdition(workno = "RJ01189945", lang = "CHI_HANS", label = "zh-cn", displayOrder = 5)
+            )
         )
 
-        assertEquals("CHI_HANT", result.selectedLang)
-        assertEquals("RJ000020", result.workno)
+        assertEquals("CHI_HANS", result.selectedLang)
+        assertEquals("RJ01189945", result.workno)
+    }
+
+    @Test
+    fun resolveInitialDlsiteLoadTarget_doesNotInventJapaneseForChineseOnlyEntry() {
+        val result = resolveInitialDlsiteLoadTarget(
+            entryRjCode = "RJ01189945",
+            editions = listOf(
+                DlsiteLanguageEdition(
+                    workno = "RJ01189945",
+                    lang = "CHI_HANS",
+                    label = "zh-cn",
+                    displayOrder = 5
+                )
+            )
+        )
+
+        assertEquals("CHI_HANS", result.selectedLang)
+        assertEquals(listOf("CHI_HANS"), result.editions.map { it.lang })
     }
 
     @Test
     fun resolveInitialDlsiteLoadTarget_keepsJpnWhenNoChineseEditionExists() {
         val result = resolveInitialDlsiteLoadTarget(
-            baseRj = "RJ000003",
+            entryRjCode = "RJ000003",
             editions = listOf(
                 DlsiteLanguageEdition(workno = "RJ000003", lang = "JPN", label = "jp", displayOrder = 1)
-            ),
-            chinesePreference = DlsiteChinesePreference.None
+            )
         )
 
         assertEquals("JPN", result.selectedLang)
@@ -52,20 +67,17 @@ class AlbumDetailDlsiteInitialTargetTest {
     }
 
     @Test
-    fun resolveInitialDlsiteLoadTarget_preservesUserSelectionWhenRequested() {
+    fun resolveInitialDlsiteLoadTarget_neverSubstitutesAnotherEdition() {
         val result = resolveInitialDlsiteLoadTarget(
-            baseRj = "RJ000004",
+            entryRjCode = "RJ000099",
             editions = listOf(
                 DlsiteLanguageEdition(workno = "RJ000004", lang = "JPN", label = "jp", displayOrder = 3),
                 DlsiteLanguageEdition(workno = "RJ000040", lang = "CHI_HANS", label = "zh-cn", displayOrder = 1),
                 DlsiteLanguageEdition(workno = "RJ000041", lang = "CHI_HANT", label = "zh-tw", displayOrder = 2)
-            ),
-            currentSelectedLang = "CHI_HANT",
-            preserveCurrentSelection = true,
-            chinesePreference = DlsiteChinesePreference.Hans
+            )
         )
 
-        assertEquals("CHI_HANT", result.selectedLang)
-        assertEquals("RJ000041", result.workno)
+        assertEquals("JPN", result.selectedLang)
+        assertEquals("RJ000099", result.workno)
     }
 }

--- a/app/src/test/java/com/asmr/player/ui/library/AlbumDetailViewModelSupportTest.kt
+++ b/app/src/test/java/com/asmr/player/ui/library/AlbumDetailViewModelSupportTest.kt
@@ -185,4 +185,87 @@ class AlbumDetailViewModelSupportTest {
 
         assertEquals("/albums/RJ123456/new-cover.jpg", current)
     }
+
+    @Test
+    fun listenTogetherSummaryRj_staysOnBaseWorkWhenLanguageEditionChanges() {
+        val model = albumDetailModel(
+            baseRjCode = "RJ01588205",
+            rjCode = "VJ01001234",
+            listenerCount = 9
+        )
+
+        assertEquals("RJ01588205", model.listenTogetherSummaryRj())
+    }
+
+    @Test
+    fun listenerCount_isPreservedWhenSameWorkModelIsRebuilt() {
+        val previous = albumDetailModel(
+            baseRjCode = "RJ01588205",
+            rjCode = "RJ01588205",
+            listenerCount = 9
+        )
+        val rebuilt = albumDetailModel(
+            baseRjCode = "RJ01588205",
+            rjCode = "VJ01001234",
+            listenerCount = null
+        )
+
+        val result = rebuilt.withPreservedListenTogetherListenerCount(previous)
+
+        assertEquals(9, result.listenTogetherRjListenerCount)
+    }
+
+    @Test
+    fun listenerCount_isNotPreservedAcrossDifferentWorks() {
+        val previous = albumDetailModel(
+            baseRjCode = "RJ01588205",
+            rjCode = "RJ01588205",
+            listenerCount = 9
+        )
+        val rebuilt = albumDetailModel(
+            baseRjCode = "RJ09999999",
+            rjCode = "RJ09999999",
+            listenerCount = null
+        )
+
+        val result = rebuilt.withPreservedListenTogetherListenerCount(previous)
+
+        assertEquals(null, result.listenTogetherRjListenerCount)
+    }
+}
+
+private fun albumDetailModel(
+    baseRjCode: String,
+    rjCode: String,
+    listenerCount: Int?
+): AlbumDetailModel {
+    return AlbumDetailModel(
+        baseRjCode = baseRjCode,
+        rjCode = rjCode,
+        listenTogetherRjListenerCount = listenerCount,
+        displayAlbum = Album(title = "作品", path = "", rjCode = rjCode),
+        localAlbum = null,
+        dlsiteInfo = null,
+        dlsiteGalleryUrls = emptyList(),
+        dlsiteTrialTracks = emptyList(),
+        dlsiteRecommendations = com.asmr.player.data.remote.scraper.DlsiteRecommendations(),
+        dlsiteWorkno = rjCode,
+        dlsitePlayWorkno = "",
+        dlsiteEditions = emptyList(),
+        dlsiteSelectedLang = "",
+        hasResolvedInitialDlsiteTarget = false,
+        hasLoadedInitialDlsiteContent = false,
+        hasResolvedAsmrOneContent = false,
+        hasResolvedDlsitePlayContent = false,
+        preserveHeaderAlbumMetadata = false,
+        isDlsiteLanguageUserSelected = false,
+        asmrOneWorkId = null,
+        asmrOneSite = null,
+        asmrOneTree = emptyList(),
+        dlsitePlayTree = emptyList(),
+        isLoadingDlsite = false,
+        isLoadingDlsiteTrial = false,
+        isLoadingAsmrOne = false,
+        isLoadingDlsitePlay = false
+    )
 }


### PR DESCRIPTION
## 问题

- 部分作品详情页的“一起听”人数会从正确值跳为 0。
- 详情加载会自动切换语言版本，且翻译子版本可能被错误识别为日文。
- 例如 `RJ01189945` 是 `RJ365382` 的简中翻译子版本，但 DLsite 的版本列表只给出中文父版本 `RJ01189944`，原解析未读取当前商品的 `translation_info.lang`。

## 修复

- 人数轮询固定使用详情入口作品编号，并在同一作品模型重建时保留已有人数。
- 详情页不再自动切换或回退语言版本，仅响应用户手动选择。
- 解析 DLsite `translation_info.lang`，让翻译子版本覆盖同语言父版本并正确成为默认选项。
- 避免为已识别的中文入口虚构日文版本。
- 清理不再使用的自动语言探测与回退代码。

## 验证

- `:app:testReleaseUnitTest` 相关人数、语言解析及详情默认版本测试通过。
- `:app:installRelease` 构建成功并安装到 Android 16 设备。