### PR TITLE
feat: support incremental album downloads and saves

### DIFF
--- a/app/src/main/java/com/asmr/player/ui/library/AlbumDetailScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/AlbumDetailScreen.kt
@@ -183,7 +183,7 @@ private enum class OnlineDownloadSource {
     DlsiteTrial
 }
 
-private enum class LocalIncrementalAction {
+private enum class IncrementalAlbumAction {
     Download,
     Save
 }
@@ -524,16 +524,12 @@ fun AlbumDetailScreen(
                         hasDlsitePlayCredentials && model.dlsitePlayTree.isNotEmpty() -> OnlineDownloadSource.DlsitePlay
                         else -> null
                     }
-                    val localOnlineTree = when (localOnlineSource) {
-                        OnlineDownloadSource.AsmrOne -> asmrOneTree
-                        OnlineDownloadSource.DlsitePlay -> model.dlsitePlayTree
-                        else -> emptyList()
-                    }
-
-                    fun prepareLocalIncrementalAction(action: LocalIncrementalAction) {
-                        val source = localOnlineSource ?: return
-                        val tree = localOnlineTree
-                        if (!hasValidLocalRj || tree.isEmpty()) return
+                    fun prepareIncrementalAlbumAction(
+                        action: IncrementalAlbumAction,
+                        source: OnlineDownloadSource,
+                        tree: List<AsmrOneTrackNodeResponse>
+                    ) {
+                        if (tree.isEmpty()) return
 
                         incrementalPreparationJob?.cancel()
                         incrementalPreparationJob = actionScope.launch {
@@ -546,12 +542,12 @@ fun AlbumDetailScreen(
                                 return@launch
                             }
                             when (action) {
-                                LocalIncrementalAction.Download -> {
+                                IncrementalAlbumAction.Download -> {
                                     downloadSource = source
                                     downloadDisabledPaths = existing.downloadedPaths
                                     showAsmrDownloadDialog = true
                                 }
-                                LocalIncrementalAction.Save -> {
+                                IncrementalAlbumAction.Save -> {
                                     onlineSaveSource = source
                                     saveDisabledPaths = existing.savedPaths
                                     showOnlineSaveDialog = true
@@ -804,6 +800,17 @@ fun AlbumDetailScreen(
                                 hasDlsitePlayCredentials = hasDlsitePlayCredentials
                             )
                             val headerAlbum = headerAlbumForTab(tab)
+                            val incrementalSource = when (tab) {
+                                0 -> localOnlineSource
+                                1 -> OnlineDownloadSource.AsmrOne
+                                2 -> OnlineDownloadSource.DlsitePlay
+                                else -> null
+                            }
+                            val incrementalTree = when (incrementalSource) {
+                                OnlineDownloadSource.AsmrOne -> asmrOneTree
+                                OnlineDownloadSource.DlsitePlay -> model.dlsitePlayTree
+                                else -> emptyList()
+                            }
                             val headerDlsiteEditions = if (isLocalTab) {
                                 emptyList()
                             } else {
@@ -827,16 +834,12 @@ fun AlbumDetailScreen(
                                 onDlsiteLangSelected = { viewModel.selectDlsiteLanguage(it) },
                                 showSaveAction = tab != 2,
                                 onDownloadClick = {
-                                    if (isLocalTab) {
-                                        prepareLocalIncrementalAction(LocalIncrementalAction.Download)
-                                    } else {
-                                        downloadDisabledPaths = emptySet()
-                                        downloadSource = if (tab == 2) {
-                                            OnlineDownloadSource.DlsitePlay
-                                        } else {
-                                            OnlineDownloadSource.AsmrOne
-                                        }
-                                        showAsmrDownloadDialog = true
+                                    incrementalSource?.let { source ->
+                                        prepareIncrementalAlbumAction(
+                                            action = IncrementalAlbumAction.Download,
+                                            source = source,
+                                            tree = incrementalTree
+                                        )
                                     }
                                 },
                                 showDlsitePlayLossless = tab == 2,
@@ -844,12 +847,12 @@ fun AlbumDetailScreen(
                                     viewModel.downloadDlsitePlayLosslessArchive()
                                 },
                                 onSaveClick = {
-                                    if (isLocalTab) {
-                                        prepareLocalIncrementalAction(LocalIncrementalAction.Save)
-                                    } else {
-                                        onlineSaveSource = OnlineDownloadSource.AsmrOne
-                                        saveDisabledPaths = emptySet()
-                                        showOnlineSaveDialog = true
+                                    incrementalSource?.let { source ->
+                                        prepareIncrementalAlbumAction(
+                                            action = IncrementalAlbumAction.Save,
+                                            source = source,
+                                            tree = incrementalTree
+                                        )
                                     }
                                 },
                                 downloadEnabled = headerDownloadEnabled,
@@ -1150,7 +1153,7 @@ fun AlbumDetailScreen(
                     AsmrOneDownloadDialog(
                         albumTitle = album.title,
                         trackTree = downloadTree,
-                        disabledPaths = if (selectedTab == 0) downloadDisabledPaths else emptySet(),
+                        disabledPaths = downloadDisabledPaths,
                         onDismiss = { showAsmrDownloadDialog = false },
                         onConfirm = { selected ->
                             when (downloadSource) {
@@ -1171,7 +1174,7 @@ fun AlbumDetailScreen(
                     OnlineSaveDialog(
                         albumTitle = album.title,
                         trackTree = saveTree,
-                        disabledPaths = if (selectedTab == 0) saveDisabledPaths else emptySet(),
+                        disabledPaths = saveDisabledPaths,
                         onDismiss = { showOnlineSaveDialog = false },
                         onConfirm = { selected ->
                             pendingOnlineSaveSelection = PendingOnlineSaveSelection(

--- a/app/src/main/java/com/asmr/player/ui/library/AlbumDetailScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/AlbumDetailScreen.kt
@@ -841,6 +841,9 @@ fun AlbumDetailScreen(
                                                     val target = PlaylistAddTarget.fromTrack(local, track)
                                                     onOpenPlaylistPicker(target.toMediaItem())
                                                 },
+                                                onDownloadOnlineTrack = { track, relativePath ->
+                                                    viewModel.downloadSavedOnlineTrack(track, relativePath)
+                                                },
                                                 onManageTrackTags = { track ->
                                                     tagManageTrack = track
                                                 },

--- a/app/src/main/java/com/asmr/player/ui/library/AlbumDetailScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/AlbumDetailScreen.kt
@@ -95,6 +95,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.core.net.toUri
 import androidx.media3.common.MediaItem
 import androidx.media3.exoplayer.ExoPlayer
@@ -130,6 +131,7 @@ import androidx.compose.material.icons.automirrored.rounded.PlaylistPlay
 import androidx.compose.material.icons.automirrored.rounded.QueueMusic
 import java.io.File
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.withContext
@@ -179,6 +181,30 @@ private enum class OnlineDownloadSource {
     AsmrOne,
     DlsitePlay,
     DlsiteTrial
+}
+
+private enum class LocalIncrementalAction {
+    Download,
+    Save
+}
+
+private data class PendingOnlineSaveSelection(
+    val paths: Set<String>,
+    val useDlsitePlayTree: Boolean
+)
+
+private data class DlsitePlayAuthSnapshot(
+    val canAuthenticate: Boolean,
+    val fingerprint: Int
+)
+
+private fun readDlsitePlayAuthSnapshot(authStore: DlsiteAuthStore): DlsitePlayAuthSnapshot {
+    val cookie = authStore.getPlayCookie().trim()
+    val expiresAt = authStore.getPlayCookieExpiresAtMs()
+    return DlsitePlayAuthSnapshot(
+        canAuthenticate = cookie.isNotBlank() && (expiresAt == null || expiresAt > System.currentTimeMillis()),
+        fingerprint = 31 * cookie.hashCode() + (expiresAt?.hashCode() ?: 0)
+    )
 }
 
 internal data class PreparedTrackPlayback(
@@ -281,10 +307,21 @@ internal data class AlbumDetailOnlineLoadPlan(
 internal fun albumDetailOnlineLoadPlan(
     selectedTab: Int,
     hasResolvedInitialDlsiteTarget: Boolean,
-    isInitialRouteReady: Boolean
+    isInitialRouteReady: Boolean,
+    hasValidLocalRj: Boolean = false,
+    hasResolvedAsmrOneContent: Boolean = false,
+    hasAsmrOneTree: Boolean = false,
+    hasDlsitePlayCredentials: Boolean = false
 ): AlbumDetailOnlineLoadPlan {
     if (!isInitialRouteReady) return AlbumDetailOnlineLoadPlan()
     return when (selectedTab) {
+        0 -> AlbumDetailOnlineLoadPlan(
+            loadAsmrOne = hasValidLocalRj,
+            loadDlsitePlay = hasValidLocalRj &&
+                hasResolvedAsmrOneContent &&
+                !hasAsmrOneTree &&
+                hasDlsitePlayCredentials
+        )
         1 -> AlbumDetailOnlineLoadPlan(loadDlsite = true, loadAsmrOne = true)
         2 -> AlbumDetailOnlineLoadPlan(
             loadDlsite = true,
@@ -305,9 +342,12 @@ internal fun albumHeaderDownloadEnabled(
     selectedTab: Int,
     hasAsmrOneTree: Boolean,
     hasDlsitePlayTree: Boolean,
-    hasResolvedInitialDlsiteTarget: Boolean
+    hasResolvedInitialDlsiteTarget: Boolean,
+    hasValidLocalRj: Boolean = false,
+    hasDlsitePlayCredentials: Boolean = true
 ): Boolean {
     return when (selectedTab) {
+        0 -> hasValidLocalRj && (hasAsmrOneTree || (hasDlsitePlayCredentials && hasDlsitePlayTree))
         1 -> canUseAsmrOneOnlineTreeActions(selectedTab, hasAsmrOneTree)
         2 -> hasResolvedInitialDlsiteTarget && hasDlsitePlayTree
         else -> false
@@ -340,6 +380,14 @@ fun AlbumDetailScreen(
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val cloudSyncSelectionDialogState by viewModel.cloudSyncSelectionDialogState.collectAsStateWithLifecycle()
     val colorScheme = AsmrTheme.colorScheme
+    val context = LocalContext.current
+    val lifecycleOwner = LocalLifecycleOwner.current
+    val authStore = remember(context) { DlsiteAuthStore(context) }
+    var dlsitePlayAuthSnapshot by remember(authStore) {
+        mutableStateOf(readDlsitePlayAuthSnapshot(authStore))
+    }
+    val hasDlsitePlayCredentials = dlsitePlayAuthSnapshot.canAuthenticate
+    val actionScope = rememberCoroutineScope()
     val screenKey = remember(albumId, rjCode) {
         val idPart = albumId?.takeIf { it > 0 }?.toString().orEmpty()
         val rjPart = rjCode?.trim().orEmpty().uppercase()
@@ -355,15 +403,49 @@ fun AlbumDetailScreen(
     val initialIntroState = remember(screenKey) { AlbumDetailIntroState(settled = false) }
     var showAsmrDownloadDialog by remember { mutableStateOf(false) }
     var showOnlineSaveDialog by remember { mutableStateOf(false) }
-    var pendingOnlineSaveSelection by remember { mutableStateOf<Set<String>?>(null) }
+    var pendingOnlineSaveSelection by remember { mutableStateOf<PendingOnlineSaveSelection?>(null) }
     var batchPlaylistItems by remember { mutableStateOf<List<MediaItem>?>(null) }
     var groupPickerAlbumId by remember { mutableStateOf<Long?>(null) }
     var downloadSource by remember { mutableStateOf(OnlineDownloadSource.AsmrOne) }
+    var onlineSaveSource by remember { mutableStateOf(OnlineDownloadSource.AsmrOne) }
+    var downloadDisabledPaths by remember { mutableStateOf<Set<String>>(emptySet()) }
+    var saveDisabledPaths by remember { mutableStateOf<Set<String>>(emptySet()) }
+    var incrementalPreparationJob by remember { mutableStateOf<Job?>(null) }
     var metaActionKeyword by rememberSaveable { mutableStateOf<String?>(null) }
 
     fun openMetaActions(value: String) {
         val keyword = value.trim()
         if (keyword.isNotBlank()) metaActionKeyword = keyword
+    }
+
+    DisposableEffect(lifecycleOwner, authStore, selectedTab, viewModel) {
+        fun refreshAuthSnapshot() {
+            val updated = readDlsitePlayAuthSnapshot(authStore)
+            actionScope.launch {
+                val didAuthStateChange = updated != dlsitePlayAuthSnapshot
+                dlsitePlayAuthSnapshot = updated
+                if (didAuthStateChange && selectedTab == 0) {
+                    incrementalPreparationJob?.cancel()
+                    showAsmrDownloadDialog = false
+                    showOnlineSaveDialog = false
+                    viewModel.invalidateDlsitePlayAccess()
+                }
+            }
+        }
+        val preferenceListener = android.content.SharedPreferences.OnSharedPreferenceChangeListener { _, _ ->
+            refreshAuthSnapshot()
+        }
+        val lifecycleObserver = LifecycleEventObserver { _, event ->
+            if (event == Lifecycle.Event.ON_RESUME) {
+                refreshAuthSnapshot()
+            }
+        }
+        authStore.registerListener(preferenceListener)
+        lifecycleOwner.lifecycle.addObserver(lifecycleObserver)
+        onDispose {
+            authStore.unregisterListener(preferenceListener)
+            lifecycleOwner.lifecycle.removeObserver(lifecycleObserver)
+        }
     }
 
     LaunchedEffect(viewModel) {
@@ -379,12 +461,16 @@ fun AlbumDetailScreen(
         onDispose {
             viewModel.setListenTogetherRjSummaryPollingEnabled(false)
             viewModel.cancelActiveLoads()
+            incrementalPreparationJob?.cancel()
         }
     }
     LaunchedEffect(pendingOnlineSaveSelection) {
         val selected = pendingOnlineSaveSelection ?: return@LaunchedEffect
         pendingOnlineSaveSelection = null
-        viewModel.saveOnlineSelectedToLibrary(selected)
+        viewModel.saveOnlineSelectedToLibrary(
+            selectedLeafPaths = selected.paths,
+            useDlsitePlayTree = selected.useDlsitePlayTree
+        )
     }
 
     Box(
@@ -423,6 +509,56 @@ fun AlbumDetailScreen(
                     val model = state.model
                     val album = model.displayAlbum
                     val asmrOneTree = model.asmrOneTree
+                    val localActionRj = remember(
+                        model.baseRjCode,
+                        model.localAlbum?.rjCode,
+                        model.localAlbum?.workId,
+                        model.localAlbum?.title,
+                        model.localAlbum?.path
+                    ) {
+                        resolveAlbumDetailRj(model.baseRjCode, model.localAlbum)
+                    }
+                    val hasValidLocalRj = localActionRj.isNotBlank()
+                    val localOnlineSource = when {
+                        asmrOneTree.isNotEmpty() -> OnlineDownloadSource.AsmrOne
+                        hasDlsitePlayCredentials && model.dlsitePlayTree.isNotEmpty() -> OnlineDownloadSource.DlsitePlay
+                        else -> null
+                    }
+                    val localOnlineTree = when (localOnlineSource) {
+                        OnlineDownloadSource.AsmrOne -> asmrOneTree
+                        OnlineDownloadSource.DlsitePlay -> model.dlsitePlayTree
+                        else -> emptyList()
+                    }
+
+                    fun prepareLocalIncrementalAction(action: LocalIncrementalAction) {
+                        val source = localOnlineSource ?: return
+                        val tree = localOnlineTree
+                        if (!hasValidLocalRj || tree.isEmpty()) return
+
+                        incrementalPreparationJob?.cancel()
+                        incrementalPreparationJob = actionScope.launch {
+                            val existing = try {
+                                viewModel.resolveLocalIncrementalSelectionPaths(tree)
+                            } catch (error: CancellationException) {
+                                throw error
+                            } catch (_: Exception) {
+                                viewModel.messageManager.showError("读取本地文件状态失败，请稍后重试")
+                                return@launch
+                            }
+                            when (action) {
+                                LocalIncrementalAction.Download -> {
+                                    downloadSource = source
+                                    downloadDisabledPaths = existing.downloadedPaths
+                                    showAsmrDownloadDialog = true
+                                }
+                                LocalIncrementalAction.Save -> {
+                                    onlineSaveSource = source
+                                    saveDisabledPaths = existing.savedPaths
+                                    showOnlineSaveDialog = true
+                                }
+                            }
+                        }
+                    }
                     val trialDownloadTree = remember(model.dlsiteTrialTracks) {
                         buildDlsiteTrialDownloadTree(model.dlsiteTrialTracks)
                     }
@@ -659,6 +795,14 @@ fun AlbumDetailScreen(
                                 selectedTab = tab,
                                 hasAsmrOneTree = asmrOneTree.isNotEmpty()
                             )
+                            val headerDownloadEnabled = albumHeaderDownloadEnabled(
+                                selectedTab = tab,
+                                hasAsmrOneTree = asmrOneTree.isNotEmpty(),
+                                hasDlsitePlayTree = model.dlsitePlayTree.isNotEmpty(),
+                                hasResolvedInitialDlsiteTarget = resolvedInitialTarget,
+                                hasValidLocalRj = hasValidLocalRj,
+                                hasDlsitePlayCredentials = hasDlsitePlayCredentials
+                            )
                             val headerAlbum = headerAlbumForTab(tab)
                             val headerDlsiteEditions = if (isLocalTab) {
                                 emptyList()
@@ -681,30 +825,36 @@ fun AlbumDetailScreen(
                                 dlsiteEditions = headerDlsiteEditions,
                                 dlsiteSelectedLang = model.dlsiteSelectedLang,
                                 onDlsiteLangSelected = { viewModel.selectDlsiteLanguage(it) },
-                                showSaveAction = tab == 1,
+                                showSaveAction = tab != 2,
                                 onDownloadClick = {
-                                    downloadSource = if (tab == 2) {
-                                        OnlineDownloadSource.DlsitePlay
+                                    if (isLocalTab) {
+                                        prepareLocalIncrementalAction(LocalIncrementalAction.Download)
                                     } else {
-                                        OnlineDownloadSource.AsmrOne
+                                        downloadDisabledPaths = emptySet()
+                                        downloadSource = if (tab == 2) {
+                                            OnlineDownloadSource.DlsitePlay
+                                        } else {
+                                            OnlineDownloadSource.AsmrOne
+                                        }
+                                        showAsmrDownloadDialog = true
                                     }
-                                    showAsmrDownloadDialog = true
                                 },
                                 showDlsitePlayLossless = tab == 2,
                                 onLosslessDownloadClick = {
                                     viewModel.downloadDlsitePlayLosslessArchive()
                                 },
                                 onSaveClick = {
-                                    showOnlineSaveDialog = true
+                                    if (isLocalTab) {
+                                        prepareLocalIncrementalAction(LocalIncrementalAction.Save)
+                                    } else {
+                                        onlineSaveSource = OnlineDownloadSource.AsmrOne
+                                        saveDisabledPaths = emptySet()
+                                        showOnlineSaveDialog = true
+                                    }
                                 },
-                                downloadEnabled = albumHeaderDownloadEnabled(
-                                    selectedTab = tab,
-                                    hasAsmrOneTree = asmrOneTree.isNotEmpty(),
-                                    hasDlsitePlayTree = model.dlsitePlayTree.isNotEmpty(),
-                                    hasResolvedInitialDlsiteTarget = resolvedInitialTarget
-                                ),
+                                downloadEnabled = headerDownloadEnabled,
                                 losslessDownloadEnabled = tab == 2 && resolvedInitialTarget && model.dlsitePlayTree.isNotEmpty(),
-                                saveEnabled = canUseAsmrOneTreeActions,
+                                saveEnabled = if (isLocalTab) headerDownloadEnabled else canUseAsmrOneTreeActions,
                                 showGroupButton = isLocalTab && model.localAlbum != null,
                                 onOpenGroupPicker = { id -> groupPickerAlbumId = id },
                                 introSessionKey = introSessionKey,
@@ -753,12 +903,21 @@ fun AlbumDetailScreen(
                                 model.rjCode,
                                 model.dlsiteWorkno,
                                 model.hasResolvedInitialDlsiteTarget,
+                                model.hasResolvedAsmrOneContent,
+                                asmrOneTree.isNotEmpty(),
+                                hasDlsitePlayCredentials,
+                                dlsitePlayAuthSnapshot.fingerprint,
+                                localActionRj,
                                 isInitialRouteReady
                             ) {
                                 val loadPlan = albumDetailOnlineLoadPlan(
                                     selectedTab = selectedTab,
                                     hasResolvedInitialDlsiteTarget = model.hasResolvedInitialDlsiteTarget,
-                                    isInitialRouteReady = isInitialRouteReady
+                                    isInitialRouteReady = isInitialRouteReady,
+                                    hasValidLocalRj = hasValidLocalRj,
+                                    hasResolvedAsmrOneContent = model.hasResolvedAsmrOneContent,
+                                    hasAsmrOneTree = asmrOneTree.isNotEmpty(),
+                                    hasDlsitePlayCredentials = hasDlsitePlayCredentials
                                 )
                                 if (loadPlan.loadDlsite) {
                                     viewModel.ensureDlsiteLoaded()
@@ -767,7 +926,7 @@ fun AlbumDetailScreen(
                                     viewModel.ensureAsmrOneLoaded()
                                 }
                                 if (loadPlan.loadDlsitePlay) {
-                                    viewModel.ensureDlsitePlayLoaded()
+                                    viewModel.ensureDlsitePlayLoaded(showFailureMessage = selectedTab != 0)
                                 }
                             }
 
@@ -891,6 +1050,7 @@ fun AlbumDetailScreen(
                                         onRefreshAsmrOne = { viewModel.refreshAsmrOneSection() },
                                         onRefreshTrial = { viewModel.refreshDlsiteTrialSection() },
                                         onDownloadTrial = {
+                                            downloadDisabledPaths = emptySet()
                                             downloadSource = OnlineDownloadSource.DlsiteTrial
                                             showAsmrDownloadDialog = true
                                         },
@@ -973,10 +1133,14 @@ fun AlbumDetailScreen(
                     }
                 }
 
-                val canSaveOnline = canUseAsmrOneOnlineTreeActions(
-                    selectedTab = selectedTab,
-                    hasAsmrOneTree = asmrOneTree.isNotEmpty()
-                )
+                val canSaveOnline = if (selectedTab == 0) {
+                    hasValidLocalRj && localOnlineSource != null
+                } else {
+                    canUseAsmrOneOnlineTreeActions(
+                        selectedTab = selectedTab,
+                        hasAsmrOneTree = asmrOneTree.isNotEmpty()
+                    )
+                }
                 if (showAsmrDownloadDialog) {
                     val downloadTree = when (downloadSource) {
                         OnlineDownloadSource.AsmrOne -> asmrOneTree
@@ -986,6 +1150,7 @@ fun AlbumDetailScreen(
                     AsmrOneDownloadDialog(
                         albumTitle = album.title,
                         trackTree = downloadTree,
+                        disabledPaths = if (selectedTab == 0) downloadDisabledPaths else emptySet(),
                         onDismiss = { showAsmrDownloadDialog = false },
                         onConfirm = { selected ->
                             when (downloadSource) {
@@ -999,13 +1164,20 @@ fun AlbumDetailScreen(
                 }
 
                 if (showOnlineSaveDialog && canSaveOnline) {
-                    val saveTree = if (model.dlsitePlayTree.isNotEmpty()) model.dlsitePlayTree else asmrOneTree
+                    val saveTree = when (onlineSaveSource) {
+                        OnlineDownloadSource.DlsitePlay -> model.dlsitePlayTree
+                        else -> asmrOneTree
+                    }
                     OnlineSaveDialog(
                         albumTitle = album.title,
                         trackTree = saveTree,
+                        disabledPaths = if (selectedTab == 0) saveDisabledPaths else emptySet(),
                         onDismiss = { showOnlineSaveDialog = false },
                         onConfirm = { selected ->
-                            pendingOnlineSaveSelection = selected
+                            pendingOnlineSaveSelection = PendingOnlineSaveSelection(
+                                paths = selected,
+                                useDlsitePlayTree = onlineSaveSource == OnlineDownloadSource.DlsitePlay
+                            )
                             showOnlineSaveDialog = false
                         }
                     )

--- a/app/src/main/java/com/asmr/player/ui/library/AlbumDetailViewModel.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/AlbumDetailViewModel.kt
@@ -466,6 +466,26 @@ class AlbumDetailViewModel @Inject constructor(
         )
     }
 
+    internal fun invalidateDlsitePlayAccess() {
+        dlsitePlayLoadJob?.cancel()
+        dlsitePlayLoadJob = null
+        dlsitePlayAttemptedRj.clear()
+        val current = _uiState.value as? AlbumDetailUiState.Success ?: return
+        if (
+            current.model.dlsitePlayTree.isEmpty() &&
+            !current.model.hasResolvedDlsitePlayContent &&
+            !current.model.isLoadingDlsitePlay
+        ) return
+        _uiState.value = AlbumDetailUiState.Success(
+            model = current.model.copy(
+                dlsitePlayWorkno = "",
+                dlsitePlayTree = emptyList(),
+                hasResolvedDlsitePlayContent = false,
+                isLoadingDlsitePlay = false
+            )
+        )
+    }
+
     suspend fun prepareDlsitePlayImagePreview(
         url: String,
         optimizedName: String?,
@@ -701,9 +721,7 @@ class AlbumDetailViewModel @Inject constructor(
                     null
                 }
 
-                val rj = rjCode?.trim().orEmpty().ifBlank {
-                    localAlbum?.rjCode?.trim().orEmpty().ifBlank { localAlbum?.workId?.trim().orEmpty() }
-                }.uppercase()
+                val rj = resolveAlbumDetailRj(rjCode, localAlbum)
 
                 val hint = AlbumCoverHintStore.peekHint(albumId, rj) ?: initialHint
                 val hintAlbum = albumFromInitialHint(rj, hint)
@@ -1598,7 +1616,7 @@ class AlbumDetailViewModel @Inject constructor(
         }
     }
 
-    fun ensureDlsitePlayLoaded() {
+    fun ensureDlsitePlayLoaded(showFailureMessage: Boolean = true) {
         val current = _uiState.value as? AlbumDetailUiState.Success ?: return
         val baseRj = current.model.baseRjCode.trim().uppercase()
         val candidates0 = DlsiteWorkNo.normalizeCandidates(
@@ -1685,7 +1703,9 @@ class AlbumDetailViewModel @Inject constructor(
                 val updated = (_uiState.value as? AlbumDetailUiState.Success)?.model ?: return@launch
                 if (pickedResult == null && lastError != null && !sawNotAvailable) {
                     dlsitePlayAttemptedRj.remove(attemptKey)
-                    messageManager.showError("DLsite Play 加载失败，请稍后重试")
+                    if (showFailureMessage) {
+                        messageManager.showError("DLsite Play 加载失败，请稍后重试")
+                    }
                 }
                 _uiState.value = AlbumDetailUiState.Success(
                     model = updated.copy(
@@ -1882,7 +1902,7 @@ class AlbumDetailViewModel @Inject constructor(
     fun downloadAsmrOneSelected(selectedLeafPaths: Set<String>) {
         val current = _uiState.value as? AlbumDetailUiState.Success ?: return
         enqueueRemoteTreeSelectionDownload(
-            album = current.model.displayAlbum,
+            model = current.model,
             tree = current.model.asmrOneTree,
             selectedLeafPaths = selectedLeafPaths,
             relativeBaseDir = ""
@@ -1892,7 +1912,7 @@ class AlbumDetailViewModel @Inject constructor(
     fun downloadDlsitePlaySelected(selectedLeafPaths: Set<String>) {
         val current = _uiState.value as? AlbumDetailUiState.Success ?: return
         enqueueRemoteTreeSelectionDownload(
-            album = current.model.displayAlbum,
+            model = current.model,
             tree = current.model.dlsitePlayTree,
             selectedLeafPaths = selectedLeafPaths,
             relativeBaseDir = ""
@@ -1984,11 +2004,61 @@ class AlbumDetailViewModel @Inject constructor(
         )
     }
 
-    fun saveOnlineSelectedToLibrary(selectedLeafPaths: Set<String>) {
+    internal suspend fun resolveLocalIncrementalSelectionPaths(
+        tree: List<AsmrOneTrackNodeResponse>
+    ): LocalIncrementalSelectionPaths {
+        val current = _uiState.value as? AlbumDetailUiState.Success
+            ?: return LocalIncrementalSelectionPaths()
+        val localAlbum = current.model.localAlbum ?: return LocalIncrementalSelectionPaths()
+        if (localAlbum.id <= 0L || tree.isEmpty()) return LocalIncrementalSelectionPaths()
+
+        return withContext(Dispatchers.IO) {
+            val savedResources = database.onlineSavedResourceDao().getForAlbumOnce(localAlbum.id)
+            val localIndex = loadOrBuildLocalTreeIndex(
+                context = context,
+                albumId = localAlbum.id,
+                albumPaths = localAlbum.getAllLocalPaths(),
+                tracks = localAlbum.tracks,
+                onlineSavedResources = savedResources
+            )
+            val localFiles = collectLocalSelectionFiles(localIndex)
+            val remoteFiles = flattenAsmrOneLeafDownloads(tree)
+                .filter { leaf ->
+                    isLibraryResourceSavableTreeFileType(
+                        treeFileTypeForNode(leaf.relativePath, leaf.url)
+                    )
+                }
+                .map { leaf ->
+                    RemoteSelectionFileRef(
+                        relativePath = leaf.relativePath,
+                        url = leaf.url
+                    )
+                }
+
+            LocalIncrementalSelectionPaths(
+                downloadedPaths = resolveExistingRemoteSelectionPaths(
+                    remoteFiles = remoteFiles,
+                    localFiles = localFiles,
+                    includeOnlineFiles = false
+                ),
+                savedPaths = resolveExistingRemoteSelectionPaths(
+                    remoteFiles = remoteFiles,
+                    localFiles = localFiles,
+                    includeOnlineFiles = true
+                )
+            )
+        }
+    }
+
+    fun saveOnlineSelectedToLibrary(
+        selectedLeafPaths: Set<String>,
+        useDlsitePlayTree: Boolean = false
+    ) {
         val current = _uiState.value as? AlbumDetailUiState.Success ?: return
         val model = current.model
-        val displayAlbum = model.displayAlbum
-        val tree = if (model.dlsitePlayTree.isNotEmpty()) model.dlsitePlayTree else model.asmrOneTree
+        val displayAlbum = resolvedOnlineActionAlbum(model)
+        val targetLocalAlbumId = model.localAlbum?.id?.takeIf { it > 0L }
+        val tree = if (useDlsitePlayTree) model.dlsitePlayTree else model.asmrOneTree
         if (tree.isEmpty()) return
 
         viewModelScope.launch {
@@ -2021,11 +2091,13 @@ class AlbumDetailViewModel @Inject constructor(
                 var resourceSavedCount = 0
                 var albumIdResult = 0L
                 database.withTransaction {
-                    val existing = if (workKey.isNotBlank()) {
-                        runCatching { albumDao.getAlbumByWorkIdOnce(workKey) }.getOrNull()
-                    } else {
-                        null
-                    }
+                    val existing = targetLocalAlbumId
+                        ?.let { albumDao.getAlbumById(it) }
+                        ?: if (workKey.isNotBlank()) {
+                            albumDao.getAlbumByWorkIdOnce(workKey)
+                        } else {
+                            null
+                        }
 
                     val tagsCsv = displayAlbum.tags.joinToString(",")
                     val entity = AlbumEntity(
@@ -2603,6 +2675,53 @@ class AlbumDetailViewModel @Inject constructor(
 
     private fun safeFileName(input: String): String {
         return input.trim().ifEmpty { "track" }.replace(Regex("""[\\/:*?"<>|]"""), "_")
+    }
+
+    private fun resolvedOnlineActionAlbum(model: AlbumDetailModel): Album {
+        val resolvedRj = resolveAlbumDetailRj(
+            routeRj = model.rjCode.ifBlank { model.baseRjCode },
+            localAlbum = model.localAlbum
+        )
+        return model.displayAlbum.withResolvedWorkIdentity(
+            rjCode = resolvedRj,
+            asmrOneWorkId = model.asmrOneWorkId
+        )
+    }
+
+    private fun enqueueRemoteTreeSelectionDownload(
+        model: AlbumDetailModel,
+        tree: List<AsmrOneTrackNodeResponse>,
+        selectedLeafPaths: Set<String>,
+        relativeBaseDir: String
+    ) {
+        val album = resolvedOnlineActionAlbum(model)
+        val localAlbum = model.localAlbum
+        val localAlbumId = localAlbum?.id ?: 0L
+        val shouldBindLocalIdentity = localAlbumId > 0L &&
+            album.rjCode.isNotBlank() &&
+            (localAlbum?.rjCode.isNullOrBlank() || localAlbum?.workId.isNullOrBlank())
+        if (!shouldBindLocalIdentity) {
+            enqueueRemoteTreeSelectionDownload(album, tree, selectedLeafPaths, relativeBaseDir)
+            return
+        }
+
+        viewModelScope.launch {
+            try {
+                withContext(Dispatchers.IO) {
+                    val entity = albumDao.getAlbumById(localAlbumId) ?: return@withContext
+                    val updated = entity.copy(
+                        workId = entity.workId.ifBlank { album.workId.ifBlank { album.rjCode } },
+                        rjCode = entity.rjCode.ifBlank { album.rjCode }
+                    )
+                    if (updated != entity) albumDao.updateAlbum(updated)
+                }
+            } catch (error: CancellationException) {
+                throw error
+            } catch (_: Exception) {
+                // 下载任务仍可通过自身的作品元信息在完成后合并进本地库。
+            }
+            enqueueRemoteTreeSelectionDownload(album, tree, selectedLeafPaths, relativeBaseDir)
+        }
     }
 
     private fun enqueueRemoteTreeSelectionDownload(

--- a/app/src/main/java/com/asmr/player/ui/library/AlbumDetailViewModel.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/AlbumDetailViewModel.kt
@@ -73,6 +73,7 @@ import com.asmr.player.util.SubtitleMatchSupport
 import com.asmr.player.util.SyncCoordinator
 import com.asmr.player.util.TagNormalizer
 import com.asmr.player.util.TrackKeyNormalizer
+import com.asmr.player.util.isOnlineTrackPath
 import com.asmr.player.work.AlbumCoverThumbWorker
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
@@ -1956,6 +1957,33 @@ class AlbumDetailViewModel @Inject constructor(
             relativeBaseDir = DlsiteTrialDownloadDirectoryName
         )
     }
+
+    fun downloadSavedOnlineTrack(track: Track, relativePath: String) {
+        val current = _uiState.value as? AlbumDetailUiState.Success ?: return
+        val url = track.path.trim()
+        if (!isOnlineTrackPath(url)) return
+
+        val normalizedRelativePath = relativePath
+            .replace('\\', '/')
+            .trim()
+            .trimStart('/')
+            .ifBlank { safeFileName(track.title) }
+        if (treeFileTypeForNode(normalizedRelativePath, url) != TreeFileType.Audio) return
+
+        enqueueRemoteLeafDownloads(
+            album = current.model.displayAlbum,
+            selected = listOf(
+                AsmrOneLeafDownload(
+                    url = url,
+                    relativePath = normalizedRelativePath,
+                    duration = track.duration
+                )
+            ),
+            relativeBaseDir = "",
+            includeCover = false
+        )
+    }
+
     fun saveOnlineSelectedToLibrary(selectedLeafPaths: Set<String>) {
         val current = _uiState.value as? AlbumDetailUiState.Success ?: return
         val model = current.model
@@ -2620,6 +2648,20 @@ class AlbumDetailViewModel @Inject constructor(
             }
         }
 
+        enqueueRemoteLeafDownloads(
+            album = album,
+            selected = selected,
+            relativeBaseDir = relativeBaseDir,
+            includeCover = true
+        )
+    }
+
+    private fun enqueueRemoteLeafDownloads(
+        album: Album,
+        selected: Collection<AsmrOneLeafDownload>,
+        relativeBaseDir: String,
+        includeCover: Boolean
+    ) {
         if (selected.isEmpty()) return
 
         val rjOrWorkId = album.rjCode.ifBlank { album.workId }
@@ -2633,12 +2675,14 @@ class AlbumDetailViewModel @Inject constructor(
         val taskKey = buildRemoteDownloadTaskKey(folderName, normalizedBaseDir)
         val taskSubtitle = album.title
 
-        enqueueRemoteDownloadCover(
-            album = album,
-            targetRootDir = targetRootDir,
-            taskKey = taskKey,
-            taskSubtitle = taskSubtitle
-        )
+        if (includeCover) {
+            enqueueRemoteDownloadCover(
+                album = album,
+                targetRootDir = targetRootDir,
+                taskKey = taskKey,
+                taskSubtitle = taskSubtitle
+            )
+        }
 
         var skipped = 0
         var enqueued = 0

--- a/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailDialogs.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailDialogs.kt
@@ -237,14 +237,15 @@ internal fun AsmrOneDownloadDialog(
                             itemsIndexed(items = entries, key = { _, it -> it.path }) { index, entry ->
                                 when (entry) {
                                     is AsmrTreeUiEntry.Folder -> {
-                                        val folderLeafPaths = leafPathsByFolder[entry.path]
-                                            .orEmpty()
-                                            .filterNot(disabledPaths::contains)
-                                        val checkedCount = folderLeafPaths.count { selected.contains(it) }
+                                        val allFolderLeafPaths = leafPathsByFolder[entry.path].orEmpty()
+                                        val selectableFolderLeafPaths = allFolderLeafPaths.filterNot(disabledPaths::contains)
+                                        val checkedCount = allFolderLeafPaths.count { path ->
+                                            disabledPaths.contains(path) || selected.contains(path)
+                                        }
                                         val state = when {
-                                            folderLeafPaths.isEmpty() -> ToggleableState.Off
+                                            allFolderLeafPaths.isEmpty() -> ToggleableState.Off
                                             checkedCount == 0 -> ToggleableState.Off
-                                            checkedCount == folderLeafPaths.size -> ToggleableState.On
+                                            checkedCount == allFolderLeafPaths.size -> ToggleableState.On
                                             else -> ToggleableState.Indeterminate
                                         }
                                         AsmrTreeFolderCheckboxRow(
@@ -252,17 +253,17 @@ internal fun AsmrOneDownloadDialog(
                                             depth = entry.depth,
                                             expanded = expanded.contains(entry.path),
                                             toggleState = state,
-                                            checkboxEnabled = folderLeafPaths.isNotEmpty(),
+                                            checkboxEnabled = selectableFolderLeafPaths.isNotEmpty(),
                                             onToggleExpand = {
                                                 if (expanded.contains(entry.path)) expanded.remove(entry.path) else expanded.add(entry.path)
                                             },
                                             onToggleCheck = {
-                                                if (folderLeafPaths.isEmpty()) return@AsmrTreeFolderCheckboxRow
+                                                if (selectableFolderLeafPaths.isEmpty()) return@AsmrTreeFolderCheckboxRow
                                                 val shouldSelectAll = state != ToggleableState.On
                                                 if (shouldSelectAll) {
-                                                    folderLeafPaths.forEach { if (!selected.contains(it)) selected.add(it) }
+                                                    selectableFolderLeafPaths.forEach { if (!selected.contains(it)) selected.add(it) }
                                                 } else {
-                                                    selected.removeAll(folderLeafPaths.toSet())
+                                                    selected.removeAll(selectableFolderLeafPaths.toSet())
                                                 }
                                             }
                                         )
@@ -501,14 +502,15 @@ internal fun OnlineSaveDialog(
                             itemsIndexed(items = entries, key = { _, it -> it.path }) { index, entry ->
                                 when (entry) {
                                     is AsmrTreeUiEntry.Folder -> {
-                                        val folderLeafPaths = leafPathsByFolder[entry.path]
-                                            .orEmpty()
-                                            .filterNot(disabledPaths::contains)
-                                        val checkedCount = folderLeafPaths.count { selected.contains(it) }
+                                        val allFolderLeafPaths = leafPathsByFolder[entry.path].orEmpty()
+                                        val selectableFolderLeafPaths = allFolderLeafPaths.filterNot(disabledPaths::contains)
+                                        val checkedCount = allFolderLeafPaths.count { path ->
+                                            disabledPaths.contains(path) || selected.contains(path)
+                                        }
                                         val state = when {
-                                            folderLeafPaths.isEmpty() -> ToggleableState.Off
+                                            allFolderLeafPaths.isEmpty() -> ToggleableState.Off
                                             checkedCount == 0 -> ToggleableState.Off
-                                            checkedCount == folderLeafPaths.size -> ToggleableState.On
+                                            checkedCount == allFolderLeafPaths.size -> ToggleableState.On
                                             else -> ToggleableState.Indeterminate
                                         }
                                         AsmrTreeFolderCheckboxRow(
@@ -516,17 +518,17 @@ internal fun OnlineSaveDialog(
                                             depth = entry.depth,
                                             expanded = expanded.contains(entry.path),
                                             toggleState = state,
-                                            checkboxEnabled = folderLeafPaths.isNotEmpty(),
+                                            checkboxEnabled = selectableFolderLeafPaths.isNotEmpty(),
                                             onToggleExpand = {
                                                 if (expanded.contains(entry.path)) expanded.remove(entry.path) else expanded.add(entry.path)
                                             },
                                             onToggleCheck = {
-                                                if (folderLeafPaths.isEmpty()) return@AsmrTreeFolderCheckboxRow
+                                                if (selectableFolderLeafPaths.isEmpty()) return@AsmrTreeFolderCheckboxRow
                                                 val shouldSelectAll = state != ToggleableState.On
                                                 if (shouldSelectAll) {
-                                                    folderLeafPaths.forEach { if (!selected.contains(it)) selected.add(it) }
+                                                    selectableFolderLeafPaths.forEach { if (!selected.contains(it)) selected.add(it) }
                                                 } else {
-                                                    selected.removeAll(folderLeafPaths.toSet())
+                                                    selected.removeAll(selectableFolderLeafPaths.toSet())
                                                 }
                                             }
                                         )

--- a/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailDialogs.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailDialogs.kt
@@ -170,14 +170,18 @@ internal fun AlbumDetailPickerSheetSurface(
 internal fun AsmrOneDownloadDialog(
     albumTitle: String,
     trackTree: List<AsmrOneTrackNodeResponse>,
+    disabledPaths: Set<String> = emptySet(),
     onDismiss: () -> Unit,
     onConfirm: (Set<String>) -> Unit
 ) {
     val mediaTree = remember(trackTree) { filterDownloadableMediaTree(trackTree) }
     val leafPaths = remember(mediaTree) { flattenAsmrOneLeafDownloads(mediaTree).map { it.relativePath } }
+    val selectableLeafPaths = remember(leafPaths, disabledPaths) { leafPaths.filterNot(disabledPaths::contains) }
     val leafPathsByFolder = remember(mediaTree) { buildLeafPathIndex(mediaTree) }
     val expanded = remember { mutableStateListOf<String>() }
-    val selected = remember(trackTree) { mutableStateListOf<String>().apply { addAll(leafPaths) } }
+    val selected = remember(trackTree, disabledPaths) {
+        mutableStateListOf<String>().apply { addAll(selectableLeafPaths) }
+    }
     val listState = rememberLazyListState()
 
     Dialog(
@@ -190,7 +194,7 @@ internal fun AsmrOneDownloadDialog(
                     title = "选择要下载的文件",
                     confirmText = "开始下载",
                     confirmIcon = Icons.Rounded.Download,
-                    confirmEnabled = leafPaths.isNotEmpty() && selected.isNotEmpty(),
+                    confirmEnabled = selected.isNotEmpty(),
                     onDismiss = onDismiss,
                     onConfirm = { onConfirm(selected.toSet()) }
                 )
@@ -204,10 +208,12 @@ internal fun AsmrOneDownloadDialog(
                     AlbumDetailSelectionSummary(
                         albumTitle = albumTitle,
                         selectedCount = selected.size,
-                        totalCount = leafPaths.size,
+                        totalCount = selectableLeafPaths.size,
+                        unavailableCount = leafPaths.size - selectableLeafPaths.size,
+                        unavailableLabel = "已下载",
                         onSelectAll = {
                             selected.clear()
-                            selected.addAll(leafPaths)
+                            selected.addAll(selectableLeafPaths)
                         },
                         onClearSelection = { selected.clear() }
                     )
@@ -231,7 +237,9 @@ internal fun AsmrOneDownloadDialog(
                             itemsIndexed(items = entries, key = { _, it -> it.path }) { index, entry ->
                                 when (entry) {
                                     is AsmrTreeUiEntry.Folder -> {
-                                        val folderLeafPaths = leafPathsByFolder[entry.path].orEmpty()
+                                        val folderLeafPaths = leafPathsByFolder[entry.path]
+                                            .orEmpty()
+                                            .filterNot(disabledPaths::contains)
                                         val checkedCount = folderLeafPaths.count { selected.contains(it) }
                                         val state = when {
                                             folderLeafPaths.isEmpty() -> ToggleableState.Off
@@ -244,6 +252,7 @@ internal fun AsmrOneDownloadDialog(
                                             depth = entry.depth,
                                             expanded = expanded.contains(entry.path),
                                             toggleState = state,
+                                            checkboxEnabled = folderLeafPaths.isNotEmpty(),
                                             onToggleExpand = {
                                                 if (expanded.contains(entry.path)) expanded.remove(entry.path) else expanded.add(entry.path)
                                             },
@@ -259,13 +268,17 @@ internal fun AsmrOneDownloadDialog(
                                         )
                                     }
                                     is AsmrTreeUiEntry.File -> {
-                                        val isChecked = selected.contains(entry.path)
+                                        val enabled = !disabledPaths.contains(entry.path)
+                                        val isChecked = !enabled || selected.contains(entry.path)
                                         AsmrTreeFileCheckboxRow(
                                             title = entry.title,
                                             depth = entry.depth,
                                             fileType = entry.fileType,
                                             checked = isChecked,
+                                            enabled = enabled,
+                                            unavailableLabel = "已下载",
                                             onCheckedChange = { checked ->
+                                                if (!enabled) return@AsmrTreeFileCheckboxRow
                                                 if (checked) {
                                                     if (!selected.contains(entry.path)) selected.add(entry.path)
                                                 } else {
@@ -421,13 +434,18 @@ private fun flattenAsmrOneSaveTreeForUi(
 internal fun OnlineSaveDialog(
     albumTitle: String,
     trackTree: List<AsmrOneTrackNodeResponse>,
+    disabledPaths: Set<String> = emptySet(),
     onDismiss: () -> Unit,
     onConfirm: (Set<String>) -> Unit
 ) {
     val leaves = remember(trackTree) { flattenOnlineSaveLeaves(trackTree) }
+    val leafPaths = remember(leaves) { leaves.map { it.relativePath } }
+    val selectableLeafPaths = remember(leafPaths, disabledPaths) { leafPaths.filterNot(disabledPaths::contains) }
     val leafPathsByFolder = remember(trackTree) { buildSaveLeafPathIndex(trackTree) }
     val expanded = remember { mutableStateListOf<String>() }
-    val selected = remember(trackTree) { mutableStateListOf<String>().apply { addAll(leaves.map { it.relativePath }) } }
+    val selected = remember(trackTree, disabledPaths) {
+        mutableStateListOf<String>().apply { addAll(selectableLeafPaths) }
+    }
     val listState = rememberLazyListState()
 
     Dialog(
@@ -440,7 +458,7 @@ internal fun OnlineSaveDialog(
                     title = "选择要保存的文件",
                     confirmText = "保存到本地库",
                     confirmIcon = Icons.Rounded.SaveAlt,
-                    confirmEnabled = leaves.isNotEmpty() && selected.isNotEmpty(),
+                    confirmEnabled = selected.isNotEmpty(),
                     onDismiss = onDismiss,
                     onConfirm = { onConfirm(selected.toSet()) }
                 )
@@ -454,10 +472,12 @@ internal fun OnlineSaveDialog(
                     AlbumDetailSelectionSummary(
                         albumTitle = albumTitle,
                         selectedCount = selected.size,
-                        totalCount = leaves.size,
+                        totalCount = selectableLeafPaths.size,
+                        unavailableCount = leaves.size - selectableLeafPaths.size,
+                        unavailableLabel = "已保存",
                         onSelectAll = {
                             selected.clear()
-                            selected.addAll(leaves.map { it.relativePath })
+                            selected.addAll(selectableLeafPaths)
                         },
                         onClearSelection = { selected.clear() }
                     )
@@ -481,12 +501,14 @@ internal fun OnlineSaveDialog(
                             itemsIndexed(items = entries, key = { _, it -> it.path }) { index, entry ->
                                 when (entry) {
                                     is AsmrTreeUiEntry.Folder -> {
-                                        val leafPaths = leafPathsByFolder[entry.path].orEmpty()
-                                        val checkedCount = leafPaths.count { selected.contains(it) }
+                                        val folderLeafPaths = leafPathsByFolder[entry.path]
+                                            .orEmpty()
+                                            .filterNot(disabledPaths::contains)
+                                        val checkedCount = folderLeafPaths.count { selected.contains(it) }
                                         val state = when {
-                                            leafPaths.isEmpty() -> ToggleableState.Off
+                                            folderLeafPaths.isEmpty() -> ToggleableState.Off
                                             checkedCount == 0 -> ToggleableState.Off
-                                            checkedCount == leafPaths.size -> ToggleableState.On
+                                            checkedCount == folderLeafPaths.size -> ToggleableState.On
                                             else -> ToggleableState.Indeterminate
                                         }
                                         AsmrTreeFolderCheckboxRow(
@@ -494,28 +516,33 @@ internal fun OnlineSaveDialog(
                                             depth = entry.depth,
                                             expanded = expanded.contains(entry.path),
                                             toggleState = state,
+                                            checkboxEnabled = folderLeafPaths.isNotEmpty(),
                                             onToggleExpand = {
                                                 if (expanded.contains(entry.path)) expanded.remove(entry.path) else expanded.add(entry.path)
                                             },
                                             onToggleCheck = {
-                                                if (leafPaths.isEmpty()) return@AsmrTreeFolderCheckboxRow
+                                                if (folderLeafPaths.isEmpty()) return@AsmrTreeFolderCheckboxRow
                                                 val shouldSelectAll = state != ToggleableState.On
                                                 if (shouldSelectAll) {
-                                                    leafPaths.forEach { if (!selected.contains(it)) selected.add(it) }
+                                                    folderLeafPaths.forEach { if (!selected.contains(it)) selected.add(it) }
                                                 } else {
-                                                    selected.removeAll(leafPaths.toSet())
+                                                    selected.removeAll(folderLeafPaths.toSet())
                                                 }
                                             }
                                         )
                                     }
                                     is AsmrTreeUiEntry.File -> {
-                                        val isChecked = selected.contains(entry.path)
+                                        val enabled = !disabledPaths.contains(entry.path)
+                                        val isChecked = !enabled || selected.contains(entry.path)
                                         AsmrTreeFileCheckboxRow(
                                             title = entry.title,
                                             depth = entry.depth,
                                             fileType = entry.fileType,
                                             checked = isChecked,
+                                            enabled = enabled,
+                                            unavailableLabel = "已保存",
                                             onCheckedChange = { checked ->
+                                                if (!enabled) return@AsmrTreeFileCheckboxRow
                                                 if (checked) {
                                                     if (!selected.contains(entry.path)) selected.add(entry.path)
                                                 } else {
@@ -587,6 +614,8 @@ private fun AlbumDetailSelectionSummary(
     albumTitle: String,
     selectedCount: Int,
     totalCount: Int,
+    unavailableCount: Int,
+    unavailableLabel: String,
     onSelectAll: () -> Unit,
     onClearSelection: () -> Unit
 ) {
@@ -613,7 +642,12 @@ private fun AlbumDetailSelectionSummary(
                 horizontalArrangement = Arrangement.spacedBy(8.dp)
             ) {
                 Text(
-                    text = "已选 $selectedCount / $totalCount",
+                    text = buildString {
+                        append("已选 $selectedCount / 可选 $totalCount")
+                        if (unavailableCount > 0) {
+                            append(" · $unavailableLabel $unavailableCount")
+                        }
+                    },
                     modifier = Modifier.weight(1f),
                     style = MaterialTheme.typography.labelMedium,
                     color = colorScheme.textSecondary,
@@ -650,9 +684,11 @@ private fun AsmrTreeFolderCheckboxRow(
     depth: Int,
     expanded: Boolean,
     toggleState: ToggleableState,
+    checkboxEnabled: Boolean,
     onToggleExpand: () -> Unit,
     onToggleCheck: () -> Unit
 ) {
+    val colorScheme = AsmrTheme.colorScheme
     Surface(
         modifier = Modifier
             .fillMaxWidth()
@@ -670,7 +706,16 @@ private fun AsmrTreeFolderCheckboxRow(
             CompositionLocalProvider(LocalMinimumInteractiveComponentEnforcement provides false) {
                 TriStateCheckbox(
                     state = toggleState,
-                    onClick = onToggleCheck,
+                    onClick = onToggleCheck.takeIf { checkboxEnabled },
+                    enabled = checkboxEnabled,
+                    colors = CheckboxDefaults.colors(
+                        checkedColor = colorScheme.primary,
+                        uncheckedColor = colorScheme.textSecondary,
+                        checkmarkColor = colorScheme.onPrimary,
+                        disabledCheckedColor = colorScheme.textTertiary.copy(alpha = 0.58f),
+                        disabledUncheckedColor = colorScheme.textTertiary.copy(alpha = 0.48f),
+                        disabledIndeterminateColor = colorScheme.textTertiary.copy(alpha = 0.58f)
+                    ),
                     modifier = Modifier.size(30.dp)
                 )
             }
@@ -699,6 +744,8 @@ private fun AsmrTreeFileCheckboxRow(
     depth: Int,
     fileType: TreeFileType,
     checked: Boolean,
+    enabled: Boolean,
+    unavailableLabel: String,
     onCheckedChange: (Boolean) -> Unit
 ) {
     val colorScheme = AsmrTheme.colorScheme
@@ -719,7 +766,15 @@ private fun AsmrTreeFileCheckboxRow(
             CompositionLocalProvider(LocalMinimumInteractiveComponentEnforcement provides false) {
                 Checkbox(
                     checked = checked,
-                    onCheckedChange = onCheckedChange,
+                    onCheckedChange = onCheckedChange.takeIf { enabled },
+                    enabled = enabled,
+                    colors = CheckboxDefaults.colors(
+                        checkedColor = colorScheme.primary,
+                        uncheckedColor = colorScheme.textSecondary,
+                        checkmarkColor = colorScheme.onPrimary,
+                        disabledCheckedColor = colorScheme.textTertiary.copy(alpha = 0.58f),
+                        disabledUncheckedColor = colorScheme.textTertiary.copy(alpha = 0.48f)
+                    ),
                     modifier = Modifier.size(30.dp)
                 )
             }
@@ -727,7 +782,7 @@ private fun AsmrTreeFileCheckboxRow(
             Icon(
                 imageVector = icon,
                 contentDescription = null,
-                tint = iconTint,
+                tint = if (enabled) iconTint else colorScheme.textTertiary.copy(alpha = 0.58f),
                 modifier = Modifier.size(20.dp)
             )
             Spacer(modifier = Modifier.width(8.dp))
@@ -735,15 +790,15 @@ private fun AsmrTreeFileCheckboxRow(
                 text = title,
                 maxLines = 1,
                 overflow = TextOverflow.Ellipsis,
-                color = colorScheme.textPrimary,
+                color = if (enabled) colorScheme.textPrimary else colorScheme.textTertiary,
                 style = MaterialTheme.typography.bodyMedium,
                 modifier = Modifier.weight(1f)
             )
             Text(
-                text = fileTypeLabel(fileType),
+                text = if (enabled) fileTypeLabel(fileType) else unavailableLabel,
                 maxLines = 1,
                 overflow = TextOverflow.Ellipsis,
-                color = colorScheme.textSecondary,
+                color = if (enabled) colorScheme.textSecondary else colorScheme.textTertiary,
                 style = MaterialTheme.typography.labelSmall,
                 modifier = Modifier.widthIn(max = 56.dp)
             )

--- a/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailDirectorySupport.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailDirectorySupport.kt
@@ -744,6 +744,11 @@ internal fun canSetDirectoryImageAsLocalCover(file: DirectoryFileItem): Boolean 
         !file.absolutePath.startsWith("http", ignoreCase = true)
 }
 
+internal fun downloadableOnlineAudioTrack(file: DirectoryFileItem): Track? {
+    if (file.fileType != TreeFileType.Audio || !file.isOnline) return null
+    return file.track?.takeIf { isOnlineTrackPath(it.path) }
+}
+
 internal class RemoteTreeNode(
     val name: String,
     val path: String,

--- a/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailDirectorySupport.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailDirectorySupport.kt
@@ -152,7 +152,9 @@ import com.asmr.player.ui.theme.dynamicPageContainerColor
 import com.asmr.player.util.Formatting
 import com.asmr.player.util.MessageManager
 import com.asmr.player.util.RemoteSubtitleSource
+import com.asmr.player.util.TrackKeyNormalizer
 import com.asmr.player.util.isOnlineTrackPath
+import java.util.ArrayDeque
 
 private const val LOCAL_TREE_CACHE_PARSER_VERSION = 2L
 
@@ -573,6 +575,150 @@ internal data class LocalTreeIndex(
     val root: LocalTreeNode,
     val folderStats: Map<String, LocalFolderStats>
 )
+
+internal data class RemoteSelectionFileRef(
+    val relativePath: String,
+    val url: String
+)
+
+internal data class LocalSelectionFileRef(
+    val relativePath: String,
+    val absolutePath: String,
+    val track: Track?
+)
+
+internal data class LocalIncrementalSelectionPaths(
+    val downloadedPaths: Set<String> = emptySet(),
+    val savedPaths: Set<String> = emptySet()
+)
+
+internal fun collectLocalSelectionFiles(index: LocalTreeIndex): List<LocalSelectionFileRef> {
+    val files = mutableListOf<LocalSelectionFileRef>()
+
+    fun collect(node: LocalTreeNode) {
+        if (node.children.isEmpty()) {
+            val absolutePath = node.absolutePath?.trim().orEmpty()
+            if (node.path.isNotBlank() && absolutePath.isNotBlank()) {
+                files += LocalSelectionFileRef(
+                    relativePath = node.path,
+                    absolutePath = absolutePath,
+                    track = node.track
+                )
+            }
+            return
+        }
+        node.children.values.forEach(::collect)
+    }
+
+    collect(index.root)
+    return files
+}
+
+internal fun resolveExistingRemoteSelectionPaths(
+    remoteFiles: List<RemoteSelectionFileRef>,
+    localFiles: List<LocalSelectionFileRef>,
+    includeOnlineFiles: Boolean
+): Set<String> {
+    data class MatchCandidate(
+        val normalizedRelativePath: String,
+        val canonicalUrl: String,
+        val fileName: String,
+        val trackKey: String,
+        val trackKeyWithoutGroup: String
+    )
+
+    fun normalizeRelativePath(path: String): String {
+        return path.replace('\\', '/').trim().trim('/').lowercase()
+    }
+
+    fun canonicalUrl(value: String): String {
+        val trimmed = value.trim()
+        if (!isOnlineTrackPath(trimmed)) return ""
+        return trimmed.substringBefore('#').substringBefore('?')
+    }
+
+    fun fileName(path: String): String {
+        return normalizeRelativePath(path).substringAfterLast('/')
+    }
+
+    fun remoteTrackKey(path: String, includeGroup: Boolean): String {
+        val normalized = path.replace('\\', '/').trim().trim('/')
+        val title = normalized.substringAfterLast('/').substringBeforeLast('.')
+        val group = if (includeGroup) normalized.substringBeforeLast('/', "") else ""
+        return TrackKeyNormalizer.buildKey(title, group, null)
+    }
+
+    val candidates = localFiles.asSequence()
+        .filter { local ->
+            includeOnlineFiles || !isOnlineTrackPath(local.track?.path.orEmpty().ifBlank { local.absolutePath })
+        }
+        .map { local ->
+            val track = local.track
+            val fallbackGroup = local.relativePath.replace('\\', '/').substringBeforeLast('/', "")
+            MatchCandidate(
+                normalizedRelativePath = normalizeRelativePath(local.relativePath),
+                canonicalUrl = canonicalUrl(track?.path.orEmpty().ifBlank { local.absolutePath }),
+                fileName = fileName(local.relativePath),
+                trackKey = track?.let {
+                    TrackKeyNormalizer.buildKey(it.title, it.group.ifBlank { fallbackGroup }, null)
+                }.orEmpty(),
+                trackKeyWithoutGroup = track?.let {
+                    TrackKeyNormalizer.buildKey(it.title, "", null)
+                }.orEmpty()
+            )
+        }
+        .toMutableList()
+
+    fun buildCandidateIndex(key: (MatchCandidate) -> String): Map<String, ArrayDeque<Int>> {
+        val index = linkedMapOf<String, ArrayDeque<Int>>()
+        candidates.forEachIndexed { candidateIndex, candidate ->
+            val value = key(candidate)
+            if (value.isNotBlank()) {
+                index.getOrPut(value) { ArrayDeque() }.addLast(candidateIndex)
+            }
+        }
+        return index
+    }
+
+    val relativePathIndex = buildCandidateIndex(MatchCandidate::normalizedRelativePath)
+    val canonicalUrlIndex = buildCandidateIndex(MatchCandidate::canonicalUrl)
+    val trackKeyIndex = buildCandidateIndex(MatchCandidate::trackKey)
+    val fileNameIndex = buildCandidateIndex(MatchCandidate::fileName)
+    val trackKeyWithoutGroupIndex = buildCandidateIndex(MatchCandidate::trackKeyWithoutGroup)
+    val available = BooleanArray(candidates.size) { true }
+
+    fun consume(index: Map<String, ArrayDeque<Int>>, key: String): Boolean {
+        if (key.isBlank()) return false
+        val candidateIndexes = index[key] ?: return false
+        while (candidateIndexes.isNotEmpty()) {
+            val candidateIndex = candidateIndexes.removeFirst()
+            if (available[candidateIndex]) {
+                available[candidateIndex] = false
+                return true
+            }
+        }
+        return false
+    }
+
+    val matched = linkedSetOf<String>()
+    remoteFiles.forEach { remote ->
+        val normalizedPath = normalizeRelativePath(remote.relativePath)
+        val remoteUrl = canonicalUrl(remote.url)
+        val remoteFileName = fileName(remote.relativePath)
+        val remoteKey = remoteTrackKey(remote.relativePath, includeGroup = true)
+        val remoteKeyWithoutGroup = remoteTrackKey(remote.relativePath, includeGroup = false)
+
+        val hasMatch = consume(relativePathIndex, normalizedPath) ||
+            consume(canonicalUrlIndex, remoteUrl) ||
+            consume(trackKeyIndex, remoteKey) ||
+            consume(fileNameIndex, remoteFileName) ||
+            consume(trackKeyWithoutGroupIndex, remoteKeyWithoutGroup)
+        if (hasMatch) {
+            matched += remote.relativePath
+        }
+    }
+    return matched
+}
 
 internal fun findLocalTreeNode(root: LocalTreeNode, folderPath: String): LocalTreeNode? {
     val normalized = folderPath.trim().trimStart('/').trimEnd('/')

--- a/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailLocalTab.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailLocalTab.kt
@@ -159,6 +159,7 @@ internal fun AlbumLocalBreadcrumbTabV2(
     preferredCurrentPath: String,
     onTogglePreferredCurrentPath: (String, Boolean) -> Unit,
     onAddToPlaylist: (Track) -> Unit,
+    onDownloadOnlineTrack: (Track, String) -> Unit,
     onManageTrackTags: (Track) -> Unit,
     onRemoveTrack: (Track) -> Unit,
     onSetCoverFromImage: (String) -> Unit,
@@ -363,6 +364,7 @@ internal fun AlbumLocalBreadcrumbTabV2(
                     fileKeyPrefix = "file",
                     fileContent = { file, selectionMode, selected, enterSelectionMode, onSelectedChange ->
                         val track = file.track
+                        val downloadableTrack = downloadableOnlineAudioTrack(file)
                         DirectoryFileRow(
                             file = file,
                             loadRemoteFileSize = { null },
@@ -471,7 +473,9 @@ internal fun AlbumLocalBreadcrumbTabV2(
                             } else {
                                 null
                             },
-                            onDownload = null,
+                            onDownload = downloadableTrack?.let {
+                                { onDownloadOnlineTrack(it, file.path) }
+                            },
                             onAddToQueue = track?.let { { onAddToQueue(it); Unit } },
                             onAddToPlaylist = track?.let { { onAddToPlaylist(it) } },
                             onGenerateSubtitles = if (subtitleFeatureSupported) {

--- a/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailViewModelSupport.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailViewModelSupport.kt
@@ -178,6 +178,19 @@ data class AlbumDetailModel(
     val isLoadingDlsitePlay: Boolean
 )
 
+internal fun resolveAlbumDetailRj(routeRj: String?, localAlbum: Album?): String {
+    return sequenceOf(
+        routeRj.orEmpty(),
+        localAlbum?.rjCode.orEmpty(),
+        localAlbum?.workId.orEmpty(),
+        localAlbum?.title.orEmpty(),
+        localAlbum?.path.orEmpty()
+    )
+        .map(DlsiteWorkNo::extractRjCode)
+        .firstOrNull { it.isNotBlank() }
+        .orEmpty()
+}
+
 internal fun AlbumDetailModel.listenTogetherSummaryRj(): String {
     return baseRjCode.trim().uppercase().ifBlank { rjCode.trim().uppercase() }
 }

--- a/app/src/test/java/com/asmr/player/ui/library/AlbumDetailDirectorySupportTest.kt
+++ b/app/src/test/java/com/asmr/player/ui/library/AlbumDetailDirectorySupportTest.kt
@@ -346,6 +346,82 @@ class AlbumDetailDirectorySupportTest {
     }
 
     @Test
+    fun resolveExistingRemoteSelectionPaths_distinguishesDownloadedAndSavedFiles() {
+        val remoteFiles = listOf(
+            RemoteSelectionFileRef("disc/online.mp3", "https://example.com/online.mp3?token=new"),
+            RemoteSelectionFileRef("disc/local.mp3", "https://example.com/local.mp3")
+        )
+        val localFiles = listOf(
+            LocalSelectionFileRef(
+                relativePath = "disc/online.mp3",
+                absolutePath = "https://example.com/online.mp3?token=old",
+                track = Track(
+                    albumId = 9L,
+                    title = "online",
+                    path = "https://example.com/online.mp3?token=old",
+                    group = "disc"
+                )
+            ),
+            LocalSelectionFileRef(
+                relativePath = "disc/local.mp3",
+                absolutePath = "/album/disc/local.mp3",
+                track = Track(
+                    albumId = 9L,
+                    title = "local",
+                    path = "/album/disc/local.mp3",
+                    group = "disc"
+                )
+            )
+        )
+
+        assertEquals(
+            setOf("disc/local.mp3"),
+            resolveExistingRemoteSelectionPaths(
+                remoteFiles = remoteFiles,
+                localFiles = localFiles,
+                includeOnlineFiles = false
+            )
+        )
+        assertEquals(
+            setOf("disc/online.mp3", "disc/local.mp3"),
+            resolveExistingRemoteSelectionPaths(
+                remoteFiles = remoteFiles,
+                localFiles = localFiles,
+                includeOnlineFiles = true
+            )
+        )
+    }
+
+    @Test
+    fun resolveExistingRemoteSelectionPaths_consumesImportedFallbackMatchesOnce() {
+        val remoteFiles = listOf(
+            RemoteSelectionFileRef("disc1/same.mp3", "https://example.com/disc1/same.mp3"),
+            RemoteSelectionFileRef("disc2/same.mp3", "https://example.com/disc2/same.mp3")
+        )
+        val localFiles = listOf(
+            LocalSelectionFileRef(
+                relativePath = "external/same.mp3",
+                absolutePath = "/import/external/same.mp3",
+                track = Track(
+                    albumId = 9L,
+                    title = "same",
+                    path = "/import/external/same.mp3",
+                    group = "external"
+                )
+            )
+        )
+
+        assertEquals(
+            setOf("disc1/same.mp3"),
+            resolveExistingRemoteSelectionPaths(
+                remoteFiles = remoteFiles,
+                localFiles = localFiles,
+                includeOnlineFiles = false
+            )
+        )
+    }
+
+    @Test
     fun buildLocalDirectoryBrowser_marksLogicalSavedAudioAsOnline() {
         val onlineTrack = Track(
             albumId = 9L,

--- a/app/src/test/java/com/asmr/player/ui/library/AlbumDetailDirectorySupportTest.kt
+++ b/app/src/test/java/com/asmr/player/ui/library/AlbumDetailDirectorySupportTest.kt
@@ -319,6 +319,33 @@ class AlbumDetailDirectorySupportTest {
     }
 
     @Test
+    fun downloadableOnlineAudioTrack_onlyReturnsSavedOnlineAudio() {
+        val onlineTrack = Track(
+            albumId = 9L,
+            title = "online",
+            path = "https://example.com/online.mp3"
+        )
+        val baseFile = DirectoryFileItem(
+            path = "disc/online.mp3",
+            title = "online",
+            fileType = TreeFileType.Audio,
+            isPlayable = true,
+            isOnline = true,
+            track = onlineTrack
+        )
+
+        assertEquals(onlineTrack, downloadableOnlineAudioTrack(baseFile))
+        assertEquals(null, downloadableOnlineAudioTrack(baseFile.copy(isOnline = false)))
+        assertEquals(
+            null,
+            downloadableOnlineAudioTrack(
+                baseFile.copy(track = onlineTrack.copy(path = "/album/online.mp3"))
+            )
+        )
+        assertEquals(null, downloadableOnlineAudioTrack(baseFile.copy(fileType = TreeFileType.Video)))
+    }
+
+    @Test
     fun buildLocalDirectoryBrowser_marksLogicalSavedAudioAsOnline() {
         val onlineTrack = Track(
             albumId = 9L,

--- a/app/src/test/java/com/asmr/player/ui/library/AlbumDetailOneStateTest.kt
+++ b/app/src/test/java/com/asmr/player/ui/library/AlbumDetailOneStateTest.kt
@@ -85,6 +85,67 @@ class AlbumDetailOneStateTest {
     }
 
     @Test
+    fun albumDetailOnlineLoadPlan_localUsesDlsiteOnlyAsAuthenticatedFallback() {
+        assertEquals(
+            AlbumDetailOnlineLoadPlan(),
+            albumDetailOnlineLoadPlan(
+                selectedTab = 0,
+                hasResolvedInitialDlsiteTarget = false,
+                isInitialRouteReady = true,
+                hasValidLocalRj = false
+            )
+        )
+        assertEquals(
+            AlbumDetailOnlineLoadPlan(loadAsmrOne = true),
+            albumDetailOnlineLoadPlan(
+                selectedTab = 0,
+                hasResolvedInitialDlsiteTarget = false,
+                isInitialRouteReady = true,
+                hasValidLocalRj = true,
+                hasResolvedAsmrOneContent = false,
+                hasAsmrOneTree = false,
+                hasDlsitePlayCredentials = true
+            )
+        )
+        assertEquals(
+            AlbumDetailOnlineLoadPlan(loadAsmrOne = true),
+            albumDetailOnlineLoadPlan(
+                selectedTab = 0,
+                hasResolvedInitialDlsiteTarget = false,
+                isInitialRouteReady = true,
+                hasValidLocalRj = true,
+                hasResolvedAsmrOneContent = true,
+                hasAsmrOneTree = false,
+                hasDlsitePlayCredentials = false
+            )
+        )
+        assertEquals(
+            AlbumDetailOnlineLoadPlan(loadAsmrOne = true, loadDlsitePlay = true),
+            albumDetailOnlineLoadPlan(
+                selectedTab = 0,
+                hasResolvedInitialDlsiteTarget = false,
+                isInitialRouteReady = true,
+                hasValidLocalRj = true,
+                hasResolvedAsmrOneContent = true,
+                hasAsmrOneTree = false,
+                hasDlsitePlayCredentials = true
+            )
+        )
+        assertEquals(
+            AlbumDetailOnlineLoadPlan(loadAsmrOne = true),
+            albumDetailOnlineLoadPlan(
+                selectedTab = 0,
+                hasResolvedInitialDlsiteTarget = false,
+                isInitialRouteReady = true,
+                hasValidLocalRj = true,
+                hasResolvedAsmrOneContent = true,
+                hasAsmrOneTree = true,
+                hasDlsitePlayCredentials = true
+            )
+        )
+    }
+
+    @Test
     fun albumDetailOnlineLoadPlan_keepsDlsitePlayBehindResolvedTarget() {
         assertEquals(
             AlbumDetailOnlineLoadPlan(loadDlsite = true, loadDlsitePlay = false),
@@ -154,6 +215,48 @@ class AlbumDetailOneStateTest {
                 hasAsmrOneTree = true,
                 hasDlsitePlayTree = false,
                 hasResolvedInitialDlsiteTarget = false
+            )
+        )
+    }
+
+    @Test
+    fun albumHeaderDownloadEnabled_localRequiresRjAndAccessibleTree() {
+        assertFalse(
+            albumHeaderDownloadEnabled(
+                selectedTab = 0,
+                hasAsmrOneTree = true,
+                hasDlsitePlayTree = false,
+                hasResolvedInitialDlsiteTarget = false,
+                hasValidLocalRj = false
+            )
+        )
+        assertTrue(
+            albumHeaderDownloadEnabled(
+                selectedTab = 0,
+                hasAsmrOneTree = false,
+                hasDlsitePlayTree = true,
+                hasResolvedInitialDlsiteTarget = false,
+                hasValidLocalRj = true
+            )
+        )
+        assertFalse(
+            albumHeaderDownloadEnabled(
+                selectedTab = 0,
+                hasAsmrOneTree = false,
+                hasDlsitePlayTree = true,
+                hasResolvedInitialDlsiteTarget = false,
+                hasValidLocalRj = true,
+                hasDlsitePlayCredentials = false
+            )
+        )
+        assertTrue(
+            albumHeaderDownloadEnabled(
+                selectedTab = 0,
+                hasAsmrOneTree = true,
+                hasDlsitePlayTree = false,
+                hasResolvedInitialDlsiteTarget = false,
+                hasValidLocalRj = true,
+                hasDlsitePlayCredentials = false
             )
         )
     }

--- a/app/src/test/java/com/asmr/player/ui/library/AlbumDetailViewModelSupportTest.kt
+++ b/app/src/test/java/com/asmr/player/ui/library/AlbumDetailViewModelSupportTest.kt
@@ -9,6 +9,38 @@ import org.junit.Test
 
 class AlbumDetailViewModelSupportTest {
     @Test
+    fun resolveAlbumDetailRj_fallsBackToImportedAlbumMetadataAndTitle() {
+        assertEquals(
+            "RJ123456",
+            resolveAlbumDetailRj(
+                routeRj = null,
+                localAlbum = Album(
+                    title = "外部导入 RJ123456",
+                    path = "/storage/emulated/0/ASMR/作品"
+                )
+            )
+        )
+        assertEquals(
+            "RJ654321",
+            resolveAlbumDetailRj(
+                routeRj = null,
+                localAlbum = Album(
+                    title = "作品",
+                    path = "/storage/emulated/0/ASMR/作品",
+                    workId = "RJ654321"
+                )
+            )
+        )
+        assertEquals(
+            "",
+            resolveAlbumDetailRj(
+                routeRj = null,
+                localAlbum = Album(title = "未绑定作品", path = "/storage/emulated/0/ASMR/作品")
+            )
+        )
+    }
+
+    @Test
     fun buildDisplayAlbum_keepsFallbackCvWhenDlsiteInfoHasNoCv() {
         val localAlbum = Album(
             title = "作品",


### PR DESCRIPTION
## 概述

- 为本地库已保存的在线音频增加单曲物理下载入口
- 本地专辑详情支持增量下载/保存多选，并置灰已下载或已保存项目
- 在线专辑详情复用本地库检测，避免重复下载和保存
- 支持从本地作品信息解析 RJ，并在 ASMR.one 未收录时通过 DLsite Play 登录账号鉴权
- 已下载/已保存文件及其目录统一显示为勾选、置灰状态
- 复用外部导入专辑记录，避免增量操作生成重复专辑

## 验证

- Release 定向单元测试通过
- :app:installRelease 构建并安装到连接设备成功