### PR TITLE
fix: prevent recommendation covers blocking local images

### DIFF
--- a/app/src/main/java/com/asmr/player/cache/ImageCacheManager.kt
+++ b/app/src/main/java/com/asmr/player/cache/ImageCacheManager.kt
@@ -76,7 +76,12 @@ class ImageCacheManager(
 
     private val scope = CoroutineScope(SupervisorJob() + decodeDispatcher)
     private val inFlight = ConcurrentHashMap<InFlightKey, InFlightLoad>()
-    private val loadSemaphore = Semaphore(config.loadParallelism)
+    // 远程推荐封面在直连较慢时会长时间占用加载许可。独立的本地通道保证文件图片
+    // 不会被网络请求饿死，横屏同时展示推荐列表时也能立即开始读取。
+    private val loadGate = ImageLoadGate(
+        remotePermits = config.loadParallelism,
+        localPermits = config.loadParallelism,
+    )
     private val preloadSemaphore = Semaphore(config.preloadParallelism)
     private val diskWriteSemaphore = Semaphore(1)
     private val memoryStateLock = Any()
@@ -185,7 +190,7 @@ class ImageCacheManager(
                             if (diskBitmap != null) {
                                 Result.success(diskBitmap)
                             } else {
-                                Result.success(loadSemaphore.withPermit {
+                                Result.success(loadGate.withPermit(model) {
                                     stats.onNetworkFetch()
                                     Trace.beginSection("img.net")
                                     val bmp = try {

--- a/app/src/main/java/com/asmr/player/cache/ImageLoadScheduling.kt
+++ b/app/src/main/java/com/asmr/player/cache/ImageLoadScheduling.kt
@@ -1,0 +1,32 @@
+package com.asmr.player.cache
+
+import kotlinx.coroutines.sync.Semaphore
+
+internal class ImageLoadGate(
+    remotePermits: Int,
+    localPermits: Int,
+) {
+    private val remoteSemaphore = Semaphore(remotePermits)
+    private val localSemaphore = Semaphore(localPermits)
+
+    suspend fun <T> withPermit(model: Any, block: suspend () -> T): T {
+        val semaphore = if (isRemoteImageModel(model)) {
+            remoteSemaphore
+        } else {
+            localSemaphore
+        }
+        semaphore.acquire()
+        return try {
+            block()
+        } finally {
+            semaphore.release()
+        }
+    }
+}
+
+internal fun isRemoteImageModel(model: Any): Boolean {
+    val data = (model as? CacheImageModel)?.data ?: model
+    val value = data as? String ?: return false
+    return value.startsWith("http://", ignoreCase = true) ||
+        value.startsWith("https://", ignoreCase = true)
+}

--- a/app/src/main/java/com/asmr/player/cache/ImageLoaderFacade.kt
+++ b/app/src/main/java/com/asmr/player/cache/ImageLoaderFacade.kt
@@ -11,6 +11,7 @@ import coil.request.ImageRequest
 import coil.request.ErrorResult
 import coil.request.SuccessResult
 import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import okhttp3.OkHttpClient
 import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
@@ -23,7 +24,9 @@ class ImageLoaderFacade(
     private val imageLoader: ImageLoader = ImageLoader.Builder(context)
         .okHttpClient { okHttpClient }
         .interceptorDispatcher(imageDispatcher)
-        .fetcherDispatcher(imageDispatcher)
+        // 网络抓取可能长时间阻塞；放到 IO 调度器，避免占满图片解码线程后连本地
+        // 文件的读取与解码也无法开始。
+        .fetcherDispatcher(Dispatchers.IO)
         .decoderDispatcher(imageDispatcher)
         .transformationDispatcher(imageDispatcher)
         .memoryCache(null)

--- a/app/src/test/java/com/asmr/player/cache/ImageLoadSchedulingTest.kt
+++ b/app/src/test/java/com/asmr/player/cache/ImageLoadSchedulingTest.kt
@@ -1,0 +1,63 @@
+package com.asmr.player.cache
+
+import java.io.File
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.async
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ImageLoadSchedulingTest {
+    @Test
+    fun remoteModelDetection_onlyClassifiesHttpSourcesAsRemote() {
+        assertTrue(isRemoteImageModel("https://example.com/cover.jpg"))
+        assertTrue(
+            isRemoteImageModel(
+                CacheImageModel(
+                    data = "HTTP://example.com/recommendation.jpg",
+                    headers = mapOf("Referer" to "https://example.com/"),
+                )
+            )
+        )
+        assertFalse(isRemoteImageModel(File("cover.jpg")))
+        assertFalse(isRemoteImageModel("content://media/external/images/1"))
+        assertFalse(isRemoteImageModel("/storage/emulated/0/Music/cover.jpg"))
+    }
+
+    @Test
+    fun localLoad_startsWhileRemoteLaneIsOccupied() {
+        runBlocking {
+            val gate = ImageLoadGate(remotePermits = 1, localPermits = 1)
+            val releaseFirstRemote = CompletableDeferred<Unit>()
+            val firstRemoteStarted = CompletableDeferred<Unit>()
+            val queuedRemoteStarted = CompletableDeferred<Unit>()
+
+            val firstRemote = async(start = CoroutineStart.UNDISPATCHED) {
+                gate.withPermit("https://example.com/first.jpg") {
+                    firstRemoteStarted.complete(Unit)
+                    releaseFirstRemote.await()
+                }
+            }
+            firstRemoteStarted.await()
+
+            val queuedRemote = async {
+                gate.withPermit("https://example.com/second.jpg") {
+                    queuedRemoteStarted.complete(Unit)
+                }
+            }
+            val local = async {
+                gate.withPermit(File("cover.jpg")) { Unit }
+            }
+
+            withTimeout(1_000) { local.await() }
+            assertFalse(queuedRemoteStarted.isCompleted)
+
+            releaseFirstRemote.complete(Unit)
+            firstRemote.await()
+            queuedRemote.await()
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- isolate local and remote image loading permits so slow recommendation covers cannot starve local files
- move Coil fetching onto the IO dispatcher so network waits do not occupy the fixed image decode executor
- add regression coverage for source classification and local-load progress while the remote lane is saturated

## Root cause
The tablet landscape album detail renders the similar-works pane alongside the local directory. Both recommendation covers and local images shared three load permits and the same three-thread image executor. Without a proxy, slow remote requests could occupy all of them, delaying local images until recommendation covers finished. Portrait does not render that pane, so it did not exhibit the issue.

## Verification
- `.\gradlew-local.bat :app:testReleaseUnitTest --tests "com.asmr.player.cache.*" --tests "com.asmr.player.ui.library.AlbumDetailLandscapeLayoutTest"`
- `.\gradlew-local.bat :app:installRelease`