### PR TITLE
完善本地库目录树翻译文案与删除能力

### DIFF
--- a/app/src/main/java/com/asmr/player/data/local/db/dao/OnlineSavedResourceDao.kt
+++ b/app/src/main/java/com/asmr/player/data/local/db/dao/OnlineSavedResourceDao.kt
@@ -21,6 +21,9 @@ interface OnlineSavedResourceDao {
     @Query("DELETE FROM online_saved_resources WHERE albumId = :albumId")
     suspend fun deleteByAlbumId(albumId: Long)
 
+    @Query("DELETE FROM online_saved_resources WHERE id IN (:ids)")
+    suspend fun deleteByIds(ids: List<Long>)
+
     @Query("UPDATE online_saved_resources SET albumId = :toAlbumId WHERE albumId = :fromAlbumId")
     suspend fun moveToAlbum(fromAlbumId: Long, toAlbumId: Long)
 }

--- a/app/src/main/java/com/asmr/player/data/local/db/dao/TrackTagDao.kt
+++ b/app/src/main/java/com/asmr/player/data/local/db/dao/TrackTagDao.kt
@@ -15,6 +15,9 @@ interface TrackTagDao {
     @Query("DELETE FROM track_tag WHERE trackId = :trackId")
     suspend fun deleteTrackTagsByTrackId(trackId: Long)
 
+    @Query("DELETE FROM track_tag WHERE trackId IN (:trackIds)")
+    suspend fun deleteTrackTagsByTrackIds(trackIds: List<Long>)
+
     @Query("DELETE FROM track_tag WHERE trackId = :trackId AND source = :source")
     suspend fun deleteTrackTagsByTrackIdAndSource(trackId: Long, source: Int)
 

--- a/app/src/main/java/com/asmr/player/ui/library/AlbumDetailScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/AlbumDetailScreen.kt
@@ -1006,6 +1006,13 @@ fun AlbumDetailScreen(
                                                 onRemoveTrack = { track ->
                                                     if (track.id > 0L) libraryViewModel.removeTrackFromAlbum(track.id)
                                                 },
+                                                onDeleteTreeEntry = { target, onComplete ->
+                                                    libraryViewModel.deleteAlbumTreeEntry(
+                                                        album = local,
+                                                        target = target,
+                                                        onComplete = onComplete,
+                                                    )
+                                                },
                                                 onSetCoverFromImage = { pathOrUri ->
                                                     viewModel.setLocalCoverPath(pathOrUri)
                                                 },

--- a/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailDirectorySupport.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailDirectorySupport.kt
@@ -181,6 +181,7 @@ internal sealed class AsmrTreeUiEntry {
 
 private val DirectoryBrowserPanelCornerRadius = 22.dp
 private val DirectoryFolderRowCornerRadius = 14.dp
+private val DirectoryFileRowCornerRadius = 12.dp
 private val DirectoryBrowserPanelVerticalPadding = 8.dp
 
 internal fun directoryBrowserHeaderBackground(colorScheme: AsmrColorScheme): Color {
@@ -218,6 +219,39 @@ private fun directoryFolderShape(position: DirectoryFolderPosition): RoundedCorn
             topEnd = 0.dp,
             bottomStart = DirectoryFolderRowCornerRadius,
             bottomEnd = DirectoryFolderRowCornerRadius,
+        )
+    }
+}
+
+internal fun directorySelectedItemPosition(
+    selected: Boolean,
+    previousSelected: Boolean,
+    nextSelected: Boolean,
+): DirectoryFolderPosition {
+    if (!selected) return DirectoryFolderPosition.Single
+    return when {
+        !previousSelected && !nextSelected -> DirectoryFolderPosition.Single
+        !previousSelected -> DirectoryFolderPosition.First
+        !nextSelected -> DirectoryFolderPosition.Last
+        else -> DirectoryFolderPosition.Middle
+    }
+}
+
+private fun directoryFileSelectionShape(position: DirectoryFolderPosition): RoundedCornerShape {
+    return when (position) {
+        DirectoryFolderPosition.Single -> RoundedCornerShape(DirectoryFileRowCornerRadius)
+        DirectoryFolderPosition.First -> RoundedCornerShape(
+            topStart = DirectoryFileRowCornerRadius,
+            topEnd = DirectoryFileRowCornerRadius,
+            bottomStart = 0.dp,
+            bottomEnd = 0.dp,
+        )
+        DirectoryFolderPosition.Middle -> RoundedCornerShape(0.dp)
+        DirectoryFolderPosition.Last -> RoundedCornerShape(
+            topStart = 0.dp,
+            topEnd = 0.dp,
+            bottomStart = DirectoryFileRowCornerRadius,
+            bottomEnd = DirectoryFileRowCornerRadius,
         )
     }
 }
@@ -436,7 +470,9 @@ internal data class DirectoryBreadcrumbSegment(
 
 internal data class DirectoryFolderItem(
     val path: String,
-    val title: String
+    val title: String,
+    val descendantTrackIds: List<Long> = emptyList(),
+    val hasLocalContent: Boolean = false,
 )
 
 internal data class DirectoryFileItem(
@@ -458,6 +494,15 @@ internal data class DirectoryFileItem(
     val dlsitePlayImageWidth: Int? = null,
     val dlsitePlayImageHeight: Int? = null,
     val dlsitePlayOptimizedName: String? = null
+)
+
+internal data class LocalTreeDeletionTarget(
+    val title: String,
+    val relativePath: String,
+    val absolutePath: String? = null,
+    val isDirectory: Boolean,
+    val trackIds: List<Long> = emptyList(),
+    val hasLocalContent: Boolean,
 )
 
 internal fun isOnlineDirectoryAudio(fileType: TreeFileType, absolutePath: String, track: Track?): Boolean {
@@ -518,6 +563,27 @@ internal fun buildBreadcrumbSegments(currentPath: String): List<DirectoryBreadcr
         out += DirectoryBreadcrumbSegment(label = segment, path = path)
     }
     return out
+}
+
+internal fun normalizeLocalTreeRelativePath(path: String): String? {
+    val segments = path
+        .replace('\\', '/')
+        .trim()
+        .trim('/')
+        .split('/')
+        .filter { it.isNotBlank() }
+    if (segments.isEmpty() || segments.any { it == "." || it == ".." }) return null
+    return segments.joinToString("/")
+}
+
+internal fun localTreePathMatchesTarget(
+    candidatePath: String,
+    targetPath: String,
+    targetIsDirectory: Boolean,
+): Boolean {
+    val candidate = normalizeLocalTreeRelativePath(candidatePath) ?: return false
+    val target = normalizeLocalTreeRelativePath(targetPath) ?: return false
+    return candidate == target || (targetIsDirectory && candidate.startsWith("$target/"))
 }
 
 internal fun albumArtistLabel(album: Album): String {
@@ -732,6 +798,21 @@ internal fun findLocalTreeNode(root: LocalTreeNode, folderPath: String): LocalTr
     return cur
 }
 
+private fun collectLocalTreeLeafNodes(root: LocalTreeNode): List<LocalTreeNode> {
+    val leaves = mutableListOf<LocalTreeNode>()
+    val pending = ArrayDeque<LocalTreeNode>()
+    pending.add(root)
+    while (pending.isNotEmpty()) {
+        val node = pending.removeLast()
+        if (node.children.isEmpty()) {
+            if (node.absolutePath != null) leaves += node
+        } else {
+            node.children.values.forEach(pending::addLast)
+        }
+    }
+    return leaves
+}
+
 internal fun siblingAudioTracksForEntry(index: LocalTreeIndex, entryPath: String): List<Track> {
     val folderPath = entryPath.substringBeforeLast('/', "")
     val node = findLocalTreeNode(index.root, folderPath) ?: index.root
@@ -836,9 +917,16 @@ internal fun buildLocalDirectoryBrowser(
         .filter { it.children.isNotEmpty() }
         .sortedBy { SmartSortKey.of(it.name) }
         .map { child ->
+            val descendantLeaves = collectLocalTreeLeafNodes(child)
             DirectoryFolderItem(
                 path = child.path,
-                title = child.name
+                title = child.name,
+                descendantTrackIds = descendantLeaves
+                    .mapNotNull { it.track?.id?.takeIf { id -> id > 0L } }
+                    .distinct(),
+                hasLocalContent = descendantLeaves.any { node ->
+                    node.absolutePath?.startsWith("http", ignoreCase = true) == false
+                },
             )
         }
         .toList()
@@ -2779,8 +2867,11 @@ internal fun DirectoryFolderRowV3(
     title: String,
     onClick: () -> Unit,
     position: DirectoryFolderPosition = DirectoryFolderPosition.Single,
+    onDelete: (() -> Unit)? = null,
 ) {
     val colorScheme = AsmrTheme.colorScheme
+    val materialColorScheme = MaterialTheme.colorScheme
+    val dynamicContainerColor = dynamicPageContainerColor(colorScheme)
     val rowContainerColor = colorScheme.surfaceVariant.copy(
         alpha = if (colorScheme.isDark) 0.42f else 0.58f
     )
@@ -2829,6 +2920,49 @@ internal fun DirectoryFolderRowV3(
                 tint = colorScheme.textTertiary,
                 modifier = Modifier.size(17.dp)
             )
+            if (onDelete != null) {
+                var showMenuExpanded by rememberSaveable(title) { mutableStateOf(false) }
+                Box {
+                    IconButton(
+                        onClick = { showMenuExpanded = true },
+                        modifier = Modifier.size(AudioItemMenuButtonSize)
+                    ) {
+                        Icon(
+                            imageVector = Icons.Rounded.MoreVert,
+                            contentDescription = "目录操作",
+                            tint = colorScheme.textSecondary,
+                            modifier = Modifier.size(20.dp)
+                        )
+                    }
+                    MaterialTheme(
+                        colorScheme = materialColorScheme.copy(
+                            surface = dynamicContainerColor,
+                            surfaceContainer = dynamicContainerColor
+                        )
+                    ) {
+                        DropdownMenu(
+                            expanded = showMenuExpanded,
+                            onDismissRequest = { showMenuExpanded = false },
+                            modifier = Modifier.background(dynamicContainerColor)
+                        ) {
+                            DropdownMenuItem(
+                                text = { Text("删除目录", color = materialColorScheme.error) },
+                                onClick = {
+                                    showMenuExpanded = false
+                                    onDelete()
+                                },
+                                leadingIcon = {
+                                    Icon(
+                                        Icons.Rounded.Delete,
+                                        contentDescription = null,
+                                        tint = materialColorScheme.error
+                                    )
+                                }
+                            )
+                        }
+                    }
+                }
+            }
         }
         if (position != DirectoryFolderPosition.Single && position != DirectoryFolderPosition.Last) {
             HorizontalDivider(
@@ -3010,6 +3144,7 @@ internal fun DirectoryBrowserPanelV4(
     folders: List<DirectoryFolderItem>,
     files: List<DirectoryFileItem>,
     onNavigate: (String) -> Unit,
+    onDeleteFolder: ((DirectoryFolderItem) -> Unit)? = null,
     onAddToFavorites: (List<MediaItem>) -> Unit,
     onOpenBatchPlaylistPicker: (List<MediaItem>) -> Unit,
     onAddMediaItemsToQueue: (List<MediaItem>) -> Unit,
@@ -3030,6 +3165,7 @@ internal fun DirectoryBrowserPanelV4(
         file: DirectoryFileItem,
         selectionMode: Boolean,
         selected: Boolean,
+        selectedPosition: DirectoryFolderPosition,
         enterSelectionMode: () -> Unit,
         onSelectedChange: (Boolean) -> Unit
     ) -> Unit
@@ -3069,9 +3205,9 @@ internal fun DirectoryBrowserPanelV4(
     var selectionMode by remember(panelKey, currentPath) { mutableStateOf(false) }
     var preferredPathState by rememberSaveable(panelKey) { mutableStateOf(preferredPath.trim().trim('/')) }
     val selectedPaths = remember(panelKey, currentPath) { mutableStateListOf<String>() }
-    val selectedFiles = remember(files, selectedPaths.toList()) {
-        val selectedSet = selectedPaths.toSet()
-        files.filter { selectedSet.contains(it.path) }
+    val selectedPathSet = remember(selectedPaths.toList()) { selectedPaths.toSet() }
+    val selectedFiles = remember(files, selectedPathSet) {
+        files.filter { selectedPathSet.contains(it.path) }
     }
     val activeTargets = remember(selectionMode, batchTargets, selectedFiles) {
         if (selectionMode) selectedFiles.mapNotNull { it.playlistTarget } else batchTargets
@@ -3180,7 +3316,7 @@ internal fun DirectoryBrowserPanelV4(
                     onOpenBatchPlaylistPicker = onOpenBatchPlaylistPicker,
                     onAddMediaItemsToQueue = onAddMediaItemsToQueue,
                     showTranslateAction = showTranslateAction,
-                    subtitleGenerationText = if (selectionMode) "生成并翻译" else "批量生成并翻译",
+                    subtitleGenerationText = if (selectionMode) "翻译选中" else "批量翻译",
                     subtitleGenerationEnabled = subtitleGenerationEnabled,
                     onGenerateSubtitles = onGenerateSubtitles,
                     onSubtitleGenerationUnavailable = onSubtitleGenerationUnavailable.takeIf {
@@ -3277,31 +3413,40 @@ internal fun DirectoryBrowserPanelV4(
                             }
                         }
                     } else {
-                        items(
+                        itemsIndexed(
                             items = folders,
-                            key = { folder -> "$folderKeyPrefix:${folder.path}" },
-                            contentType = { "folder" }
-                        ) { folder ->
+                            key = { _, folder -> "$folderKeyPrefix:${folder.path}" },
+                            contentType = { _, _ -> "folder" }
+                        ) { index, folder ->
                             val position = directoryFolderPosition(
-                                index = folders.indexOf(folder),
+                                index = index,
                                 total = folders.size,
                             )
                             DirectoryFolderRowV3(
                                 title = folder.title,
                                 onClick = { onNavigate(folder.path) },
                                 position = position,
+                                onDelete = onDeleteFolder?.let { deleteFolder ->
+                                    { deleteFolder(folder) }
+                                },
                             )
                         }
-                        items(
+                        itemsIndexed(
                             items = files,
-                            key = { file -> "$fileKeyPrefix:${file.path}" },
-                            contentType = { "file" }
-                        ) { file ->
-                            val isSelected = selectedPaths.contains(file.path)
+                            key = { _, file -> "$fileKeyPrefix:${file.path}" },
+                            contentType = { _, _ -> "file" }
+                        ) { index, file ->
+                            val isSelected = selectedPathSet.contains(file.path)
+                            val selectedPosition = directorySelectedItemPosition(
+                                selected = isSelected,
+                                previousSelected = index > 0 && selectedPathSet.contains(files[index - 1].path),
+                                nextSelected = index < files.lastIndex && selectedPathSet.contains(files[index + 1].path),
+                            )
                             fileContent(
                                 file,
                                 selectionMode,
                                 isSelected,
+                                selectedPosition,
                                 {
                                     selectionMode = true
                                     if (!selectedPaths.contains(file.path)) {
@@ -3337,6 +3482,7 @@ internal fun DirectoryFileRow(
     onPrimary: () -> Unit,
     selectionMode: Boolean = false,
     selected: Boolean = false,
+    selectedPosition: DirectoryFolderPosition = DirectoryFolderPosition.Single,
     onEnterSelectionMode: (() -> Unit)? = null,
     onSelectedChange: ((Boolean) -> Unit)? = null,
     onSetAsCover: (() -> Unit)? = null,
@@ -3346,7 +3492,8 @@ internal fun DirectoryFileRow(
     onGenerateSubtitles: (() -> Unit)? = null,
     subtitleGenerationEnabled: Boolean = true,
     onManageTags: (() -> Unit)? = null,
-    onRemoveFromAlbum: (() -> Unit)? = null
+    onRemoveFromAlbum: (() -> Unit)? = null,
+    onDelete: (() -> Unit)? = null,
 ) {
     val colorScheme = AsmrTheme.colorScheme
     val materialColorScheme = MaterialTheme.colorScheme
@@ -3372,7 +3519,7 @@ internal fun DirectoryFileRow(
     }
 
     val showPrimaryAction = file.isPlayable
-    val showMenu = showPrimaryAction || onDownload != null || onAddToQueue != null || onAddToPlaylist != null || onGenerateSubtitles != null || onManageTags != null || onRemoveFromAlbum != null
+    val showMenu = showPrimaryAction || onDownload != null || onAddToQueue != null || onAddToPlaylist != null || onGenerateSubtitles != null || onManageTags != null || onRemoveFromAlbum != null || onDelete != null
     val showTrailing = selectionMode || onSetAsCover != null || file.showSubtitleStamp || showMenu
     val rowContainerColor = if (selected) {
         colorScheme.primary.copy(alpha = if (colorScheme.isDark) 0.18f else 0.09f)
@@ -3381,7 +3528,7 @@ internal fun DirectoryFileRow(
     }
 
     Surface(
-        shape = RoundedCornerShape(12.dp),
+        shape = if (selected) directoryFileSelectionShape(selectedPosition) else RoundedCornerShape(DirectoryFileRowCornerRadius),
         color = rowContainerColor,
         modifier = Modifier
             .fillMaxWidth()
@@ -3622,6 +3769,22 @@ internal fun DirectoryFileRow(
                                             },
                                             leadingIcon = {
                                                 Icon(Icons.Rounded.Delete, contentDescription = null, tint = colorScheme.textSecondary)
+                                            }
+                                        )
+                                    }
+                                    if (onDelete != null) {
+                                        DropdownMenuItem(
+                                            text = { Text("删除", color = materialColorScheme.error) },
+                                            onClick = {
+                                                onDelete()
+                                                showMenuExpanded = false
+                                            },
+                                            leadingIcon = {
+                                                Icon(
+                                                    Icons.Rounded.Delete,
+                                                    contentDescription = null,
+                                                    tint = materialColorScheme.error
+                                                )
                                             }
                                         )
                                     }

--- a/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailDlsiteTabs.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailDlsiteTabs.kt
@@ -1150,7 +1150,7 @@ internal fun AlbumDlsiteInfoBreadcrumbTabV2(
                                     animateIntro = false,
                                     folderKeyPrefix = "asmr-folder",
                                     fileKeyPrefix = "asmr-file",
-                                    fileContent = { file, selectionMode, selected, enterSelectionMode, onSelectedChange ->
+                                    fileContent = { file, selectionMode, selected, selectedPosition, enterSelectionMode, onSelectedChange ->
                                         val leaf = asmrLeafByRelPath[file.path]
                                         DirectoryFileRow(
                                             file = file.copy(showSubtitleStamp = file.subtitleSources.isNotEmpty()),
@@ -1236,6 +1236,7 @@ internal fun AlbumDlsiteInfoBreadcrumbTabV2(
                                             },
                                             selectionMode = selectionMode,
                                             selected = selected,
+                                            selectedPosition = selectedPosition,
                                             onEnterSelectionMode = enterSelectionMode,
                                             onSelectedChange = onSelectedChange,
                                             onDownload = if (isDownloadableTreeFileType(file.fileType)) ({ onDownloadOne(file.path) }) else null,
@@ -1648,7 +1649,7 @@ internal fun AlbumDlsitePlayBreadcrumbTabV2(
                                 animateIntro = animateIntro,
                                 folderKeyPrefix = "dlplay-folder",
                                 fileKeyPrefix = "dlplay-file",
-                                fileContent = { file, selectionMode, selected, enterSelectionMode, onSelectedChange ->
+                                fileContent = { file, selectionMode, selected, selectedPosition, enterSelectionMode, onSelectedChange ->
                                     val leaf = leafByRelPath[file.path]
                                     DirectoryFileRow(
                                         file = file.copy(showSubtitleStamp = file.subtitleSources.isNotEmpty()),
@@ -1747,6 +1748,7 @@ internal fun AlbumDlsitePlayBreadcrumbTabV2(
                                         },
                                         selectionMode = selectionMode,
                                         selected = selected,
+                                        selectedPosition = selectedPosition,
                                         onEnterSelectionMode = enterSelectionMode,
                                         onSelectedChange = onSelectedChange,
                                         onDownload = if (isDownloadableTreeFileType(file.fileType)) ({ onDownloadOne(file.path) }) else null,

--- a/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailLocalTab.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailLocalTab.kt
@@ -162,6 +162,7 @@ internal fun AlbumLocalBreadcrumbTabV2(
     onDownloadOnlineTrack: (Track, String) -> Unit,
     onManageTrackTags: (Track) -> Unit,
     onRemoveTrack: (Track) -> Unit,
+    onDeleteTreeEntry: (LocalTreeDeletionTarget, (Boolean) -> Unit) -> Unit,
     onSetCoverFromImage: (String) -> Unit,
     onPreviewImages: (ImagePreviewRequest) -> Unit,
     onPreviewFile: (LocalTreeUiEntry.File) -> Unit,
@@ -169,7 +170,14 @@ internal fun AlbumLocalBreadcrumbTabV2(
     onSubtitleGenerationUnavailable: (String) -> Unit,
     onSubtitleGenerationQueued: (String) -> Unit,
 ) {
-    val queueTracks = remember(album.id, album.tracks) { album.tracks.sortedBy { it.path } }
+    var locallyDeletedTrackIds by remember(stateKey) { mutableStateOf(emptySet<Long>()) }
+    var treeRevision by rememberSaveable(stateKey) { mutableIntStateOf(0) }
+    var pendingDeletion by remember { mutableStateOf<LocalTreeDeletionTarget?>(null) }
+    val queueTracks = remember(album.id, album.tracks, locallyDeletedTrackIds) {
+        album.tracks
+            .filterNot { it.id in locallyDeletedTrackIds }
+            .sortedBy { it.path }
+    }
     val queueTrackIds = remember(queueTracks) {
         queueTracks.asSequence().map { it.id }.filter { it > 0L }.distinct().toList()
     }
@@ -184,6 +192,11 @@ internal fun AlbumLocalBreadcrumbTabV2(
         SubtitleModelInstallationState.Available
     val allPaths = remember(album) { album.getAllLocalPaths() }
     var currentPath by rememberSaveable(stateKey) { mutableStateOf(initialCurrentPath.trim().trim('/')) }
+
+    LaunchedEffect(album.tracks) {
+        val currentTrackIds = album.tracks.asSequence().map { it.id }.toSet()
+        locallyDeletedTrackIds = locallyDeletedTrackIds.intersect(currentTrackIds)
+    }
 
     val listState = rememberSaveable("scroll:$stateKey", saver = LazyListState.Saver) {
         LazyListState(initialScroll.first, initialScroll.second)
@@ -221,10 +234,11 @@ internal fun AlbumLocalBreadcrumbTabV2(
             .collect { value = it }
     }
     val treeIndex by produceState<LocalTreeIndex?>(
-        initialValue = null,
-        key1 = allPaths,
-        key2 = queueTracks,
-        key3 = onlineSavedResources
+        null,
+        allPaths,
+        queueTracks,
+        onlineSavedResources,
+        treeRevision,
     ) {
         value = withContext(Dispatchers.IO) {
             loadOrBuildLocalTreeIndex(
@@ -321,6 +335,15 @@ internal fun AlbumLocalBreadcrumbTabV2(
                     folders = browserValue.folders,
                     files = browserValue.files,
                     onNavigate = { path -> currentPath = path },
+                    onDeleteFolder = { folder ->
+                        pendingDeletion = LocalTreeDeletionTarget(
+                            title = folder.title,
+                            relativePath = folder.path,
+                            isDirectory = true,
+                            trackIds = folder.descendantTrackIds,
+                            hasLocalContent = folder.hasLocalContent,
+                        )
+                    },
                     onAddToFavorites = onAddMediaItemsToFavorites,
                     onOpenBatchPlaylistPicker = onOpenBatchPlaylistPicker,
                     onAddMediaItemsToQueue = onAddMediaItemsToQueue,
@@ -362,7 +385,7 @@ internal fun AlbumLocalBreadcrumbTabV2(
                     },
                     folderKeyPrefix = "folder",
                     fileKeyPrefix = "file",
-                    fileContent = { file, selectionMode, selected, enterSelectionMode, onSelectedChange ->
+                    fileContent = { file, selectionMode, selected, selectedPosition, enterSelectionMode, onSelectedChange ->
                         val track = file.track
                         val downloadableTrack = downloadableOnlineAudioTrack(file)
                         DirectoryFileRow(
@@ -466,6 +489,7 @@ internal fun AlbumLocalBreadcrumbTabV2(
                             },
                             selectionMode = selectionMode,
                             selected = selected,
+                            selectedPosition = selectedPosition,
                             onEnterSelectionMode = enterSelectionMode,
                             onSelectedChange = onSelectedChange,
                             onSetAsCover = if (canSetDirectoryImageAsLocalCover(file)) {
@@ -494,12 +518,69 @@ internal fun AlbumLocalBreadcrumbTabV2(
                             } else null,
                             subtitleGenerationEnabled = subtitleModelAvailable,
                             onManageTags = track?.let { if (!isOnlineTrackPath(it.path)) { { onManageTrackTags(it) } } else null },
-                            onRemoveFromAlbum = track?.let { { onRemoveTrack(it) } }
+                            onRemoveFromAlbum = track?.let { { onRemoveTrack(it) } },
+                            onDelete = if (file.fileType != TreeFileType.Audio) {
+                                {
+                                    pendingDeletion = LocalTreeDeletionTarget(
+                                        title = file.title,
+                                        relativePath = file.path,
+                                        absolutePath = file.absolutePath,
+                                        isDirectory = false,
+                                        trackIds = file.track?.id?.takeIf { it > 0L }?.let(::listOf).orEmpty(),
+                                        hasLocalContent = !file.absolutePath.startsWith("http", ignoreCase = true),
+                                    )
+                                }
+                            } else {
+                                null
+                            }
                         )
                     }
                 )
             }
         }
+    }
+
+    pendingDeletion?.let { target ->
+        AlertDialog(
+            onDismissRequest = { pendingDeletion = null },
+            title = { Text(if (target.isDirectory) "删除目录？" else "删除文件？") },
+            text = {
+                val message = when {
+                    target.isDirectory && target.hasLocalContent ->
+                        "将永久删除目录“${target.title}”及其全部内容，同时移除关联的本地库记录。此操作不可恢复。"
+                    target.isDirectory ->
+                        "将从本地库目录树移除“${target.title}”及其包含的在线资源。"
+                    target.hasLocalContent ->
+                        "将永久删除文件“${target.title}”。此操作不可恢复。"
+                    else ->
+                        "将从本地库目录树移除资源“${target.title}”。"
+                }
+                Text(message)
+            },
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        pendingDeletion = null
+                        onDeleteTreeEntry(target) { deleted ->
+                            if (deleted) {
+                                locallyDeletedTrackIds = locallyDeletedTrackIds + target.trackIds
+                                treeRevision += 1
+                            }
+                        }
+                    },
+                    colors = ButtonDefaults.textButtonColors(
+                        contentColor = MaterialTheme.colorScheme.error
+                    )
+                ) {
+                    Text("删除")
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { pendingDeletion = null }) {
+                    Text("取消")
+                }
+            }
+        )
     }
 
 }

--- a/app/src/main/java/com/asmr/player/ui/library/libraryviewmodel.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/libraryviewmodel.kt
@@ -1673,6 +1673,81 @@ class LibraryViewModel @Inject constructor(
         }
     }
 
+    internal fun deleteAlbumTreeEntry(
+        album: Album,
+        target: LocalTreeDeletionTarget,
+        onComplete: (Boolean) -> Unit = {},
+    ) {
+        viewModelScope.launch(Dispatchers.IO) {
+            val relativePath = normalizeLocalTreeRelativePath(target.relativePath)
+            if (album.id <= 0L || relativePath == null) {
+                messageManager.showError("删除失败：目录项路径无效")
+                withContext(Dispatchers.Main.immediate) { onComplete(false) }
+                return@launch
+            }
+
+            try {
+                val albumRoots = album.getAllLocalPaths()
+                val physicalDeletionSucceeded = when {
+                    !target.hasLocalContent -> true
+                    target.isDirectory -> deleteLocalTreeDirectories(albumRoots, relativePath)
+                    else -> deleteLocalTreeFile(albumRoots, target.absolutePath.orEmpty())
+                }
+                check(physicalDeletionSucceeded) {
+                    if (target.isDirectory) "无法删除目录，请检查存储权限" else "无法删除文件，请检查存储权限"
+                }
+
+                val verifiedTrackIds = target.trackIds
+                    .asSequence()
+                    .filter { it > 0L }
+                    .distinct()
+                    .toList()
+                    .takeIf { it.isNotEmpty() }
+                    ?.let { ids ->
+                        trackDao.getTracksByIdsOnce(ids)
+                            .filter { it.albumId == album.id }
+                            .map { it.id }
+                    }
+                    .orEmpty()
+                val resourceIds = database.onlineSavedResourceDao()
+                    .getForAlbumOnce(album.id)
+                    .filter { resource ->
+                        localTreePathMatchesTarget(
+                            candidatePath = resource.relativePath,
+                            targetPath = relativePath,
+                            targetIsDirectory = target.isDirectory,
+                        )
+                    }
+                    .map { it.id }
+
+                database.withTransaction {
+                    if (verifiedTrackIds.isNotEmpty()) {
+                        database.remoteSubtitleSourceDao().deleteByTrackIds(verifiedTrackIds)
+                        trackDao.deleteSubtitlesForTracks(verifiedTrackIds)
+                        database.trackTagDao().deleteTrackTagsByTrackIds(verifiedTrackIds)
+                        trackDao.deleteTracksByIds(verifiedTrackIds)
+                    }
+                    if (resourceIds.isNotEmpty()) {
+                        database.onlineSavedResourceDao().deleteByIds(resourceIds)
+                    }
+                    database.localTreeCacheDao().deleteByAlbum(album.id)
+                }
+                if (verifiedTrackIds.isNotEmpty()) {
+                    refreshAlbumAudioAggregate(album.id)
+                }
+
+                messageManager.showSuccess(if (target.isDirectory) "已删除目录" else "已删除文件")
+                withContext(Dispatchers.Main.immediate) { onComplete(true) }
+            } catch (cancelled: CancellationException) {
+                throw cancelled
+            } catch (error: Exception) {
+                Log.e(TAG, "deleteAlbumTreeEntry failed: ${target.relativePath}", error)
+                messageManager.showError("删除失败：${error.message ?: "未知错误"}")
+                withContext(Dispatchers.Main.immediate) { onComplete(false) }
+            }
+        }
+    }
+
     fun removeTrackFromAlbum(trackId: Long) {
         viewModelScope.launch(Dispatchers.IO) {
             val track = trackDao.getTrackByIdOnce(trackId) ?: return@launch
@@ -1689,7 +1764,7 @@ class LibraryViewModel @Inject constructor(
                 )
                     .mapNotNull { runCatching { it.canonicalFile }.getOrNull() ?: it.absoluteFile }
                 val target = runCatching { File(path).canonicalFile }.getOrNull() ?: File(path).absoluteFile
-                val isInAllowed = allowedRoots.any { root -> target.path.startsWith(root.path) }
+                val isInAllowed = allowedRoots.any { root -> isCanonicalDescendant(target, root) }
                 if (isInAllowed) deletePathSafely(target.absolutePath) else false
             }
 
@@ -1722,7 +1797,7 @@ class LibraryViewModel @Inject constructor(
             .mapNotNull { runCatching { it.canonicalFile }.getOrNull() ?: it.absoluteFile }
 
         val target = runCatching { File(path).canonicalFile }.getOrNull() ?: File(path).absoluteFile
-        val isAllowed = allowedRoots.any { root -> target.path.startsWith(root.path) }
+        val isAllowed = allowedRoots.any { root -> isCanonicalDescendant(target, root) }
         if (!isAllowed) return false
         if (!target.exists()) return false
 
@@ -1731,6 +1806,135 @@ class LibraryViewModel @Inject constructor(
         } else {
             runCatching { target.delete() }.getOrDefault(false)
         }
+    }
+
+    private fun deleteLocalTreeFile(albumRoots: List<String>, absolutePath: String): Boolean {
+        val normalizedPath = absolutePath.trim()
+        if (normalizedPath.isBlank()) return false
+        if (normalizedPath.startsWith("content://", ignoreCase = true)) {
+            val targetUri = runCatching { Uri.parse(normalizedPath) }.getOrNull() ?: return false
+            val allowedAuthority = albumRoots.asSequence()
+                .filter { it.startsWith("content://", ignoreCase = true) }
+                .mapNotNull { runCatching { Uri.parse(it).authority }.getOrNull() }
+                .any { it == targetUri.authority }
+            if (!allowedAuthority) return false
+            return runCatching {
+                DocumentsContract.deleteDocument(context.contentResolver, targetUri)
+            }.getOrDefault(false)
+        }
+        if (normalizedPath.startsWith("http", ignoreCase = true) || normalizedPath.startsWith("web://", ignoreCase = true)) {
+            return false
+        }
+
+        val targetFile = runCatching { File(normalizedPath).canonicalFile }.getOrNull() ?: return false
+        val allowed = albumRoots.asSequence()
+            .filterNot { it.startsWith("content://", ignoreCase = true) }
+            .filterNot { it.startsWith("http", ignoreCase = true) || it.startsWith("web://", ignoreCase = true) }
+            .mapNotNull { root -> runCatching { File(root).canonicalFile }.getOrNull() }
+            .any { root -> isCanonicalDescendant(targetFile, root) }
+        if (!allowed) return false
+        if (!targetFile.exists()) return true
+        if (!targetFile.isFile) return false
+        return runCatching { targetFile.delete() }.getOrDefault(false)
+    }
+
+    private fun deleteLocalTreeDirectories(albumRoots: List<String>, relativePath: String): Boolean {
+        var hasUsableRoot = false
+        var allDeleted = true
+        val fileTargets = linkedSetOf<File>()
+
+        albumRoots.distinct().forEach { rawRoot ->
+            when {
+                rawRoot.startsWith("content://", ignoreCase = true) -> {
+                    hasUsableRoot = true
+                    val resolved = resolveTreeDocumentUri(rawRoot, relativePath)
+                    if (resolved.isFailure) {
+                        allDeleted = false
+                    } else {
+                        resolved.getOrNull()?.let { targetUri ->
+                            val deleted = runCatching {
+                                DocumentsContract.deleteDocument(context.contentResolver, targetUri)
+                            }.getOrDefault(false)
+                            if (!deleted) allDeleted = false
+                        }
+                    }
+                }
+                rawRoot.startsWith("http", ignoreCase = true) || rawRoot.startsWith("web://", ignoreCase = true) -> Unit
+                rawRoot.isNotBlank() -> {
+                    val root = runCatching { File(rawRoot).canonicalFile }.getOrNull() ?: return@forEach
+                    val target = runCatching {
+                        File(root, relativePath.replace('/', File.separatorChar)).canonicalFile
+                    }.getOrNull() ?: return@forEach
+                    if (isCanonicalDescendant(target, root)) {
+                        hasUsableRoot = true
+                        if (target.exists()) fileTargets += target
+                    }
+                }
+            }
+        }
+
+        fileTargets
+            .sortedByDescending { it.path.length }
+            .forEach { target ->
+                if (!target.isDirectory || !runCatching { target.deleteRecursively() }.getOrDefault(false)) {
+                    allDeleted = false
+                }
+            }
+        return hasUsableRoot && allDeleted
+    }
+
+    private fun resolveTreeDocumentUri(rootUriString: String, relativePath: String): Result<Uri?> = runCatching {
+        val rootUri = Uri.parse(rootUriString)
+        val authority = requireNotNull(rootUri.authority) { "目录授权地址无效" }
+        val treeId = runCatching { DocumentsContract.getTreeDocumentId(rootUri) }.getOrDefault("")
+        var documentId = runCatching { DocumentsContract.getDocumentId(rootUri) }
+            .getOrDefault(treeId)
+            .ifBlank { treeId }
+        check(documentId.isNotBlank()) { "无法读取目录授权" }
+        val treeUri = if (treeId.isNotBlank()) {
+            DocumentsContract.buildTreeDocumentUri(authority, treeId)
+        } else {
+            rootUri
+        }
+
+        for (segment in relativePath.split('/')) {
+            val childrenUri = DocumentsContract.buildChildDocumentsUriUsingTree(treeUri, documentId)
+            val cursor = context.contentResolver.query(
+                childrenUri,
+                arrayOf(
+                    DocumentsContract.Document.COLUMN_DOCUMENT_ID,
+                    DocumentsContract.Document.COLUMN_DISPLAY_NAME,
+                    DocumentsContract.Document.COLUMN_MIME_TYPE,
+                ),
+                null,
+                null,
+                null,
+            ) ?: throw IllegalStateException("无法访问目录，请重新授权存储权限")
+            val childId = cursor.use {
+                val idIndex = cursor.getColumnIndex(DocumentsContract.Document.COLUMN_DOCUMENT_ID)
+                val nameIndex = cursor.getColumnIndex(DocumentsContract.Document.COLUMN_DISPLAY_NAME)
+                val mimeIndex = cursor.getColumnIndex(DocumentsContract.Document.COLUMN_MIME_TYPE)
+                var match: String? = null
+                while (cursor.moveToNext()) {
+                    val name = cursor.getString(nameIndex)
+                    val mime = cursor.getString(mimeIndex)
+                    if (name == segment && mime == DocumentsContract.Document.MIME_TYPE_DIR) {
+                        match = cursor.getString(idIndex)
+                        break
+                    }
+                }
+                match
+            }
+            if (childId == null) return@runCatching null
+            documentId = childId
+        }
+        DocumentsContract.buildDocumentUriUsingTree(treeUri, documentId)
+    }
+
+    private fun isCanonicalDescendant(target: File, root: File): Boolean {
+        if (target == root) return false
+        val rootPrefix = root.path.trimEnd(File.separatorChar) + File.separator
+        return target.path.startsWith(rootPrefix)
     }
 
     private fun extractWorkNo(input: String): String {

--- a/app/src/test/java/com/asmr/player/ui/library/AlbumDetailDirectorySupportTest.kt
+++ b/app/src/test/java/com/asmr/player/ui/library/AlbumDetailDirectorySupportTest.kt
@@ -45,6 +45,54 @@ class AlbumDetailDirectorySupportTest {
     }
 
     @Test
+    fun directorySelectedItemPosition_joinsAdjacentSelectedRows() {
+        assertEquals(
+            DirectoryFolderPosition.First,
+            directorySelectedItemPosition(
+                selected = true,
+                previousSelected = false,
+                nextSelected = true,
+            )
+        )
+        assertEquals(
+            DirectoryFolderPosition.Middle,
+            directorySelectedItemPosition(
+                selected = true,
+                previousSelected = true,
+                nextSelected = true,
+            )
+        )
+        assertEquals(
+            DirectoryFolderPosition.Last,
+            directorySelectedItemPosition(
+                selected = true,
+                previousSelected = true,
+                nextSelected = false,
+            )
+        )
+    }
+
+    @Test
+    fun localTreeDeletionPaths_rejectTraversalAndMatchDirectoryDescendants() {
+        assertEquals("disc1/booklet/cover.jpg", normalizeLocalTreeRelativePath("/disc1\\booklet/cover.jpg"))
+        assertEquals(null, normalizeLocalTreeRelativePath("disc1/../cover.jpg"))
+        assertTrue(
+            localTreePathMatchesTarget(
+                candidatePath = "disc1/booklet/cover.jpg",
+                targetPath = "disc1/booklet",
+                targetIsDirectory = true,
+            )
+        )
+        assertFalse(
+            localTreePathMatchesTarget(
+                candidatePath = "disc1/booklet-old/cover.jpg",
+                targetPath = "disc1/booklet",
+                targetIsDirectory = true,
+            )
+        )
+    }
+
+    @Test
     fun buildLocalDirectoryBrowser_preservesCachedLocalSizeBytes() {
         val track = Track(
             albumId = 7L,
@@ -81,6 +129,41 @@ class AlbumDetailDirectorySupportTest {
             FileSizeSource.Local(path = track.path, sizeBytes = 2_048L),
             browser.files.single().sizeSource
         )
+    }
+
+    @Test
+    fun buildLocalDirectoryBrowser_exposesFolderDeletionMetadata() {
+        val localTrack = Track(
+            id = 11L,
+            albumId = 7L,
+            title = "Track 1",
+            path = "/album/disc1/track1.mp3",
+        )
+        val index = buildLocalTreeIndexFromLeaves(
+            leaves = listOf(
+                LocalTreeLeafCacheEntry(
+                    relativePath = "disc1/track1.mp3",
+                    absolutePath = localTrack.path,
+                    fileType = TreeFileType.Audio,
+                ),
+                LocalTreeLeafCacheEntry(
+                    relativePath = "disc1/cover.jpg",
+                    absolutePath = "/album/disc1/cover.jpg",
+                    fileType = TreeFileType.Image,
+                ),
+            ),
+            tracks = listOf(localTrack),
+        )
+
+        val folder = buildLocalDirectoryBrowser(
+            index = index,
+            currentPath = "",
+            album = Album(id = 7L, title = "Album", path = "/album"),
+            shouldShowSubtitleStamp = { false },
+        ).folders.single()
+
+        assertEquals(listOf(11L), folder.descendantTrackIds)
+        assertTrue(folder.hasLocalContent)
     }
 
     @Test


### PR DESCRIPTION
## 变更内容

- 将本地库专辑详情中的“批量生成并翻译”简化为“批量翻译”，“生成并翻译”简化为“翻译选中”
- 连续选中的目录项使用无缝相连的激活色，仅保留选择段外侧圆角
- 为目录和非音频文件增加删除入口与二次确认
- 支持普通文件路径和 SAF `content://` 目录删除，并同步清理曲目、字幕、标签、在线资源记录与目录缓存
- 增加目录删除路径校验、选中形状和删除元数据相关测试

## 验证

- `./gradlew-local.bat :app:testReleaseUnitTest --tests com.asmr.player.ui.library.AlbumDetailDirectorySupportTest`
- `./gradlew-local.bat :app:installRelease`
- Release APK 已成功安装到 1 台连接设备