### PR TITLE
fix: 清理已丢失的本地作品及播放器队列

### DIFF
--- a/app/src/main/java/com/asmr/player/main/MainContainer.kt
+++ b/app/src/main/java/com/asmr/player/main/MainContainer.kt
@@ -379,6 +379,7 @@ private fun AlbumDetailRouteFrame(
     onPopBackStack: (String?) -> Unit,
     onPageOffsetReader: (() -> Float) -> Unit,
     onExitStateChanged: (Boolean) -> Unit,
+    onLocalAlbumRemoved: (AlbumDetailUiState.Removed) -> Unit = {},
     onEditRj: (String) -> Unit,
     content: @Composable (AlbumDetailViewModel, AlbumHeroBlurLayerCache) -> Unit
 ) {
@@ -411,6 +412,7 @@ private fun AlbumDetailRouteFrame(
     var exitRequested by remember(backStackEntry.id) { mutableStateOf(false) }
     val currentPopBackStack by rememberUpdatedState(onPopBackStack)
     val currentExitStateChanged by rememberUpdatedState(onExitStateChanged)
+    val currentLocalAlbumRemoved by rememberUpdatedState(onLocalAlbumRemoved)
     val closeAlbumDetail = {
         if (!exitRequested) {
             UiFrameWorkCoordinator.markFrameCritical(
@@ -424,6 +426,13 @@ private fun AlbumDetailRouteFrame(
             viewModel.cancelOnlineLoadsForExit()
             exitRequested = true
         }
+    }
+    LaunchedEffect(viewModel) {
+        val removed = viewModel.uiState
+            .filter { it is AlbumDetailUiState.Removed }
+            .first() as AlbumDetailUiState.Removed
+        currentLocalAlbumRemoved(removed)
+        closeAlbumDetail()
     }
     BackHandler(enabled = !exitRequested, onBack = closeAlbumDetail)
 
@@ -2596,6 +2605,9 @@ fun MainContainer(
                             }
                         },
                         onExitStateChanged = { albumDetailExitInProgress = it },
+                        onLocalAlbumRemoved = { removed ->
+                            playerViewModel.removeAlbumFromQueue(removed.albumId, removed.mediaIds)
+                        },
                         onEditRj = { currentRj ->
                             manualRjInput = currentRj
                             showManualRjDialog = true

--- a/app/src/main/java/com/asmr/player/playback/PlaybackQueuePruning.kt
+++ b/app/src/main/java/com/asmr/player/playback/PlaybackQueuePruning.kt
@@ -1,0 +1,14 @@
+package com.asmr.player.playback
+
+import androidx.media3.common.MediaItem
+
+internal fun shouldRemovePlaybackItem(
+    item: MediaItem,
+    removedAlbumIds: Set<Long>,
+    removedMediaIds: Set<String>,
+): Boolean {
+    if (item.mediaId in removedMediaIds) return true
+    val extras = item.mediaMetadata.extras ?: return false
+    if (!extras.containsKey("album_id")) return false
+    return extras.getLong("album_id") in removedAlbumIds
+}

--- a/app/src/main/java/com/asmr/player/playback/PlayerConnection.kt
+++ b/app/src/main/java/com/asmr/player/playback/PlayerConnection.kt
@@ -101,6 +101,8 @@ class PlayerConnection @Inject constructor(
     private val connectMutex = Mutex()
     private val mainHandler = Handler(Looper.getMainLooper())
     private var videoOutputEnabled: Boolean = false
+    private val removedAlbumIds = linkedSetOf<Long>()
+    private val removedMediaIds = linkedSetOf<String>()
     @Volatile private var reconnecting = false
 
     val appVolumePercent: StateFlow<Int> = settingsRepository.appVolumePercent
@@ -309,6 +311,7 @@ class PlayerConnection @Inject constructor(
                 applyPlayModeToController(c, mode)
             }
             updateQueue()
+            pruneRemovedMediaItems(c)
             _snapshot.value = c.toSnapshot(
                 isConnected = true,
                 audioSessionId = _snapshot.value.audioSessionId,
@@ -393,9 +396,15 @@ class PlayerConnection @Inject constructor(
                     remoteSubtitleSources = remoteSubtitleSources
                 )
             }
-        if (persisted.isEmpty()) return false
+        if (persisted.isEmpty()) {
+            playbackStateStore.clear()
+            return false
+        }
         val items = buildMediaItemsFromPersistedItems(persisted)
-        if (items.isEmpty()) return false
+        if (items.isEmpty()) {
+            playbackStateStore.clear()
+            return false
+        }
 
         val index = saved.currentIndex.coerceIn(0, items.lastIndex)
         val pos = saved.positionMs.coerceAtLeast(0L)
@@ -423,6 +432,16 @@ class PlayerConnection @Inject constructor(
             val id = persisted.mediaId.trim()
             if (id.isBlank()) return@mapNotNull null
             val track = runCatching { trackDao.getTrackByPathOnce(id) }.getOrNull()
+            if (track == null && persisted.trackId?.let { it > 0L } == true) {
+                return@mapNotNull null
+            }
+            val persistedAlbumId = persisted.albumId
+            if (track == null && persistedAlbumId != null && persistedAlbumId > 0L) {
+                val albumExists = runCatching {
+                    albumDao.getAlbumById(persistedAlbumId) != null
+                }.getOrDefault(true)
+                if (!albumExists) return@mapNotNull null
+            }
             if (track != null) {
                 val albumEntity = runCatching { albumDao.getAlbumById(track.albumId) }.getOrNull()
                 val album = Album(
@@ -670,6 +689,39 @@ class PlayerConnection @Inject constructor(
 
     fun removeMediaItem(index: Int) {
         controller?.removeMediaItem(index)
+    }
+
+    fun removeMediaItemsForAlbum(albumId: Long, mediaIds: Set<String>) {
+        if (albumId <= 0L && mediaIds.isEmpty()) return
+        scope.launch {
+            if (albumId > 0L) removedAlbumIds += albumId
+            removedMediaIds += mediaIds.map(String::trim).filter(String::isNotBlank)
+            controller?.let(::pruneRemovedMediaItems)
+        }
+    }
+
+    private fun pruneRemovedMediaItems(controller: MediaController) {
+        var removedAny = false
+        for (index in controller.mediaItemCount - 1 downTo 0) {
+            if (
+                shouldRemovePlaybackItem(
+                    item = controller.getMediaItemAt(index),
+                    removedAlbumIds = removedAlbumIds,
+                    removedMediaIds = removedMediaIds,
+                )
+            ) {
+                controller.removeMediaItem(index)
+                removedAny = true
+            }
+        }
+        if (!removedAny) return
+        if (controller.mediaItemCount == 0) controller.pause()
+        updateQueue()
+        _snapshot.value = controller.toSnapshot(
+            isConnected = true,
+            audioSessionId = _snapshot.value.audioSessionId,
+            startupRestoreResolved = restoreAttemptResolved,
+        )
     }
 
     fun sendCustomCommand(action: String, args: android.os.Bundle) {

--- a/app/src/main/java/com/asmr/player/ui/library/AlbumDetailScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/AlbumDetailScreen.kt
@@ -654,6 +654,7 @@ fun AlbumDetailScreen(
                         EaraLogoLoadingIndicator(tint = AsmrTheme.colorScheme.primary)
                     }
                 }
+                is AlbumDetailUiState.Removed -> Unit
                 is AlbumDetailUiState.Success -> {
                     LaunchedEffect(screenKey) {
                         if (viewModel.isInitialIntroSettled()) return@LaunchedEffect

--- a/app/src/main/java/com/asmr/player/ui/library/AlbumDetailViewModel.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/AlbumDetailViewModel.kt
@@ -3,7 +3,9 @@ package com.asmr.player.ui.library
 import android.content.Context
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
+import android.net.Uri
 import android.os.SystemClock
+import android.provider.DocumentsContract
 import android.util.Log
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
@@ -933,7 +935,10 @@ class AlbumDetailViewModel @Inject constructor(
         albumLoadJob = viewModelScope.launch {
             try {
                 val localAlbum = if (albumId != null && albumId > 0) {
-                    loadLocalAlbumById(albumId)
+                    when (val result = loadLocalAlbumByIdWithAvailabilityCheck(albumId)) {
+                        is LocalAlbumLoadResult.Available -> result.album
+                        LocalAlbumLoadResult.Removed -> return@launch
+                    }
                 } else if (!rjCode.isNullOrBlank()) {
                     loadLocalAlbumByRj(rjCode)
                 } else {
@@ -2087,9 +2092,97 @@ class AlbumDetailViewModel @Inject constructor(
         )
     }
 
-    private suspend fun loadLocalAlbumById(albumId: Long): Album? {
-        val entity = albumDao.getAlbumById(albumId) ?: return null
-        return entityToDomain(entity)
+    private sealed interface LocalAlbumLoadResult {
+        data class Available(val album: Album) : LocalAlbumLoadResult
+        data object Removed : LocalAlbumLoadResult
+    }
+
+    private suspend fun loadLocalAlbumByIdWithAvailabilityCheck(albumId: Long): LocalAlbumLoadResult {
+        val entity = albumDao.getAlbumById(albumId)
+        if (entity == null) {
+            notifyLocalAlbumRemoved(albumId, emptySet())
+            return LocalAlbumLoadResult.Removed
+        }
+        val tracks = trackDao.getTracksForAlbumOnce(albumId)
+        val isMissing = withContext(Dispatchers.IO) {
+            shouldRemoveMissingLocalAlbum(entity, tracks, ::queryLocalSourceAvailability)
+        }
+        if (!isMissing) {
+            return LocalAlbumLoadResult.Available(entityToDomain(entity, tracks))
+        }
+
+        var removedMediaIds: Set<String> = emptySet()
+        withContext(Dispatchers.IO) {
+            database.withTransaction {
+                val latest = albumDao.getAlbumById(albumId) ?: return@withTransaction
+                val latestTracks = trackDao.getTracksForAlbumOnce(albumId)
+                if (!shouldRemoveMissingLocalAlbum(latest, latestTracks, ::queryLocalSourceAvailability)) {
+                    return@withTransaction
+                }
+                val trackIds = latestTracks.map { it.id }
+                removedMediaIds = latestTracks.map { it.path }.filter(String::isNotBlank).toSet()
+                if (trackIds.isNotEmpty()) {
+                    database.subtitleTaskDao().deleteItemsForTracks(trackIds)
+                    database.remoteSubtitleSourceDao().deleteByTrackIds(trackIds)
+                    database.trackTagDao().deleteTrackTagsByTrackIds(trackIds)
+                }
+                trackDao.deleteSubtitlesForAlbum(albumId)
+                trackDao.deleteTracksForAlbum(albumId)
+                database.trackPlaybackProgressDao().deleteByAlbumId(albumId)
+                database.localTreeCacheDao().deleteByAlbum(albumId)
+                database.onlineSavedResourceDao().deleteByAlbumId(albumId)
+                database.tagDao().deleteAlbumTagsByAlbumId(albumId)
+                database.albumFtsDao().deleteByAlbumId(albumId)
+                database.playStatDao().deleteByAlbumId(albumId)
+                albumDao.deleteAlbum(latest)
+            }
+        }
+        val remaining = albumDao.getAlbumById(albumId)
+        if (remaining != null) {
+            return LocalAlbumLoadResult.Available(entityToDomain(remaining))
+        }
+        notifyLocalAlbumRemoved(albumId, removedMediaIds)
+        return LocalAlbumLoadResult.Removed
+    }
+
+    private fun notifyLocalAlbumRemoved(albumId: Long, mediaIds: Set<String>) {
+        _uiState.value = AlbumDetailUiState.Removed(albumId = albumId, mediaIds = mediaIds)
+        messageManager.showInfo("作品已被删除")
+    }
+
+    private fun queryLocalSourceAvailability(pathOrUri: String): LocalSourceAvailability {
+        val source = pathOrUri.trim()
+        if (source.isBlank()) return LocalSourceAvailability.Unknown
+        if (!source.startsWith("content://", ignoreCase = true)) {
+            val file = if (source.startsWith("file://", ignoreCase = true)) {
+                runCatching { Uri.parse(source).path.orEmpty() }.getOrNull()?.let(::File)
+                    ?: return LocalSourceAvailability.Unknown
+            } else {
+                File(source)
+            }
+            return if (file.exists()) LocalSourceAvailability.Available else LocalSourceAvailability.Missing
+        }
+
+        val uri = runCatching { Uri.parse(source) }.getOrNull() ?: return LocalSourceAvailability.Unknown
+        val documentUri = runCatching {
+            val documentId = runCatching { DocumentsContract.getDocumentId(uri) }.getOrNull()
+                ?: DocumentsContract.getTreeDocumentId(uri)
+            DocumentsContract.buildDocumentUriUsingTree(uri, documentId)
+        }.getOrElse { return LocalSourceAvailability.Unknown }
+        return try {
+            val projection = arrayOf(DocumentsContract.Document.COLUMN_DOCUMENT_ID)
+            context.contentResolver.query(documentUri, projection, null, null, null)?.use { cursor ->
+                if (cursor.moveToFirst()) LocalSourceAvailability.Available else LocalSourceAvailability.Missing
+            } ?: LocalSourceAvailability.Unknown
+        } catch (_: SecurityException) {
+            LocalSourceAvailability.Unknown
+        } catch (error: Exception) {
+            if (isMissingLocalDocumentFailure(error)) {
+                LocalSourceAvailability.Missing
+            } else {
+                LocalSourceAvailability.Unknown
+            }
+        }
     }
 
     private suspend fun loadLocalAlbumByRj(rjCode: String): Album? {
@@ -2100,8 +2193,11 @@ class AlbumDetailViewModel @Inject constructor(
         return entityToDomain(entity)
     }
 
-    private suspend fun entityToDomain(entity: AlbumEntity): Album {
-        val tracks = loadLocalTracks(entity)
+    private suspend fun entityToDomain(
+        entity: AlbumEntity,
+        trackEntities: List<TrackEntity>? = null,
+    ): Album {
+        val tracks = trackEntities?.map { it.toDomain() } ?: loadLocalTracks(entity)
         return Album(
             id = entity.id,
             title = entity.titleForDisplay,

--- a/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailDirectorySupport.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailDirectorySupport.kt
@@ -1643,7 +1643,7 @@ internal fun buildLocalTreeIndexByScanning(
                 }
             }
             if (rootDocId.isNotBlank()) {
-                query(rootDocId, "")
+                runCatching { query(rootDocId, "") }
             }
         } else {
             val rootDir = java.io.File(albumPath)

--- a/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailLocalAvailability.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailLocalAvailability.kt
@@ -1,0 +1,56 @@
+package com.asmr.player.ui.library
+
+import com.asmr.player.data.local.db.entities.AlbumEntity
+import com.asmr.player.data.local.db.entities.TrackEntity
+import com.asmr.player.util.isOnlineTrackPath
+import com.asmr.player.util.isVirtualAlbumPath
+import java.io.FileNotFoundException
+
+internal enum class LocalSourceAvailability {
+    Available,
+    Missing,
+    Unknown,
+}
+
+internal fun localAlbumPhysicalSources(
+    album: AlbumEntity,
+    tracks: List<TrackEntity>,
+): List<String> {
+    val albumSources = buildList {
+        album.localPath?.trim()?.takeIf(String::isNotBlank)?.let(::add)
+        album.downloadPath?.trim()?.takeIf(String::isNotBlank)?.let(::add)
+        album.path.trim()
+            .takeIf(String::isNotBlank)
+            ?.takeUnless(::isVirtualAlbumPath)
+            ?.takeUnless(::isOnlineTrackPath)
+            ?.let(::add)
+    }.distinct()
+    if (albumSources.isNotEmpty()) return albumSources
+
+    return tracks.asSequence()
+        .map { it.path.trim() }
+        .filter(String::isNotBlank)
+        .filterNot(::isOnlineTrackPath)
+        .distinct()
+        .toList()
+}
+
+internal fun shouldRemoveMissingLocalAlbum(
+    album: AlbumEntity,
+    tracks: List<TrackEntity>,
+    availability: (String) -> LocalSourceAvailability,
+): Boolean {
+    if (isVirtualAlbumPath(album.path) || tracks.any { isOnlineTrackPath(it.path) }) return false
+    val sources = localAlbumPhysicalSources(album, tracks)
+    if (sources.isEmpty()) return false
+    return sources.all { availability(it) == LocalSourceAvailability.Missing }
+}
+
+internal fun isMissingLocalDocumentFailure(error: Throwable): Boolean {
+    return generateSequence(error) { it.cause }
+        .any { cause ->
+            cause is FileNotFoundException ||
+                cause.message.orEmpty().contains("FileNotFoundException", ignoreCase = true) ||
+                cause.message.orEmpty().contains("Missing file for", ignoreCase = true)
+        }
+}

--- a/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailViewModelSupport.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailViewModelSupport.kt
@@ -112,6 +112,10 @@ internal fun centerCropSquare(src: Bitmap, size: Int): Bitmap {
 @Immutable
 sealed class AlbumDetailUiState {
     object Loading : AlbumDetailUiState()
+    data class Removed(
+        val albumId: Long,
+        val mediaIds: Set<String>,
+    ) : AlbumDetailUiState()
     data class Success(val model: AlbumDetailModel) : AlbumDetailUiState()
     data class Error(val message: String) : AlbumDetailUiState()
 }

--- a/app/src/main/java/com/asmr/player/ui/player/playerviewmodel.kt
+++ b/app/src/main/java/com/asmr/player/ui/player/playerviewmodel.kt
@@ -412,6 +412,8 @@ class PlayerViewModel @Inject constructor(
     fun previous() = playerConnection.skipToPrevious()
     fun playQueueIndex(index: Int) = playerConnection.seekToQueueIndex(index)
     fun removeFromQueue(index: Int) = playerConnection.removeMediaItem(index)
+    fun removeAlbumFromQueue(albumId: Long, mediaIds: Set<String>) =
+        playerConnection.removeMediaItemsForAlbum(albumId, mediaIds)
     fun setPlaybackSpeed(speed: Float) = playerConnection.setPlaybackSpeed(speed)
     fun setPlaybackPitch(pitch: Float) = playerConnection.setPlaybackPitch(pitch)
     fun setPlaybackParameters(speed: Float, pitch: Float) = playerConnection.setPlaybackParameters(speed, pitch)

--- a/app/src/main/java/com/asmr/player/util/EmbeddedMediaExtractor.kt
+++ b/app/src/main/java/com/asmr/player/util/EmbeddedMediaExtractor.kt
@@ -52,15 +52,17 @@ object EmbeddedMediaExtractor {
     }
 
     fun extractEmbeddedLyricsEntries(context: Context, pathOrUri: String): List<SubtitleEntry> {
-        val text = readEmbeddedLyricsText(context, pathOrUri) ?: return emptyList()
-        val hasLrcTs = text.contains('[') && text.contains(']')
-        return if (hasLrcTs) {
-            SubtitleParser.parseText("lrc", text)
-        } else {
-            val durationMs = readDurationMs(context, pathOrUri)
-            val end = if (durationMs > 0L) durationMs else 60_000L
-            listOf(SubtitleEntry(0, end, text))
-        }
+        return runCatching {
+            val text = readEmbeddedLyricsText(context, pathOrUri) ?: return@runCatching emptyList()
+            val hasLrcTs = text.contains('[') && text.contains(']')
+            if (hasLrcTs) {
+                SubtitleParser.parseText("lrc", text)
+            } else {
+                val durationMs = readDurationMs(context, pathOrUri)
+                val end = if (durationMs > 0L) durationMs else 60_000L
+                listOf(SubtitleEntry(0, end, text))
+            }
+        }.getOrDefault(emptyList())
     }
 
     private fun readDurationMs(context: Context, pathOrUri: String): Long {

--- a/app/src/test/java/com/asmr/player/playback/PlaybackQueuePruningTest.kt
+++ b/app/src/test/java/com/asmr/player/playback/PlaybackQueuePruningTest.kt
@@ -1,0 +1,56 @@
+package com.asmr.player.playback
+
+import android.app.Application
+import android.os.Bundle
+import androidx.media3.common.MediaItem
+import androidx.media3.common.MediaMetadata
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, application = Application::class)
+class PlaybackQueuePruningTest {
+    @Test
+    fun shouldRemovePlaybackItem_matchesAlbumMetadataAndLegacyMediaId() {
+        val albumItem = mediaItem(mediaId = "content://library/work/01.wav", albumId = 7L)
+        val legacyItem = mediaItem(mediaId = "content://library/work/02.wav")
+        val unrelated = mediaItem(mediaId = "content://library/other/01.wav", albumId = 8L)
+
+        assertTrue(
+            shouldRemovePlaybackItem(
+                item = albumItem,
+                removedAlbumIds = setOf(7L),
+                removedMediaIds = emptySet(),
+            )
+        )
+        assertTrue(
+            shouldRemovePlaybackItem(
+                item = legacyItem,
+                removedAlbumIds = emptySet(),
+                removedMediaIds = setOf("content://library/work/02.wav"),
+            )
+        )
+        assertFalse(
+            shouldRemovePlaybackItem(
+                item = unrelated,
+                removedAlbumIds = setOf(7L),
+                removedMediaIds = setOf("content://library/work/02.wav"),
+            )
+        )
+    }
+
+    private fun mediaItem(mediaId: String, albumId: Long? = null): MediaItem {
+        val metadata = MediaMetadata.Builder()
+            .setExtras(Bundle().apply { albumId?.let { putLong("album_id", it) } })
+            .build()
+        return MediaItem.Builder()
+            .setMediaId(mediaId)
+            .setUri(mediaId)
+            .setMediaMetadata(metadata)
+            .build()
+    }
+}

--- a/app/src/test/java/com/asmr/player/ui/library/AlbumDetailViewModelSupportTest.kt
+++ b/app/src/test/java/com/asmr/player/ui/library/AlbumDetailViewModelSupportTest.kt
@@ -4,14 +4,71 @@ import com.asmr.player.data.remote.api.Artist
 import com.asmr.player.data.remote.api.Circle
 import com.asmr.player.data.remote.api.Tag
 import com.asmr.player.data.remote.api.WorkDetailsResponse
+import com.asmr.player.data.local.db.entities.AlbumEntity
+import com.asmr.player.data.local.db.entities.TrackEntity
 import com.asmr.player.domain.model.Album
 import com.asmr.player.ui.nav.AlbumCoverHint
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Assert.assertFalse
 import org.junit.Test
+import java.io.FileNotFoundException
 
 class AlbumDetailViewModelSupportTest {
+    @Test
+    fun shouldRemoveMissingLocalAlbum_removesOnlyConfirmedMissingPhysicalWork() {
+        val album = AlbumEntity(
+            id = 7L,
+            title = "已删除作品",
+            path = "content://library/tree/root/document/root%2Fwork",
+            localPath = "content://library/tree/root/document/root%2Fwork",
+        )
+        val tracks = listOf(
+            TrackEntity(id = 11L, albumId = 7L, title = "01", path = "content://library/track/01")
+        )
+
+        assertTrue(
+            shouldRemoveMissingLocalAlbum(album, tracks) { LocalSourceAvailability.Missing }
+        )
+        assertFalse(
+            shouldRemoveMissingLocalAlbum(album, tracks) { LocalSourceAvailability.Unknown }
+        )
+    }
+
+    @Test
+    fun shouldRemoveMissingLocalAlbum_preservesHybridOnlineWork() {
+        val album = AlbumEntity(
+            id = 7L,
+            title = "混合作品",
+            path = "content://library/tree/root/document/root%2Fwork",
+            localPath = "content://library/tree/root/document/root%2Fwork",
+        )
+        val tracks = listOf(
+            TrackEntity(id = 11L, albumId = 7L, title = "在线轨道", path = "https://example.com/01.mp3")
+        )
+
+        assertFalse(
+            shouldRemoveMissingLocalAlbum(album, tracks) { LocalSourceAvailability.Missing }
+        )
+    }
+
+    @Test
+    fun isMissingLocalDocumentFailure_recognizesWrappedProviderFailure() {
+        assertTrue(
+            isMissingLocalDocumentFailure(
+                IllegalArgumentException(
+                    "Failed to determine child: java.io.FileNotFoundException: Missing file for root/work"
+                )
+            )
+        )
+        assertTrue(
+            isMissingLocalDocumentFailure(
+                IllegalStateException("provider failure", FileNotFoundException("deleted"))
+            )
+        )
+        assertFalse(isMissingLocalDocumentFailure(SecurityException("permission denied")))
+    }
+
     @Test
     fun albumDetailRequestKey_normalizesRjAndFallsBackToLocalId() {
         assertEquals("rj:RJ01554925", albumDetailRequestKey(42L, " rj01554925 "))

--- a/app/src/test/java/com/asmr/player/util/EmbeddedMediaExtractorTest.kt
+++ b/app/src/test/java/com/asmr/player/util/EmbeddedMediaExtractorTest.kt
@@ -1,0 +1,65 @@
+package com.asmr.player.util
+
+import android.app.Application
+import android.content.ContentProvider
+import android.content.ContentValues
+import android.content.Context
+import android.content.res.AssetFileDescriptor
+import android.database.Cursor
+import android.net.Uri
+import androidx.test.core.app.ApplicationProvider
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import org.robolectric.shadows.ShadowContentResolver
+
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, application = Application::class)
+class EmbeddedMediaExtractorTest {
+    @Test
+    fun extractEmbeddedLyricsEntries_returnsEmptyWhenProviderRejectsMissingDocument() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        ShadowContentResolver.registerProviderInternal(
+            "missing-media",
+            MissingMediaProvider(),
+        )
+
+        val result = EmbeddedMediaExtractor.extractEmbeddedLyricsEntries(
+            context,
+            "content://missing-media/audio.wav",
+        )
+
+        assertTrue(result.isEmpty())
+    }
+
+    private class MissingMediaProvider : ContentProvider() {
+        override fun onCreate(): Boolean = true
+
+        override fun query(
+            uri: Uri,
+            projection: Array<out String>?,
+            selection: String?,
+            selectionArgs: Array<out String>?,
+            sortOrder: String?,
+        ): Cursor? = null
+
+        override fun getType(uri: Uri): String? = null
+
+        override fun insert(uri: Uri, values: ContentValues?): Uri? = null
+
+        override fun delete(uri: Uri, selection: String?, selectionArgs: Array<out String>?): Int = 0
+
+        override fun update(
+            uri: Uri,
+            values: ContentValues?,
+            selection: String?,
+            selectionArgs: Array<out String>?,
+        ): Int = 0
+
+        override fun openAssetFile(uri: Uri, mode: String): AssetFileDescriptor? {
+            throw IllegalArgumentException("missing document")
+        }
+    }
+}


### PR DESCRIPTION
## 变更
- 打开本地作品详情时校验物理文件/目录；确认全部本地来源丢失后，以事务清理作品、音轨及关联数据
- 对 DocumentsProvider 的缺失文件异常和目录扫描竞态做容错，避免详情页闪退及重启闪退循环
- 清理完成后退出详情页并提示“作品已被删除”
- 同步移除当前播放队列中的对应音轨；冷启动时过滤并清空已失效的持久化播放状态，避免迷你播放器继续显示旧作品

## 验证
- `./gradlew-local.bat :app:testReleaseUnitTest --tests "com.asmr.player.playback.PlaybackQueuePruningTest" --tests "com.asmr.player.ui.library.AlbumDetailViewModelSupportTest" --tests "com.asmr.player.util.EmbeddedMediaExtractorTest"`
- `./gradlew-local.bat :app:installRelease`
- 真机验证缺失作品点击后被清理并显示提示，应用进程保持存活且无 AndroidRuntime 致命异常
- 真机冷启动验证旧音轨未恢复，迷你播放器不再显示