### PR TITLE
chore: 准备 v1.2.1 发布版本

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -90,8 +90,8 @@ android {
         applicationId = "com.asmr.player"
         minSdk = 24
         targetSdk = 34
-        versionCode = 10200
-        versionName = "1.2.0"
+        versionCode = 10201
+        versionName = "1.2.1"
         buildConfigField("String", "UPDATE_REPO_OWNER", "\"eValDoll\"")
         buildConfigField("String", "UPDATE_REPO_NAME", "\"EaraAsmrPlayer\"")
         buildConfigField("String", "LISTEN_TOGETHER_BASE_URL", "\"$listenTogetherBaseUrl\"")


### PR DESCRIPTION
发布前同步应用内部版本信息：

- `versionName`: `1.2.0` → `1.2.1`
- `versionCode`: `10200` → `10201`

确保 `v1.2.1` 标签构建的 APK 内部版本与 GitHub Release 一致。