### PR TITLE
fix: 修复已购专辑下载图片错乱

### DIFF
--- a/app/src/main/java/com/asmr/player/cache/CacheKeyFactory.kt
+++ b/app/src/main/java/com/asmr/player/cache/CacheKeyFactory.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.content.res.Configuration
 import androidx.compose.ui.unit.IntSize
 import coil.request.ImageRequest
+import java.io.File
 import java.security.MessageDigest
 import java.util.LinkedHashMap
 
@@ -56,6 +57,7 @@ object CacheKeyFactory {
         return when (data) {
             null -> "null"
             is String -> data.trim()
+            is File -> "file:${data.absolutePath}|${data.length()}|${data.lastModified()}"
             else -> data.toString()
         }
     }

--- a/app/src/main/java/com/asmr/player/data/local/db/AppDatabaseMigrations.kt
+++ b/app/src/main/java/com/asmr/player/data/local/db/AppDatabaseMigrations.kt
@@ -555,6 +555,14 @@ object AppDatabaseMigrations {
         }
     }
 
+    val MIGRATION_29_30: Migration = object : Migration(29, 30) {
+        override fun migrate(db: SupportSQLiteDatabase) {
+            db.execSQL("ALTER TABLE download_items ADD COLUMN `dlsitePlayImageSeed` INTEGER")
+            db.execSQL("ALTER TABLE download_items ADD COLUMN `dlsitePlayImageWidth` INTEGER")
+            db.execSQL("ALTER TABLE download_items ADD COLUMN `dlsitePlayImageHeight` INTEGER")
+        }
+    }
+
     private fun createItemChildTable(
         db: SupportSQLiteDatabase,
         table: String,

--- a/app/src/main/java/com/asmr/player/data/local/db/AppDatabaseProvider.kt
+++ b/app/src/main/java/com/asmr/player/data/local/db/AppDatabaseProvider.kt
@@ -44,7 +44,8 @@ object AppDatabaseProvider {
                 AppDatabaseMigrations.MIGRATION_25_26,
                 AppDatabaseMigrations.MIGRATION_26_27,
                 AppDatabaseMigrations.MIGRATION_27_28,
-                AppDatabaseMigrations.MIGRATION_28_29
+                AppDatabaseMigrations.MIGRATION_28_29,
+                AppDatabaseMigrations.MIGRATION_29_30
             )
             // Never wipe the local database during app upgrades.
             // If a migration is missing, fail loudly so user data can still be recovered.

--- a/app/src/main/java/com/asmr/player/data/local/db/appdatabase.kt
+++ b/app/src/main/java/com/asmr/player/data/local/db/appdatabase.kt
@@ -89,7 +89,7 @@ import com.asmr.player.data.local.db.entities.TrackPlaybackProgressEntity
         SubtitleCommittedCaptionEntity::class,
         SubtitleTitleOwnerEntity::class
     ],
-    version = 29,
+    version = 30,
     exportSchema = false
 )
 abstract class AppDatabase : RoomDatabase() {

--- a/app/src/main/java/com/asmr/player/data/local/db/entities/DownloadItemEntity.kt
+++ b/app/src/main/java/com/asmr/player/data/local/db/entities/DownloadItemEntity.kt
@@ -34,6 +34,9 @@ data class DownloadItemEntity(
     val total: Long,
     val speed: Long,
     val createdAt: Long,
-    val updatedAt: Long
+    val updatedAt: Long,
+    val dlsitePlayImageSeed: Int? = null,
+    val dlsitePlayImageWidth: Int? = null,
+    val dlsitePlayImageHeight: Int? = null
 )
 

--- a/app/src/main/java/com/asmr/player/data/remote/dlsite/DlsitePlayImageSupport.kt
+++ b/app/src/main/java/com/asmr/player/data/remote/dlsite/DlsitePlayImageSupport.kt
@@ -1,6 +1,10 @@
 package com.asmr.player.data.remote.dlsite
 
 import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import java.io.File
+import java.io.FileOutputStream
+import java.io.IOException
 import kotlin.math.ceil
 import kotlin.math.floor
 
@@ -61,6 +65,54 @@ internal fun descrambleDlsitePlayBitmap(src: Bitmap, seed: Int, width: Int, heig
     val cropped = Bitmap.createBitmap(out, 0, 0, croppedWidth, croppedHeight)
     if (cropped !== out) out.recycle()
     return cropped
+}
+
+internal fun descrambleDlsitePlayImageFile(
+    scrambledFile: File,
+    outputFile: File,
+    seed: Int,
+    width: Int,
+    height: Int
+) {
+    require(width > 0 && height > 0) { "Invalid DLsite Play image dimensions" }
+    val scrambled = BitmapFactory.decodeFile(scrambledFile.absolutePath)
+        ?: throw IOException("Unable to decode DLsite Play image")
+    var descrambled: Bitmap? = null
+    val temporaryOutput = File(outputFile.parentFile, ".${outputFile.name}.descrambling")
+    try {
+        descrambled = descrambleDlsitePlayBitmap(scrambled, seed, width, height)
+        outputFile.parentFile?.mkdirs()
+        FileOutputStream(temporaryOutput).use { output ->
+            val compressed = descrambled.compress(
+                dlsitePlayOutputFormat(outputFile.extension),
+                100,
+                output
+            )
+            if (!compressed) throw IOException("Unable to encode descrambled DLsite Play image")
+        }
+        if (outputFile.exists() && !outputFile.delete()) {
+            throw IOException("Unable to replace downloaded DLsite Play image")
+        }
+        if (!temporaryOutput.renameTo(outputFile)) {
+            temporaryOutput.copyTo(outputFile, overwrite = true)
+            temporaryOutput.delete()
+        }
+    } finally {
+        if (temporaryOutput.exists()) temporaryOutput.delete()
+        if (descrambled != null && descrambled !== scrambled && !descrambled.isRecycled) {
+            descrambled.recycle()
+        }
+        if (!scrambled.isRecycled) scrambled.recycle()
+    }
+}
+
+@Suppress("DEPRECATION")
+private fun dlsitePlayOutputFormat(extension: String): Bitmap.CompressFormat {
+    return when (extension.lowercase()) {
+        "jpg", "jpeg" -> Bitmap.CompressFormat.JPEG
+        "webp" -> Bitmap.CompressFormat.WEBP
+        else -> Bitmap.CompressFormat.PNG
+    }
 }
 
 private fun dlsitePlayMtShuffledTiles(seed: Int, length: Int): List<Int> {

--- a/app/src/main/java/com/asmr/player/data/remote/download/DownloadManager.kt
+++ b/app/src/main/java/com/asmr/player/data/remote/download/DownloadManager.kt
@@ -8,6 +8,7 @@ import com.asmr.player.data.remote.auth.DlsiteAuthStore
 import com.asmr.player.data.remote.auth.buildDlsiteCookieHeader
 import com.asmr.player.data.remote.auth.mergeDlsiteCookieHeaders
 import com.asmr.player.data.remote.NetworkHeaders
+import com.asmr.player.data.remote.dlsite.descrambleDlsitePlayImageFile
 import com.asmr.player.data.local.db.entities.AlbumEntity
 import com.asmr.player.data.local.db.entities.AlbumFtsEntity
 import com.asmr.player.data.local.db.dao.DownloadDao
@@ -46,6 +47,7 @@ import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import java.io.File
 import java.io.FileOutputStream
+import java.io.IOException
 import java.io.InputStream
 import java.text.SimpleDateFormat
 import java.nio.charset.Charset
@@ -58,6 +60,18 @@ import kotlin.math.max
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import javax.inject.Inject
 import javax.inject.Singleton
+
+private const val DLSITE_PLAY_SCRAMBLED_PART_SUFFIX = ".dlsite-scrambled.part"
+
+internal fun dlsitePlayImagePartFile(outputFile: File): File {
+    return File(outputFile.parentFile, outputFile.name + DLSITE_PLAY_SCRAMBLED_PART_SUFFIX)
+}
+
+private fun DownloadItemEntity.hasDlsitePlayImageTransform(): Boolean {
+    return dlsitePlayImageSeed != null &&
+        (dlsitePlayImageWidth ?: 0) > 0 &&
+        (dlsitePlayImageHeight ?: 0) > 0
+}
 
 private class SessionCookieJar : CookieJar {
     private val store = LinkedHashMap<String, MutableList<Cookie>>()
@@ -136,7 +150,10 @@ class DownloadManager @Inject constructor(
         albumCoverUrl: String = "",
         albumDescription: String = "",
         albumWorkId: String = "",
-        albumRjCode: String = ""
+        albumRjCode: String = "",
+        dlsitePlayImageSeed: Int? = null,
+        dlsitePlayImageWidth: Int? = null,
+        dlsitePlayImageHeight: Int? = null
     ) {
         scope.launch {
             val now = System.currentTimeMillis()
@@ -154,6 +171,12 @@ class DownloadManager @Inject constructor(
             val safeAlbumDescription = albumDescription.trim().take(0)
             val safeAlbumWorkId = albumWorkId.trim().take(40)
             val safeAlbumRjCode = albumRjCode.trim().take(40)
+            val hasDlsitePlayImageTransform = dlsitePlayImageSeed != null &&
+                (dlsitePlayImageWidth ?: 0) > 0 &&
+                (dlsitePlayImageHeight ?: 0) > 0
+            val safeDlsitePlayImageSeed = dlsitePlayImageSeed.takeIf { hasDlsitePlayImageTransform }
+            val safeDlsitePlayImageWidth = dlsitePlayImageWidth.takeIf { hasDlsitePlayImageTransform }
+            val safeDlsitePlayImageHeight = dlsitePlayImageHeight.takeIf { hasDlsitePlayImageTransform }
             val taskId = ensureTask(
                 taskKey = taskKey,
                 title = taskTitle,
@@ -238,7 +261,10 @@ class DownloadManager @Inject constructor(
             }
 
             val existingItem = downloadDao.getItemByFilePath(filePath)
-            val existingBytes = runCatching { File(filePath).length() }.getOrDefault(0L).coerceAtLeast(0L)
+            val partialFile = dlsitePlayImagePartFile(File(filePath))
+            val existingBytes = runCatching {
+                if (hasDlsitePlayImageTransform && partialFile.exists()) partialFile.length() else File(filePath).length()
+            }.getOrDefault(0L).coerceAtLeast(0L)
             if (existingItem != null) {
                 val file = File(existingItem.filePath.ifBlank { filePath })
                 if (existingItem.state == WorkInfo.State.SUCCEEDED.name && file.exists() && file.isFile) {
@@ -252,13 +278,16 @@ class DownloadManager @Inject constructor(
                 ) {
                     return@launch
                 }
-                downloadDao.updateItemProgress(
-                    workId = existingItem.workId,
-                    state = DOWNLOAD_STATE_QUEUED,
-                    downloaded = existingBytes,
-                    total = existingItem.total,
-                    speed = 0L,
-                    updatedAt = now
+                downloadDao.upsertItem(
+                    existingItem.copy(
+                        state = DOWNLOAD_STATE_QUEUED,
+                        downloaded = existingBytes,
+                        speed = 0L,
+                        updatedAt = now,
+                        dlsitePlayImageSeed = safeDlsitePlayImageSeed,
+                        dlsitePlayImageWidth = safeDlsitePlayImageWidth,
+                        dlsitePlayImageHeight = safeDlsitePlayImageHeight
+                    )
                 )
             } else {
                 downloadDao.upsertItem(
@@ -275,7 +304,10 @@ class DownloadManager @Inject constructor(
                         total = -1L,
                         speed = 0L,
                         createdAt = now,
-                        updatedAt = now
+                        updatedAt = now,
+                        dlsitePlayImageSeed = safeDlsitePlayImageSeed,
+                        dlsitePlayImageWidth = safeDlsitePlayImageWidth,
+                        dlsitePlayImageHeight = safeDlsitePlayImageHeight
                     )
                 )
             }
@@ -493,7 +525,10 @@ object DownloadQueueCoordinator {
                             "albumCoverUrl" to task.albumCoverUrl,
                             "albumDescription" to task.albumDescription,
                             "albumWorkId" to task.albumWorkId,
-                            "albumRjCode" to task.albumRjCode
+                            "albumRjCode" to task.albumRjCode,
+                            "dlsitePlayImageSeed" to (item.dlsitePlayImageSeed ?: -1),
+                            "dlsitePlayImageWidth" to (item.dlsitePlayImageWidth ?: -1),
+                            "dlsitePlayImageHeight" to (item.dlsitePlayImageHeight ?: -1)
                         )
                     )
                     .addTag("download")
@@ -508,7 +543,9 @@ object DownloadQueueCoordinator {
                 wm.enqueue(request)
 
                 val existingBytes = runCatching {
-                    File(item.filePath.ifBlank { File(item.targetDir, item.fileName).absolutePath }).length()
+                    val outputFile = File(item.filePath.ifBlank { File(item.targetDir, item.fileName).absolutePath })
+                    val partialFile = dlsitePlayImagePartFile(outputFile)
+                    if (item.hasDlsitePlayImageTransform() && partialFile.exists()) partialFile.length() else outputFile.length()
                 }.getOrDefault(item.downloaded).coerceAtLeast(0L)
 
                 dao.replaceWorkIdForResume(
@@ -588,7 +625,9 @@ object DownloadQueueCoordinator {
 
     private fun resolveExistingBytes(item: DownloadItemEntity): Long {
         return runCatching {
-            File(item.filePath.ifBlank { File(item.targetDir, item.fileName).absolutePath }).length()
+            val outputFile = File(item.filePath.ifBlank { File(item.targetDir, item.fileName).absolutePath })
+            val partialFile = dlsitePlayImagePartFile(outputFile)
+            if (item.hasDlsitePlayImageTransform() && partialFile.exists()) partialFile.length() else outputFile.length()
         }.getOrDefault(item.downloaded).coerceAtLeast(0L)
     }
 }
@@ -621,6 +660,12 @@ class DownloadWorker(context: Context, parameters: WorkerParameters) : Coroutine
         val albumDescription = inputData.getString("albumDescription").orEmpty()
         val albumWorkId = inputData.getString("albumWorkId").orEmpty()
         val albumRjCode = inputData.getString("albumRjCode").orEmpty()
+        val dlsitePlayImageSeed = inputData.getInt("dlsitePlayImageSeed", -1).takeIf { it >= 0 }
+        val dlsitePlayImageWidth = inputData.getInt("dlsitePlayImageWidth", -1).takeIf { it > 0 }
+        val dlsitePlayImageHeight = inputData.getInt("dlsitePlayImageHeight", -1).takeIf { it > 0 }
+        val hasDlsitePlayImageTransform = dlsitePlayImageSeed != null &&
+            dlsitePlayImageWidth != null &&
+            dlsitePlayImageHeight != null
 
         return try {
             val workId = id.toString()
@@ -697,6 +742,8 @@ class DownloadWorker(context: Context, parameters: WorkerParameters) : Coroutine
 
             val targetFolder = File(targetDir)
             val file = File(targetFolder, fileName)
+            val partialFile = dlsitePlayImagePartFile(file)
+            val transferFile = if (hasDlsitePlayImageTransform) partialFile else file
             if (!targetFolder.exists()) targetFolder.mkdirs()
             runCatching {
                 val albumsRoot = File(applicationContext.getExternalFilesDir(null), "albums")
@@ -713,7 +760,8 @@ class DownloadWorker(context: Context, parameters: WorkerParameters) : Coroutine
                 .url(url)
                 .header("User-Agent", NetworkHeaders.USER_AGENT)
             
-            var existingBytes = if (file.exists()) file.length().coerceAtLeast(0L) else 0L
+            val transformAlreadyApplied = hasDlsitePlayImageTransform && file.exists() && !partialFile.exists()
+            var existingBytes = if (transferFile.exists()) transferFile.length().coerceAtLeast(0L) else 0L
             val lowerUrl = url.lowercase()
             val sessionCookieJar = SessionCookieJar()
             if (lowerUrl.contains("play.dlsite.com")) {
@@ -750,8 +798,9 @@ class DownloadWorker(context: Context, parameters: WorkerParameters) : Coroutine
                 requestBuilder.addHeader("Range", "bytes=$existingBytes-")
             }
 
-            var total: Long
-            var downloaded = existingBytes
+            val knownTotal = dao.getItemByWorkId(workId)?.total?.takeIf { it > 0L } ?: -1L
+            var total = knownTotal
+            var downloaded = if (transformAlreadyApplied) knownTotal.coerceAtLeast(file.length()) else existingBytes
             val today = SimpleDateFormat("yyyy-MM-dd", Locale.US).format(Date(now0))
             var pendingTrafficBytes = 0L
 
@@ -786,7 +835,9 @@ class DownloadWorker(context: Context, parameters: WorkerParameters) : Coroutine
                 )
             }
 
-            client.newCall(requestBuilder.build()).execute().use { response ->
+            val transferAlreadyComplete = transformAlreadyApplied ||
+                (hasDlsitePlayImageTransform && knownTotal > 0L && existingBytes >= knownTotal)
+            if (!transferAlreadyComplete) client.newCall(requestBuilder.build()).execute().use { response ->
                 if (!response.isSuccessful) {
                     Log.w(TAG, "download failed code=${response.code} url=${response.request.url}")
                     return failCurrentDownload(totalBytes = existingBytes.coerceAtLeast(0L))
@@ -821,12 +872,15 @@ class DownloadWorker(context: Context, parameters: WorkerParameters) : Coroutine
                         total = total,
                         speed = 0L,
                         createdAt = now0,
-                        updatedAt = now0
+                        updatedAt = now0,
+                        dlsitePlayImageSeed = dlsitePlayImageSeed,
+                        dlsitePlayImageWidth = dlsitePlayImageWidth,
+                        dlsitePlayImageHeight = dlsitePlayImageHeight
                     )
                 )
 
                 body.byteStream().use { input ->
-                    FileOutputStream(file, existingBytes > 0L).use { output ->
+                    FileOutputStream(transferFile, existingBytes > 0L).use { output ->
                         while (true) {
                             if (isStopped) {
                                 val now = System.currentTimeMillis()
@@ -868,6 +922,18 @@ class DownloadWorker(context: Context, parameters: WorkerParameters) : Coroutine
                             }
                         }
                     }
+                }
+            }
+            if (hasDlsitePlayImageTransform && !transformAlreadyApplied) {
+                descrambleDlsitePlayImageFile(
+                    scrambledFile = partialFile,
+                    outputFile = file,
+                    seed = checkNotNull(dlsitePlayImageSeed),
+                    width = checkNotNull(dlsitePlayImageWidth),
+                    height = checkNotNull(dlsitePlayImageHeight)
+                )
+                if (partialFile.exists() && !partialFile.delete()) {
+                    throw IOException("Unable to remove scrambled DLsite Play image")
                 }
             }
             val now = System.currentTimeMillis()

--- a/app/src/main/java/com/asmr/player/ui/downloads/DownloadsViewModel.kt
+++ b/app/src/main/java/com/asmr/player/ui/downloads/DownloadsViewModel.kt
@@ -15,6 +15,7 @@ import com.asmr.player.data.local.db.dao.TrackDao
 import com.asmr.player.data.remote.download.DOWNLOAD_STATE_QUEUED
 import com.asmr.player.data.remote.download.DownloadQueueCoordinator
 import com.asmr.player.data.remote.download.FinalizeDownloadTaskWorker
+import com.asmr.player.data.remote.download.dlsitePlayImagePartFile
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.Dispatchers
@@ -500,7 +501,9 @@ class DownloadsViewModel @Inject constructor(
             if (!deleted) {
                 val items = downloadDao.getItemsForTask(taskId)
                 items.forEach { it ->
-                    deletePathSafely(it.filePath.ifBlank { File(it.targetDir, it.fileName).absolutePath })
+                    val outputFile = File(it.filePath.ifBlank { File(it.targetDir, it.fileName).absolutePath })
+                    deletePathSafely(outputFile.absolutePath)
+                    deletePathSafely(dlsitePlayImagePartFile(outputFile).absolutePath)
                 }
                 deletePathSafely(task.rootDir)
             }
@@ -519,6 +522,7 @@ class DownloadsViewModel @Inject constructor(
             runCatching { workManager.cancelWorkById(java.util.UUID.fromString(workId)) }
             val primary = item.filePath.ifBlank { File(item.targetDir, item.fileName).absolutePath }
             val deleted = deletePathSafely(primary)
+            deletePathSafely(dlsitePlayImagePartFile(File(primary)).absolutePath)
             if (!deleted && item.targetDir.isNotBlank() && item.fileName.isNotBlank()) {
                 deletePathSafely(File(item.targetDir, item.fileName).absolutePath)
             }

--- a/app/src/main/java/com/asmr/player/ui/library/AlbumDetailViewModel.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/AlbumDetailViewModel.kt
@@ -2978,7 +2978,10 @@ class AlbumDetailViewModel @Inject constructor(
                 albumTagsCsv = album.tags.joinToString(","),
                 albumCoverUrl = album.coverUrl,
                 albumWorkId = album.workId,
-                albumRjCode = album.rjCode
+                albumRjCode = album.rjCode,
+                dlsitePlayImageSeed = item.dlsitePlayImageSeed,
+                dlsitePlayImageWidth = item.dlsitePlayImageWidth,
+                dlsitePlayImageHeight = item.dlsitePlayImageHeight
             )
             enqueued += 1
         }

--- a/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailViewModelSupport.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailViewModelSupport.kt
@@ -30,6 +30,7 @@ import com.asmr.player.data.remote.dlsite.DlsiteProductInfoClient
 import com.asmr.player.data.remote.dlsite.resolveCloudSyncWorkId
 import com.asmr.player.data.remote.dlsite.resolveDlsiteCloudSync
 import com.asmr.player.data.remote.dlsite.resolveSelectedDlsiteCloudSync
+import com.asmr.player.data.remote.dlsite.parseDlsitePlayImageSeed
 import com.asmr.player.data.remote.download.DownloadManager
 import com.asmr.player.data.remote.scraper.DLSiteScraper
 import com.asmr.player.data.remote.scraper.DlsiteRecommendedWork
@@ -532,7 +533,10 @@ private fun asmrOneEditionMatchesLanguage(languageLabel: String, selectedLang: S
 internal data class AsmrOneLeafDownload(
     val url: String,
     val relativePath: String,
-    val duration: Double?
+    val duration: Double?,
+    val dlsitePlayImageSeed: Int? = null,
+    val dlsitePlayImageWidth: Int? = null,
+    val dlsitePlayImageHeight: Int? = null
 )
 
 internal const val DlsiteTrialDownloadDirectoryName = "体验版"
@@ -673,7 +677,23 @@ internal fun flattenAsmrOneLeafDownloads(tree: List<AsmrOneTrackNodeResponse>): 
             val children = node.children.orEmpty()
             val url = node.mediaDownloadUrl ?: node.streamUrl
             if (!url.isNullOrBlank() && children.isEmpty()) {
-                out.add(AsmrOneLeafDownload(url = url, relativePath = path, duration = node.duration))
+                val imageWidth = node.dlsitePlayImageWidth?.takeIf { it > 0 }
+                val imageHeight = node.dlsitePlayImageHeight?.takeIf { it > 0 }
+                val imageSeed = if (node.dlsitePlayImageCrypt && imageWidth != null && imageHeight != null) {
+                    parseDlsitePlayImageSeed(node.dlsitePlayOptimizedName)
+                } else {
+                    null
+                }
+                out.add(
+                    AsmrOneLeafDownload(
+                        url = url,
+                        relativePath = path,
+                        duration = node.duration,
+                        dlsitePlayImageSeed = imageSeed,
+                        dlsitePlayImageWidth = imageWidth.takeIf { imageSeed != null },
+                        dlsitePlayImageHeight = imageHeight.takeIf { imageSeed != null }
+                    )
+                )
             } else if (children.isNotEmpty()) {
                 walk(children, path)
             }

--- a/app/src/test/java/com/asmr/player/cache/CacheKeyFactoryTest.kt
+++ b/app/src/test/java/com/asmr/player/cache/CacheKeyFactoryTest.kt
@@ -1,0 +1,48 @@
+package com.asmr.player.cache
+
+import android.content.Context
+import androidx.compose.ui.unit.IntSize
+import androidx.test.core.app.ApplicationProvider
+import java.io.File
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class CacheKeyFactoryTest {
+    private val context = ApplicationProvider.getApplicationContext<Context>()
+
+    @Test
+    fun localFileKeyChangesWhenFileIsReplacedAtSamePath() {
+        val file = File(context.cacheDir, "cache-key-image.jpg")
+        try {
+            file.writeBytes(byteArrayOf(1))
+            val initialModifiedAt = file.lastModified()
+            val firstKey = CacheKeyFactory.createKey(
+                context = context,
+                model = file,
+                size = IntSize(320, 240),
+                version = "test"
+            )
+
+            file.writeBytes(byteArrayOf(1, 2))
+            file.setLastModified(initialModifiedAt + 1_000L)
+            val replacedKey = CacheKeyFactory.createKey(
+                context = context,
+                model = file,
+                size = IntSize(320, 240),
+                version = "test"
+            )
+
+            assertNotEquals(firstKey, replacedKey)
+            assertEquals(
+                replacedKey,
+                CacheKeyFactory.createKey(context, file, IntSize(320, 240), "test")
+            )
+        } finally {
+            file.delete()
+        }
+    }
+}

--- a/app/src/test/java/com/asmr/player/data/local/db/AppDatabaseMigrationsTest.kt
+++ b/app/src/test/java/com/asmr/player/data/local/db/AppDatabaseMigrationsTest.kt
@@ -15,6 +15,55 @@ import java.io.File
 @Config(application = Application::class, sdk = [34])
 class AppDatabaseMigrationsTest {
     @Test
+    fun migration29To30_preservesDownloadAndAddsEmptyDlsiteImageMetadata() {
+        val context = RuntimeEnvironment.getApplication()
+        val dbName = "migration-test-${System.nanoTime()}.db"
+        val dbFile = context.getDatabasePath(dbName)
+        dbFile.parentFile?.mkdirs()
+        if (dbFile.exists()) dbFile.delete()
+        val helper = FrameworkSQLiteOpenHelperFactory().create(
+            androidx.sqlite.db.SupportSQLiteOpenHelper.Configuration.builder(context)
+                .name(dbName)
+                .callback(object : androidx.sqlite.db.SupportSQLiteOpenHelper.Callback(29) {
+                    override fun onCreate(db: androidx.sqlite.db.SupportSQLiteDatabase) {
+                        db.execSQL(
+                            "CREATE TABLE download_items (" +
+                                "`id` INTEGER NOT NULL PRIMARY KEY, `fileName` TEXT NOT NULL)"
+                        )
+                        db.execSQL("INSERT INTO download_items VALUES(1,'晚安.jpg')")
+                    }
+
+                    override fun onUpgrade(
+                        db: androidx.sqlite.db.SupportSQLiteDatabase,
+                        oldVersion: Int,
+                        newVersion: Int
+                    ) = Unit
+                })
+                .build()
+        )
+        val db = helper.writableDatabase
+
+        AppDatabaseMigrations.MIGRATION_29_30.migrate(db)
+
+        db.query(
+            "SELECT fileName, dlsitePlayImageSeed, dlsitePlayImageWidth, dlsitePlayImageHeight " +
+                "FROM download_items WHERE id = 1"
+        ).use { cursor ->
+            assertTrue(cursor.moveToFirst())
+            assertEquals("晚安.jpg", cursor.getString(0))
+            assertTrue(cursor.isNull(1))
+            assertTrue(cursor.isNull(2))
+            assertTrue(cursor.isNull(3))
+        }
+
+        db.close()
+        helper.close()
+        File(dbFile.absolutePath).delete()
+        File(dbFile.absolutePath + "-wal").delete()
+        File(dbFile.absolutePath + "-shm").delete()
+    }
+
+    @Test
     fun migration28To29_preservesTaskItemAndAddsEmptyModelSnapshot() {
         val context = RuntimeEnvironment.getApplication()
         val dbName = "migration-test-${System.nanoTime()}.db"

--- a/app/src/test/java/com/asmr/player/data/remote/dlsite/DlsitePlayImageSupportTest.kt
+++ b/app/src/test/java/com/asmr/player/data/remote/dlsite/DlsitePlayImageSupportTest.kt
@@ -1,6 +1,9 @@
 package com.asmr.player.data.remote.dlsite
 
 import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import java.io.File
+import java.io.FileOutputStream
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
@@ -56,5 +59,39 @@ class DlsitePlayImageSupportTest {
 
         descrambled.recycle()
         scrambled.recycle()
+    }
+
+    @Test
+    fun descrambleDlsitePlayImageFile_writesCroppedReadableImage() {
+        val directory = File(System.getProperty("java.io.tmpdir"), "dlsite-image-${System.nanoTime()}").apply {
+            mkdirs()
+        }
+        val scrambledFile = File(directory, "scrambled.png")
+        val outputFile = File(directory, "restored.png")
+        val scrambled = Bitmap.createBitmap(256, 256, Bitmap.Config.ARGB_8888).apply {
+            eraseColor(0xFF000000.toInt())
+            setPixels(IntArray(128 * 128) { 0xFFFF0000.toInt() }, 0, 128, 0, 128, 128, 128)
+            setPixels(IntArray(128 * 128) { 0xFF00FF00.toInt() }, 0, 128, 128, 0, 128, 128)
+            setPixels(IntArray(128 * 128) { 0xFF0000FF.toInt() }, 0, 128, 128, 128, 128, 128)
+        }
+        FileOutputStream(scrambledFile).use { output ->
+            assertTrue(scrambled.compress(Bitmap.CompressFormat.PNG, 100, output))
+        }
+        scrambled.recycle()
+
+        descrambleDlsitePlayImageFile(
+            scrambledFile = scrambledFile,
+            outputFile = outputFile,
+            seed = 0,
+            width = 200,
+            height = 160
+        )
+
+        val restored = BitmapFactory.decodeFile(outputFile.absolutePath)
+        assertEquals(200, restored.width)
+        assertEquals(160, restored.height)
+        assertEquals(0xFF0000FF.toInt(), restored.getPixel(0, 129))
+        restored.recycle()
+        directory.deleteRecursively()
     }
 }

--- a/app/src/test/java/com/asmr/player/ui/library/AlbumDetailDirectorySupportTest.kt
+++ b/app/src/test/java/com/asmr/player/ui/library/AlbumDetailDirectorySupportTest.kt
@@ -278,6 +278,26 @@ class AlbumDetailDirectorySupportTest {
     }
 
     @Test
+    fun flattenAsmrOneLeafDownloads_preservesDlsitePlayImageDescrambleMetadata() {
+        val leaf = flattenAsmrOneLeafDownloads(
+            listOf(
+                AsmrOneTrackNodeResponse(
+                    title = "01.パッケージ.jpg",
+                    mediaDownloadUrl = "https://play.dlsite.com/optimized/00000abc1234.jpg",
+                    dlsitePlayImageCrypt = true,
+                    dlsitePlayImageWidth = 1200,
+                    dlsitePlayImageHeight = 900,
+                    dlsitePlayOptimizedName = "00000abc1234.jpg"
+                )
+            )
+        ).single()
+
+        assertEquals(0xabc1234, leaf.dlsitePlayImageSeed)
+        assertEquals(1200, leaf.dlsitePlayImageWidth)
+        assertEquals(900, leaf.dlsitePlayImageHeight)
+    }
+
+    @Test
     fun flattenOnlineSaveLeaves_includesResourceFilesButSkipsSubtitles() {
         val leaves = flattenOnlineSaveLeaves(
             listOf(


### PR DESCRIPTION
## 问题

“已购”专辑详情页下载的 DLsite Play 加密图片会以打乱的图片方块保存到本地；即使重新下载，按路径缓存的旧位图也可能继续显示。

历史提交 `501dd6a` 只覆盖了在线预览解乱，没有覆盖下载落盘和同路径文件替换后的缓存失效。

## 修复

- 将 DLsite Play 图片的 seed、宽度和高度传入并持久化到下载任务
- 下载到临时文件后执行方块解乱，再原子替换最终图片
- 支持暂停、恢复及删除任务时处理加密图片临时文件
- 本地文件缓存键加入文件大小和修改时间，避免重新下载后继续命中旧位图
- 数据库升级到 30，并补充迁移和图片解乱测试

## 验证
- Release 安装后，在本地目录重新打开显示正常
- `./gradlew-local.bat :app:testReleaseUnitTest --tests "com.asmr.player.cache.CacheKeyFactoryTest" --tests "com.asmr.player.data.remote.dlsite.DlsitePlayImageSupportTest" --tests "com.asmr.player.ui.library.AlbumDetailDirectorySupportTest" --tests "com.asmr.player.data.local.db.AppDatabaseMigrationsTest"`
- `./gradlew-local.bat :app:installRelease`