### PR TITLE
fix: 优化专辑详情主题过渡与苹果风布局

### DIFF
--- a/app/src/main/java/com/asmr/player/MainActivity.kt
+++ b/app/src/main/java/com/asmr/player/MainActivity.kt
@@ -179,9 +179,7 @@ import com.asmr.player.ui.theme.ThemeTransitionRequest
 import com.asmr.player.ui.theme.ThemeTransitionTriggerRequest
 import com.asmr.player.ui.theme.LocalThemeTransitionTrigger
 import com.asmr.player.ui.theme.ThemeCircularRevealOverlay
-import androidx.compose.ui.graphics.ImageBitmap
-import android.graphics.Bitmap
-import androidx.compose.ui.graphics.asImageBitmap
+import com.asmr.player.ui.theme.captureThemeTransitionBitmap
 import com.asmr.player.ui.common.AppVolumeHearingWarningDialog
 import com.asmr.player.ui.common.AppVolumeWarningSessionState
 import com.asmr.player.ui.common.rememberAppVolumeWarningSessionState
@@ -544,29 +542,28 @@ class MainActivity : ComponentActivity() {
             val transitionScope = rememberCoroutineScope()
             var themeTransitionSeq by remember { mutableLongStateOf(0L) }
             var themeTransition by remember { mutableStateOf<ThemeTransitionRequest?>(null) }
+            var themeTransitionCapturePending by remember { mutableStateOf(false) }
             val currentMode by rememberUpdatedState(mode)
             val themeTransitionTrigger: (ThemeTransitionTriggerRequest) -> Unit = remember {
                 { triggerReq ->
-                    if (themeTransition == null) {
-                        val bitmap = runCatching {
-                            val w = this@MainActivity.window.decorView.width
-                            val h = this@MainActivity.window.decorView.height
-                            if (w > 0 && h > 0) {
-                                val bmp = Bitmap.createBitmap(w, h, Bitmap.Config.ARGB_8888)
-                                val canvas = android.graphics.Canvas(bmp)
-                                this@MainActivity.window.decorView.draw(canvas)
-                                bmp.asImageBitmap()
-                            } else null
-                        }.getOrNull()
-                        val bgColor = neutralPaletteForMode(currentMode).background
-                        themeTransition = ThemeTransitionRequest(
-                            origin = triggerReq.origin,
-                            oldContentBitmap = bitmap,
-                            oldBackgroundColor = bgColor,
-                            token = ++themeTransitionSeq
-                        )
+                    if (themeTransition == null && !themeTransitionCapturePending) {
+                        themeTransitionCapturePending = true
                         transitionScope.launch {
-                            settingsDataStore.setTheme(triggerReq.targetPref)
+                            try {
+                                val oldMode = currentMode
+                                val bitmap = captureThemeTransitionBitmap(this@MainActivity.window)
+                                if (themeTransition != null) return@launch
+                                themeTransition = ThemeTransitionRequest(
+                                    origin = triggerReq.origin,
+                                    oldContentBitmap = bitmap,
+                                    oldBackgroundColor = neutralPaletteForMode(oldMode).background,
+                                    targetIsDark = triggerReq.targetPref == "dark",
+                                    token = ++themeTransitionSeq
+                                )
+                                settingsDataStore.setTheme(triggerReq.targetPref)
+                            } finally {
+                                themeTransitionCapturePending = false
+                            }
                         }
                     }
                 }
@@ -660,6 +657,7 @@ class MainActivity : ComponentActivity() {
                         val currentToken = request.token
                         ThemeCircularRevealOverlay(
                             request = request,
+                            targetReady = mode.isDark == request.targetIsDark,
                             onAnimationEnd = {
                                 if (themeTransition?.token == currentToken) {
                                     themeTransition = null

--- a/app/src/main/java/com/asmr/player/ui/library/AlbumDetailScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/AlbumDetailScreen.kt
@@ -13,7 +13,6 @@ import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.animate
 import androidx.compose.animation.core.FastOutLinearInEasing
 import androidx.compose.animation.core.FastOutSlowInEasing
-import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.spring
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.expandVertically
@@ -63,7 +62,6 @@ import androidx.compose.ui.graphics.Shadow
 import androidx.compose.ui.graphics.TransformOrigin
 import androidx.compose.ui.graphics.asComposeRenderEffect
 import androidx.compose.ui.graphics.compositeOver
-import androidx.compose.ui.graphics.lerp
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.foundation.gestures.detectTransformGestures
 import androidx.compose.ui.graphics.graphicsLayer
@@ -80,6 +78,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.stateDescription
 import androidx.compose.ui.state.ToggleableState
 import androidx.compose.ui.text.font.FontWeight
@@ -258,11 +257,6 @@ private val AlbumHeaderEnterTweenSpec = tween<Float>(
 private val AlbumHeaderExpandTweenSpec = tween<IntSize>(
     durationMillis = 320,
     easing = FastOutLinearInEasing
-)
-
-private val AlbumHeaderActionColorTweenSpec = tween<Float>(
-    durationMillis = 280,
-    easing = FastOutSlowInEasing
 )
 
 private val DlsiteSectionResizeTweenSpec = tween<IntSize>(
@@ -1741,15 +1735,13 @@ private fun AlbumHeroIdentityOverlay(
                 modifier = Modifier.fillMaxWidth(),
                 verticalAlignment = Alignment.CenterVertically
             ) {
-                AlbumPrimaryMetaRow(
+                AlbumHeroPrimaryMetaLightweight(
                     rjCode = rj,
                     circle = circle,
                     modifier = Modifier.weight(1f),
                     rjOnClick = { copyMeta("作品编号", rj) },
                     circleOnClick = { copyMeta("社团", circle) },
                     circleOnLongClick = { onMetaLongClick(circle) },
-                    appearance = AlbumMetaAppearance.OnImage,
-                    leadingVisual = AlbumMetaLeadingVisual.Icon,
                 )
                 AlbumOnlineListenerInfo(
                     listenerCount = listenTogetherRjListenerCount,
@@ -1947,8 +1939,6 @@ private fun AlbumHeader(
     messageManager: MessageManager,
     onMetaLongClick: (String) -> Unit
 ) {
-    val context = LocalContext.current
-    val colorScheme = AsmrTheme.colorScheme
     val copyMeta = rememberAlbumMetaCopyAction(messageManager)
 
     val headerAnimationScopeKey = remember(introSessionKey) { "albumHeader:$introSessionKey" }
@@ -1962,19 +1952,6 @@ private fun AlbumHeader(
     val headerContainerModifier = Modifier
         .fillMaxWidth()
         .padding(horizontal = AlbumDetailHorizontalPadding)
-    val langCandidates = remember(dlsiteEditions) {
-        dlsiteEditions
-            .filter { it.lang in setOf("JPN", "CHI_HANS", "CHI_HANT") }
-            .distinctBy { it.lang }
-            .sortedWith(compareBy({ it.displayOrder }, { it.lang }))
-    }
-    val selectedLangLabel = remember(dlsiteSelectedLang, langCandidates) {
-        langCandidates.firstOrNull { it.lang.equals(dlsiteSelectedLang, ignoreCase = true) }
-            ?.let { dlsiteLanguageButtonLabel(it.lang) }
-            ?: dlsiteLanguageButtonLabel(dlsiteSelectedLang)
-    }
-    var languageMenuExpanded by rememberSaveable { mutableStateOf(false) }
-
     Column(
         modifier = headerContainerModifier.padding(top = 4.dp, bottom = 12.dp)
         // 不用 spacedBy 控制信息行之间的间距：cv/tags 行在网络数据到达后会以 0 高度组合、再通过
@@ -2020,198 +1997,265 @@ private fun AlbumHeader(
             }
         }
 
-        Box(
+        AlbumHeaderActionBar(
+            groupState = when {
+                showDlsitePlayLossless -> AlbumHeaderButtonGroupState.Lossless
+                showSaveAction -> AlbumHeaderButtonGroupState.Save
+                else -> AlbumHeaderButtonGroupState.DownloadOnly
+            },
+            onDownloadClick = onDownloadClick,
+            onSaveClick = onSaveClick,
+            onLosslessDownloadClick = onLosslessDownloadClick,
+            downloadEnabled = downloadEnabled,
+            saveEnabled = saveEnabled,
+            losslessDownloadEnabled = losslessDownloadEnabled,
+            showGroupAction = showGroupButton,
+            groupEnabled = album.id > 0L,
+            onGroupClick = {
+                val id = album.id
+                if (id > 0L) onOpenGroupPicker(id)
+            },
+            dlsiteEditions = dlsiteEditions,
+            dlsiteSelectedLang = dlsiteSelectedLang,
+            onDlsiteLangSelected = onDlsiteLangSelected,
+            dlsiteUrl = dlsiteUrl,
+            asmrOneUrl = asmrOneUrl,
+            availableWidth = availableWidth,
+        )
+    }
+}
+
+@Composable
+private fun AlbumHeaderActionBar(
+    groupState: AlbumHeaderButtonGroupState,
+    onDownloadClick: () -> Unit,
+    onSaveClick: () -> Unit,
+    onLosslessDownloadClick: () -> Unit,
+    downloadEnabled: Boolean,
+    saveEnabled: Boolean,
+    losslessDownloadEnabled: Boolean,
+    showGroupAction: Boolean,
+    groupEnabled: Boolean,
+    onGroupClick: () -> Unit,
+    dlsiteEditions: List<DlsiteLanguageEdition>,
+    dlsiteSelectedLang: String,
+    onDlsiteLangSelected: (String) -> Unit,
+    dlsiteUrl: String,
+    asmrOneUrl: String,
+    availableWidth: Dp,
+) {
+    val context = LocalContext.current
+    val colorScheme = AsmrTheme.colorScheme
+    val compact = availableWidth < 400.dp
+    val shape = RoundedCornerShape(15.dp)
+    val containerColor = if (colorScheme.isDark) {
+        colorScheme.surfaceVariant.copy(alpha = 0.58f)
+    } else {
+        colorScheme.surface.copy(alpha = 0.88f)
+    }
+    val borderColor = colorScheme.onSurfaceVariant.copy(
+        alpha = if (colorScheme.isDark) 0.18f else 0.12f
+    )
+    val langCandidates = remember(dlsiteEditions) {
+        dlsiteEditions
+            .filter { it.lang in setOf("JPN", "CHI_HANS", "CHI_HANT") }
+            .distinctBy { it.lang }
+            .sortedWith(compareBy({ it.displayOrder }, { it.lang }))
+    }
+    val selectedLangLabel = remember(dlsiteSelectedLang, langCandidates) {
+        langCandidates.firstOrNull { it.lang.equals(dlsiteSelectedLang, ignoreCase = true) }
+            ?.let { dlsiteLanguageButtonLabel(it.lang) }
+            ?: dlsiteLanguageButtonLabel(dlsiteSelectedLang)
+    }
+    var languageMenuExpanded by rememberSaveable { mutableStateOf(false) }
+    val secondaryAction = when (groupState) {
+        AlbumHeaderButtonGroupState.Save -> Triple("保存", Icons.Rounded.Bookmark, saveEnabled)
+        AlbumHeaderButtonGroupState.Lossless -> Triple("无损下载", Icons.Rounded.LibraryMusic, losslessDownloadEnabled)
+        AlbumHeaderButtonGroupState.DownloadOnly -> null
+    }
+
+    Surface(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(46.dp),
+        shape = shape,
+        color = containerColor,
+        contentColor = colorScheme.textPrimary,
+        border = androidx.compose.foundation.BorderStroke(0.5.dp, borderColor),
+        tonalElevation = 0.dp,
+        shadowElevation = 0.dp,
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(3.dp),
+            horizontalArrangement = Arrangement.spacedBy(2.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            AlbumHeaderBarAction(
+                label = "下载",
+                icon = Icons.Rounded.Download,
+                showLabel = true,
+                enabled = downloadEnabled,
+                prominent = true,
+                onClick = onDownloadClick,
+                modifier = Modifier
+                    .weight(1f)
+                    .fillMaxHeight(),
+            )
+
+            secondaryAction?.let { (label, icon, enabled) ->
+                AlbumHeaderBarAction(
+                    label = label,
+                    icon = icon,
+                    showLabel = true,
+                    enabled = enabled,
+                    onClick = when (groupState) {
+                        AlbumHeaderButtonGroupState.Save -> onSaveClick
+                        AlbumHeaderButtonGroupState.Lossless -> onLosslessDownloadClick
+                        AlbumHeaderButtonGroupState.DownloadOnly -> ({})
+                    },
                     modifier = Modifier
-                        .fillMaxWidth()
+                        .weight(1f)
+                        .fillMaxHeight(),
+                )
+            }
+
+            VerticalDivider(
+                modifier = Modifier
+                    .padding(horizontal = 2.dp)
+                    .height(20.dp),
+                thickness = 0.5.dp,
+                color = borderColor,
+            )
+
+            if (showGroupAction) {
+                AlbumHeaderBarAction(
+                    label = "分组",
+                    icon = Icons.Rounded.CreateNewFolder,
+                    showLabel = true,
+                    enabled = groupEnabled,
+                    onClick = onGroupClick,
+                    modifier = Modifier
+                        .width(70.dp)
+                        .fillMaxHeight(),
+                )
+            }
+
+            if (langCandidates.isNotEmpty()) {
+                val languageSelectable = langCandidates.size > 1
+                Box(
+                    modifier = Modifier
+                        .width(if (compact) 60.dp else 88.dp)
+                        .fillMaxHeight()
                 ) {
-                        val compact = availableWidth < 400.dp
-                        val ultraCompact = availableWidth < 340.dp
-                        val actionGap = if (compact) 8.dp else 10.dp
-                        val primaryButtonPadding = when {
-                            ultraCompact -> 6.dp
-                            compact -> 8.dp
-                            else -> 12.dp
+                    AlbumHeaderBarAction(
+                        label = selectedLangLabel,
+                        icon = Icons.Rounded.Translate,
+                        showLabel = true,
+                        enabled = languageSelectable,
+                        onClick = { languageMenuExpanded = true },
+                        modifier = Modifier.fillMaxSize(),
+                    )
+                    AlbumHeaderLanguageDropdownMenu(
+                        expanded = languageMenuExpanded,
+                        candidates = langCandidates,
+                        selectedLang = dlsiteSelectedLang,
+                        onDismiss = { languageMenuExpanded = false },
+                        onSelect = { lang ->
+                            languageMenuExpanded = false
+                            onDlsiteLangSelected(lang)
                         }
-                        val smallButtonPadding = when {
-                            ultraCompact -> 6.dp
-                            compact -> 8.dp
-                            else -> 12.dp
-                        }
-                        val primaryIconSize = if (compact) 16.dp else 18.dp
-                        val primaryIconGap = if (compact) 4.dp else 6.dp
-                        val selectorMinWidth = when {
-                            ultraCompact -> 68.dp
-                            compact -> 76.dp
-                            else -> 96.dp
-                        }
-                        val selectorMaxWidth = when {
-                            ultraCompact -> 92.dp
-                            compact -> 104.dp
-                            else -> 140.dp
-                        }
-                        val externalMinWidth = when {
-                            ultraCompact -> 46.dp
-                            compact -> 50.dp
-                            else -> 56.dp
-                        }
-                        val externalMaxWidth = when {
-                            ultraCompact -> 58.dp
-                            compact -> 64.dp
-                            else -> 76.dp
-                        }
-
-                        Row(
-                            modifier = Modifier.fillMaxWidth(),
-                            horizontalArrangement = Arrangement.spacedBy(actionGap),
-                            verticalAlignment = Alignment.CenterVertically
-                        ) {
-                            Row(
-                                modifier = Modifier
-                                    .height(36.dp)
-                                    .weight(1f)
-                            ) {
-                                val groupState = when {
-                                    showDlsitePlayLossless -> AlbumHeaderButtonGroupState.Lossless
-                                    showSaveAction -> AlbumHeaderButtonGroupState.Save
-                                    else -> AlbumHeaderButtonGroupState.DownloadOnly
-                                }
-                                AlbumHeaderDownloadAction(
-                                    groupState = groupState,
-                                    onDownloadClick = onDownloadClick,
-                                    onSaveClick = onSaveClick,
-                                    onLosslessDownloadClick = onLosslessDownloadClick,
-                                    downloadEnabled = downloadEnabled,
-                                    saveEnabled = saveEnabled,
-                                    losslessDownloadEnabled = losslessDownloadEnabled,
-                                    horizontalPadding = primaryButtonPadding,
-                                    iconSize = primaryIconSize,
-                                    iconGap = primaryIconGap,
-                                    modifier = Modifier.fillMaxSize()
-                                )
-                            }
-
-                            if (showGroupButton) {
-                                OutlinedButton(
-                                    onClick = {
-                                        val id = album.id
-                                        if (id > 0L) onOpenGroupPicker(id)
-                                    },
-                                    enabled = album.id > 0L,
-                                    modifier = Modifier
-                                        .height(36.dp)
-                                        .widthIn(min = selectorMinWidth, max = selectorMaxWidth),
-                                    shape = RoundedCornerShape(10.dp),
-                                    contentPadding = PaddingValues(horizontal = smallButtonPadding, vertical = 0.dp),
-                                    border = androidx.compose.foundation.BorderStroke(1.dp, colorScheme.primary.copy(alpha = 0.3f))
-                                ) {
-                                    Icon(
-                                        Icons.Rounded.CreateNewFolder,
-                                        contentDescription = null,
-                                        tint = colorScheme.primary,
-                                        modifier = Modifier.size(primaryIconSize)
-                                    )
-                                    Spacer(modifier = Modifier.width(primaryIconGap))
-                                    Text("分组", style = MaterialTheme.typography.labelMedium, color = colorScheme.primary, maxLines = 1)
-                                }
-                            }
-
-                            if (langCandidates.isNotEmpty()) {
-                                val languageSelectable = langCandidates.size > 1
-                                val languageContainerColor = colorScheme.primary.copy(
-                                    alpha = if (languageSelectable) {
-                                        if (colorScheme.isDark) 0.18f else 0.10f
-                                    } else {
-                                        if (colorScheme.isDark) 0.08f else 0.06f
-                                    }
-                                )
-                                val languageContentColor = if (languageSelectable) {
-                                    colorScheme.primary
-                                } else {
-                                    colorScheme.textSecondary
-                                }
-                                Box {
-                                    OutlinedButton(
-                                        onClick = {
-                                            if (languageSelectable) languageMenuExpanded = true
-                                        },
-                                        enabled = languageSelectable,
-                                        modifier = Modifier
-                                            .height(36.dp)
-                                            .widthIn(min = selectorMinWidth, max = selectorMaxWidth),
-                                        shape = RoundedCornerShape(10.dp),
-                                        contentPadding = PaddingValues(horizontal = smallButtonPadding, vertical = 0.dp),
-                                        border = androidx.compose.foundation.BorderStroke(
-                                            1.dp,
-                                            colorScheme.primary.copy(alpha = if (languageSelectable) 0.34f else 0.16f)
-                                        ),
-                                        colors = ButtonDefaults.outlinedButtonColors(
-                                            containerColor = languageContainerColor,
-                                            contentColor = languageContentColor,
-                                            disabledContainerColor = languageContainerColor,
-                                            disabledContentColor = languageContentColor
-                                        )
-                                    ) {
-                                        Icon(
-                                            imageVector = Icons.Rounded.Translate,
-                                            contentDescription = null,
-                                            tint = languageContentColor,
-                                            modifier = Modifier.size(primaryIconSize)
-                                        )
-                                        Spacer(modifier = Modifier.width(primaryIconGap))
-                                        Text(
-                                            text = selectedLangLabel,
-                                            style = MaterialTheme.typography.labelMedium,
-                                            color = languageContentColor,
-                                            maxLines = 1
-                                        )
-                                        Spacer(modifier = Modifier.width(if (compact) 2.dp else 4.dp))
-                                        Icon(
-                                            imageVector = Icons.Rounded.ArrowDropDown,
-                                            contentDescription = null,
-                                            tint = if (languageSelectable) colorScheme.primary else colorScheme.textTertiary,
-                                            modifier = Modifier.size(primaryIconSize)
-                                        )
-                                    }
-                                    AlbumHeaderLanguageDropdownMenu(
-                                        expanded = languageMenuExpanded,
-                                        candidates = langCandidates,
-                                        selectedLang = dlsiteSelectedLang,
-                                        onDismiss = { languageMenuExpanded = false },
-                                        onSelect = { lang ->
-                                            languageMenuExpanded = false
-                                            onDlsiteLangSelected(lang)
-                                        }
-                                    )
-                                }
-                            }
-
-                            listOf(
-                                "DLsite" to dlsiteUrl,
-                                "ONE" to asmrOneUrl
-                            ).forEach { (label, url) ->
-                                OutlinedButton(
-                                    onClick = {
-                                        if (url.isNotBlank()) {
-                                            context.startActivity(
-                                                Intent(Intent.ACTION_VIEW, Uri.parse(url)).addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-                                            )
-                                        }
-                                    },
-                                    enabled = url.isNotBlank(),
-                                    modifier = Modifier
-                                        .height(36.dp)
-                                        .widthIn(min = externalMinWidth, max = externalMaxWidth),
-                                    shape = RoundedCornerShape(10.dp),
-                                    contentPadding = PaddingValues(horizontal = smallButtonPadding, vertical = 0.dp),
-                                    border = androidx.compose.foundation.BorderStroke(1.dp, colorScheme.primary.copy(alpha = 0.3f))
-                                ) {
-                                    Text(label, style = MaterialTheme.typography.labelMedium, color = colorScheme.primary, maxLines = 1)
-                                }
-                            }
-                        }
+                    )
                 }
             }
+
+            listOf(
+                Triple("DLsite", dlsiteUrl, 64.dp),
+                Triple("ONE", asmrOneUrl, if (compact) 44.dp else 56.dp),
+            ).forEach { (label, url, width) ->
+                AlbumHeaderBarAction(
+                    label = label,
+                    showLabel = true,
+                    enabled = url.isNotBlank(),
+                    onClick = {
+                        if (url.isNotBlank()) {
+                            context.startActivity(
+                                Intent(Intent.ACTION_VIEW, Uri.parse(url))
+                                    .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                            )
+                        }
+                    },
+                    modifier = Modifier
+                        .width(width)
+                        .fillMaxHeight(),
+                )
+            }
         }
+    }
+}
+
+@Composable
+private fun AlbumHeaderBarAction(
+    label: String,
+    showLabel: Boolean,
+    enabled: Boolean,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    icon: ImageVector? = null,
+    prominent: Boolean = false,
+) {
+    val colorScheme = AsmrTheme.colorScheme
+    val shape = RoundedCornerShape(11.dp)
+    val contentColor = when {
+        !enabled -> colorScheme.textTertiary.copy(alpha = 0.72f)
+        prominent -> colorScheme.primaryStrong
+        else -> colorScheme.primary
+    }
+    val containerColor = if (prominent && enabled) {
+        colorScheme.primary.copy(alpha = if (colorScheme.isDark) 0.18f else 0.10f)
+    } else {
+        Color.Transparent
+    }
+
+    CompositionLocalProvider(LocalContentColor provides contentColor) {
+        Row(
+            modifier = modifier
+                .clip(shape)
+                .background(containerColor, shape)
+                .clickable(
+                    enabled = enabled,
+                    role = Role.Button,
+                    onClick = onClick,
+                )
+                .padding(horizontal = if (showLabel && icon != null) 7.dp else 5.dp),
+            horizontalArrangement = Arrangement.Center,
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            if (icon != null) {
+                Icon(
+                    imageVector = icon,
+                    contentDescription = if (showLabel) null else label,
+                    tint = contentColor,
+                    modifier = Modifier.size(17.dp),
+                )
+            }
+            if (showLabel) {
+                if (icon != null) Spacer(modifier = Modifier.width(4.dp))
+                Text(
+                    text = label,
+                    style = MaterialTheme.typography.labelMedium.copy(
+                        fontWeight = if (prominent) FontWeight.SemiBold else FontWeight.Medium,
+                    ),
+                    color = contentColor,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
+        }
+    }
+}
+
 private fun dlsiteLanguageButtonLabel(lang: String): String {
     return when (lang.trim().uppercase()) {
         "CHI_HANS" -> "简中"
@@ -2301,142 +2345,6 @@ private fun AlbumHeaderLanguageDropdownMenu(
                         disabledTrailingIconColor = colorScheme.textTertiary
                     )
                 )
-            }
-        }
-    }
-}
-
-@Composable
-private fun AlbumHeaderDownloadAction(
-    groupState: AlbumHeaderButtonGroupState,
-    onDownloadClick: () -> Unit,
-    onSaveClick: () -> Unit,
-    onLosslessDownloadClick: () -> Unit,
-    downloadEnabled: Boolean,
-    saveEnabled: Boolean,
-    losslessDownloadEnabled: Boolean,
-    horizontalPadding: Dp,
-    iconSize: Dp,
-    iconGap: Dp,
-    modifier: Modifier = Modifier
-) {
-    val colorScheme = AsmrTheme.colorScheme
-    val hasSecondaryAction = groupState != AlbumHeaderButtonGroupState.DownloadOnly
-    val secondaryActionEnabled = when (groupState) {
-        AlbumHeaderButtonGroupState.Save -> saveEnabled
-        AlbumHeaderButtonGroupState.Lossless -> losslessDownloadEnabled
-        AlbumHeaderButtonGroupState.DownloadOnly -> false
-    }
-    val downloadColorProgress by animateFloatAsState(
-        targetValue = if (downloadEnabled) 1f else 0f,
-        animationSpec = AlbumHeaderActionColorTweenSpec,
-        label = "albumHeaderDownloadColor"
-    )
-    val secondaryColorProgress by animateFloatAsState(
-        targetValue = if (secondaryActionEnabled) 1f else 0f,
-        animationSpec = AlbumHeaderActionColorTweenSpec,
-        label = "albumHeaderSecondaryActionColor"
-    )
-    val radius = 10.dp
-    val mainShape = RoundedCornerShape(
-        topStart = radius,
-        bottomStart = radius,
-        topEnd = if (hasSecondaryAction) 0.dp else radius,
-        bottomEnd = if (hasSecondaryAction) 0.dp else radius
-    )
-    val secondaryShape = RoundedCornerShape(
-        topStart = 0.dp,
-        bottomStart = 0.dp,
-        topEnd = radius,
-        bottomEnd = radius
-    )
-    val disabledContainer = colorScheme.surfaceVariant.copy(
-        alpha = if (colorScheme.isDark) 0.54f else 0.74f
-    )
-    val disabledContent = colorScheme.textTertiary.copy(alpha = if (colorScheme.isDark) 0.72f else 0.86f)
-    val primaryContainer = lerp(disabledContainer, colorScheme.primary, downloadColorProgress)
-    val primaryContent = lerp(disabledContent, colorScheme.onPrimary, downloadColorProgress)
-    val secondaryDisabledContainer = colorScheme.surfaceVariant.copy(
-        alpha = if (colorScheme.isDark) 0.42f else 0.62f
-    )
-    val secondaryActiveContainer = colorScheme.primary.copy(
-        alpha = if (colorScheme.isDark) 0.22f else 0.14f
-    )
-    val secondaryContainer = lerp(
-        secondaryDisabledContainer,
-        secondaryActiveContainer,
-        secondaryColorProgress
-    )
-    val secondaryContent = lerp(disabledContent, colorScheme.primary, secondaryColorProgress)
-
-    Row(
-        modifier = modifier,
-        verticalAlignment = Alignment.CenterVertically
-    ) {
-        Button(
-            onClick = onDownloadClick,
-            enabled = downloadEnabled,
-            modifier = Modifier
-                .fillMaxHeight()
-                .weight(1f),
-            shape = mainShape,
-            contentPadding = PaddingValues(horizontal = horizontalPadding, vertical = 0.dp),
-            colors = ButtonDefaults.buttonColors(
-                containerColor = primaryContainer,
-                contentColor = primaryContent,
-                disabledContainerColor = primaryContainer,
-                disabledContentColor = primaryContent
-            )
-        ) {
-            Icon(Icons.Rounded.Download, contentDescription = null, modifier = Modifier.size(iconSize))
-            Spacer(modifier = Modifier.width(iconGap))
-            Text("下载", style = MaterialTheme.typography.labelMedium, maxLines = 1)
-        }
-        if (hasSecondaryAction) {
-            Box(
-                modifier = Modifier
-                    .fillMaxHeight()
-                    .weight(1f)
-            ) {
-                when (groupState) {
-                    AlbumHeaderButtonGroupState.Save -> Button(
-                        onClick = onSaveClick,
-                        enabled = saveEnabled,
-                        modifier = Modifier.fillMaxSize(),
-                        shape = secondaryShape,
-                        contentPadding = PaddingValues(horizontal = horizontalPadding, vertical = 0.dp),
-                        colors = ButtonDefaults.buttonColors(
-                            containerColor = secondaryContainer,
-                            contentColor = secondaryContent,
-                            disabledContainerColor = secondaryContainer,
-                            disabledContentColor = secondaryContent
-                        )
-                    ) {
-                        Icon(Icons.Rounded.Bookmark, contentDescription = null, modifier = Modifier.size(iconSize))
-                        Spacer(modifier = Modifier.width(iconGap))
-                        Text("保存", style = MaterialTheme.typography.labelMedium, maxLines = 1)
-                    }
-
-                    AlbumHeaderButtonGroupState.Lossless -> Button(
-                        onClick = onLosslessDownloadClick,
-                        enabled = losslessDownloadEnabled,
-                        modifier = Modifier.fillMaxSize(),
-                        shape = secondaryShape,
-                        contentPadding = PaddingValues(horizontal = horizontalPadding, vertical = 0.dp),
-                        colors = ButtonDefaults.buttonColors(
-                            containerColor = secondaryContainer,
-                            contentColor = secondaryContent,
-                            disabledContainerColor = secondaryContainer,
-                            disabledContentColor = secondaryContent
-                        )
-                    ) {
-                        Icon(Icons.Rounded.LibraryMusic, contentDescription = null, modifier = Modifier.size(iconSize))
-                        Spacer(modifier = Modifier.width(iconGap))
-                        Text("无损下载", style = MaterialTheme.typography.labelMedium, maxLines = 1)
-                    }
-
-                    AlbumHeaderButtonGroupState.DownloadOnly -> Unit
-                }
             }
         }
     }

--- a/app/src/main/java/com/asmr/player/ui/library/AlbumDetailScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/AlbumDetailScreen.kt
@@ -2073,6 +2073,18 @@ private fun AlbumHeaderActionBar(
         AlbumHeaderButtonGroupState.Lossless -> Triple("无损下载", Icons.Rounded.LibraryMusic, losslessDownloadEnabled)
         AlbumHeaderButtonGroupState.DownloadOnly -> null
     }
+    val hasSecondaryAction = secondaryAction != null
+    val downloadShape = if (hasSecondaryAction) {
+        RoundedCornerShape(topStart = 11.dp, topEnd = 0.dp, bottomEnd = 0.dp, bottomStart = 11.dp)
+    } else {
+        RoundedCornerShape(11.dp)
+    }
+    val secondaryShape = RoundedCornerShape(
+        topStart = 0.dp,
+        topEnd = 11.dp,
+        bottomEnd = 11.dp,
+        bottomStart = 0.dp,
+    )
 
     Surface(
         modifier = Modifier
@@ -2092,33 +2104,43 @@ private fun AlbumHeaderActionBar(
             horizontalArrangement = Arrangement.spacedBy(2.dp),
             verticalAlignment = Alignment.CenterVertically,
         ) {
-            AlbumHeaderBarAction(
-                label = "下载",
-                icon = Icons.Rounded.Download,
-                showLabel = true,
-                enabled = downloadEnabled,
-                prominent = true,
-                onClick = onDownloadClick,
+            Row(
                 modifier = Modifier
                     .weight(1f)
                     .fillMaxHeight(),
-            )
-
-            secondaryAction?.let { (label, icon, enabled) ->
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
                 AlbumHeaderBarAction(
-                    label = label,
-                    icon = icon,
+                    label = "下载",
+                    icon = Icons.Rounded.Download,
                     showLabel = true,
-                    enabled = enabled,
-                    onClick = when (groupState) {
-                        AlbumHeaderButtonGroupState.Save -> onSaveClick
-                        AlbumHeaderButtonGroupState.Lossless -> onLosslessDownloadClick
-                        AlbumHeaderButtonGroupState.DownloadOnly -> ({})
-                    },
+                    enabled = downloadEnabled,
+                    style = AlbumHeaderActionStyle.Primary,
+                    shape = downloadShape,
+                    onClick = onDownloadClick,
                     modifier = Modifier
                         .weight(1f)
                         .fillMaxHeight(),
                 )
+
+                secondaryAction?.let { (label, icon, enabled) ->
+                    AlbumHeaderBarAction(
+                        label = label,
+                        icon = icon,
+                        showLabel = true,
+                        enabled = enabled,
+                        style = AlbumHeaderActionStyle.Secondary,
+                        shape = secondaryShape,
+                        onClick = when (groupState) {
+                            AlbumHeaderButtonGroupState.Save -> onSaveClick
+                            AlbumHeaderButtonGroupState.Lossless -> onLosslessDownloadClick
+                            AlbumHeaderButtonGroupState.DownloadOnly -> ({})
+                        },
+                        modifier = Modifier
+                            .weight(1f)
+                            .fillMaxHeight(),
+                    )
+                }
             }
 
             VerticalDivider(
@@ -2195,6 +2217,12 @@ private fun AlbumHeaderActionBar(
     }
 }
 
+private enum class AlbumHeaderActionStyle {
+    Standard,
+    Primary,
+    Secondary,
+}
+
 @Composable
 private fun AlbumHeaderBarAction(
     label: String,
@@ -2203,19 +2231,22 @@ private fun AlbumHeaderBarAction(
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
     icon: ImageVector? = null,
-    prominent: Boolean = false,
+    style: AlbumHeaderActionStyle = AlbumHeaderActionStyle.Standard,
+    shape: RoundedCornerShape = RoundedCornerShape(11.dp),
 ) {
     val colorScheme = AsmrTheme.colorScheme
-    val shape = RoundedCornerShape(11.dp)
     val contentColor = when {
         !enabled -> colorScheme.textTertiary.copy(alpha = 0.72f)
-        prominent -> colorScheme.primaryStrong
-        else -> colorScheme.primary
+        style == AlbumHeaderActionStyle.Primary -> colorScheme.onPrimary
+        else -> colorScheme.primaryStrong
     }
-    val containerColor = if (prominent && enabled) {
-        colorScheme.primary.copy(alpha = if (colorScheme.isDark) 0.18f else 0.10f)
-    } else {
-        Color.Transparent
+    val containerColor = when {
+        !enabled -> Color.Transparent
+        style == AlbumHeaderActionStyle.Primary -> colorScheme.primaryStrong
+        style == AlbumHeaderActionStyle.Secondary -> colorScheme.primary.copy(
+            alpha = if (colorScheme.isDark) 0.28f else 0.15f
+        )
+        else -> Color.Transparent
     }
 
     CompositionLocalProvider(LocalContentColor provides contentColor) {
@@ -2245,7 +2276,11 @@ private fun AlbumHeaderBarAction(
                 Text(
                     text = label,
                     style = MaterialTheme.typography.labelMedium.copy(
-                        fontWeight = if (prominent) FontWeight.SemiBold else FontWeight.Medium,
+                        fontWeight = if (style == AlbumHeaderActionStyle.Standard) {
+                            FontWeight.Medium
+                        } else {
+                            FontWeight.SemiBold
+                        },
                     ),
                     color = contentColor,
                     maxLines = 1,

--- a/app/src/main/java/com/asmr/player/ui/library/AlbumMetaChips.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/AlbumMetaChips.kt
@@ -55,7 +55,6 @@ import com.asmr.player.util.MessageManager
 
 private val AlbumMetaPillShape = RoundedCornerShape(999.dp)
 private val AlbumMetaTagShape = RoundedCornerShape(7.dp)
-private val AlbumMetaDenseTagShape = RoundedCornerShape(6.dp)
 private val AlbumHeaderMetaExpandCollapseSpec = tween<IntSize>(
     durationMillis = 280,
     easing = FastOutSlowInEasing,
@@ -68,19 +67,9 @@ private data class AlbumMetaPalette(
     val border: Color,
 )
 
-internal enum class AlbumMetaAppearance {
-    Default,
-    OnImage,
-}
-
 internal enum class AlbumMetaLeadingVisual {
     None,
     Icon,
-}
-
-internal enum class AlbumPrimaryMetaOrder {
-    RjThenCircle,
-    CircleThenRj,
 }
 
 @Composable
@@ -114,67 +103,6 @@ private fun normalizeAlbumTags(tags: List<String>): List<String> {
         .map { it.trim() }
         .filter { it.isNotBlank() }
         .distinct()
-}
-
-@Composable
-internal fun AlbumPrimaryMetaRow(
-    rjCode: String,
-    circle: String,
-    modifier: Modifier = Modifier,
-    rjOnClick: (() -> Unit)? = null,
-    circleOnClick: (() -> Unit)? = null,
-    circleOnLongClick: (() -> Unit)? = null,
-    appearance: AlbumMetaAppearance = AlbumMetaAppearance.Default,
-    leadingVisual: AlbumMetaLeadingVisual = AlbumMetaLeadingVisual.None,
-    order: AlbumPrimaryMetaOrder = AlbumPrimaryMetaOrder.RjThenCircle,
-) {
-    val normalizedRj = remember(rjCode) { rjCode.trim() }
-    val normalizedCircle = remember(circle) { circle.trim() }
-    if (normalizedRj.isBlank() && normalizedCircle.isBlank()) return
-
-    val rjBadge: @Composable () -> Unit = {
-        if (normalizedRj.isNotBlank()) {
-            AlbumMetaBadge(
-                text = normalizedRj,
-                tone = AlbumMetaTone.Rj,
-                shape = AlbumMetaDenseTagShape,
-                onClick = rjOnClick,
-                appearance = appearance,
-            )
-        }
-    }
-    val circleBadge: @Composable () -> Unit = {
-        if (normalizedCircle.isNotBlank()) {
-            AlbumMetaBadge(
-                text = normalizedCircle,
-                tone = AlbumMetaTone.Circle,
-                shape = AlbumMetaPillShape,
-                onClick = circleOnClick,
-                onLongClick = circleOnLongClick,
-                appearance = appearance,
-                leadingIcon = if (leadingVisual == AlbumMetaLeadingVisual.Icon) AlbumMetaLeadingIconKind.Club else null,
-            )
-        }
-    }
-
-    Row(
-        modifier = modifier
-            .clipToBounds()
-            .horizontalScroll(rememberScrollState()),
-        horizontalArrangement = Arrangement.spacedBy(4.dp),
-        verticalAlignment = Alignment.CenterVertically,
-    ) {
-        when (order) {
-            AlbumPrimaryMetaOrder.RjThenCircle -> {
-                rjBadge()
-                circleBadge()
-            }
-            AlbumPrimaryMetaOrder.CircleThenRj -> {
-                circleBadge()
-                rjBadge()
-            }
-        }
-    }
 }
 
 @Composable
@@ -701,15 +629,12 @@ private fun albumMetaFlowLineCountWithTrailing(
 }
 
 private enum class AlbumMetaTone {
-    Rj,
-    Circle,
     CvLabel,
     CvValue,
     Tag,
 }
 
 private enum class AlbumMetaLeadingIconKind {
-    Club,
     Cv,
     Tags,
 }
@@ -718,16 +643,14 @@ private enum class AlbumMetaLeadingIconKind {
 private fun AlbumMetaLeadingIcon(
     kind: AlbumMetaLeadingIconKind,
     modifier: Modifier = Modifier,
-    appearance: AlbumMetaAppearance = AlbumMetaAppearance.Default,
     iconSize: Dp = 14.dp,
 ) {
     val colorScheme = AsmrTheme.colorScheme
     val (iconRes, tone) = when (kind) {
-        AlbumMetaLeadingIconKind.Club -> R.drawable.ic_album_meta_club to AlbumMetaTone.Circle
         AlbumMetaLeadingIconKind.Cv -> R.drawable.ic_album_meta_cv to AlbumMetaTone.CvLabel
         AlbumMetaLeadingIconKind.Tags -> R.drawable.ic_album_meta_tags to AlbumMetaTone.Tag
     }
-    val tint = albumMetaPalette(tone, colorScheme, appearance).content
+    val tint = albumMetaPalette(tone, colorScheme).content
 
     Icon(
         painter = painterResource(id = iconRes),
@@ -748,12 +671,11 @@ private fun AlbumMetaBadge(
     onClick: (() -> Unit)? = null,
     onLongClick: (() -> Unit)? = null,
     textWeight: FontWeight? = null,
-    appearance: AlbumMetaAppearance = AlbumMetaAppearance.Default,
     leadingIcon: AlbumMetaLeadingIconKind? = null,
     minTextWidth: Dp? = null,
 ) {
     val colorScheme = AsmrTheme.colorScheme
-    val palette = albumMetaPalette(tone, colorScheme, appearance)
+    val palette = albumMetaPalette(tone, colorScheme)
     val styledModifier = modifier
         .then(if (maxWidth != null) Modifier.widthIn(max = maxWidth) else Modifier)
         .clip(shape)
@@ -782,7 +704,6 @@ private fun AlbumMetaBadge(
         if (leadingIcon != null) {
             AlbumMetaLeadingIcon(
                 kind = leadingIcon,
-                appearance = appearance,
                 iconSize = if (text.isBlank()) 14.dp else 12.dp,
             )
         }
@@ -806,57 +727,8 @@ private fun AlbumMetaBadge(
 private fun albumMetaPalette(
     tone: AlbumMetaTone,
     colorScheme: com.asmr.player.ui.theme.AsmrColorScheme,
-    appearance: AlbumMetaAppearance,
 ): AlbumMetaPalette {
-    if (appearance == AlbumMetaAppearance.OnImage) {
-        val primaryContainer = colorScheme.primary.copy(alpha = if (colorScheme.isDark) 0.36f else 0.30f)
-        val primarySoftContainer = colorScheme.primary.copy(alpha = if (colorScheme.isDark) 0.24f else 0.20f)
-        val primaryContent = if (colorScheme.isDark) {
-            Color.White.copy(alpha = 0.96f)
-        } else {
-            colorScheme.textPrimary.copy(alpha = 0.88f)
-        }
-        val primaryBorder = colorScheme.primary.copy(alpha = if (colorScheme.isDark) 0.52f else 0.42f)
-        return when (tone) {
-            AlbumMetaTone.Rj -> AlbumMetaPalette(
-                container = primaryContainer,
-                content = primaryContent,
-                border = primaryBorder,
-            )
-            AlbumMetaTone.Circle -> AlbumMetaPalette(
-                container = primarySoftContainer,
-                content = primaryContent,
-                border = primaryBorder.copy(alpha = 0.78f),
-            )
-            AlbumMetaTone.CvLabel -> AlbumMetaPalette(
-                container = primarySoftContainer,
-                content = primaryContent,
-                border = primaryBorder.copy(alpha = 0.72f),
-            )
-            AlbumMetaTone.CvValue -> AlbumMetaPalette(
-                container = colorScheme.primary.copy(alpha = if (colorScheme.isDark) 0.18f else 0.16f),
-                content = primaryContent,
-                border = primaryBorder.copy(alpha = 0.56f),
-            )
-            AlbumMetaTone.Tag -> AlbumMetaPalette(
-                container = colorScheme.primary.copy(alpha = if (colorScheme.isDark) 0.18f else 0.14f),
-                content = primaryContent.copy(alpha = 0.92f),
-                border = primaryBorder.copy(alpha = 0.42f),
-            )
-        }
-    }
-
     return when (tone) {
-        AlbumMetaTone.Rj -> AlbumMetaPalette(
-            container = colorScheme.primary.copy(alpha = if (colorScheme.isDark) 0.38f else 0.28f),
-            content = colorScheme.primary,
-            border = colorScheme.primary.copy(alpha = 0.36f),
-        )
-        AlbumMetaTone.Circle -> AlbumMetaPalette(
-            container = colorScheme.primary.copy(alpha = if (colorScheme.isDark) 0.1f else 0.06f),
-            content = colorScheme.primary,
-            border = colorScheme.primary.copy(alpha = 0.14f),
-        )
         AlbumMetaTone.CvLabel -> AlbumMetaPalette(
             container = colorScheme.primary.copy(alpha = if (colorScheme.isDark) 0.16f else 0.1f),
             content = colorScheme.primary,

--- a/app/src/main/java/com/asmr/player/ui/library/AlbumMetaLightweight.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/AlbumMetaLightweight.kt
@@ -158,6 +158,7 @@ internal fun AlbumItemPrimaryMetaLightweight(
     if (normalizedRj.isBlank() && normalizedCircle.isBlank()) return
 
     val colorScheme = AsmrTheme.colorScheme
+    val identityContentColor = if (colorScheme.isDark) Color.White else Color.Black
 
     Row(
         modifier = modifier
@@ -180,7 +181,7 @@ internal fun AlbumItemPrimaryMetaLightweight(
                 Icon(
                     painter = painterResource(id = R.drawable.ic_album_meta_club),
                     contentDescription = null,
-                    tint = colorScheme.textTertiary,
+                    tint = identityContentColor,
                     modifier = Modifier
                         .padding(end = 6.dp)
                         .size(13.dp)
@@ -190,7 +191,7 @@ internal fun AlbumItemPrimaryMetaLightweight(
                     style = MaterialTheme.typography.labelSmall.copy(
                         fontSize = 13.sp,
                     ),
-                    color = colorScheme.textSecondary,
+                    color = identityContentColor,
                     maxLines = 1,
                     overflow = TextOverflow.Ellipsis,
                     modifier = Modifier
@@ -250,6 +251,7 @@ internal fun AlbumItemCvLightweight(
         values = cvs,
         iconRes = R.drawable.ic_album_meta_cv,
         layout = layout,
+        prominent = true,
         modifier = modifier,
         onValueClick = onCvClick,
         onValueLongClick = onCvLongClick,
@@ -289,12 +291,19 @@ private fun AlbumItemInlineValuesLightweight(
     layout: AlbumInlineValuesLayout,
     modifier: Modifier = Modifier,
     valuePrefix: String = "",
+    prominent: Boolean = false,
     onValueClick: ((String) -> Unit)? = null,
     onValueLongClick: ((String) -> Unit)? = null,
 ) {
     if (values.isEmpty()) return
 
     val colorScheme = AsmrTheme.colorScheme
+    val valueColor = if (prominent) {
+        if (colorScheme.isDark) Color.White else Color.Black
+    } else {
+        colorScheme.textSecondary
+    }
+    val iconColor = if (prominent) valueColor else colorScheme.textTertiary
 
     Row(
         modifier = modifier
@@ -305,7 +314,7 @@ private fun AlbumItemInlineValuesLightweight(
         Icon(
             painter = painterResource(id = iconRes),
             contentDescription = null,
-            tint = colorScheme.textTertiary,
+            tint = iconColor,
             modifier = Modifier
                 .padding(top = 3.dp, end = 6.dp)
                 .size(13.dp)
@@ -325,6 +334,7 @@ private fun AlbumItemInlineValuesLightweight(
                     AlbumItemInlineValueItems(
                         values = values,
                         valuePrefix = valuePrefix,
+                        valueColor = valueColor,
                         onValueClick = onValueClick,
                         onValueLongClick = onValueLongClick,
                     )
@@ -340,6 +350,7 @@ private fun AlbumItemInlineValuesLightweight(
                 AlbumItemInlineValueItems(
                     values = values,
                     valuePrefix = valuePrefix,
+                    valueColor = valueColor,
                     onValueClick = onValueClick,
                     onValueLongClick = onValueLongClick,
                 )
@@ -353,16 +364,16 @@ private fun AlbumItemInlineValuesLightweight(
 private fun AlbumItemInlineValueItems(
     values: List<String>,
     valuePrefix: String,
+    valueColor: Color,
     onValueClick: ((String) -> Unit)?,
     onValueLongClick: ((String) -> Unit)?,
 ) {
-    val colorScheme = AsmrTheme.colorScheme
     values.forEach { value ->
         Row(verticalAlignment = Alignment.CenterVertically) {
             Text(
                 text = valuePrefix + value.removePrefix(valuePrefix),
                 style = MaterialTheme.typography.labelSmall.copy(fontSize = 12.sp),
-                color = colorScheme.textSecondary,
+                color = valueColor,
                 maxLines = 1,
                 overflow = TextOverflow.Ellipsis,
                 modifier = Modifier

--- a/app/src/main/java/com/asmr/player/ui/library/AlbumMetaLightweight.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/AlbumMetaLightweight.kt
@@ -2,6 +2,7 @@ package com.asmr.player.ui.library
 
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.ScrollState
+import androidx.compose.foundation.background
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
@@ -10,8 +11,10 @@ import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Icon
@@ -30,6 +33,7 @@ import androidx.compose.ui.graphics.BlendMode
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.CompositingStrategy
+import androidx.compose.ui.graphics.Shadow
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
@@ -38,6 +42,106 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.asmr.player.R
 import com.asmr.player.ui.theme.AsmrTheme
+
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+internal fun AlbumHeroPrimaryMetaLightweight(
+    rjCode: String,
+    circle: String,
+    modifier: Modifier = Modifier,
+    rjOnClick: (() -> Unit)? = null,
+    circleOnClick: (() -> Unit)? = null,
+    circleOnLongClick: (() -> Unit)? = null,
+) {
+    val normalizedRj = remember(rjCode) { rjCode.trim() }
+    val normalizedCircle = remember(circle) { circle.trim() }
+    if (normalizedRj.isBlank() && normalizedCircle.isBlank()) return
+
+    val colorScheme = AsmrTheme.colorScheme
+    val contentColor = if (colorScheme.isDark) {
+        Color.White.copy(alpha = 0.94f)
+    } else {
+        Color.Black.copy(alpha = 0.84f)
+    }
+    val rjColor = colorScheme.primary
+    val secondaryContentColor = contentColor.copy(alpha = 0.76f)
+    val textShadow = Shadow(
+        color = if (colorScheme.isDark) {
+            Color.Black.copy(alpha = 0.42f)
+        } else {
+            Color.White.copy(alpha = 0.62f)
+        },
+        offset = Offset(0f, 1f),
+        blurRadius = 5f,
+    )
+
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .clipToBounds(),
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        if (normalizedRj.isNotBlank()) {
+            Text(
+                text = normalizedRj,
+                modifier = Modifier
+                    .clip(RoundedCornerShape(5.dp))
+                    .combinedClickable(onClick = { rjOnClick?.invoke() })
+                    .padding(horizontal = 2.dp, vertical = 2.dp),
+                style = MaterialTheme.typography.labelMedium.copy(
+                    fontSize = 12.sp,
+                    fontWeight = FontWeight.Bold,
+                    letterSpacing = 0.35.sp,
+                    shadow = textShadow,
+                ),
+                color = rjColor,
+                maxLines = 1,
+            )
+        }
+
+        if (normalizedRj.isNotBlank() && normalizedCircle.isNotBlank()) {
+            Spacer(
+                modifier = Modifier
+                    .width(0.5.dp)
+                    .height(12.dp)
+                    .background(secondaryContentColor.copy(alpha = 0.46f))
+            )
+        }
+
+        if (normalizedCircle.isNotBlank()) {
+            Row(
+                modifier = Modifier
+                    .then(if (normalizedRj.isNotBlank()) Modifier.weight(1f) else Modifier.fillMaxWidth())
+                    .clip(RoundedCornerShape(5.dp))
+                    .combinedClickable(
+                        onClick = { circleOnClick?.invoke() },
+                        onLongClick = circleOnLongClick,
+                    )
+                    .padding(horizontal = 2.dp, vertical = 2.dp),
+                horizontalArrangement = Arrangement.spacedBy(5.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Icon(
+                    painter = painterResource(id = R.drawable.ic_album_meta_club),
+                    contentDescription = null,
+                    tint = secondaryContentColor,
+                    modifier = Modifier.size(13.dp),
+                )
+                Text(
+                    text = normalizedCircle,
+                    style = MaterialTheme.typography.labelMedium.copy(
+                        fontSize = 13.sp,
+                        shadow = textShadow,
+                    ),
+                    color = contentColor,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
+        }
+    }
+}
 
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
@@ -363,14 +467,7 @@ internal fun AlbumHeaderCvLightweight(
             horizontalArrangement = Arrangement.spacedBy(6.dp),
             verticalAlignment = Alignment.CenterVertically,
         ) {
-            cvs.forEachIndexed { index, cv ->
-                if (index > 0) {
-                    Text(
-                        text = "·",
-                        style = MaterialTheme.typography.labelMedium,
-                        color = colorScheme.textTertiary.copy(alpha = 0.6f),
-                    )
-                }
+            cvs.forEach { cv ->
                 Text(
                     text = cv,
                     style = MaterialTheme.typography.labelMedium.copy(fontSize = 13.sp),

--- a/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailDirectorySupport.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailDirectorySupport.kt
@@ -179,12 +179,12 @@ internal sealed class AsmrTreeUiEntry {
     ) : AsmrTreeUiEntry()
 }
 
-private val DirectoryBrowserPanelCornerRadius = 10.dp
-private val DirectoryFolderRowCornerRadius = 10.dp
-private val DirectoryBrowserPanelVerticalPadding = 4.dp
+private val DirectoryBrowserPanelCornerRadius = 22.dp
+private val DirectoryFolderRowCornerRadius = 14.dp
+private val DirectoryBrowserPanelVerticalPadding = 8.dp
 
 internal fun directoryBrowserHeaderBackground(colorScheme: AsmrColorScheme): Color {
-    return colorScheme.primarySoft.copy(alpha = if (colorScheme.isDark) 0.28f else 0.88f)
+    return colorScheme.surface.copy(alpha = if (colorScheme.isDark) 0.72f else 0.9f)
 }
 
 internal enum class DirectoryFolderPosition {
@@ -2022,11 +2022,17 @@ internal fun CompactBreadcrumbNode(
     onClick: () -> Unit
 ) {
     val colorScheme = AsmrTheme.colorScheme
+    val containerColor = if (selected) {
+        colorScheme.primary.copy(alpha = if (colorScheme.isDark) 0.2f else 0.11f)
+    } else {
+        Color.Transparent
+    }
     Row(
         modifier = Modifier
-            .clip(RoundedCornerShape(8.dp))
+            .clip(RoundedCornerShape(9.dp))
+            .background(containerColor)
             .clickable(onClick = onClick)
-            .padding(horizontal = 2.dp, vertical = 2.dp),
+            .padding(horizontal = if (selected) 8.dp else 3.dp, vertical = 5.dp),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(4.dp)
     ) {
@@ -2417,19 +2423,20 @@ internal fun DirectoryActionGroupButton(
     modifier: Modifier = Modifier,
     onDisabledClick: (() -> Unit)? = null
 ) {
-    TextButton(
+    val colorScheme = AsmrTheme.colorScheme
+    FilledTonalButton(
         onClick = {
             if (enabled) onClick() else onDisabledClick?.invoke()
         },
         enabled = enabled || onDisabledClick != null,
-        modifier = modifier.height(34.dp),
-        contentPadding = PaddingValues(horizontal = 10.dp, vertical = 0.dp),
-        colors = ButtonDefaults.textButtonColors(
-            contentColor = if (enabled) {
-                MaterialTheme.colorScheme.primary
-            } else {
-                AsmrTheme.colorScheme.textTertiary
-            }
+        modifier = modifier.height(32.dp),
+        shape = RoundedCornerShape(10.dp),
+        contentPadding = PaddingValues(horizontal = 9.dp, vertical = 0.dp),
+        colors = ButtonDefaults.filledTonalButtonColors(
+            containerColor = colorScheme.primary.copy(alpha = if (colorScheme.isDark) 0.18f else 0.1f),
+            contentColor = colorScheme.primary,
+            disabledContainerColor = colorScheme.surfaceVariant.copy(alpha = 0.48f),
+            disabledContentColor = colorScheme.textTertiary
         )
     ) {
         Icon(icon, contentDescription = null, modifier = Modifier.size(14.dp))
@@ -2478,7 +2485,10 @@ internal fun DirectoryBatchBarEmbeddedV3(
             )
         }
         if (showActions) {
-            Row(verticalAlignment = Alignment.CenterVertically) {
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(4.dp)
+            ) {
                 DirectoryActionGroupButton(
                     text = "收藏",
                     icon = Icons.Rounded.FavoriteBorder,
@@ -2729,7 +2739,7 @@ internal fun CompactDirectoryBreadcrumbContentV3(
     Row(
         modifier = modifier
             .fillMaxWidth()
-            .padding(horizontal = 10.dp, vertical = 8.dp),
+            .padding(horizontal = 12.dp, vertical = 10.dp),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(4.dp)
     ) {
@@ -2740,10 +2750,11 @@ internal fun CompactDirectoryBreadcrumbContentV3(
             onClick = { onNavigate("") }
         )
         displayedCrumbs.forEach { crumb ->
-            Text(
-                text = "/",
-                style = MaterialTheme.typography.labelLarge,
-                color = colorScheme.textTertiary
+            Icon(
+                imageVector = Icons.AutoMirrored.Rounded.KeyboardArrowRight,
+                contentDescription = null,
+                tint = colorScheme.textTertiary.copy(alpha = 0.72f),
+                modifier = Modifier.size(14.dp)
             )
             if (crumb.label == "..." && crumb.path.isBlank()) {
                 Text(
@@ -2770,37 +2781,62 @@ internal fun DirectoryFolderRowV3(
     position: DirectoryFolderPosition = DirectoryFolderPosition.Single,
 ) {
     val colorScheme = AsmrTheme.colorScheme
-    Row(
+    val rowContainerColor = colorScheme.surfaceVariant.copy(
+        alpha = if (colorScheme.isDark) 0.42f else 0.58f
+    )
+    Column(
         modifier = Modifier
             .fillMaxWidth()
-            .defaultMinSize(minHeight = 42.dp)
             .clip(directoryFolderShape(position))
-            .background(colorScheme.primary.copy(alpha = 0.08f))
-            .clickable(onClick = onClick)
-            .padding(horizontal = 12.dp, vertical = 5.dp),
-        verticalAlignment = Alignment.CenterVertically
+            .background(rowContainerColor)
     ) {
-        Icon(
-            imageVector = Icons.Rounded.Folder,
-            contentDescription = null,
-            tint = colorScheme.primary,
-            modifier = Modifier.size(18.dp)
-        )
-        Spacer(modifier = Modifier.width(10.dp))
-        Text(
-            text = title,
-            modifier = Modifier.weight(1f),
-            maxLines = 1,
-            overflow = TextOverflow.Ellipsis,
-            style = MaterialTheme.typography.bodyLarge,
-            color = colorScheme.textPrimary
-        )
-        Icon(
-            imageVector = Icons.AutoMirrored.Rounded.KeyboardArrowRight,
-            contentDescription = null,
-            tint = colorScheme.textSecondary,
-            modifier = Modifier.size(18.dp)
-        )
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .defaultMinSize(minHeight = 52.dp)
+                .clickable(onClick = onClick)
+                .padding(horizontal = 12.dp, vertical = 7.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Box(
+                modifier = Modifier
+                    .size(32.dp)
+                    .clip(RoundedCornerShape(9.dp))
+                    .background(
+                        colorScheme.primary.copy(alpha = if (colorScheme.isDark) 0.2f else 0.12f)
+                    ),
+                contentAlignment = Alignment.Center
+            ) {
+                Icon(
+                    imageVector = Icons.Rounded.Folder,
+                    contentDescription = null,
+                    tint = colorScheme.primary,
+                    modifier = Modifier.size(18.dp)
+                )
+            }
+            Spacer(modifier = Modifier.width(11.dp))
+            Text(
+                text = title,
+                modifier = Modifier.weight(1f),
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                style = MaterialTheme.typography.bodyLarge.copy(fontWeight = FontWeight.Medium),
+                color = colorScheme.textPrimary
+            )
+            Icon(
+                imageVector = Icons.AutoMirrored.Rounded.KeyboardArrowRight,
+                contentDescription = null,
+                tint = colorScheme.textTertiary,
+                modifier = Modifier.size(17.dp)
+            )
+        }
+        if (position != DirectoryFolderPosition.Single && position != DirectoryFolderPosition.Last) {
+            HorizontalDivider(
+                modifier = Modifier.padding(start = 55.dp, end = 12.dp),
+                thickness = 0.5.dp,
+                color = colorScheme.textTertiary.copy(alpha = if (colorScheme.isDark) 0.2f else 0.13f)
+            )
+        }
     }
 }
 
@@ -2843,21 +2879,22 @@ internal fun DirectoryBatchBarEmbeddedV4(
             )
         }
         if (showActions) {
-            Row(verticalAlignment = Alignment.CenterVertically) {
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(4.dp)
+            ) {
                 DirectoryActionGroupButton(
                     text = "收藏",
                     icon = Icons.Rounded.FavoriteBorder,
                     enabled = hasMediaItems,
                     onClick = { onAddToFavorites(mediaItems) }
                 )
-                Text("|", color = AsmrTheme.colorScheme.textTertiary, style = MaterialTheme.typography.labelMedium)
                 DirectoryActionGroupButton(
                     text = "列表",
                     icon = Icons.AutoMirrored.Rounded.PlaylistAdd,
                     enabled = hasMediaItems,
                     onClick = { onOpenBatchPlaylistPicker(mediaItems) }
                 )
-                Text("|", color = AsmrTheme.colorScheme.textTertiary, style = MaterialTheme.typography.labelMedium)
                 DirectoryActionGroupButton(
                     text = "队列",
                     icon = Icons.AutoMirrored.Rounded.PlaylistPlay,
@@ -2916,14 +2953,16 @@ internal fun DirectoryBatchBarEmbeddedV5(
             )
         }
         if (showActions) {
-            Row(verticalAlignment = Alignment.CenterVertically) {
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(4.dp)
+            ) {
                 DirectoryActionGroupButton(
                     text = "收藏",
                     icon = Icons.Rounded.FavoriteBorder,
                     enabled = hasMediaItems,
                     onClick = { onAddToFavorites(mediaItems) }
                 )
-                Text("|", color = AsmrTheme.colorScheme.textTertiary, style = MaterialTheme.typography.labelMedium)
                 DirectoryActionGroupButton(
                     text = "列表",
                     icon = Icons.AutoMirrored.Rounded.PlaylistAdd,
@@ -2934,7 +2973,6 @@ internal fun DirectoryBatchBarEmbeddedV5(
                         }
                     }
                 )
-                Text("|", color = AsmrTheme.colorScheme.textTertiary, style = MaterialTheme.typography.labelMedium)
                 DirectoryActionGroupButton(
                     text = "队列",
                     icon = Icons.AutoMirrored.Rounded.PlaylistPlay,
@@ -2942,7 +2980,6 @@ internal fun DirectoryBatchBarEmbeddedV5(
                     onClick = { onAddMediaItemsToQueue(mediaItems) }
                 )
                 if (showTranslateAction) {
-                    Text("|", color = AsmrTheme.colorScheme.textTertiary, style = MaterialTheme.typography.labelMedium)
                     DirectoryActionGroupButton(
                         text = subtitleGenerationText,
                         icon = Icons.Rounded.Translate,
@@ -3077,10 +3114,16 @@ internal fun DirectoryBrowserPanelV4(
         (screenHeight * 0.48f).coerceIn(240.dp, 460.dp)
     }
     val colorScheme = AsmrTheme.colorScheme
+    val containerColor = dynamicPageContainerColor(colorScheme)
     val headerSectionColor = directoryBrowserHeaderBackground(colorScheme)
-    val actionSectionColor = colorScheme.surfaceVariant.copy(alpha = if (colorScheme.isDark) 0.24f else 0.42f)
-    val listSectionColor = colorScheme.surface.copy(alpha = if (colorScheme.isDark) 0.28f else 0.62f)
-    val sectionDividerColor = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.12f)
+    val actionSectionColor = colorScheme.surface.copy(alpha = if (colorScheme.isDark) 0.56f else 0.78f)
+    val listSectionColor = colorScheme.surface.copy(alpha = if (colorScheme.isDark) 0.42f else 0.66f)
+    val sectionDividerColor = colorScheme.textTertiary.copy(alpha = if (colorScheme.isDark) 0.18f else 0.11f)
+    val panelBorderColor = if (colorScheme.isDark) {
+        Color.White.copy(alpha = 0.1f)
+    } else {
+        colorScheme.textPrimary.copy(alpha = 0.08f)
+    }
 
     LaunchedEffect(panelKey, currentPath) {
         browserListState.scrollToItem(0)
@@ -3088,11 +3131,12 @@ internal fun DirectoryBrowserPanelV4(
 
     Surface(
         shape = RoundedCornerShape(DirectoryBrowserPanelCornerRadius),
-        tonalElevation = 1.dp,
-        color = colorScheme.surfaceVariant.copy(alpha = if (colorScheme.isDark) 0.28f else 0.46f),
+        tonalElevation = 0.dp,
+        shadowElevation = 0.dp,
+        color = containerColor,
         border = BorderStroke(
             width = 0.5.dp,
-            color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.12f)
+            color = panelBorderColor
         ),
         modifier = Modifier
             .fillMaxWidth()
@@ -3120,7 +3164,7 @@ internal fun DirectoryBrowserPanelV4(
                     modifier = Modifier
                         .fillMaxWidth()
                         .background(actionSectionColor)
-                        .padding(horizontal = 10.dp, vertical = 6.dp),
+                        .padding(horizontal = 12.dp, vertical = 8.dp),
                     enabled = animateIntro
                 ),
                 verticalAlignment = Alignment.CenterVertically,
@@ -3147,35 +3191,24 @@ internal fun DirectoryBrowserPanelV4(
                     val preferredIcon = if (isPreferredPath) Icons.Rounded.Bookmark else Icons.Rounded.BookmarkBorder
                     val preferredTextColor = if (isPreferredPath) colorScheme.primary else colorScheme.textSecondary
                     val preferredContainerColor = colorScheme.primary.copy(alpha = if (colorScheme.isDark) 0.22f else 0.12f)
-                    val preferredButton: @Composable (@Composable () -> Unit) -> Unit = { content ->
-                        if (isPreferredPath) {
-                            FilledTonalButton(
-                                onClick = {
-                                    preferredPathState = ""
-                                    onTogglePreferredPath(false)
-                                },
-                                colors = ButtonDefaults.filledTonalButtonColors(
-                                    containerColor = preferredContainerColor,
-                                    contentColor = preferredTextColor
-                                ),
-                                contentPadding = PaddingValues(horizontal = 6.dp, vertical = 0.dp),
-                                modifier = Modifier.height(30.dp)
-                            ) { content() }
-                        } else {
-                            TextButton(
-                                onClick = {
-                                    preferredPathState = normalizedCurrentPath
-                                    onTogglePreferredPath(true)
-                                },
-                                colors = ButtonDefaults.textButtonColors(
-                                    contentColor = preferredTextColor
-                                ),
-                                contentPadding = PaddingValues(horizontal = 6.dp, vertical = 0.dp),
-                                modifier = Modifier.height(30.dp)
-                            ) { content() }
-                        }
-                    }
-                    preferredButton {
+                    FilledTonalButton(
+                        onClick = {
+                            val enable = !isPreferredPath
+                            preferredPathState = if (enable) normalizedCurrentPath else ""
+                            onTogglePreferredPath(enable)
+                        },
+                        colors = ButtonDefaults.filledTonalButtonColors(
+                            containerColor = if (isPreferredPath) {
+                                preferredContainerColor
+                            } else {
+                                colorScheme.surfaceVariant.copy(alpha = if (colorScheme.isDark) 0.5f else 0.72f)
+                            },
+                            contentColor = preferredTextColor
+                        ),
+                        shape = RoundedCornerShape(10.dp),
+                        contentPadding = PaddingValues(horizontal = 9.dp, vertical = 0.dp),
+                        modifier = Modifier.height(32.dp)
+                    ) {
                         Icon(
                             imageVector = preferredIcon,
                             contentDescription = null,
@@ -3203,7 +3236,7 @@ internal fun DirectoryBrowserPanelV4(
                     .nestedScroll(listNestedScrollConnection)
                     .thinScrollbar(browserListState),
                 flingBehavior = rememberCalmScrollableFlingBehavior(),
-                contentPadding = PaddingValues(horizontal = 8.dp, vertical = 5.dp)
+                contentPadding = PaddingValues(horizontal = 10.dp, vertical = 9.dp)
             ) {
                     if (folders.isEmpty() && files.isEmpty()) {
                         item(key = "empty") {
@@ -3213,10 +3246,34 @@ internal fun DirectoryBrowserPanelV4(
                                     .height(fixedHeight - 24.dp),
                                 contentAlignment = Alignment.Center
                             ) {
-                                Text(
-                                    text = emptyText,
-                                    color = colorScheme.textSecondary
-                                )
+                                Column(
+                                    horizontalAlignment = Alignment.CenterHorizontally,
+                                    verticalArrangement = Arrangement.spacedBy(10.dp)
+                                ) {
+                                    Box(
+                                        modifier = Modifier
+                                            .size(44.dp)
+                                            .clip(RoundedCornerShape(14.dp))
+                                            .background(
+                                                colorScheme.primary.copy(
+                                                    alpha = if (colorScheme.isDark) 0.17f else 0.09f
+                                                )
+                                            ),
+                                        contentAlignment = Alignment.Center
+                                    ) {
+                                        Icon(
+                                            imageVector = Icons.Rounded.FolderOpen,
+                                            contentDescription = null,
+                                            tint = colorScheme.primary,
+                                            modifier = Modifier.size(22.dp)
+                                        )
+                                    }
+                                    Text(
+                                        text = emptyText,
+                                        color = colorScheme.textSecondary,
+                                        style = MaterialTheme.typography.bodyMedium.copy(fontWeight = FontWeight.Medium)
+                                    )
+                                }
                             }
                         }
                     } else {
@@ -3317,9 +3374,15 @@ internal fun DirectoryFileRow(
     val showPrimaryAction = file.isPlayable
     val showMenu = showPrimaryAction || onDownload != null || onAddToQueue != null || onAddToPlaylist != null || onGenerateSubtitles != null || onManageTags != null || onRemoveFromAlbum != null
     val showTrailing = selectionMode || onSetAsCover != null || file.showSubtitleStamp || showMenu
+    val rowContainerColor = if (selected) {
+        colorScheme.primary.copy(alpha = if (colorScheme.isDark) 0.18f else 0.09f)
+    } else {
+        Color.Transparent
+    }
 
     Surface(
-        color = Color.Transparent,
+        shape = RoundedCornerShape(12.dp),
+        color = rowContainerColor,
         modifier = Modifier
             .fillMaxWidth()
             .combinedClickable(
@@ -3346,7 +3409,9 @@ internal fun DirectoryFileRow(
             verticalAlignment = Alignment.CenterVertically
         ) {
             Box(
-                modifier = Modifier.width(if (file.fileType == TreeFileType.Image && file.thumbnailModel != null) 42.dp else 24.dp),
+                modifier = Modifier.size(
+                    if (file.fileType == TreeFileType.Image && file.thumbnailModel != null) 42.dp else 32.dp
+                ),
                 contentAlignment = Alignment.Center
             ) {
                 if (file.fileType == TreeFileType.Image && file.thumbnailModel != null) {
@@ -3360,15 +3425,25 @@ internal fun DirectoryFileRow(
                         placeholderCornerRadius = 8
                     )
                 } else {
-                    Icon(
-                        imageVector = icon,
-                        contentDescription = null,
-                        tint = iconTint,
-                        modifier = Modifier.size(21.dp)
-                    )
+                    Box(
+                        modifier = Modifier
+                            .size(32.dp)
+                            .clip(RoundedCornerShape(9.dp))
+                            .background(
+                                iconTint.copy(alpha = if (colorScheme.isDark) 0.17f else 0.09f)
+                            ),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        Icon(
+                            imageVector = icon,
+                            contentDescription = null,
+                            tint = iconTint,
+                            modifier = Modifier.size(18.dp)
+                        )
+                    }
                 }
             }
-            Spacer(modifier = Modifier.width(8.dp))
+            Spacer(modifier = Modifier.width(10.dp))
             Column(
                 modifier = Modifier.weight(1f),
                 verticalArrangement = Arrangement.spacedBy(2.dp)

--- a/app/src/main/java/com/asmr/player/ui/theme/ThemeTransitionOverlay.kt
+++ b/app/src/main/java/com/asmr/player/ui/theme/ThemeTransitionOverlay.kt
@@ -1,5 +1,12 @@
 package com.asmr.player.ui.theme
 
+import android.graphics.Bitmap
+import android.os.Build
+import android.os.Handler
+import android.os.Looper
+import android.view.PixelCopy
+import android.view.Window
+import androidx.annotation.RequiresApi
 import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.FastOutSlowInEasing
 import androidx.compose.animation.core.tween
@@ -13,6 +20,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.staticCompositionLocalOf
+import androidx.compose.runtime.withFrameNanos
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
@@ -20,14 +28,18 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.Path
 import androidx.compose.ui.graphics.PathOperation
+import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.graphics.drawscope.clipPath
 import androidx.compose.ui.layout.onSizeChanged
+import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlin.math.sqrt
+import kotlin.coroutines.resume
 
 data class ThemeTransitionRequest(
     val origin: Offset,
     val oldContentBitmap: ImageBitmap?,
     val oldBackgroundColor: Color,
+    val targetIsDark: Boolean,
     val token: Long
 )
 
@@ -41,13 +53,18 @@ val LocalThemeTransitionTrigger = staticCompositionLocalOf<((ThemeTransitionTrig
 @Composable
 fun ThemeCircularRevealOverlay(
     request: ThemeTransitionRequest,
+    targetReady: Boolean,
     onAnimationEnd: () -> Unit
 ) {
     val animationProgress = remember { Animatable(0f) }
     var overlaySize by remember { mutableStateOf(Size.Zero) }
 
-    LaunchedEffect(request) {
+    LaunchedEffect(request, targetReady) {
         animationProgress.snapTo(0f)
+        if (!targetReady) return@LaunchedEffect
+        // 等新主题完成一次组合与绘制后再揭开旧画面，避免底层主题尚未切换时
+        // 动画先跑出一小段，随后整块 GPU 图层突然换色。
+        withFrameNanos { }
         animationProgress.animateTo(
             targetValue = 1f,
             animationSpec = tween(durationMillis = 700, easing = FastOutSlowInEasing)
@@ -102,5 +119,49 @@ fun ThemeCircularRevealOverlay(
                 }
             }
         }
+    }
+}
+
+/**
+ * 捕获窗口最终合成后的画面，确保 Compose graphicsLayer、离屏混合和阴影也进入主题过渡快照。
+ * Android 8 以下或 PixelCopy 失败时退回 View.draw，主题切换仍可继续完成。
+ */
+internal suspend fun captureThemeTransitionBitmap(window: Window): ImageBitmap? {
+    val decorView = window.decorView
+    val width = decorView.width
+    val height = decorView.height
+    if (width <= 0 || height <= 0) return null
+
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+        val bitmap = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888)
+        val result = try {
+            requestWindowPixelCopy(window, bitmap)
+        } catch (_: Exception) {
+            PixelCopy.ERROR_UNKNOWN
+        }
+        if (result == PixelCopy.SUCCESS) {
+            return bitmap.asImageBitmap()
+        }
+        bitmap.recycle()
+    }
+
+    return runCatching {
+        Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888).also { bitmap ->
+            decorView.draw(android.graphics.Canvas(bitmap))
+        }.asImageBitmap()
+    }.getOrNull()
+}
+
+@RequiresApi(Build.VERSION_CODES.O)
+private suspend fun requestWindowPixelCopy(window: Window, bitmap: Bitmap): Int {
+    return suspendCancellableCoroutine { continuation ->
+        PixelCopy.request(
+            window,
+            bitmap,
+            { result ->
+                if (continuation.isActive) continuation.resume(result)
+            },
+            Handler(Looper.getMainLooper())
+        )
     }
 }

--- a/app/src/test/java/com/asmr/player/ui/library/AlbumMetaLightweightTest.kt
+++ b/app/src/test/java/com/asmr/player/ui/library/AlbumMetaLightweightTest.kt
@@ -97,6 +97,7 @@ class AlbumMetaLightweightTest {
         composeRule.onNodeWithText("详情声优甲").assertExists()
         composeRule.onNodeWithText("详情声优乙").assertExists()
         composeRule.onNodeWithText("详情声优丙").assertExists()
+        composeRule.onNodeWithText("·").assertDoesNotExist()
         composeRule.onNodeWithText("#详情标签甲").assertExists()
         composeRule.onNodeWithText("#详情标签乙").assertExists()
         composeRule.onNodeWithText("#详情标签丙").assertExists()


### PR DESCRIPTION
## 变更概览

- 优化明暗主题切换截图与过渡时序，消除封面阴影及 CV、tags 裁剪阴影闪烁
- 重构专辑详情页 RJ、社团、CV、tags 与操作行的苹果风视觉层级
- 将下载/保存类操作改为深浅分明、无缝衔接的分段按钮
- 优化本地与在线详情共用的目录树材质、面包屑、批量工具条及分组列表
- 移除目录树独立阴影层，避免阴影早于容器首帧渲染
- 提升专辑网格卡片与列表中社团、CV 的黑白对比度，保持 tags 次级色

## 验证

- 通过 .gradlew-local.bat :app:installRelease 构建并安装至 Android 16 设备
- AlbumDetailDirectorySupportTest 与 TreeFileTypeResolverTest 定向测试通过
- 已检查目录树浅色/深色主题，以及可用操作按钮的分段色阶与接缝