### PR TITLE
feat: export generated subtitles as Chinese LRC

### DIFF
--- a/app/src/main/java/com/asmr/player/AsmrApp.kt
+++ b/app/src/main/java/com/asmr/player/AsmrApp.kt
@@ -11,7 +11,9 @@ import com.asmr.player.cache.ImageCacheManager
 import com.asmr.player.data.remote.download.DownloadQueueCoordinator
 import com.asmr.player.data.remote.download.DownloadRuntimeConfig
 import com.asmr.player.data.settings.SettingsRepository
+import com.asmr.player.subtitle.GeneratedSubtitleFileBackfill
 import com.asmr.player.subtitle.SubtitleTaskRepository
+import com.asmr.player.util.MessageManager
 import com.tom_roush.pdfbox.android.PDFBoxResourceLoader
 import dagger.hilt.android.HiltAndroidApp
 import kotlinx.coroutines.CoroutineScope
@@ -36,6 +38,9 @@ class AsmrApp : Application(), ImageLoaderFactory, Configuration.Provider {
     @Inject
     lateinit var appCacheManager: AppCacheManager
 
+    @Inject
+    lateinit var messageManager: MessageManager
+
     override fun onCreate() {
         super.onCreate()
         appCacheManager.start()
@@ -50,6 +55,32 @@ class AsmrApp : Application(), ImageLoaderFactory, Configuration.Provider {
             if (runCatching { database.downloadDao().countRecoverableItems() > 0 }.getOrDefault(false)) {
                 runCatching { DownloadQueueCoordinator.recoverDownloadsOnAppLaunch(applicationContext) }
             }
+            runCatching { GeneratedSubtitleFileBackfill(applicationContext, database).runOnce() }
+                .getOrNull()
+                ?.let { summary ->
+                    when {
+                        summary.unavailableCount > 0 -> messageManager.showWarning(
+                            "已为旧版字幕补导出 ${summary.exportedCount} 个 LRC，" +
+                                "另有 ${summary.unavailableCount} 个因目录不可写未导出" +
+                                if (summary.preservedCount > 0) {
+                                    "，并保留 ${summary.preservedCount} 个已有同名文件"
+                                } else {
+                                    ""
+                                }
+                        )
+                        summary.exportedCount > 0 -> messageManager.showSuccess(
+                            "已为旧版生成字幕补导出 ${summary.exportedCount} 个 LRC 文件" +
+                                if (summary.preservedCount > 0) {
+                                    "，并保留 ${summary.preservedCount} 个已有同名文件"
+                                } else {
+                                    ""
+                                }
+                        )
+                        summary.preservedCount > 0 -> messageManager.showInfo(
+                            "检测到 ${summary.preservedCount} 个已有同名 LRC，补导出时未覆盖"
+                        )
+                    }
+                }
         }
     }
 

--- a/app/src/main/java/com/asmr/player/data/local/db/dao/TrackDao.kt
+++ b/app/src/main/java/com/asmr/player/data/local/db/dao/TrackDao.kt
@@ -100,6 +100,9 @@ interface TrackDao {
     @Query("SELECT DISTINCT trackId FROM subtitles WHERE trackId IN (:trackIds)")
     suspend fun getTrackIdsWithSubtitles(trackIds: List<Long>): List<Long>
 
+    @Query("SELECT DISTINCT trackId FROM subtitles WHERE TRIM(japaneseText) != '' ORDER BY trackId ASC")
+    suspend fun getTrackIdsWithGeneratedSubtitles(): List<Long>
+
     @Query("SELECT DISTINCT trackId FROM subtitles WHERE trackId IN (:trackIds)")
     fun observeTrackIdsWithSubtitles(trackIds: List<Long>): Flow<List<Long>>
 

--- a/app/src/main/java/com/asmr/player/data/settings/SettingsDataStore.kt
+++ b/app/src/main/java/com/asmr/player/data/settings/SettingsDataStore.kt
@@ -24,6 +24,7 @@ object SettingsKeys {
     val SEARCH_BLOCKED_KEYWORDS = stringPreferencesKey("search_blocked_keywords")
     val DOWNLOAD_DIRECTORY_TREE_URI = stringPreferencesKey("download_directory_tree_uri")
     val DOWNLOAD_DIRECTORY_LABEL = stringPreferencesKey("download_directory_label")
+    val GENERATED_SUBTITLE_FILE_BACKFILL_VERSION = intPreferencesKey("generated_subtitle_file_backfill_version")
 
     val PLAY_MODE = intPreferencesKey("play_mode")
 

--- a/app/src/main/java/com/asmr/player/subtitle/GeneratedSubtitleFileExporter.kt
+++ b/app/src/main/java/com/asmr/player/subtitle/GeneratedSubtitleFileExporter.kt
@@ -1,0 +1,193 @@
+package com.asmr.player.subtitle
+
+import android.content.Context
+import android.net.Uri
+import android.provider.DocumentsContract
+import androidx.datastore.preferences.core.edit
+import com.asmr.player.data.local.db.AppDatabase
+import com.asmr.player.data.local.db.entities.SubtitleEntity
+import com.asmr.player.data.remote.download.DownloadStorageGateway
+import com.asmr.player.data.settings.SettingsKeys
+import com.asmr.player.data.settings.settingsDataStore
+import java.io.File
+import java.util.Locale
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.yield
+
+internal sealed interface GeneratedSubtitleExportResult {
+    data class Exported(val reference: String) : GeneratedSubtitleExportResult
+    data class ExistingFilePreserved(val reference: String) : GeneratedSubtitleExportResult
+    data object UnsupportedTrackLocation : GeneratedSubtitleExportResult
+}
+
+/**
+ * 把自动生成的中文字幕导出为音频同目录、同名的 LRC 文件。
+ *
+ * 数据库仍是应用内播放的权威数据源；此文件用于用户管理以及其他播放器识别。
+ */
+internal class GeneratedSubtitleFileExporter(
+    private val context: Context,
+    private val database: AppDatabase,
+    private val storage: DownloadStorageGateway = DownloadStorageGateway(context)
+) {
+    suspend fun export(
+        trackId: Long,
+        overwriteExisting: Boolean = true
+    ): GeneratedSubtitleExportResult = withContext(Dispatchers.IO) {
+        val track = database.trackDao().getTrackByIdOnce(trackId)
+            ?: return@withContext GeneratedSubtitleExportResult.UnsupportedTrackLocation
+        val target = resolveTarget(track.path)
+            ?: return@withContext GeneratedSubtitleExportResult.UnsupportedTrackLocation
+        val subtitles = database.trackDao().getSubtitlesForTrack(trackId).sortedWith(SUBTITLE_ORDER)
+        check(subtitles.isNotEmpty()) { "没有可导出的字幕" }
+        val existing = storage.findFile(target.directory, target.fileName)
+        if (existing != null && !overwriteExisting) {
+            return@withContext GeneratedSubtitleExportResult.ExistingFilePreserved(existing)
+        }
+        val reference = storage.ensureFile(
+            directory = target.directory,
+            name = target.fileName,
+            mimeType = LRC_MIME_TYPE
+        )
+        storage.openOutput(reference).buffered().use { output ->
+            output.write(renderChineseLrc(subtitles).toByteArray(Charsets.UTF_8))
+        }
+        GeneratedSubtitleExportResult.Exported(reference)
+    }
+
+    private fun resolveTarget(trackPath: String): SubtitleExportTarget? {
+        val normalizedPath = trackPath.trim()
+        if (
+            normalizedPath.isBlank() ||
+            normalizedPath.startsWith("http://", ignoreCase = true) ||
+            normalizedPath.startsWith("https://", ignoreCase = true) ||
+            normalizedPath.startsWith("web://", ignoreCase = true)
+        ) {
+            return null
+        }
+        if (normalizedPath.startsWith("content://", ignoreCase = true)) {
+            return resolveDocumentTarget(Uri.parse(normalizedPath))
+        }
+        val audioFile = if (normalizedPath.startsWith("file://", ignoreCase = true)) {
+            Uri.parse(normalizedPath).path?.let(::File)
+        } else {
+            File(normalizedPath)
+        } ?: return null
+        val parent = audioFile.parentFile ?: return null
+        return SubtitleExportTarget(
+            directory = parent.absolutePath,
+            fileName = subtitleFileName(audioFile.name)
+        )
+    }
+
+    private fun resolveDocumentTarget(audioUri: Uri): SubtitleExportTarget? {
+        if (!DocumentsContract.isDocumentUri(context, audioUri)) return null
+        val treeId = runCatching { DocumentsContract.getTreeDocumentId(audioUri) }.getOrNull().orEmpty()
+        val documentId = runCatching { DocumentsContract.getDocumentId(audioUri) }.getOrNull().orEmpty()
+        if (treeId.isBlank() || documentId.isBlank() || documentId == treeId) return null
+        val parentId = documentId.substringBeforeLast('/', missingDelimiterValue = treeId)
+        val parentUri = DocumentsContract.buildDocumentUriUsingTree(audioUri, parentId)
+        return SubtitleExportTarget(
+            directory = parentUri.toString(),
+            fileName = subtitleFileName(storage.displayName(audioUri))
+        )
+    }
+
+    private data class SubtitleExportTarget(
+        val directory: String,
+        val fileName: String
+    )
+
+    private companion object {
+        const val LRC_MIME_TYPE = "text/plain"
+    }
+}
+
+internal data class GeneratedSubtitleBackfillSummary(
+    val exportedCount: Int,
+    val preservedCount: Int,
+    val unavailableCount: Int
+)
+
+/** 升级后只执行一次，把旧版本已存入数据库的生成字幕补写到音频目录。 */
+internal class GeneratedSubtitleFileBackfill(
+    private val context: Context,
+    private val database: AppDatabase
+) {
+    suspend fun runOnce(): GeneratedSubtitleBackfillSummary? = withContext(Dispatchers.IO) {
+        val completedVersion = context.settingsDataStore.data.first()[
+            SettingsKeys.GENERATED_SUBTITLE_FILE_BACKFILL_VERSION
+        ] ?: 0
+        if (completedVersion >= BACKFILL_VERSION) return@withContext null
+
+        val activeTrackIds = database.subtitleTaskDao().getAllItems()
+            .mapTo(mutableSetOf()) { item -> item.trackId }
+        val trackIds = database.trackDao().getTrackIdsWithGeneratedSubtitles()
+            .filterNot(activeTrackIds::contains)
+        val exporter = GeneratedSubtitleFileExporter(context, database)
+        val overwritePreviousExport = completedVersion == PREVIOUS_EXPORT_VERSION
+        var exportedCount = 0
+        var preservedCount = 0
+        var unavailableCount = 0
+        trackIds.forEach { trackId ->
+            when (
+                runCatching {
+                    exporter.export(trackId, overwriteExisting = overwritePreviousExport)
+                }.getOrNull()
+            ) {
+                is GeneratedSubtitleExportResult.Exported -> exportedCount += 1
+                is GeneratedSubtitleExportResult.ExistingFilePreserved -> preservedCount += 1
+                GeneratedSubtitleExportResult.UnsupportedTrackLocation,
+                null -> unavailableCount += 1
+            }
+            yield()
+        }
+        context.settingsDataStore.edit { preferences ->
+            preferences[SettingsKeys.GENERATED_SUBTITLE_FILE_BACKFILL_VERSION] = BACKFILL_VERSION
+        }
+        GeneratedSubtitleBackfillSummary(
+            exportedCount = exportedCount,
+            preservedCount = preservedCount,
+            unavailableCount = unavailableCount
+        )
+    }
+
+    private companion object {
+        const val PREVIOUS_EXPORT_VERSION = 1
+        const val BACKFILL_VERSION = 2
+    }
+}
+
+internal fun subtitleFileName(audioFileName: String): String {
+    val normalized = audioFileName.trim().ifBlank { "subtitle" }
+    val baseName = normalized.substringBeforeLast('.', missingDelimiterValue = normalized)
+        .ifBlank { normalized }
+    return "$baseName.lrc"
+}
+
+internal fun renderChineseLrc(subtitles: List<SubtitleEntity>): String {
+    val lines = subtitles.flatMap { subtitle ->
+        normalizeLrcText(subtitle.text)
+            .map { text -> "[${formatLrcTime(subtitle.startMs)}]$text" }
+    }
+    return if (lines.isEmpty()) "" else lines.joinToString(separator = "\r\n", postfix = "\r\n")
+}
+
+private fun normalizeLrcText(value: String): List<String> {
+    return value.replace("\r\n", "\n")
+        .replace('\r', '\n')
+        .lineSequence()
+        .map(String::trim)
+        .filter(String::isNotBlank)
+        .toList()
+}
+
+private fun formatLrcTime(timeMs: Long): String {
+    val safeTimeMs = timeMs.coerceAtLeast(0L)
+    val minutes = safeTimeMs / 60_000L
+    val seconds = safeTimeMs / 1_000L % 60L
+    val milliseconds = safeTimeMs % 1_000L
+    return String.format(Locale.ROOT, "%02d:%02d.%03d", minutes, seconds, milliseconds)
+}

--- a/app/src/main/java/com/asmr/player/subtitle/SubtitleTaskService.kt
+++ b/app/src/main/java/com/asmr/player/subtitle/SubtitleTaskService.kt
@@ -92,6 +92,7 @@ internal class SubtitleTaskService : Service() {
     private lateinit var settingsRepository: SettingsRepository
     private lateinit var messageManager: MessageManager
     private lateinit var deepSeekAccountRepository: DeepSeekAccountRepository
+    private lateinit var generatedSubtitleFileExporter: GeneratedSubtitleFileExporter
     private var transcriptionJob: Job? = null
     private var transcriptionItemId: String? = null
     private val translationJobs = ConcurrentHashMap<String, Job>()
@@ -125,6 +126,7 @@ internal class SubtitleTaskService : Service() {
         settingsRepository = entryPoint.settingsRepository()
         messageManager = entryPoint.messageManager()
         deepSeekAccountRepository = entryPoint.deepSeekAccountRepository()
+        generatedSubtitleFileExporter = GeneratedSubtitleFileExporter(applicationContext, database)
         createNotificationChannel()
         startAsForeground(buildNotification(emptyList()))
         wakeLock = getSystemService(PowerManager::class.java)
@@ -619,7 +621,30 @@ internal class SubtitleTaskService : Service() {
         } finally {
             requestBalanceRefresh()
         }
+        exportGeneratedSubtitleFile(itemId)
         repository.finishSucceeded(itemId)
+    }
+
+    private suspend fun exportGeneratedSubtitleFile(itemId: String) {
+        val item = database.subtitleTaskDao().getItem(itemId) ?: return
+        if (item.mode != SubtitleTaskMode.GENERATED) return
+        runCatching { generatedSubtitleFileExporter.export(item.trackId) }
+            .onSuccess { result ->
+                when (result) {
+                    is GeneratedSubtitleExportResult.Exported -> {
+                        Log.i(TAG, "自动生成字幕已导出 trackId=${item.trackId} reference=${result.reference}")
+                    }
+                    is GeneratedSubtitleExportResult.ExistingFilePreserved -> Unit
+                    GeneratedSubtitleExportResult.UnsupportedTrackLocation -> {
+                        Log.w(TAG, "音频位置不支持同目录字幕导出 trackId=${item.trackId}")
+                        messageManager.showWarning("字幕已生成，但当前音频位置不支持导出 LRC 文件")
+                    }
+                }
+            }
+            .onFailure { error ->
+                Log.w(TAG, "自动生成字幕导出失败 trackId=${item.trackId}", error)
+                messageManager.showWarning("字幕已生成，但写入音频目录失败：${error.message ?: "未知错误"}")
+            }
     }
 
     /**

--- a/app/src/test/java/com/asmr/player/subtitle/GeneratedSubtitleFileExporterTest.kt
+++ b/app/src/test/java/com/asmr/player/subtitle/GeneratedSubtitleFileExporterTest.kt
@@ -1,0 +1,57 @@
+package com.asmr.player.subtitle
+
+import com.asmr.player.data.local.db.entities.SubtitleEntity
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class GeneratedSubtitleFileExporterTest {
+    @Test
+    fun `subtitle file uses audio base name`() {
+        assertEquals("track 01.lrc", subtitleFileName("track 01.flac"))
+        assertEquals("voice.part01.lrc", subtitleFileName("voice.part01.m4a"))
+        assertEquals("voice.lrc", subtitleFileName("voice"))
+    }
+
+    @Test
+    fun `renders utf8 chinese lrc with normalized timestamps`() {
+        val rendered = renderChineseLrc(
+            listOf(
+                SubtitleEntity(
+                    trackId = 1L,
+                    startMs = 1_234L,
+                    endMs = 65_678L,
+                    text = "早上好",
+                    japaneseText = "おはよう"
+                ),
+                SubtitleEntity(
+                    trackId = 1L,
+                    startMs = 3_600_000L,
+                    endMs = 3_601_000L,
+                    text = "同一句",
+                    japaneseText = "同一句"
+                )
+            )
+        )
+
+        assertEquals(
+            "[00:01.234]早上好\r\n" +
+                "[60:00.000]同一句\r\n",
+            rendered
+        )
+    }
+
+    @Test
+    fun `omits blank captions`() {
+        val rendered = renderChineseLrc(
+            listOf(
+                SubtitleEntity(trackId = 1L, startMs = 0L, endMs = 100L, text = ""),
+                SubtitleEntity(trackId = 1L, startMs = 100L, endMs = 200L, text = "字幕")
+            )
+        )
+
+        assertEquals(
+            "[00:00.100]字幕\r\n",
+            rendered
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- export completed generated subtitles as UTF-8 Chinese-only LRC files beside the audio
- support regular paths and SAF document trees
- backfill subtitles generated by older app versions without rerunning transcription or translation
- preserve pre-existing user-managed LRC files during first-time backfill

## Verification
- .\gradlew-local.bat :app:testReleaseUnitTest --tests com.asmr.player.subtitle.GeneratedSubtitleFileExporterTest
- .\gradlew-local.bat :app:installRelease
- installed successfully on device 23078RKD5C