### PR TITLE
feat: 支持剪贴板 RJ 快速跳转

### DIFF
--- a/app/src/main/java/com/asmr/player/data/local/datastore/SettingsDataStore.kt
+++ b/app/src/main/java/com/asmr/player/data/local/datastore/SettingsDataStore.kt
@@ -50,6 +50,7 @@ class SettingsDataStore @Inject constructor(
     private val miniPlayerDisplayModeKey = stringPreferencesKey("mini_player_display_mode")
     private val bottomChromePinnedRouteKey = stringPreferencesKey("bottom_chrome_pinned_route")
     private val autoUpdateCheckEnabledKey = booleanPreferencesKey("auto_update_check_enabled")
+    private val lastHandledClipboardEventKey = stringPreferencesKey("last_handled_clipboard_event")
 
     val theme: Flow<String> = context.settingsDataStore.data.map { it[themeKey] ?: "system" }
     val sfwMode: Flow<Boolean> = context.settingsDataStore.data.map { it[sfwModeKey] ?: false }
@@ -112,6 +113,9 @@ class SettingsDataStore @Inject constructor(
     }
     val autoUpdateCheckEnabled: Flow<Boolean> = context.settingsDataStore.data.map { prefs ->
         prefs[autoUpdateCheckEnabledKey] ?: true
+    }
+    val lastHandledClipboardEvent: Flow<String?> = context.settingsDataStore.data.map { prefs ->
+        prefs[lastHandledClipboardEventKey]
     }
 
     suspend fun setTheme(theme: String) {
@@ -216,6 +220,14 @@ class SettingsDataStore @Inject constructor(
     suspend fun setAutoUpdateCheckEnabled(enabled: Boolean) {
         context.settingsDataStore.edit { prefs ->
             prefs[autoUpdateCheckEnabledKey] = enabled
+        }
+    }
+
+    suspend fun setLastHandledClipboardEvent(eventKey: String) {
+        val normalized = eventKey.trim()
+        if (normalized.isBlank()) return
+        context.settingsDataStore.edit { prefs ->
+            prefs[lastHandledClipboardEventKey] = normalized
         }
     }
 

--- a/app/src/main/java/com/asmr/player/data/remote/crawler/AsmrOneCrawler.kt
+++ b/app/src/main/java/com/asmr/player/data/remote/crawler/AsmrOneCrawler.kt
@@ -46,7 +46,7 @@ class AsmrOneCrawler @Inject constructor(
 ) {
     suspend fun searchWithTrace(keyword: String, page: Int = 1): AsmrOneSearchResult {
         val normalized = keyword.trim()
-        val selected = selectedApi()
+        val selected = selectedMetadataApi()
         if (normalized.isBlank()) {
             return emptySearchResult(normalized, page, selected.site)
         }
@@ -72,7 +72,7 @@ class AsmrOneCrawler @Inject constructor(
     suspend fun getDetails(workId: String): WorkDetailsResponse {
         val normalized = workId.trim()
         require(normalized.isNotBlank()) { "asmr.one work id is blank" }
-        val selected = selectedApi()
+        val selected = selectedMetadataApi()
         return withTimeout(ONLINE_DIRECTORY_REQUEST_TIMEOUT_MS) {
             selected.api.getWorkDetails(
                 workId = normalized,
@@ -102,9 +102,9 @@ class AsmrOneCrawler @Inject constructor(
         return AsmrOneEndpoint.normalize(configured)
     }
 
-    private suspend fun selectedApi(): AsmrSelectedApiEntry {
+    private suspend fun selectedMetadataApi(): AsmrSelectedApiEntry {
         return selectedApi(
-            preferredSite = currentSite(),
+            preferredSite = resolveAsmrOneMetadataEndpoint(currentSite()),
             asmrOneApi = asmrOneApi,
             asmr100Api = asmr100Api,
             asmr200Api = asmr200Api,
@@ -123,6 +123,15 @@ class AsmrOneCrawler @Inject constructor(
 }
 
 private val RJ_CODE_REGEX = Regex("""RJ\d{6,}""")
+
+internal fun resolveAsmrOneMetadataEndpoint(preferredSite: Int): Int {
+    val normalized = AsmrOneEndpoint.normalize(preferredSite)
+    return if (normalized == AsmrOneEndpoint.BACKUP) {
+        AsmrOneEndpoint.MIRROR_200
+    } else {
+        normalized
+    }
+}
 
 private fun emptySearchResult(keyword: String, page: Int, site: Int): AsmrOneSearchResult {
     return AsmrOneSearchResult(

--- a/app/src/main/java/com/asmr/player/main/ClipboardRjNavigation.kt
+++ b/app/src/main/java/com/asmr/player/main/ClipboardRjNavigation.kt
@@ -1,0 +1,285 @@
+package com.asmr.player
+
+import android.content.ClipboardManager
+import android.content.Context
+import android.os.Build
+import android.view.ViewTreeObserver
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalView
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.compose.LocalLifecycleOwner
+import com.asmr.player.data.local.datastore.SettingsDataStore
+import com.asmr.player.ui.common.FlatActionDialog
+import com.asmr.player.ui.common.FlatDialogAction
+import com.asmr.player.ui.common.FlatDialogActionTone
+import com.asmr.player.util.DlsiteWorkNo
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+
+internal fun extractClipboardRjCode(text: CharSequence?): String {
+    return DlsiteWorkNo.extractRjCode(text?.toString().orEmpty())
+}
+
+private data class ClipboardSnapshot(
+    val text: String,
+    val eventKey: String
+)
+
+private data class ClipboardRjPrompt(
+    val rjCode: String,
+    val eventKey: String
+)
+
+internal fun clipboardEventKey(
+    text: String,
+    timestampMillis: Long,
+    legacyChangeGeneration: Long = 0L
+): String {
+    val contentMarker = "${text.length}:${text.hashCode()}"
+    return if (timestampMillis > 0L) {
+        "timestamp:$timestampMillis:$contentMarker"
+    } else {
+        "legacy:$legacyChangeGeneration:$contentMarker"
+    }
+}
+
+internal fun shouldShowClipboardRjPrompt(
+    detectedRj: String,
+    eventKey: String,
+    lastHandledEventKey: String?,
+    currentPromptEventKey: String?
+): Boolean {
+    if (detectedRj.isBlank() || eventKey.isBlank()) return false
+    return eventKey != lastHandledEventKey && eventKey != currentPromptEventKey
+}
+
+private fun readPrimaryClipboardSnapshot(
+    clipboard: ClipboardManager,
+    legacyChangeGeneration: Long
+): ClipboardSnapshot? {
+    val clip = runCatching { clipboard.primaryClip }.getOrNull() ?: return null
+    if (clip.itemCount == 0) return null
+    val text = clip.getItemAt(0).text?.toString().orEmpty()
+    val timestampMillis = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+        clip.description.timestamp
+    } else {
+        0L
+    }
+    return ClipboardSnapshot(
+        text = text,
+        eventKey = clipboardEventKey(text, timestampMillis, legacyChangeGeneration)
+    )
+}
+
+@Composable
+internal fun ClipboardRjNavigationPrompt(
+    enabled: Boolean,
+    settingsDataStore: SettingsDataStore,
+    onNavigate: (String) -> Unit
+) {
+    val context = LocalContext.current
+    val clipboard = remember(context) {
+        context.getSystemService(Context.CLIPBOARD_SERVICE) as? ClipboardManager
+    }
+    val rootView = LocalView.current
+    val lifecycleOwner = LocalLifecycleOwner.current
+    val scope = rememberCoroutineScope()
+    val currentOnNavigate by rememberUpdatedState(onNavigate)
+    var prompt by remember { mutableStateOf<ClipboardRjPrompt?>(null) }
+    var lastHandledEventThisSession by remember { mutableStateOf<String?>(null) }
+    var shouldInspectOnResume by remember { mutableStateOf(true) }
+    var inspectionJob by remember { mutableStateOf<Job?>(null) }
+
+    DisposableEffect(lifecycleOwner, clipboard, rootView, settingsDataStore, enabled) {
+        var legacyExternalChangeGeneration = 0L
+
+        fun markEventHandled(eventKey: String) {
+            if (eventKey.isBlank()) return
+            lastHandledEventThisSession = eventKey
+            scope.launch {
+                settingsDataStore.setLastHandledClipboardEvent(eventKey)
+            }
+        }
+
+        fun inspectClipboard() {
+            val clipboardManager = clipboard ?: return
+            val snapshot = readPrimaryClipboardSnapshot(
+                clipboard = clipboardManager,
+                legacyChangeGeneration = legacyExternalChangeGeneration
+            ) ?: return
+            val detectedRj = extractClipboardRjCode(snapshot.text)
+            if (!shouldShowClipboardRjPrompt(
+                    detectedRj = detectedRj,
+                    eventKey = snapshot.eventKey,
+                    lastHandledEventKey = lastHandledEventThisSession,
+                    currentPromptEventKey = prompt?.eventKey
+                )
+            ) {
+                return
+            }
+
+            inspectionJob?.cancel()
+            inspectionJob = scope.launch {
+                val persistedEventKey = settingsDataStore.lastHandledClipboardEvent.first()
+                if (!shouldShowClipboardRjPrompt(
+                        detectedRj = detectedRj,
+                        eventKey = snapshot.eventKey,
+                        lastHandledEventKey = persistedEventKey,
+                        currentPromptEventKey = prompt?.eventKey
+                    ) || !lifecycleOwner.lifecycle.currentState.isAtLeast(Lifecycle.State.RESUMED)
+                ) {
+                    return@launch
+                }
+
+                lastHandledEventThisSession = snapshot.eventKey
+                prompt = ClipboardRjPrompt(
+                    rjCode = detectedRj,
+                    eventKey = snapshot.eventKey
+                )
+                inspectionJob = null
+                settingsDataStore.setLastHandledClipboardEvent(snapshot.eventKey)
+            }
+        }
+
+        val observeClipboardWhileBackground = Build.VERSION.SDK_INT < Build.VERSION_CODES.O
+        var observingClipboard = false
+        val clipboardListener = ClipboardManager.OnPrimaryClipChangedListener {
+            inspectionJob?.cancel()
+            inspectionJob = null
+            val isAppForeground = rootView.hasWindowFocus() &&
+                lifecycleOwner.lifecycle.currentState.isAtLeast(Lifecycle.State.RESUMED)
+            if (isAppForeground) {
+                clipboard
+                    ?.let { readPrimaryClipboardSnapshot(it, legacyExternalChangeGeneration) }
+                    ?.eventKey
+                    ?.let(::markEventHandled)
+            } else {
+                legacyExternalChangeGeneration += 1L
+                shouldInspectOnResume = true
+            }
+        }
+        fun startObservingClipboard() {
+            if (clipboard == null || observingClipboard) return
+            clipboard.addPrimaryClipChangedListener(clipboardListener)
+            observingClipboard = true
+        }
+        fun stopObservingClipboard() {
+            if (clipboard == null || !observingClipboard) return
+            clipboard.removePrimaryClipChangedListener(clipboardListener)
+            observingClipboard = false
+        }
+
+        fun inspectAfterExternalEntryIfReady() {
+            if (!enabled ||
+                !shouldInspectOnResume ||
+                !rootView.hasWindowFocus() ||
+                !lifecycleOwner.lifecycle.currentState.isAtLeast(Lifecycle.State.RESUMED)
+            ) {
+                return
+            }
+            shouldInspectOnResume = false
+            inspectClipboard()
+        }
+
+        val windowFocusListener = ViewTreeObserver.OnWindowFocusChangeListener { hasFocus ->
+            if (hasFocus &&
+                enabled &&
+                lifecycleOwner.lifecycle.currentState.isAtLeast(Lifecycle.State.RESUMED)
+            ) {
+                inspectAfterExternalEntryIfReady()
+                startObservingClipboard()
+            } else {
+                if (!hasFocus && enabled) {
+                    shouldInspectOnResume = true
+                    inspectionJob?.cancel()
+                    inspectionJob = null
+                }
+                if (!observeClipboardWhileBackground) {
+                    stopObservingClipboard()
+                }
+            }
+        }
+        val viewTreeObserver = rootView.viewTreeObserver
+        viewTreeObserver.addOnWindowFocusChangeListener(windowFocusListener)
+
+        val observer = LifecycleEventObserver { _, event ->
+            when (event) {
+                Lifecycle.Event.ON_PAUSE -> {
+                    shouldInspectOnResume = true
+                    inspectionJob?.cancel()
+                    inspectionJob = null
+                    if (!observeClipboardWhileBackground) {
+                        stopObservingClipboard()
+                    }
+                }
+
+                Lifecycle.Event.ON_STOP -> {
+                    shouldInspectOnResume = true
+                    inspectionJob?.cancel()
+                }
+
+                Lifecycle.Event.ON_RESUME -> {
+                    inspectAfterExternalEntryIfReady()
+                    if (rootView.hasWindowFocus()) {
+                        startObservingClipboard()
+                    }
+                }
+
+                else -> Unit
+            }
+        }
+        lifecycleOwner.lifecycle.addObserver(observer)
+        inspectAfterExternalEntryIfReady()
+        if (observeClipboardWhileBackground ||
+            (rootView.hasWindowFocus() && lifecycleOwner.lifecycle.currentState.isAtLeast(Lifecycle.State.RESUMED))
+        ) {
+            startObservingClipboard()
+        }
+
+        onDispose {
+            stopObservingClipboard()
+            if (viewTreeObserver.isAlive) {
+                viewTreeObserver.removeOnWindowFocusChangeListener(windowFocusListener)
+            } else {
+                rootView.viewTreeObserver.removeOnWindowFocusChangeListener(windowFocusListener)
+            }
+            lifecycleOwner.lifecycle.removeObserver(observer)
+            inspectionJob?.cancel()
+            if (enabled && prompt == null) {
+                shouldInspectOnResume = true
+            }
+        }
+    }
+
+    prompt?.takeIf { enabled }?.let { currentPrompt ->
+        val rjCode = currentPrompt.rjCode
+        FlatActionDialog(
+            message = "检测到剪贴板中的 $rjCode，是否快速跳转至该作品的专辑详情？",
+            onDismissRequest = { prompt = null },
+            actions = listOf(
+                FlatDialogAction(
+                    text = "取消",
+                    onClick = { prompt = null }
+                ),
+                FlatDialogAction(
+                    text = "立即跳转",
+                    tone = FlatDialogActionTone.Primary,
+                    onClick = {
+                        prompt = null
+                        currentOnNavigate(rjCode)
+                    }
+                )
+            )
+        )
+    }
+}

--- a/app/src/main/java/com/asmr/player/main/MainContainer.kt
+++ b/app/src/main/java/com/asmr/player/main/MainContainer.kt
@@ -3126,6 +3126,16 @@ fun MainContainer(
 
         val automaticUpdateAvailable = (updateState as? AppUpdateState.UpdateAvailable)
             ?.takeIf { it.source == UpdateCheckSource.Automatic && !automaticUpdateDialogDismissed }
+
+        ClipboardRjNavigationPrompt(
+            enabled = !forceImmersive && automaticUpdateAvailable == null,
+            settingsDataStore = settingsDataStore,
+            onNavigate = { rjCode ->
+                closeNowPlaying()
+                navigator.openAlbumDetailByRjStacked(rjCode)
+            }
+        )
+
         automaticUpdateAvailable?.let { available ->
             val release = available.release
             FlatActionDialog(

--- a/app/src/main/java/com/asmr/player/ui/library/AlbumDetailScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/AlbumDetailScreen.kt
@@ -1815,11 +1815,28 @@ private fun AlbumOnlineListenerInfo(
     }
 }
 
-private data class StableAlbumHeroIdentity(
+internal data class StableAlbumHeroIdentity(
     val title: String,
     val rj: String,
     val circle: String
 )
+
+internal fun resolveStableAlbumHeroIdentity(
+    stable: StableAlbumHeroIdentity,
+    current: StableAlbumHeroIdentity
+): StableAlbumHeroIdentity {
+    val stableTitleIsPlaceholder = stable.title.isBlank() ||
+        stable.title == "专辑" ||
+        stable.title.equals(stable.rj, ignoreCase = true)
+    val currentTitleIsResolved = current.title.isNotBlank() &&
+        current.title != "专辑" &&
+        !current.title.equals(current.rj, ignoreCase = true)
+    return StableAlbumHeroIdentity(
+        title = if (stableTitleIsPlaceholder && currentTitleIsResolved) current.title else stable.title,
+        rj = stable.rj.ifBlank { current.rj },
+        circle = stable.circle.ifBlank { current.circle }
+    )
+}
 
 @Composable
 private fun rememberStableAlbumHeroIdentity(album: Album, identitySessionKey: String): StableAlbumHeroIdentity {
@@ -1828,7 +1845,11 @@ private fun rememberStableAlbumHeroIdentity(album: Album, identitySessionKey: St
         rj = album.rjCode.ifBlank { album.workId }.trim(),
         circle = album.circle.trim()
     )
-    return remember(identitySessionKey) { current }
+    var stable by remember(identitySessionKey) { mutableStateOf(current) }
+    LaunchedEffect(current) {
+        stable = resolveStableAlbumHeroIdentity(stable, current)
+    }
+    return stable
 }
 
 @Composable

--- a/app/src/main/java/com/asmr/player/ui/library/AlbumDetailViewModel.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/AlbumDetailViewModel.kt
@@ -36,6 +36,7 @@ import com.asmr.player.data.remote.ONLINE_DIRECTORY_REQUEST_TIMEOUT_MS
 import com.asmr.player.data.remote.api.AsmrOneAvailabilityApi
 import com.asmr.player.data.remote.api.AsmrOneEndpoint
 import com.asmr.player.data.remote.api.AsmrOneTrackNodeResponse
+import com.asmr.player.data.remote.api.WorkDetailsResponse
 import com.asmr.player.data.remote.auth.DlsiteAuthStore
 import com.asmr.player.data.remote.auth.buildDlsiteCookieHeader
 import com.asmr.player.data.remote.crawler.AsmrOneCrawler
@@ -208,6 +209,7 @@ class AlbumDetailViewModel @Inject constructor(
     private val dlsitePlayAttemptedRj = linkedSetOf<String>()
     private val asmrOneCollectedCache = linkedMapOf<String, Pair<Long, Boolean?>>()
     private val asmrOneResolvedCache = linkedMapOf<String, Pair<Long, Pair<String, Int?>?>>()
+    private val asmrOneResolvedDetailsCache = linkedMapOf<String, WorkDetailsResponse>()
     private val asmrOneResolutionInFlight = mutableMapOf<String, Deferred<Pair<String, Int?>?>>()
     private val asmrOneTracksCache = linkedMapOf<String, Pair<Long, AsmrOneTracksResult>>()
 
@@ -303,7 +305,6 @@ class AlbumDetailViewModel @Inject constructor(
     ): Pair<String, Int?>? {
         val key = workNo.trim().uppercase()
         if (key.isBlank()) return null
-        if (asmrOneCrawler.selectedEndpoint() == AsmrOneEndpoint.BACKUP) return null
         val now = SystemClock.elapsedRealtime()
         val cached = asmrOneResolvedCache[key]
         if (cached != null) {
@@ -318,13 +319,21 @@ class AlbumDetailViewModel @Inject constructor(
                 ?.works
                 ?.firstOrNull { work -> asmrOneWorkMatchesRj(work, key) }
             val workId = found?.id?.toString()?.trim().orEmpty()
+            if (found == null) {
+                asmrOneResolvedDetailsCache.remove(key)
+            } else {
+                asmrOneResolvedDetailsCache[key] = found
+            }
             val resolved = workId
                 .takeIf { it.isNotBlank() }
                 ?.let { it to result?.trace?.site }
             asmrOneResolvedCache[key] = SystemClock.elapsedRealtime() to resolved
             if (asmrOneResolvedCache.size > 500) {
                 val firstKey = asmrOneResolvedCache.entries.firstOrNull()?.key
-                if (firstKey != null) asmrOneResolvedCache.remove(firstKey)
+                if (firstKey != null) {
+                    asmrOneResolvedCache.remove(firstKey)
+                    asmrOneResolvedDetailsCache.remove(firstKey)
+                }
             }
             resolved
         }.also { deferred ->
@@ -694,14 +703,17 @@ class AlbumDetailViewModel @Inject constructor(
         val normalizedRj = rjCode?.trim().orEmpty().uppercase()
         val key = if (normalizedRj.isNotBlank()) "rj:$normalizedRj" else "id:${albumId ?: 0L}"
         val current = _uiState.value as? AlbumDetailUiState.Success
-        if (!force && current != null && lastAlbumKey == key) return
+        val isAlbumSwitch = lastAlbumKey != key
+        if (!force && current != null && !isAlbumSwitch) return
         cancelPendingOnlineJobs(resetLoadingState = false)
         albumLoadJob?.cancel()
+        localTracksObserveJob?.cancel()
+        localTracksObserveJob = null
         lastAlbumKey = key
         val initialHint = AlbumCoverHintStore.peekHint(albumId, normalizedRj)
         val initialRj = normalizedRj.ifBlank { initialHint?.rjCode.orEmpty() }
         val initialHintAlbum = albumFromInitialHint(initialRj, initialHint)
-        if (force || current == null) {
+        if (force || current == null || isAlbumSwitch) {
             _uiState.value = AlbumDetailUiState.Success(
                 model = createInitialAlbumDetailModel(
                     rj = initialRj,
@@ -1358,6 +1370,7 @@ class AlbumDetailViewModel @Inject constructor(
         asmrOneAttemptedRj.remove(keyRj)
         asmrOneCollectedCache.remove(keyRj)
         asmrOneResolvedCache.remove(keyRj)
+        asmrOneResolvedDetailsCache.remove(keyRj)
         asmrOneResolutionInFlight.remove(keyRj)?.cancel()
 
         val oldWorkId = current.model.asmrOneWorkId?.trim().orEmpty()
@@ -1483,7 +1496,8 @@ class AlbumDetailViewModel @Inject constructor(
                 fun finishWithResolvedAsmrOneTree(
                     workId: String?,
                     site: Int?,
-                    tree: List<AsmrOneTrackNodeResponse>
+                    tree: List<AsmrOneTrackNodeResponse>,
+                    resolvedDetails: WorkDetailsResponse? = null
                 ): Boolean {
                     val updated = (_uiState.value as? AlbumDetailUiState.Success)?.model ?: return true
                     if (token != asmrOneLoadToken) {
@@ -1492,10 +1506,11 @@ class AlbumDetailViewModel @Inject constructor(
                         return true
                     }
                     val resolvedWorkId = workId?.trim().orEmpty().ifBlank { updated.asmrOneWorkId.orEmpty() }
-                    val displayAlbum = mergeDetailHeaderAlbum(
+                    val displayAlbum = mergeAsmrOneHeaderAlbum(
                         currentDisplayAlbum = updated.displayAlbum,
                         localAlbum = updated.localAlbum,
                         fetchedDlsiteInfo = updated.dlsiteInfo,
+                        resolvedAsmrOneDetails = resolvedDetails,
                         rjCode = updated.rjCode,
                         asmrOneWorkId = resolvedWorkId.takeIf { it.isNotBlank() } ?: updated.asmrOneWorkId,
                         preserveHeaderAlbumMetadata = updated.preserveHeaderAlbumMetadata
@@ -1513,21 +1528,32 @@ class AlbumDetailViewModel @Inject constructor(
                     return true
                 }
 
-                suspend fun loadBackupEndpointAndFinishIfFound(): Boolean {
-                    val backupResult = fetchAsmrOneTracksFromBackup(
-                        candidateRjs = directoryRjs,
-                        fetchBackup = { fetchBackupAsmrOneTracksByRj(it) }
-                    )
-                    if (backupResult.second.isEmpty()) return false
-                    return finishWithResolvedAsmrOneTree(
-                        workId = backupResult.first,
-                        site = AsmrOneEndpoint.BACKUP,
-                        tree = backupResult.second
-                    )
-                }
-
                 if (asmrOneCrawler.selectedEndpoint() == AsmrOneEndpoint.BACKUP) {
-                    if (!loadBackupEndpointAndFinishIfFound()) {
+                    val (backupResult, metadataResult) = coroutineScope {
+                        val backupDeferred = async {
+                            fetchAsmrOneTracksFromBackup(
+                                candidateRjs = directoryRjs,
+                                fetchBackup = { fetchBackupAsmrOneTracksByRj(it) }
+                            )
+                        }
+                        val metadataDeferred = async {
+                            val metadataRj = latestBase.ifBlank { keyRj }
+                            val resolution = resolveAsmrOneWork(metadataRj, timeoutMs = 2_500L)
+                            resolution to asmrOneResolvedDetailsCache[metadataRj]
+                        }
+                        backupDeferred.await() to metadataDeferred.await()
+                    }
+                    val metadataResolution = metadataResult.first
+                    val metadataDetails = metadataResult.second
+                    if (backupResult.second.isNotEmpty() || metadataResolution != null) {
+                        finishWithResolvedAsmrOneTree(
+                            workId = backupResult.first.orEmpty()
+                                .ifBlank { metadataResolution?.first.orEmpty() },
+                            site = AsmrOneEndpoint.BACKUP,
+                            tree = backupResult.second,
+                            resolvedDetails = metadataDetails
+                        )
+                    } else {
                         asmrOneAttemptedRj.remove(keyRj)
                         finishAsmrOneLoad(keyRj, resolved = true)
                     }
@@ -1535,17 +1561,28 @@ class AlbumDetailViewModel @Inject constructor(
                 }
 
                 var preferredInitialResolution: Pair<String, Int?>? = null
+                var preferredInitialDetails: WorkDetailsResponse? = null
                 if (preferInitialRj) {
                     val preferredInitial = resolveAsmrOneWork(latestBase)
                     if (preferredInitial != null) {
                         preferredInitialResolution = preferredInitial
                         val preferredWorkId = preferredInitial.first
-                        val preferredResult = getAsmrOneTracksCached(preferredWorkId)
+                        val searchDetails = asmrOneResolvedDetailsCache[latestBase]
+                        val (preferredResult, preferredDetails) = coroutineScope {
+                            val tracksDeferred = async { getAsmrOneTracksCached(preferredWorkId) }
+                            val detailsDeferred = async {
+                                searchDetails
+                                    ?: runCatching { asmrOneCrawler.getDetails(preferredWorkId) }.getOrNull()
+                            }
+                            tracksDeferred.await() to detailsDeferred.await()
+                        }
+                        preferredInitialDetails = preferredDetails
                         if (preferredResult.tree.isNotEmpty()) {
                             finishWithResolvedAsmrOneTree(
                                 workId = preferredWorkId,
                                 site = preferredResult.site,
-                                tree = preferredResult.tree
+                                tree = preferredResult.tree,
+                                resolvedDetails = preferredDetails
                             )
                             return@launch
                         }
@@ -1564,6 +1601,7 @@ class AlbumDetailViewModel @Inject constructor(
                     for (candidateRj in directRjs) {
                         val resolved = resolveAsmrOneWork(candidateRj) ?: continue
                         resolvedOriginal = resolved
+                        preferredInitialDetails = asmrOneResolvedDetailsCache[candidateRj]
                         break
                     }
                 }
@@ -1578,9 +1616,32 @@ class AlbumDetailViewModel @Inject constructor(
                 }
                 val originalWorkId = resolvedOriginal.first
 
-                val originalDetails = runCatching {
-                    asmrOneCrawler.getDetails(originalWorkId)
-                }.getOrNull()
+                val originalDetails = preferredInitialDetails
+                    ?.takeIf { preferredInitialResolution?.first == originalWorkId }
+                    ?: runCatching { asmrOneCrawler.getDetails(originalWorkId) }.getOrNull()
+
+                if (originalDetails != null) {
+                    val updated = (_uiState.value as? AlbumDetailUiState.Success)?.model ?: return@launch
+                    if (token != asmrOneLoadToken) {
+                        asmrOneAttemptedRj.remove(keyRj)
+                        finishAsmrOneLoad(keyRj, resolved = false)
+                        return@launch
+                    }
+                    _uiState.value = AlbumDetailUiState.Success(
+                        model = updated.copy(
+                            displayAlbum = mergeAsmrOneHeaderAlbum(
+                                currentDisplayAlbum = updated.displayAlbum,
+                                localAlbum = updated.localAlbum,
+                                fetchedDlsiteInfo = updated.dlsiteInfo,
+                                resolvedAsmrOneDetails = originalDetails,
+                                rjCode = updated.rjCode,
+                                asmrOneWorkId = originalWorkId,
+                                preserveHeaderAlbumMetadata = updated.preserveHeaderAlbumMetadata
+                            ),
+                            asmrOneWorkId = originalWorkId
+                        )
+                    )
+                }
 
                 val workId = resolveAsmrOneTrackWorkId(
                     resolvedWorkId = originalWorkId,
@@ -1604,7 +1665,8 @@ class AlbumDetailViewModel @Inject constructor(
                 finishWithResolvedAsmrOneTree(
                     workId = workId,
                     site = trackResult.site,
-                    tree = trackResult.tree
+                    tree = trackResult.tree,
+                    resolvedDetails = originalDetails
                 )
             } catch (e: CancellationException) {
                 asmrOneAttemptedRj.remove(keyRj)

--- a/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailViewModelSupport.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailViewModelSupport.kt
@@ -287,10 +287,31 @@ internal fun mergeDetailHeaderAlbum(
         )
     }
     return if (fetchedDlsiteInfo != null) {
+        val mergedOnlineInfo = fetchedDlsiteInfo.copy(
+            title = fetchedDlsiteInfo.title
+                .takeUnless { title ->
+                    title.isBlank() ||
+                        title == "专辑" ||
+                        title.equals(fetchedDlsiteInfo.rjCode, ignoreCase = true)
+                }
+                ?: currentDisplayAlbum.title,
+            circle = fetchedDlsiteInfo.circle.ifBlank { currentDisplayAlbum.circle },
+            cv = fetchedDlsiteInfo.cv.ifBlank { currentDisplayAlbum.cv },
+            tags = fetchedDlsiteInfo.tags.ifEmpty { currentDisplayAlbum.tags },
+            coverUrl = fetchedDlsiteInfo.coverUrl.ifBlank { currentDisplayAlbum.coverUrl },
+            ratingValue = fetchedDlsiteInfo.ratingValue ?: currentDisplayAlbum.ratingValue,
+            ratingCount = fetchedDlsiteInfo.ratingCount.takeIf { it > 0 }
+                ?: currentDisplayAlbum.ratingCount,
+            releaseDate = fetchedDlsiteInfo.releaseDate.ifBlank { currentDisplayAlbum.releaseDate },
+            dlCount = fetchedDlsiteInfo.dlCount.takeIf { it > 0 } ?: currentDisplayAlbum.dlCount,
+            priceJpy = fetchedDlsiteInfo.priceJpy.takeIf { it > 0 } ?: currentDisplayAlbum.priceJpy,
+            hasAsmrOne = fetchedDlsiteInfo.hasAsmrOne || currentDisplayAlbum.hasAsmrOne,
+            description = fetchedDlsiteInfo.description.ifBlank { currentDisplayAlbum.description }
+        )
         buildDisplayAlbum(
             rjCode = rjCode,
             localAlbum = localAlbum,
-            dlsiteInfo = fetchedDlsiteInfo,
+            dlsiteInfo = mergedOnlineInfo,
             asmrOneWorkId = asmrOneWorkId,
             fallbackCv = currentDisplayAlbum.cv,
             fallbackCoverUrl = currentDisplayAlbum.coverUrl
@@ -301,6 +322,69 @@ internal fun mergeDetailHeaderAlbum(
             asmrOneWorkId = asmrOneWorkId
         )
     }
+}
+
+internal fun mergeAsmrOneHeaderAlbum(
+    currentDisplayAlbum: Album,
+    localAlbum: Album?,
+    fetchedDlsiteInfo: Album?,
+    resolvedAsmrOneDetails: WorkDetailsResponse?,
+    rjCode: String,
+    asmrOneWorkId: String?,
+    preserveHeaderAlbumMetadata: Boolean
+): Album {
+    val asmrOneInfo = resolvedAsmrOneDetails?.let { details ->
+        Album(
+            title = details.title.trim().ifBlank { currentDisplayAlbum.title },
+            path = "",
+            workId = asmrOneWorkId.orEmpty(),
+            rjCode = rjCode,
+            circle = details.circle?.name.orEmpty().trim(),
+            cv = details.vas.orEmpty()
+                .map { it.name.trim() }
+                .filter { it.isNotBlank() }
+                .distinct()
+                .joinToString(", "),
+            tags = details.tags.orEmpty()
+                .map { it.name.trim() }
+                .filter { it.isNotBlank() }
+                .distinct(),
+            coverUrl = details.mainCoverUrl.trim(),
+            dlCount = details.dl_count.coerceAtLeast(0),
+            priceJpy = details.price.coerceAtLeast(0),
+            hasAsmrOne = true
+        )
+    }
+    val mergedOnlineInfo = when {
+        fetchedDlsiteInfo == null -> asmrOneInfo
+        asmrOneInfo == null -> fetchedDlsiteInfo
+        else -> fetchedDlsiteInfo.copy(
+            title = fetchedDlsiteInfo.title
+                .takeUnless { title ->
+                    title.isBlank() ||
+                        title == "专辑" ||
+                        title.equals(fetchedDlsiteInfo.rjCode, ignoreCase = true)
+                }
+                ?: asmrOneInfo.title,
+            circle = fetchedDlsiteInfo.circle.ifBlank { asmrOneInfo.circle },
+            cv = fetchedDlsiteInfo.cv.ifBlank { asmrOneInfo.cv },
+            tags = fetchedDlsiteInfo.tags.ifEmpty { asmrOneInfo.tags },
+            coverUrl = fetchedDlsiteInfo.coverUrl.ifBlank { asmrOneInfo.coverUrl },
+            workId = fetchedDlsiteInfo.workId.ifBlank { asmrOneInfo.workId },
+            rjCode = fetchedDlsiteInfo.rjCode.ifBlank { asmrOneInfo.rjCode },
+            dlCount = fetchedDlsiteInfo.dlCount.takeIf { it > 0 } ?: asmrOneInfo.dlCount,
+            priceJpy = fetchedDlsiteInfo.priceJpy.takeIf { it > 0 } ?: asmrOneInfo.priceJpy,
+            hasAsmrOne = fetchedDlsiteInfo.hasAsmrOne || asmrOneInfo.hasAsmrOne
+        )
+    }
+    return mergeDetailHeaderAlbum(
+        currentDisplayAlbum = currentDisplayAlbum,
+        localAlbum = localAlbum,
+        fetchedDlsiteInfo = mergedOnlineInfo,
+        rjCode = rjCode,
+        asmrOneWorkId = asmrOneWorkId,
+        preserveHeaderAlbumMetadata = preserveHeaderAlbumMetadata
+    )
 }
 
 internal fun shouldPreserveHeaderAlbumMetadata(hint: AlbumCoverHint?): Boolean {

--- a/app/src/main/java/com/asmr/player/util/DlsiteWorkNo.kt
+++ b/app/src/main/java/com/asmr/player/util/DlsiteWorkNo.kt
@@ -1,7 +1,7 @@
 package com.asmr.player.util
 
 object DlsiteWorkNo {
-    private val rjRegex = Regex("""RJ\d+""", RegexOption.IGNORE_CASE)
+    private val rjRegex = Regex("""(?<![A-Z0-9])RJ\d+(?![A-Z0-9])""", RegexOption.IGNORE_CASE)
 
     fun extractRjCode(input: String): String {
         return rjRegex.find(input)?.value?.uppercase() ?: ""

--- a/app/src/test/java/com/asmr/player/ClipboardRjNavigationTest.kt
+++ b/app/src/test/java/com/asmr/player/ClipboardRjNavigationTest.kt
@@ -1,0 +1,101 @@
+package com.asmr.player
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ClipboardRjNavigationTest {
+    @Test
+    fun extractClipboardRjCode_returnsFirstCode() {
+        assertEquals(
+            "RJ123456",
+            extractClipboardRjCode("先看 rj123456，之后再看 RJ999999")
+        )
+    }
+
+    @Test
+    fun extractClipboardRjCode_supportsDlsiteUrl() {
+        assertEquals(
+            "RJ01522140",
+            extractClipboardRjCode("https://www.dlsite.com/maniax/work/=/product_id/RJ01522140.html")
+        )
+    }
+
+    @Test
+    fun extractClipboardRjCode_returnsBlankWithoutCode() {
+        assertEquals("", extractClipboardRjCode("普通剪贴板内容"))
+    }
+
+    @Test
+    fun clipboardEventKey_distinguishesSameContentCopiedAgain() {
+        val firstCopy = clipboardEventKey("RJ123456", timestampMillis = 100L)
+        val secondCopy = clipboardEventKey("RJ123456", timestampMillis = 200L)
+
+        assertFalse(firstCopy == secondCopy)
+    }
+
+    @Test
+    fun clipboardEventKey_keepsSameCopyEventStable() {
+        val firstRead = clipboardEventKey("RJ123456", timestampMillis = 100L)
+        val secondRead = clipboardEventKey("RJ123456", timestampMillis = 100L)
+
+        assertEquals(firstRead, secondRead)
+    }
+
+    @Test
+    fun clipboardEventKey_legacyGenerationDistinguishesSameContentCopiedAgain() {
+        val firstCopy = clipboardEventKey("RJ123456", timestampMillis = 0L, legacyChangeGeneration = 1L)
+        val secondCopy = clipboardEventKey("RJ123456", timestampMillis = 0L, legacyChangeGeneration = 2L)
+
+        assertFalse(firstCopy == secondCopy)
+    }
+
+    @Test
+    fun shouldShowClipboardRjPrompt_rejectsAlreadyHandledCopyEvent() {
+        assertFalse(
+            shouldShowClipboardRjPrompt(
+                detectedRj = "RJ123456",
+                eventKey = "event-1",
+                lastHandledEventKey = "event-1",
+                currentPromptEventKey = null
+            )
+        )
+    }
+
+    @Test
+    fun shouldShowClipboardRjPrompt_rejectsCopyEventAlreadyBeingPrompted() {
+        assertFalse(
+            shouldShowClipboardRjPrompt(
+                detectedRj = "RJ123456",
+                eventKey = "event-1",
+                lastHandledEventKey = null,
+                currentPromptEventKey = "event-1"
+            )
+        )
+    }
+
+    @Test
+    fun shouldShowClipboardRjPrompt_acceptsSameRjFromNewCopyEvent() {
+        assertTrue(
+            shouldShowClipboardRjPrompt(
+                detectedRj = "RJ123456",
+                eventKey = "event-2",
+                lastHandledEventKey = "event-1",
+                currentPromptEventKey = null
+            )
+        )
+    }
+
+    @Test
+    fun shouldShowClipboardRjPrompt_acceptsNewRjFromNewCopyEvent() {
+        assertTrue(
+            shouldShowClipboardRjPrompt(
+                detectedRj = "RJ654321",
+                eventKey = "event-2",
+                lastHandledEventKey = "event-1",
+                currentPromptEventKey = null
+            )
+        )
+    }
+}

--- a/app/src/test/java/com/asmr/player/data/remote/crawler/AsmrOneSiteSelectionTest.kt
+++ b/app/src/test/java/com/asmr/player/data/remote/crawler/AsmrOneSiteSelectionTest.kt
@@ -29,6 +29,18 @@ class AsmrOneSiteSelectionTest {
     }
 
     @Test
+    fun metadataEndpoint_usesMirror200WhenTracksUseBackup() {
+        assertEquals(
+            AsmrOneEndpoint.MIRROR_200,
+            resolveAsmrOneMetadataEndpoint(AsmrOneEndpoint.BACKUP)
+        )
+        assertEquals(
+            AsmrOneEndpoint.MIRROR_100,
+            resolveAsmrOneMetadataEndpoint(AsmrOneEndpoint.MIRROR_100)
+        )
+    }
+
+    @Test
     fun fetchTracks_requestsOnlySelectedEndpoint() = runBlocking {
         val calls = mutableListOf<Int>()
         val tree = listOf(track("selected.wav"))

--- a/app/src/test/java/com/asmr/player/ui/library/AlbumDetailViewModelSupportTest.kt
+++ b/app/src/test/java/com/asmr/player/ui/library/AlbumDetailViewModelSupportTest.kt
@@ -1,5 +1,9 @@
 package com.asmr.player.ui.library
 
+import com.asmr.player.data.remote.api.Artist
+import com.asmr.player.data.remote.api.Circle
+import com.asmr.player.data.remote.api.Tag
+import com.asmr.player.data.remote.api.WorkDetailsResponse
 import com.asmr.player.domain.model.Album
 import com.asmr.player.ui.nav.AlbumCoverHint
 import org.junit.Assert.assertEquals
@@ -122,6 +126,147 @@ class AlbumDetailViewModelSupportTest {
         assertEquals("抓取标题", result.title)
         assertEquals("抓取CV", result.cv)
         assertEquals(listOf("抓取标签"), result.tags)
+    }
+
+    @Test
+    fun mergeDetailHeaderAlbum_keepsResolvedMetadataWhenLateDlsiteDataIsPartial() {
+        val resolved = Album(
+            title = "ASMR 标题",
+            path = "",
+            rjCode = "RJ01491538",
+            circle = "猫麦",
+            cv = "大山チロル, 陽向葵ゅか, 柚木つばめ",
+            tags = listOf("纯爱/甜蜜", "后宫", "环绕音"),
+            hasAsmrOne = true
+        )
+        val partialDlsite = Album(
+            title = "DLsite 标题",
+            path = "",
+            rjCode = "RJ01491538",
+            coverUrl = "https://example.com/dlsite-cover.jpg"
+        )
+
+        val result = mergeDetailHeaderAlbum(
+            currentDisplayAlbum = resolved,
+            localAlbum = null,
+            fetchedDlsiteInfo = partialDlsite,
+            rjCode = "RJ01491538",
+            asmrOneWorkId = "1491538",
+            preserveHeaderAlbumMetadata = false
+        )
+
+        assertEquals("DLsite 标题", result.title)
+        assertEquals("猫麦", result.circle)
+        assertEquals("大山チロル, 陽向葵ゅか, 柚木つばめ", result.cv)
+        assertEquals(listOf("纯爱/甜蜜", "后宫", "环绕音"), result.tags)
+        assertTrue(result.hasAsmrOne)
+    }
+
+    @Test
+    fun mergeAsmrOneHeaderAlbum_replacesPlaceholderWithResolvedMetadata() {
+        val result = mergeAsmrOneHeaderAlbum(
+            currentDisplayAlbum = Album(
+                title = "专辑",
+                path = "",
+                rjCode = "RJ01522140"
+            ),
+            localAlbum = null,
+            fetchedDlsiteInfo = null,
+            resolvedAsmrOneDetails = WorkDetailsResponse(
+                id = 1522140,
+                source_id = "RJ01522140",
+                title = "真实作品标题",
+                circle = Circle("真实社团"),
+                vas = listOf(Artist("声优A"), Artist("声优B")),
+                tags = listOf(Tag("治愈"), Tag("耳语")),
+                duration = 0,
+                mainCoverUrl = "https://example.com/cover.jpg",
+                dl_count = 123,
+                price = 770
+            ),
+            rjCode = "RJ01522140",
+            asmrOneWorkId = "1522140",
+            preserveHeaderAlbumMetadata = false
+        )
+
+        assertEquals("真实作品标题", result.title)
+        assertEquals("真实社团", result.circle)
+        assertEquals("声优A, 声优B", result.cv)
+        assertEquals(listOf("治愈", "耳语"), result.tags)
+        assertEquals("https://example.com/cover.jpg", result.coverUrl)
+        assertEquals("1522140", result.workId)
+        assertTrue(result.hasAsmrOne)
+    }
+
+    @Test
+    fun mergeAsmrOneHeaderAlbum_fillsMissingDlsiteMetadata() {
+        val result = mergeAsmrOneHeaderAlbum(
+            currentDisplayAlbum = Album(
+                title = "专辑",
+                path = "",
+                rjCode = "RJ01491538"
+            ),
+            localAlbum = null,
+            fetchedDlsiteInfo = Album(
+                title = "专辑",
+                path = "",
+                rjCode = "RJ01491538",
+                coverUrl = "https://example.com/dlsite-cover.jpg"
+            ),
+            resolvedAsmrOneDetails = WorkDetailsResponse(
+                id = 1491538,
+                source_id = "RJ01491538",
+                title = "真实作品标题",
+                circle = Circle("猫麦"),
+                vas = listOf(Artist("大山チロル"), Artist("陽向葵ゅか"), Artist("柚木つばめ")),
+                tags = listOf(Tag("纯爱/甜蜜"), Tag("后宫"), Tag("环绕音")),
+                duration = 0,
+                mainCoverUrl = "https://example.com/asmr-cover.jpg",
+                dl_count = 456,
+                price = 990
+            ),
+            rjCode = "RJ01491538",
+            asmrOneWorkId = "1491538",
+            preserveHeaderAlbumMetadata = false
+        )
+
+        assertEquals("真实作品标题", result.title)
+        assertEquals("猫麦", result.circle)
+        assertEquals("大山チロル, 陽向葵ゅか, 柚木つばめ", result.cv)
+        assertEquals(listOf("纯爱/甜蜜", "后宫", "环绕音"), result.tags)
+        assertEquals("https://example.com/dlsite-cover.jpg", result.coverUrl)
+        assertTrue(result.hasAsmrOne)
+    }
+
+    @Test
+    fun resolveStableAlbumHeroIdentity_upgradesPlaceholderWithoutReplacingRealTitle() {
+        val placeholder = StableAlbumHeroIdentity(
+            title = "专辑",
+            rj = "RJ01522140",
+            circle = ""
+        )
+        val resolved = StableAlbumHeroIdentity(
+            title = "真实作品标题",
+            rj = "RJ01522140",
+            circle = "真实社团"
+        )
+
+        assertEquals(resolved, resolveStableAlbumHeroIdentity(placeholder, resolved))
+        assertEquals(
+            StableAlbumHeroIdentity(
+                title = "列表已有标题",
+                rj = "RJ01522140",
+                circle = "列表社团"
+            ),
+            resolveStableAlbumHeroIdentity(
+                stable = StableAlbumHeroIdentity(
+                    title = "列表已有标题",
+                    rj = "RJ01522140",
+                    circle = "列表社团"
+                ),
+                current = resolved
+            )
+        )
     }
 
     @Test

--- a/app/src/test/java/com/asmr/player/util/DlsiteWorkNoTest.kt
+++ b/app/src/test/java/com/asmr/player/util/DlsiteWorkNoTest.kt
@@ -28,6 +28,12 @@ class DlsiteWorkNoTest {
     }
 
     @Test
+    fun extractRjCode_ignoresEmbeddedLettersAndNumbers() {
+        assertEquals("", DlsiteWorkNo.extractRjCode("MRJ123456"))
+        assertEquals("", DlsiteWorkNo.extractRjCode("RJ123456ABC"))
+    }
+
+    @Test
     fun normalizeCandidates_dedupAndUppercase() {
         val out = DlsiteWorkNo.normalizeCandidates(listOf(" rj1 ", "RJ1", "", "rj2"))
         assertEquals(listOf("RJ1", "RJ2"), out)


### PR DESCRIPTION
## 概要

- 在应用从外部回到前台时检测剪贴板中的第一个 RJ 号，并提示快速进入作品详情
- 按剪贴板复制事件去重：未发生新复制不重复提示，重新复制相同内容仍会重新检测
- 避免应用内复制频繁触发，同时覆盖仅切到其他应用再切回的场景
- 修复连续跳转详情页时标题、社团、CV、标签和音轨数据未刷新的问题
- 为 ASMR.ONE 备用线路补充元数据回退，并防止后到的部分 DLsite 数据清空已解析字段

## 验证

- Release 相关单元测试通过（详情元数据支持测试 14/14）
- `./gradlew-local.bat :app:installRelease` 构建并安装成功
- 真机验证 `RJ01522140 → RJ01491538` 连续外部复制与跳转：目标页显示真实标题、社团“猫麦”、三位 CV、标签及 ONE 音轨目录