### PR TITLE
fix: 优化隐私空间无 profile 时的列表滚动

### DIFF
--- a/app/src/main/java/com/asmr/player/ui/common/AsmrAsyncImage.kt
+++ b/app/src/main/java/com/asmr/player/ui/common/AsmrAsyncImage.kt
@@ -55,6 +55,7 @@ fun AsmrAsyncImage(
     reloadKey: Any? = null,
     loadWhenSizeStableForMillis: Long = 0L,
     fadeIn: Boolean = true,
+    fadeInState: State<Boolean>? = null,
     fadeInMillis: Int = 500,
     peekAnySizeForInitial: Boolean = false,
     requestSize: IntSize? = null,
@@ -88,7 +89,8 @@ fun AsmrAsyncImage(
     val loadedSize: MutableState<IntSize?> = remember(normalizedModel, reloadKey) { mutableStateOf(null) }
     val crossfade = remember(normalizedModel, reloadKey) { Animatable(if (seededPainter != null) 1f else 0f) }
     val crossfadeRunning = remember(normalizedModel, reloadKey) { mutableStateOf(false) }
-    val latestFadeIn by rememberUpdatedState(fadeIn)
+    val resolvedFadeIn = fadeInState?.value ?: fadeIn
+    val latestFadeIn by rememberUpdatedState(resolvedFadeIn)
     val containerModifier = if (requestSize == null) {
         modifier.onSizeChanged { sz ->
             if (sz.width > 0 && sz.height > 0) measuredSize.value = IntSize(sz.width, sz.height)
@@ -183,8 +185,8 @@ fun AsmrAsyncImage(
     LaunchedEffect(p, bitmapPainterAlpha) {
         latestBitmapPainterObserver?.invoke(p as? BitmapPainter, bitmapPainterAlpha)
     }
-    LaunchedEffect(fadeIn, p) {
-        if (!fadeIn && p != null) {
+    LaunchedEffect(resolvedFadeIn, p) {
+        if (!resolvedFadeIn && p != null) {
             crossfadeRunning.value = false
             crossfade.snapTo(1f)
         }
@@ -209,7 +211,7 @@ fun AsmrAsyncImage(
                     loading(loadingModifier)
                 }
                 if (p != null) {
-                    val imageModifier = if (fadeIn && !hasSeededPainter && crossfadeRunning.value) {
+                    val imageModifier = if (resolvedFadeIn && !hasSeededPainter && crossfadeRunning.value) {
                         contentModifier.graphicsLayer {
                             this.alpha = crossfade.value.coerceIn(0f, 1f)
                             compositingStrategy = CompositingStrategy.ModulateAlpha

--- a/app/src/main/java/com/asmr/player/ui/hotlistening/HotListeningScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/hotlistening/HotListeningScreen.kt
@@ -44,6 +44,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.State
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
@@ -158,8 +159,6 @@ fun HotListeningScreen(
     val selectedPeriod by viewModel.selectedPeriod.collectAsStateWhileActive(isDataActive)
     val colorScheme = AsmrTheme.colorScheme
     val copyMeta = rememberAlbumMetaCopyAction(viewModel.messageManager)
-    val playlistsViewModel: PlaylistsViewModel = hiltViewModel()
-    val albumGroupsViewModel: AlbumGroupsViewModel = hiltViewModel()
     val settingsViewModel: SettingsViewModel = hiltViewModel()
     val searchBlockedKeywords by settingsViewModel.searchBlockedKeywords.collectAsStateWhileActive(isDataActive)
     val scope = rememberCoroutineScope()
@@ -172,8 +171,8 @@ fun HotListeningScreen(
     }
     val listState = rememberSaveablePrefetchedLazyListState(
         stateKey = contentScrollKey,
-        forwardCompositionPrefetchCount = 2,
-        backwardCompositionPrefetchCount = 2,
+        forwardCompositionPrefetchCount = 4,
+        backwardCompositionPrefetchCount = 4,
     )
     val gridState = rememberSaveable(contentScrollKey, saver = LazyStaggeredGridState.Saver) {
         LazyStaggeredGridState()
@@ -328,15 +327,10 @@ fun HotListeningScreen(
                     val listItemHeight = (screenWidthDp.dp * 0.24f).coerceIn(112.dp, 140.dp)
                     val coverPx = remember(listItemHeight, density) { with(density) { listItemHeight.roundToPx() } }
                     val preloadSize = remember(coverPx) { IntSize(coverPx, coverPx) }
-                    val listIsScrolling = listState.isScrollInProgress
-                    val listCoverFadeIn = shouldFadeInCover(listIsScrolling)
-                    // 滚动中不读 layoutInfo，避免可见索引每帧变化引起重组。
-                    // 停止后只保留当前真正可见的卡片纹理，让 Lazy 预取/复用槽
-                    // 中的屏外大图层及时释放。
-                    val idleVisibleListIndices = if (listIsScrolling) {
-                        emptySet()
-                    } else {
-                        listState.layoutInfo.visibleItemsInfo.mapTo(mutableSetOf()) { it.index }
+                    val listCoverFadeInState = remember(listState) {
+                        derivedStateOf {
+                            shouldFadeInCover(listState.isScrollInProgress)
+                        }
                     }
                     LazyListPreloader(
                         state = listState,
@@ -371,16 +365,13 @@ fun HotListeningScreen(
                                     items = state.entries,
                                     key = { _, entry -> hotListeningItemKey("visible", entry.album) },
                                     contentType = { _, _ -> "album" }
-                                ) { index, entry ->
+                                ) { _, entry ->
                                     HotListeningListItem(
                                         entry = entry,
                                         onAlbumClick = onAlbumClick,
                                         copyMeta = copyMeta,
                                         onMetaLongClick = ::openMetaActions,
-                                        coverFadeIn = listCoverFadeIn,
-                                        // 排行卡片在滚动期间内容静止，仅位置变化；缓存
-                                        // RenderNode 层可避免每帧重放整卡文字、圆角和图片。
-                                        cacheDrawLayer = listIsScrolling || index in idleVisibleListIndices,
+                                        coverFadeInState = listCoverFadeInState,
                                     )
                                 }
                                 if (state.blockedEntries.isNotEmpty()) {
@@ -401,15 +392,13 @@ fun HotListeningScreen(
                                                 hotListeningItemKey("blocked", entry.album)
                                             },
                                             contentType = { _, _ -> "album" }
-                                        ) { index, entry ->
+                                        ) { _, entry ->
                                             HotListeningListItem(
                                                 entry = entry,
                                                 onAlbumClick = onAlbumClick,
                                                 copyMeta = copyMeta,
                                                 onMetaLongClick = ::openMetaActions,
-                                                coverFadeIn = listCoverFadeIn,
-                                                cacheDrawLayer = listIsScrolling ||
-                                                    (state.entries.size + 1 + index) in idleVisibleListIndices,
+                                                coverFadeInState = listCoverFadeInState,
                                             )
                                         }
                                     }
@@ -427,8 +416,11 @@ fun HotListeningScreen(
                     val density = LocalDensity.current
                     val gridCoverPx = remember(adaptiveCellSize, density) { with(density) { adaptiveCellSize.roundToPx() } }
                     val gridPreloadSize = remember(gridCoverPx) { IntSize(gridCoverPx, gridCoverPx) }
-                    val gridIsScrolling = gridState.isScrollInProgress
-                    val gridCoverFadeIn = shouldFadeInCover(gridIsScrolling)
+                    val gridCoverFadeInState = remember(gridState) {
+                        derivedStateOf {
+                            shouldFadeInCover(gridState.isScrollInProgress)
+                        }
+                    }
                     LazyStaggeredGridPreloader(
                         state = gridState,
                         itemCount = state.entries.size,
@@ -474,7 +466,7 @@ fun HotListeningScreen(
                                         onAlbumClick = onAlbumClick,
                                         copyMeta = copyMeta,
                                         onMetaLongClick = ::openMetaActions,
-                                        coverFadeIn = gridCoverFadeIn
+                                        coverFadeInState = gridCoverFadeInState,
                                     )
                                 }
                                 if (state.blockedEntries.isNotEmpty()) {
@@ -505,7 +497,7 @@ fun HotListeningScreen(
                                                 onAlbumClick = onAlbumClick,
                                                 copyMeta = copyMeta,
                                                 onMetaLongClick = ::openMetaActions,
-                                                coverFadeIn = gridCoverFadeIn
+                                                coverFadeInState = gridCoverFadeInState,
                                             )
                                         }
                                     }
@@ -519,6 +511,8 @@ fun HotListeningScreen(
     }
 
     metaActionKeyword?.let { keyword ->
+        val playlistsViewModel: PlaylistsViewModel = hiltViewModel()
+        val albumGroupsViewModel: AlbumGroupsViewModel = hiltViewModel()
         AlbumMetaActionDialog(
             keyword = keyword,
             onDismissRequest = { metaActionKeyword = null },
@@ -536,8 +530,7 @@ private fun HotListeningListItem(
     onAlbumClick: (Album) -> Unit,
     copyMeta: (String, String) -> Unit,
     onMetaLongClick: (String) -> Unit,
-    coverFadeIn: Boolean = true,
-    cacheDrawLayer: Boolean = false,
+    coverFadeInState: State<Boolean>? = null,
 ) {
     val album = entry.album
     val colorScheme = AsmrTheme.colorScheme
@@ -551,8 +544,8 @@ private fun HotListeningListItem(
         coverRetainPainterDuringReload = true,
         coverBadge = coverBadge,
         animateOnlineDetails = false,
-        coverFadeIn = coverFadeIn,
-        cacheDrawLayer = cacheDrawLayer,
+        coverFadeInState = coverFadeInState,
+        cacheDrawLayer = true,
         containerColor = containerColor,
         onRjClick = { copyMeta("RJ", it) },
         onCircleClick = { copyMeta("社团", it) },
@@ -570,7 +563,7 @@ private fun HotListeningGridItem(
     onAlbumClick: (Album) -> Unit,
     copyMeta: (String, String) -> Unit,
     onMetaLongClick: (String) -> Unit,
-    coverFadeIn: Boolean = true
+    coverFadeInState: State<Boolean>? = null,
 ) {
     val album = entry.album
     val colorScheme = AsmrTheme.colorScheme
@@ -584,7 +577,7 @@ private fun HotListeningGridItem(
         coverRetainPainterDuringReload = true,
         coverBadge = coverBadge,
         animateOnlineDetails = false,
-        coverFadeIn = coverFadeIn,
+        coverFadeInState = coverFadeInState,
         containerColor = containerColor,
         onRjClick = { copyMeta("RJ", it) },
         onCircleClick = { copyMeta("社团", it) },

--- a/app/src/main/java/com/asmr/player/ui/library/AlbumItem.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/AlbumItem.kt
@@ -38,6 +38,7 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.State
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -129,6 +130,7 @@ fun AlbumItem(
     onlineCvLoading: Boolean = onlineDetailLoading,
     animateOnlineDetails: Boolean = true,
     coverFadeIn: Boolean = true,
+    coverFadeInState: State<Boolean>? = null,
     coverReloadKey: Any? = null,
     coverRetainPainterDuringReload: Boolean = false,
     containerColor: Color? = null,
@@ -215,6 +217,7 @@ fun AlbumItem(
                         contentScale = ContentScale.Crop,
                         placeholderCornerRadius = 0,
                         fadeIn = coverFadeIn,
+                        fadeInState = coverFadeInState,
                         reloadKey = coverReloadKey,
                         retainPainterDuringReload = coverRetainPainterDuringReload,
                         peekAnySizeForInitial = true,
@@ -434,6 +437,7 @@ fun AlbumGridItem(
     onlineCvLoading: Boolean = onlineDetailLoading,
     animateOnlineDetails: Boolean = true,
     coverFadeIn: Boolean = true,
+    coverFadeInState: State<Boolean>? = null,
     coverReloadKey: Any? = null,
     coverRetainPainterDuringReload: Boolean = false,
     containerColor: Color? = null,
@@ -467,6 +471,7 @@ fun AlbumGridItem(
                 contentScale = ContentScale.Crop,
                 placeholderCornerRadius = 0,
                 fadeIn = coverFadeIn,
+                fadeInState = coverFadeInState,
                 reloadKey = coverReloadKey,
                 retainPainterDuringReload = coverRetainPainterDuringReload,
                 peekAnySizeForInitial = true,

--- a/app/src/main/java/com/asmr/player/ui/library/LibraryScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/LibraryScreen.kt
@@ -95,6 +95,7 @@ import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.State
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
@@ -804,7 +805,11 @@ fun LibraryScreen(
                                     val gridCellSize = if (isCompact) 150.dp else 200.dp
                                     val gridCoverPx = remember(gridCellSize, density) { with(density) { gridCellSize.roundToPx() } }
                                     val gridPreloadSize = remember(gridCoverPx) { IntSize(gridCoverPx, gridCoverPx) }
-                                    val coverFadeIn = shouldFadeInCover(gridState.isScrollInProgress)
+                                    val coverFadeInState = remember(gridState) {
+                                        derivedStateOf {
+                                            shouldFadeInCover(gridState.isScrollInProgress)
+                                        }
+                                    }
                                     LazyStaggeredGridPreloader(
                                         state = gridState,
                                         itemCount = pagedAlbums.itemCount,
@@ -859,7 +864,7 @@ fun LibraryScreen(
                                                 onCvLongClick = ::openMetaActions,
                                                 onTagClick = { copyMeta("标签", it) },
                                                 onTagLongClick = ::openMetaActions,
-                                                coverFadeIn = coverFadeIn,
+                                                coverFadeInState = coverFadeInState,
                                             )
                                         }
                                     }
@@ -874,7 +879,11 @@ fun LibraryScreen(
                                     val listItemHeight = (screenWidthDp.dp * 0.24f).coerceIn(112.dp, 140.dp)
                                     val coverPx = remember(listItemHeight, density) { with(density) { listItemHeight.roundToPx() } }
                                     val preloadSize = remember(coverPx) { IntSize(coverPx, coverPx) }
-                                    val coverFadeIn = shouldFadeInCover(listState.isScrollInProgress)
+                                    val coverFadeInState = remember(listState) {
+                                        derivedStateOf {
+                                            shouldFadeInCover(listState.isScrollInProgress)
+                                        }
+                                    }
                                     LazyListPreloader(
                                         state = listState,
                                         itemCount = pagedAlbums.itemCount,
@@ -926,7 +935,7 @@ fun LibraryScreen(
                                                 onCvLongClick = ::openMetaActions,
                                                 onTagClick = { copyMeta("标签", it) },
                                                 onTagLongClick = ::openMetaActions,
-                                                coverFadeIn = coverFadeIn,
+                                                coverFadeInState = coverFadeInState,
                                             )
                                         }
                                     }
@@ -1507,7 +1516,7 @@ private fun AlbumGridItem(
     onCvLongClick: ((String) -> Unit)? = null,
     onTagClick: ((String) -> Unit)? = null,
     onTagLongClick: ((String) -> Unit)? = null,
-    coverFadeIn: Boolean = true,
+    coverFadeInState: State<Boolean>? = null,
 ) {
     val colorScheme = AsmrTheme.colorScheme
     val coverShape = remember {
@@ -1541,7 +1550,7 @@ private fun AlbumGridItem(
                 contentDescription = null,
                 contentScale = ContentScale.Crop,
                 placeholderCornerRadius = 0,
-                fadeIn = coverFadeIn,
+                fadeInState = coverFadeInState,
                 peekAnySizeForInitial = true,
                 loading = NoImageLoadingIndicator,
                 modifier = Modifier.fillMaxSize().clip(coverShape),
@@ -1692,7 +1701,7 @@ private fun AlbumItem(
     onCvLongClick: ((String) -> Unit)? = null,
     onTagClick: ((String) -> Unit)? = null,
     onTagLongClick: ((String) -> Unit)? = null,
-    coverFadeIn: Boolean = true,
+    coverFadeInState: State<Boolean>? = null,
 ) {
     val colorScheme = AsmrTheme.colorScheme
     val coverShape = remember {
@@ -1743,7 +1752,7 @@ private fun AlbumItem(
                         contentDescription = null,
                         contentScale = ContentScale.Crop,
                         placeholderCornerRadius = 0,
-                        fadeIn = coverFadeIn,
+                        fadeInState = coverFadeInState,
                         peekAnySizeForInitial = true,
                         loading = NoImageLoadingIndicator,
                         modifier = Modifier.fillMaxSize().clip(coverShape),

--- a/app/src/main/java/com/asmr/player/ui/search/SearchScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/search/SearchScreen.kt
@@ -1035,7 +1035,11 @@ fun SearchScreen(
                                     val listItemHeight = (screenWidthDp.dp * 0.24f).coerceIn(112.dp, 140.dp)
                                     val coverPx = remember(listItemHeight, density) { with(density) { listItemHeight.roundToPx() } }
                                     val preloadSize = remember(coverPx) { IntSize(coverPx, coverPx) }
-                                    val coverFadeIn = shouldFadeInCover(listState.isScrollInProgress)
+                                    val coverFadeInState = remember(listState) {
+                                        derivedStateOf {
+                                            shouldFadeInCover(listState.isScrollInProgress)
+                                        }
+                                    }
                                     LazyListPreloader(
                                         state = listState,
                                         itemCount = state.results.size,
@@ -1075,7 +1079,7 @@ fun SearchScreen(
                                                 ),
                                                 onlineDetailLoading = onlineDetailLoading,
                                                 onlineCvLoading = onlineDetailLoading,
-                                                coverFadeIn = coverFadeIn,
+                                                coverFadeInState = coverFadeInState,
                                                 coverReloadKey = state.resultRevision,
                                                 onRjClick = { copyMeta("RJ", it) },
                                                 onCircleClick = { copyMeta("社团", it) },
@@ -1097,7 +1101,11 @@ fun SearchScreen(
                                     val gridCellSize = if (isCompact) 150.dp else 200.dp
                                     val gridCoverPx = remember(gridCellSize, density) { with(density) { gridCellSize.roundToPx() } }
                                     val gridPreloadSize = remember(gridCoverPx) { IntSize(gridCoverPx, gridCoverPx) }
-                                    val coverFadeIn = shouldFadeInCover(gridState.isScrollInProgress)
+                                    val coverFadeInState = remember(gridState) {
+                                        derivedStateOf {
+                                            shouldFadeInCover(gridState.isScrollInProgress)
+                                        }
+                                    }
                                     LazyStaggeredGridPreloader(
                                         state = gridState,
                                         itemCount = state.results.size,
@@ -1145,7 +1153,7 @@ fun SearchScreen(
                                                 ),
                                                 onlineDetailLoading = onlineDetailLoading,
                                                 onlineCvLoading = onlineDetailLoading,
-                                                coverFadeIn = coverFadeIn,
+                                                coverFadeInState = coverFadeInState,
                                                 coverReloadKey = state.resultRevision,
                                                 onRjClick = { copyMeta("RJ", it) },
                                                 onCircleClick = { copyMeta("社团", it) },


### PR DESCRIPTION
## 问题

隐私空间内 ProfileInstaller 写入返回结果码 4，应用可能长期运行在未按 profile 优化的路径；复杂专辑列表在滚动开始/结束时会放大 Compose 重组和整卡绘制开销。

## 修改

- 将滚动状态读取下沉到封面图片的重启作用域，避免滚动状态变化重组整张复杂专辑卡片
- 保持热门列表的绘制层结构稳定，并仅让近窗口卡片保留离屏合成
- 延迟创建仅元数据操作弹窗需要的 ViewModel
- 提高热门列表组合预取窗口；同步覆盖热门、资料库和搜索的列表/卡片视图

## 验证

- Release APK 已通过 `gradlew-local.bat :app:installRelease` 的构建阶段
- 最终用户状态：主空间未安装、隐私空间已安装
- 强制 dexopt 为 `verify` 后冷启动，确认优化不依赖 speed/profile
- 重复往返滑动：3796 帧，deadline jank 0；UI P50/P95/P99 = 7/14/18 ms，GPU P99 = 9 ms
- 4 次 SurfaceFlinger 单滑：P95 = 8.35–8.51 ms，P99 = 8.56–8.71 ms，超过 12.5 ms 的间隔为 0
- 修复前同场景 SurfaceFlinger P95/P99 约 16.58/16.61 ms，125 个间隔中 8 个超过 12.5 ms；重复滑动 UI P99 为 36 ms
- 列表/卡片视觉、标签、封面、点击区域和切换行为已在真机核对