### PR TITLE
feat: read 台本 script files to assist subtitle translation

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -215,6 +215,9 @@ dependencies {
     // Jsoup
     implementation("org.jsoup:jsoup:1.17.2")
 
+    // PDFBox (Android port) — extract text from 台本 PDF files
+    implementation("com.tom-roush:pdfbox-android:2.0.27.0")
+
     // DataStore
     implementation("androidx.datastore:datastore-preferences:1.0.0")
 

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -22,3 +22,7 @@
 
 # sherpa-onnx 通过 JNI 解析 Kotlin 配置和推理结果。
 -keep class com.k2fsa.sherpa.onnx.** { *; }
+
+# pdfbox-android：R8 收缩会破坏其反射调用与 CMap/字体资源加载（尤其日文 CID 字体）。
+-keep class com.tom_roush.** { *; }
+-dontwarn com.tom_roush.**

--- a/app/src/main/java/com/asmr/player/AsmrApp.kt
+++ b/app/src/main/java/com/asmr/player/AsmrApp.kt
@@ -12,6 +12,7 @@ import com.asmr.player.data.remote.download.DownloadQueueCoordinator
 import com.asmr.player.data.remote.download.DownloadRuntimeConfig
 import com.asmr.player.data.settings.SettingsRepository
 import com.asmr.player.subtitle.SubtitleTaskRepository
+import com.tom_roush.pdfbox.android.PDFBoxResourceLoader
 import dagger.hilt.android.HiltAndroidApp
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -38,6 +39,7 @@ class AsmrApp : Application(), ImageLoaderFactory, Configuration.Provider {
     override fun onCreate() {
         super.onCreate()
         appCacheManager.start()
+        runCatching { PDFBoxResourceLoader.init(applicationContext) }
         applicationScope.launch {
             runCatching { settingsRepository.clearSleepTimer() }
             val database = runCatching { AppDatabaseProvider.get(applicationContext) }.getOrNull()

--- a/app/src/main/java/com/asmr/player/subtitle/SubtitleScriptContext.kt
+++ b/app/src/main/java/com/asmr/player/subtitle/SubtitleScriptContext.kt
@@ -1,0 +1,38 @@
+package com.asmr.player.subtitle
+
+/**
+ * 作品目录下可供翻译 agent 检索查看的台本/文本文件索引项。
+ * 只暴露文件名与索引，不暴露本机绝对路径。
+ */
+internal data class SubtitleScriptFile(
+    val index: Int,
+    val name: String
+)
+
+/**
+ * 按字符偏移分页读取台本文件文本的结果。
+ */
+internal data class SubtitleScriptReadResult(
+    val fileIndex: Int,
+    val name: String,
+    val offset: Int,
+    val totalChars: Int,
+    val content: String,
+    val truncated: Boolean
+)
+
+/**
+ * 由服务层实现的文件读取器，按字符偏移分页读取台本文件文本。
+ * 返回 null 表示该文件当前不可读（例如文件已不存在）。
+ */
+internal fun interface SubtitleScriptReader {
+    suspend fun read(fileIndex: Int, offset: Int, limit: Int): SubtitleScriptReadResult?
+}
+
+/**
+ * 翻译 agent 可用的台本上下文：作品目录下发现的文本文件及其读取器。
+ */
+internal data class SubtitleScriptContext(
+    val files: List<SubtitleScriptFile>,
+    val reader: SubtitleScriptReader
+)

--- a/app/src/main/java/com/asmr/player/subtitle/SubtitleScriptTextCodec.kt
+++ b/app/src/main/java/com/asmr/player/subtitle/SubtitleScriptTextCodec.kt
@@ -1,0 +1,51 @@
+package com.asmr.player.subtitle
+
+import java.nio.ByteBuffer
+import java.nio.charset.Charset
+import java.nio.charset.CodingErrorAction
+
+/**
+ * 台本/文本文件的编码识别与解码。
+ *
+ * 顺序：先按 BOM 识别 UTF-8 / UTF-16LE / UTF-16BE；无 BOM 时按
+ * UTF-8 → Shift-JIS → GBK 依次做“严格”解码（非法字节直接报错而非替换），
+ * 取第一个能完整解码的编码；全部失败则退回宽松 UTF-8 兜底。
+ *
+ * 局限（诚实说明）：Shift-JIS / GBK / EUC-JP 等 CJK 编码的字节区间互相重叠，
+ * 纯字节判断无法 100% 区分——例如部分 GBK 中文、以及绝大多数 EUC-JP 文本在
+ * Shift-JIS 下也能“成功”解码（只是变成乱码）。因此：
+ * - UTF-8 / UTF-16（带 BOM）能可靠识别；
+ * - 非 UTF-8 的文本默认按 Shift-JIS（日文台本最常见）解析；
+ * - GBK 仅在字节恰好不是合法 Shift-JIS 时才生效。
+ * 需要更强识别时（如区分 EUC-JP / GBK），应改用统计式字符集检测器。
+ */
+internal object SubtitleScriptTextCodec {
+
+    fun decode(bytes: ByteArray): String {
+        if (bytes.isEmpty()) return ""
+        if (bytes.startsWith(UTF8_BOM)) return decodeStrict(bytes, UTF8_BOM.size, "UTF-8").orEmpty()
+        if (bytes.startsWith(UTF16LE_BOM)) return decodeStrict(bytes, UTF16LE_BOM.size, "UTF-16LE").orEmpty()
+        if (bytes.startsWith(UTF16BE_BOM)) return decodeStrict(bytes, UTF16BE_BOM.size, "UTF-16BE").orEmpty()
+        for (name in FALLBACK_CHARSETS) {
+            decodeStrict(bytes, 0, name)?.let { return it }
+        }
+        return bytes.toString(Charsets.UTF_8)
+    }
+
+    private fun decodeStrict(bytes: ByteArray, offset: Int, charsetName: String): String? = runCatching {
+        Charset.forName(charsetName).newDecoder()
+            .onMalformedInput(CodingErrorAction.REPORT)
+            .onUnmappableCharacter(CodingErrorAction.REPORT)
+            .decode(ByteBuffer.wrap(bytes, offset, bytes.size - offset))
+            .toString()
+    }.getOrNull()
+
+    private fun ByteArray.startsWith(prefix: ByteArray): Boolean =
+        size >= prefix.size && prefix.indices.all { this[it] == prefix[it] }
+
+    private val FALLBACK_CHARSETS = listOf("UTF-8", "Shift_JIS", "GBK")
+
+    private val UTF8_BOM = byteArrayOf(0xEF.toByte(), 0xBB.toByte(), 0xBF.toByte())
+    private val UTF16LE_BOM = byteArrayOf(0xFF.toByte(), 0xFE.toByte())
+    private val UTF16BE_BOM = byteArrayOf(0xFE.toByte(), 0xFF.toByte())
+}

--- a/app/src/main/java/com/asmr/player/subtitle/SubtitleTaskService.kt
+++ b/app/src/main/java/com/asmr/player/subtitle/SubtitleTaskService.kt
@@ -11,6 +11,7 @@ import android.content.pm.ServiceInfo
 import android.net.ConnectivityManager
 import android.net.Network
 import android.net.NetworkCapabilities
+import android.net.Uri
 import android.os.Build
 import android.os.IBinder
 import android.os.PowerManager
@@ -33,13 +34,20 @@ import com.asmr.player.data.local.db.entities.TrackEntity
 import com.asmr.player.data.local.db.entities.titleForDisplay
 import com.asmr.player.data.settings.SettingsRepository
 import com.asmr.player.di.DEEPSEEK_HTTP_CLIENT
+import com.asmr.player.domain.model.Track
+import com.asmr.player.ui.library.LocalTreeNode
+import com.asmr.player.ui.library.TreeFileType
+import com.asmr.player.ui.library.loadOrBuildLocalTreeIndex
 import com.asmr.player.util.MessageManager
 import com.google.gson.Gson
 import com.google.gson.reflect.TypeToken
+import com.tom_roush.pdfbox.pdmodel.PDDocument
+import com.tom_roush.pdfbox.text.PDFTextStripper
 import dagger.hilt.EntryPoint
 import dagger.hilt.InstallIn
 import dagger.hilt.android.EntryPointAccessors
 import dagger.hilt.components.SingletonComponent
+import java.io.File
 import java.io.IOException
 import java.util.concurrent.ConcurrentHashMap
 import javax.inject.Named
@@ -598,7 +606,8 @@ internal class SubtitleTaskService : Service() {
                 sources = sources,
                 allowMerging = allowMerging,
                 confirmedCaptions = confirmed,
-                workContext = buildSubtitleWorkContext(itemId)
+                workContext = buildSubtitleWorkContext(itemId),
+                scriptContext = buildSubtitleScriptContext(itemId)
             ) { captions ->
                 commitTranslationProgress(
                     itemId = itemId,
@@ -689,6 +698,139 @@ internal class SubtitleTaskService : Service() {
             cv = album?.cv.orEmpty()
         )
     }
+
+    /**
+     * 为字幕翻译 agent 构建台本上下文：扫描作品目录下可读的文本文件（台本/剧本等）
+     * 与 PDF，让 agent 通过 list/read 工具自行检索查看，辅助统一人名、术语、情节与语气。
+     * 未发现任何可读文件时返回 null（此时不会向 agent 暴露台本工具）。
+     */
+    private suspend fun buildSubtitleScriptContext(itemId: String): SubtitleScriptContext? {
+        val item = database.subtitleTaskDao().getItem(itemId) ?: return null
+        val track = database.trackDao().getTrackByIdOnce(item.trackId) ?: return null
+        val album = database.albumDao().getAlbumById(track.albumId) ?: return null
+        val roots = listOfNotNull(album.path, album.localPath, album.downloadPath)
+            .map { it.trim() }
+            .filter { it.isNotBlank() && !it.startsWith("http", ignoreCase = true) && !it.startsWith("web://", ignoreCase = true) }
+            .distinct()
+        if (roots.isEmpty()) return null
+        val tracks = database.trackDao().getTracksForAlbumOrderedOnce(album.id).map { entity ->
+            Track(
+                id = entity.id,
+                albumId = entity.albumId,
+                title = entity.title,
+                path = entity.path,
+                duration = entity.duration,
+                group = entity.group
+            )
+        }
+        val index = withContext(Dispatchers.IO) {
+            runCatching {
+                loadOrBuildLocalTreeIndex(
+                    context = applicationContext,
+                    albumId = album.id,
+                    albumPaths = roots,
+                    tracks = tracks
+                )
+            }.getOrNull()
+        } ?: return null
+        val scriptFiles = collectScriptFiles(index.root)
+        if (scriptFiles.isEmpty()) return null
+        val files = scriptFiles.mapIndexed { fileIndex, ref ->
+            SubtitleScriptFile(index = fileIndex, name = ref.name)
+        }
+        val textCache = ConcurrentHashMap<String, String>()
+        val reader = SubtitleScriptReader { fileIndex, offset, limit ->
+            val ref = scriptFiles.getOrNull(fileIndex) ?: return@SubtitleScriptReader null
+            val full = textCache[ref.absolutePath] ?: withContext(Dispatchers.IO) {
+                if (ref.isPdf) extractPdfText(ref.absolutePath) else readScriptTextFile(ref.absolutePath)
+            }?.also { cached -> textCache[ref.absolutePath] = cached } ?: return@SubtitleScriptReader null
+            val safeOffset = offset.coerceIn(0, full.length)
+            val end = (safeOffset + limit).coerceAtMost(full.length)
+            SubtitleScriptReadResult(
+                fileIndex = fileIndex,
+                name = ref.name,
+                offset = safeOffset,
+                totalChars = full.length,
+                content = full.substring(safeOffset, end),
+                truncated = end < full.length
+            )
+        }
+        return SubtitleScriptContext(files = files, reader = reader)
+    }
+
+    private fun collectScriptFiles(root: LocalTreeNode): List<ScriptFileRef> {
+        val out = mutableListOf<ScriptFileRef>()
+        fun walk(node: LocalTreeNode) {
+            if (node.children.isEmpty()) {
+                val absolutePath = node.absolutePath?.trim().orEmpty()
+                if (absolutePath.isBlank()) return
+                when (node.fileType) {
+                    TreeFileType.Text -> out += ScriptFileRef(absolutePath, node.path, isPdf = false)
+                    TreeFileType.Pdf -> out += ScriptFileRef(absolutePath, node.path, isPdf = true)
+                    else -> Unit
+                }
+                return
+            }
+            node.children.values.sortedBy { it.name }.forEach(::walk)
+        }
+        walk(root)
+        return out
+    }
+
+    private fun readScriptTextFile(path: String): String? {
+        val bytes = readFileBytes(path) ?: return null
+        return SubtitleScriptTextCodec.decode(bytes).let { text ->
+            if (text.length > MAX_SCRIPT_FILE_CHARS) text.take(MAX_SCRIPT_FILE_CHARS) else text
+        }
+    }
+
+    private fun extractPdfText(path: String): String? {
+        val bytes = readFileBytes(path) ?: return null
+        val text = runCatching {
+            val document = PDDocument.load(bytes)
+            try {
+                PDFTextStripper().getText(document)
+            } finally {
+                document.close()
+            }
+        }.getOrNull()?.trim().orEmpty()
+        if (text.isEmpty()) return null
+        return if (text.length > MAX_SCRIPT_FILE_CHARS) text.take(MAX_SCRIPT_FILE_CHARS) else text
+    }
+
+    private fun readFileBytes(path: String): ByteArray? = when {
+        path.startsWith("content://", ignoreCase = true) -> {
+            val size = queryContentSize(path)
+            if (size != null && size > MAX_SCRIPT_FILE_BYTES) {
+                null
+            } else {
+                runCatching {
+                    applicationContext.contentResolver.openInputStream(Uri.parse(path))?.use { it.readBytes() }
+                }.getOrNull()
+            }
+        }
+        else -> {
+            val file = File(path)
+            if (file.length() > MAX_SCRIPT_FILE_BYTES) {
+                null
+            } else {
+                runCatching { file.readBytes() }.getOrNull()
+            }
+        }
+    }
+
+    private fun queryContentSize(path: String): Long? = runCatching {
+        applicationContext.contentResolver.query(
+            Uri.parse(path),
+            arrayOf(android.provider.OpenableColumns.SIZE),
+            null,
+            null,
+            null
+        )?.use { cursor ->
+            val index = cursor.getColumnIndex(android.provider.OpenableColumns.SIZE)
+            if (index >= 0 && cursor.moveToFirst() && !cursor.isNull(index)) cursor.getLong(index) else null
+        }
+    }.getOrNull()
 
     /**
      * 作品级最终润色：读取作品全部音轨的已翻译字幕，交给润色 agent 逐条精修
@@ -1135,6 +1277,8 @@ internal class SubtitleTaskService : Service() {
         private const val NOTIFICATION_ID = 7412
         private const val WARNING_NOTIFICATION_ID = 7413
         private const val MAX_TRANSLATION_ATTEMPTS = 4
+        private const val MAX_SCRIPT_FILE_CHARS = 200_000
+        private const val MAX_SCRIPT_FILE_BYTES = 20L * 1024L * 1024L
         private const val BASE_RETRY_DELAY_MS = 1_000L
         private const val RETRY_JITTER_MS = 250L
         private const val SCHEDULER_TICK_MS = 500L
@@ -1159,6 +1303,12 @@ internal class SubtitleTaskService : Service() {
         }
     }
 }
+
+private data class ScriptFileRef(
+    val absolutePath: String,
+    val name: String,
+    val isPdf: Boolean
+)
 
 internal data class GeneratedTranslationLayout(
     val sources: List<SubtitleTranslationSourceEntity>,

--- a/app/src/main/java/com/asmr/player/subtitle/SubtitleTranslationClient.kt
+++ b/app/src/main/java/com/asmr/player/subtitle/SubtitleTranslationClient.kt
@@ -139,6 +139,7 @@ internal class SubtitleTranslationClient(
         allowMerging: Boolean,
         confirmedCaptions: List<GeneratedSubtitleCaption> = emptyList(),
         workContext: SubtitleWorkContext? = null,
+        scriptContext: SubtitleScriptContext? = null,
         onCaptionsConfirmed: suspend (List<GeneratedSubtitleCaption>) -> Unit
     ): List<GeneratedSubtitleCaption> {
         require(sources.isNotEmpty()) { "完整字幕不能为空" }
@@ -160,17 +161,19 @@ internal class SubtitleTranslationClient(
             sources = sources,
             allowMerging = allowMerging,
             confirmedCaptions = confirmed,
-            workContext = workContext
+            workContext = workContext,
+            scriptContext = scriptContext
         ).toMutableList()
         var stalledTurnCount = 0
         while (confirmedSourceCount < sources.size) {
             val response = requestSubtitleAgentResponse(
                 messages = messages,
-                targetIndices = sources.drop(confirmedSourceCount).map(GeneratedSubtitleSource::index)
+                targetIndices = sources.drop(confirmedSourceCount).map(GeneratedSubtitleSource::index),
+                scriptContext = scriptContext
             )
             messages += response.assistantMessage
             val toolCalls = response.assistantMessage.toolCalls.orEmpty()
-            var wroteCaptions = false
+            var madeProgress = false
             if (toolCalls.isEmpty()) {
                 stalledTurnCount += 1
                 messages += DeepSeekChatMessage(
@@ -209,7 +212,7 @@ internal class SubtitleTranslationClient(
                                     confirmed += captions
                                     val writtenSourceCount = captions.sumOf { it.sourceIndices.size }
                                     confirmedSourceCount += writtenSourceCount
-                                    wroteCaptions = true
+                                    madeProgress = true
                                     buildSubtitleWriteToolResultMessage(
                                         gson = gson,
                                         toolCallId = toolCallId,
@@ -229,6 +232,48 @@ internal class SubtitleTranslationClient(
                             )
                         }
 
+                        SCRIPT_LIST_TOOL_NAME -> scriptContext?.let { context ->
+                            madeProgress = true
+                            buildScriptListToolResultMessage(gson, toolCallId, context)
+                        } ?: buildSubtitleToolErrorMessage(
+                            gson = gson,
+                            toolCallId = toolCallId,
+                            message = "台本检索不可用"
+                        )
+
+                        SCRIPT_READ_TOOL_NAME -> scriptContext?.let { context ->
+                            val parsed = runCatching {
+                                parseScriptReadToolArguments(
+                                    arguments = toolCall.function.arguments.orEmpty(),
+                                    fileCount = context.files.size
+                                )
+                            }
+                            parsed.fold(
+                                onSuccess = { args ->
+                                    madeProgress = true
+                                    buildScriptReadToolResultMessage(
+                                        gson = gson,
+                                        toolCallId = toolCallId,
+                                        context = context,
+                                        fileIndex = args.fileIndex,
+                                        offset = args.offset,
+                                        limit = args.limit
+                                    )
+                                },
+                                onFailure = { error ->
+                                    buildSubtitleToolErrorMessage(
+                                        gson = gson,
+                                        toolCallId = toolCallId,
+                                        message = error.message.orEmpty().ifBlank { "台本读取参数无效" }
+                                    )
+                                }
+                            )
+                        } ?: buildSubtitleToolErrorMessage(
+                            gson = gson,
+                            toolCallId = toolCallId,
+                            message = "台本检索不可用"
+                        )
+
                         else -> buildSubtitleToolErrorMessage(
                             gson = gson,
                             toolCallId = toolCallId,
@@ -237,7 +282,7 @@ internal class SubtitleTranslationClient(
                     }
                     messages += toolResult
                 }
-                stalledTurnCount = if (wroteCaptions) 0 else stalledTurnCount + 1
+                stalledTurnCount = if (madeProgress) 0 else stalledTurnCount + 1
             }
             if (stalledTurnCount >= MAX_SUBTITLE_AGENT_STALLED_TURNS) {
                 throw SubtitleTranslationException(
@@ -413,7 +458,8 @@ internal class SubtitleTranslationClient(
     private suspend fun requestSubtitleAgentResponse(
         messages: List<DeepSeekChatMessage>,
         targetIndices: List<Int>,
-        polishMode: Boolean = false
+        polishMode: Boolean = false,
+        scriptContext: SubtitleScriptContext? = null
     ): SubtitleAgentResponse {
         val requestBody = if (polishMode) {
             buildPolishAgentRequest(
@@ -425,7 +471,8 @@ internal class SubtitleTranslationClient(
             buildDeepSeekSubtitleAgentRequest(
                 gson = gson,
                 messages = messages,
-                settings = settings
+                settings = settings,
+                scriptContext = scriptContext
             )
         }
         return executeTranslationRequest(
@@ -609,10 +656,14 @@ internal const val SUBTITLE_READ_TOOL_NAME = "read_subtitle_translation_state"
 internal const val SUBTITLE_WRITE_TOOL_NAME = "write_timed_chinese_subtitles"
 internal const val POLISH_READ_TOOL_NAME = "read_subtitle_polish_state"
 internal const val POLISH_WRITE_TOOL_NAME = "write_polished_chinese_subtitles"
+internal const val SCRIPT_LIST_TOOL_NAME = "list_work_script_files"
+internal const val SCRIPT_READ_TOOL_NAME = "read_work_script_file"
 private const val DEEPSEEK_CHAT_COMPLETIONS_URL = "https://api.deepseek.com/chat/completions"
 private const val MAX_SUBTITLE_AGENT_STALLED_TURNS = 4
 private const val MAX_POLISH_AGENT_STALLED_TURNS = 4
 private const val POLISH_READ_PAGE_SIZE = 40
+private const val SCRIPT_READ_DEFAULT_LIMIT = 4_000
+private const val SCRIPT_READ_MAX_LIMIT = 8_000
 
 /**
  * 字幕翻译 agent 可用的作品级静态元数据。
@@ -740,6 +791,7 @@ internal fun buildDeepSeekSubtitleTranslationRequest(
     allowMerging: Boolean,
     confirmedCaptions: List<GeneratedSubtitleCaption> = emptyList(),
     workContext: SubtitleWorkContext? = null,
+    scriptContext: SubtitleScriptContext? = null,
     settings: DeepSeekTranslationSettings = DeepSeekTranslationSettings()
 ): String {
     val messages = buildSubtitleAgentInitialMessages(
@@ -747,9 +799,10 @@ internal fun buildDeepSeekSubtitleTranslationRequest(
         sources = sources,
         allowMerging = allowMerging,
         confirmedCaptions = confirmedCaptions,
-        workContext = workContext
+        workContext = workContext,
+        scriptContext = scriptContext
     )
-    return buildDeepSeekSubtitleAgentRequest(gson, messages, settings)
+    return buildDeepSeekSubtitleAgentRequest(gson, messages, settings, scriptContext)
 }
 
 internal fun buildSubtitleAgentInitialMessages(
@@ -757,7 +810,8 @@ internal fun buildSubtitleAgentInitialMessages(
     sources: List<GeneratedSubtitleSource>,
     allowMerging: Boolean,
     confirmedCaptions: List<GeneratedSubtitleCaption> = emptyList(),
-    workContext: SubtitleWorkContext? = null
+    workContext: SubtitleWorkContext? = null,
+    scriptContext: SubtitleScriptContext? = null
 ): List<DeepSeekChatMessage> {
     require(sources.isNotEmpty())
     val confirmedSourceCount = confirmedCaptions.sumOf { it.sourceIndices.size }
@@ -772,7 +826,7 @@ internal fun buildSubtitleAgentInitialMessages(
     return listOf(
         DeepSeekChatMessage(
             role = "system",
-            content = subtitleToolTranslationSystemPrompt(targetIndices, allowMerging, workContext)
+            content = subtitleToolTranslationSystemPrompt(targetIndices, allowMerging, workContext, scriptContext)
         ),
         DeepSeekChatMessage(
             role = "user",
@@ -784,7 +838,8 @@ internal fun buildSubtitleAgentInitialMessages(
 internal fun buildDeepSeekSubtitleAgentRequest(
     gson: Gson,
     messages: List<DeepSeekChatMessage>,
-    settings: DeepSeekTranslationSettings = DeepSeekTranslationSettings()
+    settings: DeepSeekTranslationSettings = DeepSeekTranslationSettings(),
+    scriptContext: SubtitleScriptContext? = null
 ): String {
     require(messages.isNotEmpty())
     return gson.toJson(
@@ -797,7 +852,7 @@ internal fun buildDeepSeekSubtitleAgentRequest(
                 settings.thinkingEnabled
             },
             responseFormat = null,
-            tools = subtitleTranslationTools()
+            tools = subtitleTranslationTools(scriptContext)
         )
     )
 }
@@ -1084,11 +1139,158 @@ internal fun buildSubtitleToolErrorMessage(
     toolCallId = toolCallId
 )
 
-private fun subtitleTranslationTools(): List<DeepSeekToolDefinition> = listOf(
+internal data class ScriptReadToolArgs(
+    val fileIndex: Int,
+    val offset: Int,
+    val limit: Int
+)
+
+internal fun parseScriptReadToolArguments(arguments: String, fileCount: Int): ScriptReadToolArgs {
+    require(fileCount > 0) { "作品目录没有台本文件" }
+    val root = runCatching {
+        JsonParser.parseString(arguments.trim()).asJsonObject
+    }.getOrElse { error ->
+        throw IllegalArgumentException("台本读取工具参数不是有效 JSON 对象", error)
+    }
+    val fileIndex = runCatching { root.get("file_index").asInt }
+        .getOrElse { error -> throw IllegalArgumentException("台本读取工具缺少 file_index", error) }
+    require(fileIndex in 0 until fileCount) { "file_index 超出范围：$fileIndex" }
+    val offset = runCatching { root.get("offset").asInt }.getOrDefault(0).coerceAtLeast(0)
+    val limit = runCatching { root.get("limit").asInt }
+        .getOrDefault(SCRIPT_READ_DEFAULT_LIMIT)
+        .coerceIn(1, SCRIPT_READ_MAX_LIMIT)
+    return ScriptReadToolArgs(fileIndex = fileIndex, offset = offset, limit = limit)
+}
+
+internal fun buildScriptListToolResultMessage(
+    gson: Gson,
+    toolCallId: String,
+    context: SubtitleScriptContext
+): DeepSeekChatMessage {
+    require(toolCallId.isNotBlank())
+    val result = mapOf(
+        "files" to context.files.map { file ->
+            mapOf("index" to file.index, "name" to file.name)
+        },
+        "total_files" to context.files.size
+    )
+    return DeepSeekChatMessage(
+        role = "tool",
+        content = gson.toJson(result),
+        toolCallId = toolCallId
+    )
+}
+
+internal suspend fun buildScriptReadToolResultMessage(
+    gson: Gson,
+    toolCallId: String,
+    context: SubtitleScriptContext,
+    fileIndex: Int,
+    offset: Int,
+    limit: Int
+): DeepSeekChatMessage {
+    require(toolCallId.isNotBlank())
+    val file = context.files.getOrNull(fileIndex)
+    if (file == null) {
+        return buildSubtitleToolErrorMessage(gson, toolCallId, "未知台本文件索引：$fileIndex")
+    }
+    val read = context.reader.read(fileIndex, offset, limit)
+    if (read == null) {
+        return buildSubtitleToolErrorMessage(gson, toolCallId, "无法读取台本文件：${file.name}")
+    }
+    val result = mapOf(
+        "file_index" to read.fileIndex,
+        "name" to read.name,
+        "offset" to read.offset,
+        "total_chars" to read.totalChars,
+        "content" to read.content,
+        "truncated" to read.truncated,
+        "completed" to (read.offset + read.content.length >= read.totalChars)
+    )
+    return DeepSeekChatMessage(
+        role = "tool",
+        content = gson.toJson(result),
+        toolCallId = toolCallId
+    )
+}
+
+private fun subtitleTranslationTools(scriptContext: SubtitleScriptContext?): List<DeepSeekToolDefinition> {
+    val tools = mutableListOf(
+        DeepSeekToolDefinition(
+            function = DeepSeekFunctionDefinition(
+                name = SUBTITLE_READ_TOOL_NAME,
+                description = TranslationPrompts.subtitleToolReadDescription(),
+                parameters = mapOf(
+                    "type" to "object",
+                    "properties" to emptyMap<String, Any>(),
+                    "additionalProperties" to false
+                )
+            )
+        ),
+        DeepSeekToolDefinition(
+            function = DeepSeekFunctionDefinition(
+                name = SUBTITLE_WRITE_TOOL_NAME,
+                description = TranslationPrompts.subtitleToolWriteDescription(),
+                parameters = mapOf(
+                    "type" to "object",
+                    "properties" to mapOf(
+                        "captions" to mapOf(
+                            "type" to "array",
+                            "minItems" to 1,
+                            "items" to mapOf(
+                                "type" to "object",
+                                "properties" to mapOf(
+                                    "source_indices" to mapOf(
+                                        "type" to "array",
+                                        "minItems" to 1,
+                                        "items" to mapOf("type" to "integer")
+                                    ),
+                                    "start_ms" to mapOf(
+                                        "type" to "integer",
+                                        "minimum" to 0
+                                    ),
+                                    "end_ms" to mapOf(
+                                        "type" to "integer",
+                                        "minimum" to 0
+                                    ),
+                                    "japanese" to mapOf(
+                                        "type" to "string",
+                                        "minLength" to 1
+                                    ),
+                                    "chinese" to mapOf(
+                                        "type" to "string",
+                                        "minLength" to 1,
+                                        "description" to TranslationPrompts.subtitleToolChineseFieldDescription()
+                                    )
+                                ),
+                                "required" to listOf(
+                                    "source_indices",
+                                    "start_ms",
+                                    "end_ms",
+                                    "japanese",
+                                    "chinese"
+                                ),
+                                "additionalProperties" to false
+                            )
+                        )
+                    ),
+                    "required" to listOf("captions"),
+                    "additionalProperties" to false
+                )
+            )
+        )
+    )
+    if (scriptContext != null && scriptContext.files.isNotEmpty()) {
+        tools += scriptTranslationTools()
+    }
+    return tools
+}
+
+private fun scriptTranslationTools(): List<DeepSeekToolDefinition> = listOf(
     DeepSeekToolDefinition(
         function = DeepSeekFunctionDefinition(
-            name = SUBTITLE_READ_TOOL_NAME,
-            description = TranslationPrompts.subtitleToolReadDescription(),
+            name = SCRIPT_LIST_TOOL_NAME,
+            description = TranslationPrompts.subtitleScriptListToolDescription(),
             parameters = mapOf(
                 "type" to "object",
                 "properties" to emptyMap<String, Any>(),
@@ -1098,52 +1300,16 @@ private fun subtitleTranslationTools(): List<DeepSeekToolDefinition> = listOf(
     ),
     DeepSeekToolDefinition(
         function = DeepSeekFunctionDefinition(
-            name = SUBTITLE_WRITE_TOOL_NAME,
-            description = TranslationPrompts.subtitleToolWriteDescription(),
+            name = SCRIPT_READ_TOOL_NAME,
+            description = TranslationPrompts.subtitleScriptReadToolDescription(),
             parameters = mapOf(
                 "type" to "object",
                 "properties" to mapOf(
-                    "captions" to mapOf(
-                        "type" to "array",
-                        "minItems" to 1,
-                        "items" to mapOf(
-                            "type" to "object",
-                            "properties" to mapOf(
-                                "source_indices" to mapOf(
-                                    "type" to "array",
-                                    "minItems" to 1,
-                                    "items" to mapOf("type" to "integer")
-                                ),
-                                "start_ms" to mapOf(
-                                    "type" to "integer",
-                                    "minimum" to 0
-                                ),
-                                "end_ms" to mapOf(
-                                    "type" to "integer",
-                                    "minimum" to 0
-                                ),
-                                "japanese" to mapOf(
-                                    "type" to "string",
-                                    "minLength" to 1
-                                ),
-                                "chinese" to mapOf(
-                                    "type" to "string",
-                                    "minLength" to 1,
-                                    "description" to TranslationPrompts.subtitleToolChineseFieldDescription()
-                                )
-                            ),
-                            "required" to listOf(
-                                "source_indices",
-                                "start_ms",
-                                "end_ms",
-                                "japanese",
-                                "chinese"
-                            ),
-                            "additionalProperties" to false
-                        )
-                    )
+                    "file_index" to mapOf("type" to "integer", "minimum" to 0),
+                    "offset" to mapOf("type" to "integer", "minimum" to 0),
+                    "limit" to mapOf("type" to "integer", "minimum" to 1)
                 ),
-                "required" to listOf("captions"),
+                "required" to listOf("file_index"),
                 "additionalProperties" to false
             )
         )
@@ -1250,7 +1416,8 @@ private fun parseTranslationContentJsonObject(content: String) = content.trim()
 internal fun subtitleToolTranslationSystemPrompt(
     targetIndices: List<Int>,
     allowMerging: Boolean,
-    workContext: SubtitleWorkContext? = null
+    workContext: SubtitleWorkContext? = null,
+    scriptContext: SubtitleScriptContext? = null
 ): String {
     require(targetIndices.isNotEmpty())
     require(targetIndices.distinct().size == targetIndices.size)
@@ -1259,15 +1426,26 @@ internal fun subtitleToolTranslationSystemPrompt(
     } else {
         TranslationPrompts.subtitleSegmentationRulesNoMerge()
     }
+    val scriptToolsSection = if (scriptContext != null && scriptContext.files.isNotEmpty()) {
+        subtitleScriptToolsSection()
+    } else {
+        ""
+    }
     return TranslationPrompts.subtitleAgentSystemPromptTemplate()
         .replace("{{SOURCE_COUNT}}", targetIndices.size.toString())
         .replace("{{WORK_CONTEXT}}", buildSubtitleWorkContextSection(workContext))
         .replace("{{READ_TOOL_NAME}}", SUBTITLE_READ_TOOL_NAME)
         .replace("{{WRITE_TOOL_NAME}}", SUBTITLE_WRITE_TOOL_NAME)
+        .replace("{{SCRIPT_TOOLS}}", scriptToolsSection)
         .replace("{{STYLE_GUIDE}}", TranslationPrompts.subtitleStyleGuide())
         .replace("{{REFERENCE_TABLE}}", TranslationPrompts.subtitleReferenceTable())
         .replace("{{SEGMENTATION_RULES}}", segmentationRules)
         .trim()
 }
+
+internal fun subtitleScriptToolsSection(): String =
+    TranslationPrompts.subtitleScriptToolsSection()
+        .replace("{{SCRIPT_LIST_TOOL_NAME}}", SCRIPT_LIST_TOOL_NAME)
+        .replace("{{SCRIPT_READ_TOOL_NAME}}", SCRIPT_READ_TOOL_NAME)
 
 private const val BASE_RETRY_DELAY_MS = 1_000L

--- a/app/src/main/java/com/asmr/player/subtitle/TranslationPrompts.kt
+++ b/app/src/main/java/com/asmr/player/subtitle/TranslationPrompts.kt
@@ -67,6 +67,12 @@ internal object TranslationPrompts {
 
     internal fun subtitleToolChineseFieldDescription(): String = raw(KEY_SUBTITLE_TOOL_CHINESE_FIELD_DESCRIPTION)
 
+    internal fun subtitleScriptToolsSection(): String = raw(KEY_SUBTITLE_SCRIPT_TOOLS_SECTION)
+
+    internal fun subtitleScriptListToolDescription(): String = raw(KEY_SUBTITLE_SCRIPT_LIST_TOOL_DESCRIPTION)
+
+    internal fun subtitleScriptReadToolDescription(): String = raw(KEY_SUBTITLE_SCRIPT_READ_TOOL_DESCRIPTION)
+
     internal const val KEY_DISPLAY_NAME_SYSTEM_PROMPT = "display_name_system_prompt"
     internal const val KEY_SUBTITLE_AGENT_SYSTEM_PROMPT_TEMPLATE = "subtitle_agent_system_prompt_template"
     internal const val KEY_SUBTITLE_POLISH_SYSTEM_PROMPT = "subtitle_polish_system_prompt"
@@ -87,6 +93,9 @@ internal object TranslationPrompts {
     internal const val KEY_SUBTITLE_TOOL_READ_DESCRIPTION = "subtitle_tool_read_description"
     internal const val KEY_SUBTITLE_TOOL_WRITE_DESCRIPTION = "subtitle_tool_write_description"
     internal const val KEY_SUBTITLE_TOOL_CHINESE_FIELD_DESCRIPTION = "subtitle_tool_chinese_field_description"
+    internal const val KEY_SUBTITLE_SCRIPT_TOOLS_SECTION = "subtitle_script_tools_section"
+    internal const val KEY_SUBTITLE_SCRIPT_LIST_TOOL_DESCRIPTION = "subtitle_script_list_tool_description"
+    internal const val KEY_SUBTITLE_SCRIPT_READ_TOOL_DESCRIPTION = "subtitle_script_read_tool_description"
 }
 
 /**

--- a/app/src/main/java/com/asmr/player/subtitle/TranslationPromptsEncoded.kt
+++ b/app/src/main/java/com/asmr/player/subtitle/TranslationPromptsEncoded.kt
@@ -37,62 +37,62 @@ internal object TranslationPromptsEncoded {
         "HZivPXl8L6lc27tbHHiNT3p9/Ml/TohunjlKbFnP70gdLtjNf/ifvAk4/42evFltnLl9X5tvrmnd38xuzuh87PkvvTuMLsiu" +
         "TczdazT0xSGjokPzsEKT4tKj1iDDsjOSwJEYrs6Irr6ZGr89X4wZfW85TW/bfNz5zL6MnJ8YfMz5L707nl24XNwMrunKP39Y" +
         "Ts5IjLxY/h+4HKrrXZw5Hm24je9Zfp9JTMrrCs5If696TX95TNzY7F6ZaXzJDt243PyYDM2or9/pOV+9n4z5TN4JTW1bfXzJ" +
-        "zj683T92h+jczhjfbzivHYkrf42MX7l/rflsn/tsHCn/P1yuvYhPv5kNbBtu7visv8y/umoNjnjv3oi+7Qi9rxgN+5tsz3kd" +
-        "bxhcTrm+/3mMups7fchPfEpMTIl9Xbhcb4l4PLluL2jMPJgNXFh9LkkbXIESYOHxEtFhkXNFEVCxAXDrXi1JDSz4nv8ZfB4Z" +
-        "b8vrmNyYflwajv7ZXry4bCyJqe0JL23IzDyYDVxYzt8n4kLUoWNSstBCwqJxkoJAQYeCQoDjAxLzE+IB4xKjIkNWwadDgceG" +
-        "s6CD43FyEkNzEzeho6LCs7ISAgAw8SZ3qciNfX9OOd3dt5XFxwiefggPeLteLUkNL6TBc1EwtNlcOLs7Tyic31pOjzlcroQR" +
-        "cACloMAAwAGxUCFjwTGwgUK0c4VSAZUoT984jV24Pd9YP+p7b7/Z3Izonf35rJ65fvuL6O24bJzKbp6ZTMxobG3pqBwpPY5I" +
-        "7AzoDs54DR65CW29T79pvmzJbJ/7Ps4JHSwcvcwoH06J3t8rbO4I7w9cfRvKPv4IfJ5Yvk4InD54LGjLbJ95fp9mZXflKL1f" +
-        "2ciNfW6OiU9PWb0Nq16cmQ5trJ7M6K2/iRwum19OKI9u3L05Sm4fCH7vyK0/6Ez92Byq62xe2Sx8GJ1eGVxOaV+Z2+gcaG5s" +
-        "lhCBYlAiU1PDomYRw5PTooOSkYLZ3T4Zn0tLOJ/YXK4affzJfW9YT8wJWU9VVam9TqXVNwlPLMldm5s4jQjs76qdzAlunlic" +
-        "fclbvfkdr5jOTkjNDwifrGkaH51f7ElPr1lt3jtuT3ns3/y/fvjcjlnNP8tf3Fi+jbxumqoNvUhM7+hNTYhOv7gNehvMnukN" +
-        "H5iv3/lPPBleiesZDph/LGqOr9l9jagvnneB19VREACAYYOj0BT4ji+A4zXyE+HxJhluLkuOvLnMrLy+nhhM75k9jHtc76iu" +
-        "rwyMGHrPbGifzHgs7LifHxgMuYteLUkNTLi/H4m8n7lMyEsIvVhsbDpM/4lcroQQoRE1wnKg8HSZH+6bbu74jg+srusaHZ2I" +
-        "f744rG8ond7ILoqnMQDBA2GR+G0PBlWV5URDdBJA8XEiRTi+r/ic7AgMi6cwYNARsXCTo5HAsEExFddtflwJfO+Jb9/Lf25Z" +
-        "Hi2MnXw4TjzJL64rPy7Yj/28rtlKHe3Ifs0ITmyYnM7obyr7Xjz5zG+Y/l0ZTP6pf2l7WxxIndzKTJ4pfC4Ifh65S27Z3N8o" +
-        "z8x4zE64fC35uSzdX97JXA75bD6Lb7153a78nG7If69pLo6rPy7WdFWg41WSwPFxIkU4vq/4nOwIDIurbb7pL8wITK/ZbW5J" +
-        "fuqr6274b216bd7Zbt/4XByJS41Jre+IzL6YzxyYro2J2t/tX43pX16ZTD8rTR8p3d38jF8orK+pHr37/O44rW9cj7k6PP+Y" +
-        "bU6onJ64jc7IPli7Xj5ZHo84n13Z3T5ZXNnbOwwoTi7G6U5PW17eac9f/B7/yB9OiS+8C25OiLwf3L+6ah2eGE0f6L+saK9t" +
-        "yD5Km72u+S2POD2cuW1/6W6KezociJ3eyi8+yUzMOJ1siXvN+S3+WOz/CN//+L1fCRkN3XyeiU/e2V4uK3yNuRyv/I3OWGyv" +
-        "KT9uG0z/OI4/XK7ruh2fmH1/SI4NyL9dGN3aO2+uCc6feExPiawPyW/L6yieiH5Oauz+WX9u5BNzEgzdP0hP3ikNbBs/Luic" +
-        "nHyuyVosz7jv36gs7cic/ngO6GteLCktrhhMrBl+jXl+6qs5XTh+/EqdzglNnhhPzkmoDrkd/LjuDEgejfifv3nIH71Ofilt" +
-        "nsltrAuez7nvHaycnxi+vanMP0tvr5iszdy9CopuHwa3ddTZfV5IT135em1ZP+/YHVxI3uzIvQ7JO6/tbf5ZrO7JXd5rTU75" +
-        "/y0srs1IT1xpHjxrXW24jR38vTtKbh8ITuyonI3o/h9YbzrLD145fo9o/k0pHv7JP1prWxxILz6aLyzpHRxIL55JGv0Zbj2o" +
-        "r07YbR9Izv45eu19LH8pHhzJTA+7fzzJ3a8cvwxYvr2pvQ6bXU7Yvu6MvZm6P53YTg2Ij31Y/h+IDrhLbW0pLh4ory8JTr4p" +
-        "TNp7+2yITW7K7P4Zffw4XCwJey+1UIFRkVAgAjF0+JyNnL3pGg78mHyeWIzuGJ7e+KzqIwHQsaDAcJRbTK4oXW9cjKi6PDwo" +
-        "jB44nK+ovewo3dv7zJ+ZLx+ovE/prOxZjKkLOq24TI9aLz7JXa1YnIzpGu0pPh/oHa2obQ84j7zJO5zdLF4Jf32ZXs3bbk95" +
-        "HC4Mbax4rVwZLQ8bbl2YjK4MjauK3O34Tj8InNzYv04IbyrFlCTFSP//OA88KHwv2XrtfXzv6U4cCbwv+1/u2f+fvL1fCH2t" +
-        "CQ0fm35seK6vDL9YGs/sGHzvyI9MmJ3vyM05W78siT7cKI2s2V+vSfyLWyiciEzPak8/KU6OmG6eOagf6T0uCB2+GA2NKJ4/" +
-        "mRjebY2tKW28qX1sSz7OCc79rK7umK1cGT4tW2+vmL+OTK7Iug5/eE78qO8tJmWVdFlZHonc3lj/rGje7sjO3xko7R1sfYke" +
-        "HAm873ucnRnsnUy9zCgfTokergtdzWic/pycqupuHzhubDiOPsifP1gPeduuHMkvXbhMr9l9DomdWVv7DwhNzppPbcl8Dghs" +
-        "bemoHCnMH6j9TQhtDwi9Dskb3X1f3rltnKlfv1tNTMnt7ry9TPhe7tkNbfteLijvD1xuyaodrPgsHyitXgifDFgM2rutTZkN" +
-        "HRisXslOPkmNuLsonPhcrqp+XqlevzhcHllpPskvbchsjggej/itPnkaHw2MXBms7Qlv3/tuT3n9LFycfdhszkkfzptfT2i8" +
-        "PhweqqoPH+hfnzhdXChOjLgO6GteDWnNTcieramtjFmMmGso7Yh/7gpcvtmtfYgvnneBd9VYrbxJHW6rXg44XR3Mboj6De94" +
-        "jgyIjPwont74HKlLvyyJPtwojd/ZT56pX7jb6e6I7O7aXL4Jr27YXG+JW7ypP10YHbwY3/34rX/5KmwNjF8ZrOzJT2xrjD8J" +
-        "7y58bszI3I8pznwLfp24Xf5cntoqP/7oTd24nK/Yr3/oz1orfN753p7oXE6pTn+5b4qbKK5oXK7KfL6J3s4If17JaW/pP084" +
-        "HVxI3uzIvU0JKt+djC7JXaxZvC37XW7prl88by0IrC2pLk87jC7IvlwMjatqHa0YLB8WdDYEJBnN3KxvT0hOPMnMPIt8n8i+" +
-        "7wy+m0rMDJh836icr9ivf+gcuOtfbNkv3NiePJndPhl9KvsJznhunVqdz8lu/xhuz8l6DMk/Tzj9Xqg87EgNHqfg52EWVMUo" +
-        "LB/4nN/oXEyY3dg7zJ6ZDTzon13V2IysCRv+rSxeyW3N2X1cm4w8yf7eTJ9MWH5dWS+9O/zueI1vYOsa3aiO/DpujDkdHGhu" +
-        "X6l4vbktz6ivTtgtTTifjFl6/81MHLm8fYnNH7v9Dtnd3/xvX0itv4kuT1cpfSz5Xal76eyI7O6qXJ15fA4UOW2f7L6eGE/u" +
-        "OQ08u519+F39nI3bej6eKJ8eCF3f2K6e+N04u72s+b1fiJw9JQiPHvkYve1vvvltnBlv3jtNThn/neyP7Whc/mVk6B7OqGy+" +
-        "mRr+DU9fWW3dua8cC169uR2uvK6v2L6NGd7fa36OuJyPTHy5Nnjs76S1NNUnBBQZrl/naw9MyX6OeP5PiR7+CT9KIO0sTPke" +
-        "PDkOzcs+zsmuX+drD0ypfo8I/k1pHv4JfZp7OJ44TPw6TP4pfA4YnW6JW015L92YHbwYrs/onh+ZyB+9Tn4prO0JXl4rjry5" +
-        "7hxMrr2ITi7pvQ6bTK4oXW9cjKi6PDwoX+7ornyU45nv/2yun+hPfsW4jdzJrK0lKTg9/Z5Mma3/+c0elaTEFZRV8OsPXul+" +
-        "noj+THke7Lk/W5tbD7gvPnovPglujhid/klpbTkNz/gdv9g9jiTYvg6gGzjcFOltnMlt39tdPiW4Lfp7zJ7pLl/YnL3JTn/Z" +
-        "b8uL+w0of036ncwJTg+InW9JSmw53l3o7w2oHo34n795uSzTtlQVJBbFOF0PuJ69GA/Yu8yeqX6eiP59mR7eGT9qW5jcyE/c" +
-        "uk78WW6MGH7+Kbqd+Q8viP1NuN19iI6caSueDW0clQiePYT53s4ITpw5emypP2zY3M14Da2onl5pKj9Nnq1ZTS1JzR/rnt3p" +
-        "zg/wy718mRxOOJ6vVQh9Luk7r+1OXnl+7hnNHpWkxBWUVfDrbQ0ZLp04TK/Zff05/IprWx2YLz6qLy+pHS5YL55JGuz5bj1I" +
-        "r244bQ84zt7Jes2dLEzJ3dyJfV/LfNz5HL1sb82ITE/ZvQ7bPy847x7M3Usqbg2ILA947y0Y/h5YbzibD09Zfr84/l0ZHv8Z" +
-        "P1jrWzyI7O6KXL4Jr27Yj59ZqB3pL5wIHb/YPY4k2JyPnIzp6g8eVDrs/hlNzlidbIlJ7HkvbcS5H8wn+XwNSV5Il51N36UI" +
-        "bs+oX1+ovlz4DWqrTl5JvV72ZFcFJPQFCXrtrSxf2R4O+Q7NJ/j+HlhvC9sPTFl+jtj+XdlcLkmNuasKnLid3Mp8P5lujhid" +
-        "/klpbTkNz/jP7MR7bqwI/w0snMtWeOzu2n/+SW6OaFwe6UuNSS/vWO4cmD2OSJ+cmckebe+fp4QWFTTV9wivTVjd2Du9rVkt" +
-        "j2g9nYke/xk/W7tbDegvPHovLikdHMgvjwka/XluL1ivTwhtH9jOzQl6/D0sTlkeHAkO3us+3lmuTtzdLVgfXkl+3bs/P2gs" +
-        "z9yu68rcfzh93Ji9DghM7og/q+cZ3Nw4zx7Y3+yonl4VbB6r2g7tGJ7t6Jyv2L+s2D/Iu72vOS4eROjf7bieXhlq7wHqPp44" +
-        "fc1o/y9kOH8vmUp8uX4tJLkeHWtf3AgszvJHYRZUFfQaLz4ZHRxIL48pGv9Zbg9kaX7c2z8/iO8dIBtbDugvPJovLOkdHKgv" +
-        "nolYPak8Pyj+rajf//huzPkavb2erwlOnRUYnPzIjZw4fyiLXox5zGwE6CyvaL1Nads/TZwPWd3c2V4fu4w8ycx/HIx8yK88" +
-        "OT6NO43duLw+HN1rNPUENPYZbr67XpxJzS18vWwof765L51bbS04jM+8rui6rd6Gs6UQ4TIBgIFgsBDGkuGVYaGxkXMxcwBB" +
-        "4QRzVUNkNIOnFfXC98ThINBABaDBgRVlNEQEc1HAsyHQcMbABwUUJNYxkMAjECBAoAUBRxk8LVjNvVgMD8iPf0krnz19PmUE" +
-        "1jEAUbPgkSHEdIDLba25HT4Iv/1JXB7ZTJvbKJ6Ifk5mMOMA8=" +
+        "zj683T92h+Eg8/JgI7PzkvIGEZfRYcD2tLl9X/uMrgnPnayMrbi/Tzkff7tdbii93XyMC2odnfh87jicj0iv35gsmmttj1kd" +
+        "Dhg9nLlPPtl8+ms5zShMv0pMzom/HXiPn/mpHUkOTtjPHJgOfXiujHkJHL1Oj5keHDltrXtenWkdrmy8jrQhcGGRwJNQYKCU" +
+        "0AXCNUZYfl16XI1pfazYTX6ZSmw5re+I/jzIzM8ojW15OV+9n14pX16Zba17Xp1prl8CRZDhknPS0gIA81OiQ0MVMrO08aCT" +
+        "MENSggFSIiPDombxE5JwkUfmYeKyEqKj0xYAJwESg9Lx4hOD4VPxwEb3jG9fSExeub0P9aQ0FNlfK3s7Tgh+XXpcjjUiIJAB" +
+        "1Fl5n2kOfDgcv4gMvsiPf0VEAzSTE+Bw81AQwcIwAADQAWcTobBhERVInZ0JfI5p/IorC9zIT8/qjS15fq44nf45W1xZ3d6o" +
+        "7PwYLK9onx2pOR7dnq8JTb0ZTZ0LXQ9JbZ6crr+IfK/p3r6LXW4o7w9cbhgqDuxYLB8oTzx4rd9obyr7ry75Ln5ortxpT53Z" +
+        "XWsLGF54TO9KLz73hiQkGd3f/G9fSF2eCS+dG4z8eI9dzH1Zmi3smJ7uKI3NyJ5/SA9Le28MeX6faKyt+VzsOY2oqyicWEwu" +
+        "6n3diX4N2G0u6Xo+Cd0veO4MRFKwk4PzkgawllCi4+Pg8yIDctEY7F6ZuuyZDazI3M7IP804rr6ZGr89b/x1JZrs7zQ2ZMh+" +
+        "TEl4PEkNvhhsj3jf/fi9T5nJDv1tDtltnMlv36uezjn/LEy9zahs/MkvfRtcL+i/jiyf68oMXojv3/hc3Jie7Tg+qBu8r5kd" +
+        "PSierdm8nlmP6ss5TKjs7tpcvglMjDh+XJl7LjksPYj/TLjMniiuXGl67UO3ZPUhI1Eh8GDwESWYDgonMQDBA2GR9Ftf35hf" +
+        "fey/mIoNvmh/vjisbyid3sguiqteLUnf7AhNjkndP2leSms4jzh+XXpc7SlcTEiN/zlpb5k9jkjsDOgOzniPf0VF0iUDcVLQ" +
+        "wyU4jg3Ir9+YDioLfN4pDR3orfwJXbz5XIu7GrwUEXDyUsAAGz7ONzUVwOORQSFQcRHwBwlPfClduXs4vRQQEONAEOFw8FDx" +
+        "0MEUsgVYTUyJHD3LXi4Yrq8MbRm6LlxIfW1ovk14/h+4D9gbfOx5DW2orI85v79JXZubWxxIfkzKnc4JHQ7YfZ4pWs6pbi9Y" +
+        "HbwYDq/Yr//JK22Nfd35rOx5bl2bn4+JHK3cHv7obM5JPNy7Xc9YvnwsrprKL064TP7Iv234/h+29HAHMWCh0HER8AcJT3wp" +
+        "Xbl7OL0YTc7afm2Zr/wYXA7JW0153l3o7w2oL+8ovQ45CW+9fT5p3dzZbS97nN2pzg2sfQ3YbJ1pP4zbfc74nN58runKP39Y" +
+        "n/4Ij16oPd9YLUr7XYwJLH/4vwyZbU1pTJu7Cm4Ifk5qTy6pfA4Y7F7ZeX4JDj84zk4Uq3++iI8fPLxryq3fuCwfKL5fWK9/" +
+        "6Dw6e22PWQ0eeJ9d2U5/uW44uwp8KJ3eynwuqd7PeFwfaUstqQ8vmB2+GG0POJ8d+cgfvU1+2V3NCU1u64w+yd3fLL7f6E+O" +
+        "CS8Mm2/f+K1M7G+byj7uKF/+iK6NSI3OWA4a+3zeiQ0f+K89eX/eGX4Ia+nsiE/eOp8+6a8cSJ1vSUpsOR2tmP4uuK7PqKy/" +
+        "JUYAJjpuHzh8j4icj0j+H4gcudt8/Gk8T9g9nZndPhldqws63th+XBp8D4mv/9hP7flbTXkMbij+nJjf//ieT9kavX2evZlt" +
+        "z+lPnatNTMn/P1xvzYh9bqkNTItcXdhPDuycKZovv2iN7Ahd3Biunvgs6HtvP7l+n2ZlN+Uoro+JGi7NTN55T9yJvM2rjS35" +
+        "3Y7snH3YXu7ZzDyLbC+4nI+sjBkaHe04fA3Ij984nFzYDThbbw55fp9onK6ZbV45P0orWwx4Ly4KLy75HR7oL55JGv25bi9Y" +
+        "r15IbR0Yzs2Jeu19LE45Hg75Dt87Pt55rn4c3T9IH2+pfs6Lff5orv2crpsqDCwojewILO3InH+4Pssrb6yJLx24nE+5fq6J" +
+        "P0r7Oo74TR0af7+5THzIf96paX2pzl+YzQ4Yrs/ori35CV89TZyVILIAMMHDUfBFmByoO2/cKR58+K7caX09yV+Li5jckCGg" +
+        "gvFh4XcIjZ9I3Ur7Xp2JLLxIXlwJbXx5fLlb6e1I7O+qfr45XxwonYzZqQ7ZD56ozO+IbQ84jnyZyf/dLF4JTiy5vDxLPs4J" +
+        "7zzsnE7oH06JH6/bbzwIv44sbxo63owIng24vOxIr2z4DIurX565zG2YnH05bQ8Jfht7Wxx2tFT2GV5u21z9GRyv/N0/SE//" +
+        "aS7OS43eKI4vjIyrig5/eE78qJz8yL9dGC6Kq21tKd9seK6t+X6fSVy6u/kP6J9cum99uW7/GG7PydksiR2vmMyvuA0O2J1f" +
+        "WTvtDZ6syU0dWbwv+15MGf6/vL8MWL69qQ1u60ydmO8PXL3Jmh3O6J4NuK/OCK6e+D+r63z9iR7/GJy+mR7+96TAB21vrams" +
+        "7QlePYuNL/muXzyPPyhfbQl+zkuNHqhNXEyfqXoO7FgsHyiPTVic/Agc2ztOn9l+n1i8Lgl/7Rleais7T2iObPp+/Cmv/BhM" +
+        "bgm4/onOPBjNrkgNXDiv38k5Ht2erwm8LPlc3Os+zjndjuy8D0hszjkNTutuToicjZye2ooObIhtv3icjqifH0hvKvu8/JkN" +
+        "LJj+XRlcjdleWSs47AiNPapcvIlPDQh/XsmoH2kdr+jczng8b1iNbvkJbW1fjelfXpnNH+tNTsnNvly9zTi/TJnMP0teLii/" +
+        "jiyOGGovXahfn+iOLciefgg8G7vMn5kfn4iN3Qmsj/mP2cs63th+fVqc7Fl9/mic7NmpP7kd3pj/jtgejyh+rEl67UO3xPUo" +
+        "nu3ojI34nz9Y3ThrvL3JHW8YXE65fS/5X4uLKJ/4n1y6b325bowYfv4peh8J3N2YbI4IHo/4fL8ZCRy9bQ+JT25JvC37jDzJ" +
+        "zf/cjb44v0+ZzD6Lfp24Xf5cnBpK3ey4796IX59Yv6zY3dv7TO8ZL36In5+JbXwJbiqb+2yYXK7Kjz95vx1ofx85Si1JHZ14" +
+        "3M4YPo94DR/JKi39X9zJT3xpvM2rjS353c0sjQ2ovz5JPX4bjdwojK+83WsK3A14n3wIv6xoTR+oPnmrX55ZDS14/l0nheXV" +
+        "5Uy+6Jrcbzh9bWhd39i9rqg+yqtsrnncjPiunZltfAluKpsojlh/HOp+fUl9b1jsXplYjSk8/Wju/Yjf/ji9Ltk7vP1Mv+lP" +
+        "fGlcz0tvLXltnoJHNVQlREVI/l3JbQw5nRnr6e6I7O6qXJ15fA4U6ewsLLwsmB9OSQ0fm0ytSF39nI3qeixsKE0M+L5eaD3f" +
+        "GA1Kxzkv7rgOnOgsvcjOzak7LJ1ODpld/PkO3zt+jAn/DHzdLfh/DDncr8v87mgsz4yu68rcfzie7ii/rAToTEx5eA6p3N+Y" +
+        "bI54HqyIr9/VbB6r2g2+aHy/mJzf6FxMmN3YO1/uSS4eSE1cOawMCW/Li+kOCJ3cyuz+GX9u5Dnvnty/b9hcrnkNTlteL+ic" +
+        "j0yMqdo8zRhvr8T1C00PmQw+vL0sOHxP2Q0P+57t2I987G6aih2PqI3cuE88OL+/2Byq666MBWhsj3b3BST01dVM3WvR2C88" +
+        "+i8v6R0cSC+eiRrt8tgfXHl+7ns/PBjvD5zda9HYLzyaLy6ZHR6oL56JWD2pDa0ozJzoDs/Yr9/ZyB29bf5ZX+7JvC37/Q7Z" +
+        "/p+8b82IfW6pzD9Lb6/4X33snSh6HZ34fX9ILO3IjZ9I3Ur7Xp2JLLxIjazZX69FIsycy1odv5h8L2Qpbo8Inc2lDJ/vyK1c" +
+        "Gc0tu/zvRnUFQOdhxlgvLtovPxkdH7gvjDka/EluPKivXqhtD/i9X9nIjX1f3hl9/Km8LjtuTxW4PisHyQ3vBGkNTotcLgiM" +
+        "/3DLGczI7O7af/5Jf+4Ifx9ZSmxZzj44/y0o3/34nd5JyBx9fN8Zrm65TpxLTUzJ/z9cHv7mhUSVRMSHCazcaV/oazvuCOzu" +
+        "mi8/GR0uWC++mRrNia3v2M+8aAzNqL1d2SuNHYwu2X8c2VzcW468ue4cTIxMOF4MFWhMf7UIDR/JG+8NTN+JT1+JfVybXmyZ" +
+        "/t5Mje14rb3ZLf8L/O44Txy8vTvGeJ0Mqk3vqX38lDkdrsycfdh9TvkePFv870Z1BUDnYcZYTX0qfzypr/wYTJ252S25bi6I" +
+        "r154bR5Yzv+Zeu19LF/ZHg4ZDv/bPs4Jrl7s3R+oH1xJvQ7LTK4YrR2sb4la3O34fx54LO2I/h5YbztrD34Zfo3o/k1JHv7J" +
+        "P0srWw4oLz9qLx6pHQ7YL5+ZGv85bg+YbI5YHo/4fL8Z2uxtnq7JX69ZvC47bk8VuByqO17c2R+eNOiuz+ieH5nIH71/X1lf" +
+        "XpUYji90OE1tyXvvRah+zyVovI2Zrox5fwmLOVwYbi567P9nhwTEFZSFLN0/mB9PWX7cuz889Ck/SytbPWgvPGovL0kdDhht" +
+        "TsmoHnk/r6gdvBg+Dmi9X9nIjX1f3hl9/KlufScor51ofyiLTv5laGyOCD3PuL1fqQlt3X0+aV/cCU+Ne25Pef8cvG7MWNyP" +
+        "J+TEVwUkJNluGCvp7oid3Wp8Lvnezkgvn5ka/GluPvivXKhtH9jOzQl6/D0sTlkeHAkO3us+3umuTSzdLggfXtl+zks/Lzjv" +
+        "HwzdeupuDSgsD+jvPuj+Dgis6nt83vnM/1ivnqlM3dmNu/sLnVQ5rO9pbo87jC2Z/t4wy8ye6R5teEyv2W18CX75qwv+CJ3f" +
+        "Cn+/1QuMLIn+3jzNPTTZLh5Yr49ZDvy1+SpcrXzPmQ4edRiP/jie7Wis61WVVCVElZTIbQ/ozs2JevwdLEx5Hjw1yO8/iP4O" +
+        "6G84h8luPfivXEhtHRjOzWl67b1ujolMDHlfPEuMPskOTNy9b4itv4kuT1cpbS8ZTMlLSx44fvxKnc2VC39uWd3NTHzteK8f" +
+        "2b0Om2/uaF39nL9LKj9cuJxtmK9uaEzs2Dwbuw9eB+WEVCRbX09oj10cvhlKDkxYTO8Yvn4IrBxYDOobfN2JvV7mYechEOHQ" +
+        "QdQThCZ1spGmMAAgciDwQmDBxKOhYHB0tON1V8QzJBUgdaN0MxPh8SY0ldXnIJDx06H11xT1NBWURARzoTHwweEV0zE39DlM" +
+        "HglsLLtfzvnv/2yMTQhOLuVkBHMxoGAxUHS3QLZ4Td2KTJ+ZXK6IbX5ZaTwJHa2Y/i60ctLxI=" +
         "\n" +
         "subtitle_continue_message_generic=oNzhhMj+iN/HidjsgMK0tenIkcf4iu3Ake/vmNuZsLvPhM/ypPrgl+fehsLqlY" +
         "/9kMzuju7ogejyit3/koDj1f3MlPfGlsDltdX0ns75y97Gh/LwkenAtcXKiPXDweq9oOf/hvrUisn9icX9guKotuXsk9LZie" +
@@ -298,6 +298,28 @@ internal object TranslationPromptsEncoded {
         "tjdDBjOz7l6/bEaLM+0EAICAgcIn9w4Prgbva75H13Ir8/pvv95Xbl76e2IXKzKfezpfo1InW9Jep6Zre743M7IPH1IfS65G" +
         "r89fN8Zbb+5vC37XO4pbZ/snIzYfx2pHmzbTP84nI+svZvKDb5oX6/ov+2Yrp6YHIlLTu1pPwyYXG3pTP0ZXQqrGhw4Ly4w=" +
         "=" +
+        "\n" +
+        "subtitle_script_list_tool_description=oOnlhMbJic/MifL4gumAtsj3kNH/i//Ul+DdluiCedTMxpT97ZTA+7b65p" +
+        "/53sjF8obP35Lk83AiKyufyKawp8KFydek4+CW6OKGzceXksaa3v2GyOCCxNqL1/6ckNPUz8iV3vqbwuO2+9efxvLJ59eH+9" +
+        "mcw+iz8u6I+dPI1bSj8OqJ5/KO8tGI28OC+4e729yRx+6LyNmW1+eUzKWwp8KC8uM=" +
+        "\n" +
+        "subtitle_script_read_tool_description=o+37hOzkit72ieD2gtWVtv3kncjBhMrrl+D7lvips5/fhP3Rp+/BlMbrhc" +
+        "LTlKbFVTIwL1SL/9SU+eqW6IKzt8CE3Niuz+GVxMSFw+uUsfaS/v+M+9yN//+M7fGRp/HXxuSU8Nmby/Oz7OCd38jJ2tyK2t" +
+        "eRwv+33+aJyP7K7rqj9/WJ//aI+PmL3sKN3b+w9eA=" +
+        "\n" +
+        "subtitle_script_tools_section=o8zWhOXlgs7ciNzlgOGvtO7MkdThiN39mtD1lfu/sb/1hcjnpPzdlMzATpzs1cjP2Y" +
+        "XZ4JL64rbuw4vm88rth6Pp5EERNyud7OSE9sqare6Q7vGM5MeA38KHwv2XrtfUzMaU4sSV/Oq4yuCf7eTK6c+F/cCcwtu13P" +
+        "WCzP3N1rOh3NKEztyJyfWK7fCM7q63yN2T/dyI3vWW1+aVw4uztPKH0eGmx8+Uz8mG5e6akcqR2O+M8umA/suA0fyTuv7V/+" +
+        "+V2t6X1fK01tuc9f/N0/SF09mR/dmz8u6L7NvG+Zym4fOHwvaF+NKI2feN3YO1xfab1e+I2NaU8+2Xz6a/sd+Jzeak9fSX1c" +
+        "mEzsCXq+SR3emM2fSCyvaKwOeRl8PV/uyX7uuW4fe1/MqQ+sHH8eSH+9mcw+i13daIyuDJzLWiz/KF/OCJyv2K9/6CzZW72v" +
+        "Ob1fiI3d2ayeyW/qS+jtyFyPqk/N2UzMCE/+CXgOqQ7OuP1NuA1uuK6NWRg8HU/PSd3dt5Z19wFxoqJiBnAyE9OCAnODoEPS" +
+        "AhLzpvG3Q4HJ3d25bl5bXr253Y7svA9IXvx5HR8LTK5Irq8MvZgaP93k6n5eqUzMCH7+KWleWT6uJJJCgjv87ni+bzyu2HoP" +
+        "H/hfn9isbyid3sis6nsPXgnfX0hMPRl+rllM6ovpbmh+7opODHlur3hPbVlLL/k/Tzjc/ag8fEh93zk7r+0sXjeExhCBYhEz" +
+        "4oKTEtfBY0Jis9OyMpDzwuIDUJU7mN34f+6KTe+pX8yoT46pWJ6JDq8oDV2Y3/yYri5pKxxtX9y5fu8ZXx3rb65p3exMjb40" +
+        "IkLTJMgsr2ifv3krL61MPkl8/4kO3wtePjn/DCDjUcDhE2HQIBNQpPicjOyMC2odrEhvXRiM7Fg93xgcmgtv31nMjcidL1l+" +
+        "ramPqZs77Tjs7ors/hHTYKEhwRUsrrz4rB3pHL7rXf+Irc0svXvqLGyY79+4TUxorN2I3dlbb69JP93ExVv87mgsz4Qj9cLB" +
+        "VShfnJi+78is3Yg+6uttH4nMbPierGlfXpldm5sZ3jh+fRovPvlMbrhcLTmpDQnPfLj+PajMzyiuX2kYrM1+nAms76luLkv9" +
+        "DtnNLXy9bCisv9kff7cBEAAAAYSyJUIVwGEzQWTZrxxIbd35eZ4Z3Nz4za4IPFxon795CV4NLF4w==" +
         "\n" +
         "subtitle_segmentation_rules_merge=o/bXh9f0iPzPivf+gMWctM7tk9L7hNrXl+fwltmLvp7ohcvopPvrl9/JjsXplI" +
         "Hckdrej878guTQitHlna3r193OltnBlfDTtePOnu7eyfj+hOzXk8jft+jriPDtx9a4oMzlhPjmgs7ciNn0jO6uu9Pjne75iv" +

--- a/app/src/test/java/com/asmr/player/subtitle/SubtitleScriptTextCodecTest.kt
+++ b/app/src/test/java/com/asmr/player/subtitle/SubtitleScriptTextCodecTest.kt
@@ -1,0 +1,51 @@
+package com.asmr.player.subtitle
+
+import java.nio.charset.Charset
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class SubtitleScriptTextCodecTest {
+
+    @Test
+    fun decode_utf8WithoutBom() {
+        val text = "こんにちは、おやすみなさい"
+        val bytes = text.toByteArray(Charsets.UTF_8)
+        assertEquals(text, SubtitleScriptTextCodec.decode(bytes))
+    }
+
+    @Test
+    fun decode_utf8WithBom() {
+        val text = "こんにちは"
+        val bytes = byteArrayOf(0xEF.toByte(), 0xBB.toByte(), 0xBF.toByte()) +
+            text.toByteArray(Charsets.UTF_8)
+        assertEquals(text, SubtitleScriptTextCodec.decode(bytes))
+    }
+
+    @Test
+    fun decode_shiftJis() {
+        val text = "こんにちは、おやすみなさい"
+        val bytes = text.toByteArray(Charset.forName("Shift_JIS"))
+        assertEquals(text, SubtitleScriptTextCodec.decode(bytes))
+    }
+
+    @Test
+    fun decode_utf16leWithBom() {
+        val text = "あいうえお、おやすみ"
+        val bytes = byteArrayOf(0xFF.toByte(), 0xFE.toByte()) +
+            text.toByteArray(Charsets.UTF_16LE)
+        assertEquals(text, SubtitleScriptTextCodec.decode(bytes))
+    }
+
+    @Test
+    fun decode_utf16beWithBom() {
+        val text = "あいうえお、おやすみ"
+        val bytes = byteArrayOf(0xFE.toByte(), 0xFF.toByte()) +
+            text.toByteArray(Charsets.UTF_16BE)
+        assertEquals(text, SubtitleScriptTextCodec.decode(bytes))
+    }
+
+    @Test
+    fun decode_emptyReturnsEmpty() {
+        assertEquals("", SubtitleScriptTextCodec.decode(ByteArray(0)))
+    }
+}

--- a/app/src/test/java/com/asmr/player/subtitle/SubtitleTranslationClientTest.kt
+++ b/app/src/test/java/com/asmr/player/subtitle/SubtitleTranslationClientTest.kt
@@ -540,6 +540,10 @@ class SubtitleTranslationClientTest {
         assert(TranslationPrompts.subtitleToolReadDescription().isNotBlank())
         assert(TranslationPrompts.subtitleToolWriteDescription().isNotBlank())
         assert(TranslationPrompts.subtitleToolChineseFieldDescription().isNotBlank())
+        assert(TranslationPrompts.subtitleScriptToolsSection().isNotBlank())
+        assert(TranslationPrompts.subtitleScriptListToolDescription().isNotBlank())
+        assert(TranslationPrompts.subtitleScriptReadToolDescription().isNotBlank())
+        assert(TranslationPrompts.subtitleAgentSystemPromptTemplate().contains("{{SCRIPT_TOOLS}}"))
         assert(TranslationPrompts.subtitleAgentSystemPromptTemplate().contains("{{SOURCE_COUNT}}"))
         assert(TranslationPrompts.subtitleAgentSystemPromptTemplate().contains("{{REFERENCE_TABLE}}"))
         // 翻译提示词包含结构级翻译腔归化约束
@@ -685,6 +689,116 @@ class SubtitleTranslationClientTest {
         assertEquals("Hello", String(TranslationPromptsCodec.decodeBase64("SGVsbG8="), Charsets.UTF_8))
         assertEquals("a", String(TranslationPromptsCodec.decodeBase64("YQ=="), Charsets.UTF_8))
         assertEquals("", String(TranslationPromptsCodec.decodeBase64(""), Charsets.UTF_8))
+    }
+
+    @Test
+    fun scriptTools_exposedOnlyWhenContextHasFiles() {
+        val gson = Gson()
+        val source = sources(1)
+        val base = JsonParser.parseString(
+            buildDeepSeekSubtitleTranslationRequest(gson, source, allowMerging = false)
+        ).asJsonObject
+        assertEquals(
+            listOf(SUBTITLE_READ_TOOL_NAME, SUBTITLE_WRITE_TOOL_NAME),
+            base.getAsJsonArray("tools").map { it.asJsonObject.getAsJsonObject("function").get("name").asString }
+        )
+
+        val context = SubtitleScriptContext(
+            files = listOf(SubtitleScriptFile(index = 0, name = "台本.txt")),
+            reader = SubtitleScriptReader { _, _, _ -> null }
+        )
+        val withScript = JsonParser.parseString(
+            buildDeepSeekSubtitleTranslationRequest(
+                gson,
+                source,
+                allowMerging = false,
+                scriptContext = context
+            )
+        ).asJsonObject
+        assertEquals(
+            listOf(SUBTITLE_READ_TOOL_NAME, SUBTITLE_WRITE_TOOL_NAME, SCRIPT_LIST_TOOL_NAME, SCRIPT_READ_TOOL_NAME),
+            withScript.getAsJsonArray("tools").map { it.asJsonObject.getAsJsonObject("function").get("name").asString }
+        )
+    }
+
+    @Test
+    fun prompt_injectsScriptToolsSectionWhenContextPresent() {
+        val context = SubtitleScriptContext(
+            files = listOf(SubtitleScriptFile(index = 0, name = "台本.txt")),
+            reader = SubtitleScriptReader { _, _, _ -> null }
+        )
+        val withScript = subtitleToolTranslationSystemPrompt(
+            listOf(0),
+            allowMerging = true,
+            scriptContext = context
+        )
+        val withoutScript = subtitleToolTranslationSystemPrompt(listOf(0), allowMerging = true)
+
+        assert(withScript.contains(SCRIPT_LIST_TOOL_NAME))
+        assert(withScript.contains(SCRIPT_READ_TOOL_NAME))
+        assert(withScript.contains("台本"))
+        assert(!withScript.contains("{{"))
+        assert(!withoutScript.contains(SCRIPT_LIST_TOOL_NAME))
+        assert(!withoutScript.contains("{{"))
+    }
+
+    @Test
+    fun scriptListTool_listsFiles() {
+        val gson = Gson()
+        val context = SubtitleScriptContext(
+            files = listOf(
+                SubtitleScriptFile(index = 0, name = "台本.txt"),
+                SubtitleScriptFile(index = 1, name = "plot.md")
+            ),
+            reader = SubtitleScriptReader { _, _, _ -> null }
+        )
+        val msg = buildScriptListToolResultMessage(gson, "c1", context)
+        val json = JsonParser.parseString(msg.content).asJsonObject
+        assertEquals(2, json.get("total_files").asInt)
+        assertEquals("台本.txt", json.getAsJsonArray("files")[0].asJsonObject.get("name").asString)
+    }
+
+    @Test
+    fun scriptReadTool_pagesAndMarksCompletion() = runBlocking {
+        val gson = Gson()
+        val full = "abcdefghij"
+        val context = SubtitleScriptContext(
+            files = listOf(SubtitleScriptFile(index = 0, name = "台本.txt")),
+            reader = SubtitleScriptReader { index, offset, limit ->
+                val end = (offset + limit).coerceAtMost(full.length)
+                SubtitleScriptReadResult(
+                    fileIndex = index,
+                    name = "台本.txt",
+                    offset = offset,
+                    totalChars = full.length,
+                    content = full.substring(offset, end),
+                    truncated = end < full.length
+                )
+            }
+        )
+
+        val first = buildScriptReadToolResultMessage(gson, "c1", context, 0, 0, 4)
+        val firstJson = JsonParser.parseString(first.content).asJsonObject
+        assertEquals("abcd", firstJson.get("content").asString)
+        assertEquals(10, firstJson.get("total_chars").asInt)
+        assertEquals(false, firstJson.get("completed").asBoolean)
+
+        val last = buildScriptReadToolResultMessage(gson, "c2", context, 0, 8, 4)
+        val lastJson = JsonParser.parseString(last.content).asJsonObject
+        assertEquals("ij", lastJson.get("content").asString)
+        assertEquals(true, lastJson.get("completed").asBoolean)
+    }
+
+    @Test
+    fun scriptReadTool_parsesArgumentsAndRejectsOutOfRangeIndex() {
+        val args = parseScriptReadToolArguments("""{"file_index":1}""", fileCount = 3)
+        assertEquals(1, args.fileIndex)
+        assertEquals(0, args.offset)
+        assert(args.limit > 0)
+
+        assertThrows(IllegalArgumentException::class.java) {
+            parseScriptReadToolArguments("""{"file_index":5}""", fileCount = 3)
+        }
     }
 
     private fun sources(count: Int): List<GeneratedSubtitleSource> = List(count) { index ->


### PR DESCRIPTION
## 背景
LLM 翻译时，部分作品目录里还有「台本」文件（台词/剧情纲要等）。本次让翻译 agent 能自行检索查看这些内容，辅助统一人名、称呼、术语、情节与语气，提升翻译质量。

## 变更
- 翻译 agent 新增两个工具（仅在目录存在台本文件时注入，无台本时行为不变）：
  - `list_work_script_files`：列出作品目录下的台本/文本/PDF 文件（文件名 + 索引）
  - `read_work_script_file`：按字符偏移分页读取文件内容
- 目录扫描复用本地树索引（`loadOrBuildLocalTreeIndex`），支持普通路径与 SAF `content://`；文本按 `Text`、PDF 按 `Pdf` 类型收集。
- 支持 PDF 文本抽取：引入 `com.tom-roush:pdfbox-android:2.0.27.0`，`AsmrApp` 中初始化 `PDFBoxResourceLoader`，并新增 ProGuard keep 规则。
- 加固编码检测：BOM 识别（UTF-8 / UTF-16LE / UTF-16BE）+ `CharsetDecoder` 严格解码回退（UTF-8 → Shift-JIS → GBK）。
- 安全边界：单文件读取上限 20 万字符、20MB；扫描版/无文本层 PDF 视为不可读（暂不支持OCR）。

## 验证
- 单元测试：`SubtitleScriptTextCodecTest`、`SubtitleTranslationClientTest` 全部通过。
- `:app:installRelease` 编译 + 安装到设备成功（含 R8 minify）。
