### PR TITLE
perf: 优化底部导航切页动画性能

### DIFF
--- a/app/src/main/java/com/asmr/player/main/MainContainer.kt
+++ b/app/src/main/java/com/asmr/player/main/MainContainer.kt
@@ -267,7 +267,10 @@ private const val SecondaryPageExitDurationMs = 420
 private const val SecondaryPageTouchBlockDurationMs = 320
 private const val AlbumDetailPresentedStateKey = "album_detail_presented"
 private const val PrimaryPagerSnapThreshold = 0.16f
+private const val PrimaryPageSwitchDurationMs = 320
+private const val PrimaryPageSwitchQuietTailMs = 120L
 private val SecondaryPageSlideEasing = CubicBezierEasing(0.215f, 0.61f, 0.355f, 1f)
+private val PrimaryPageSwitchEasing = CubicBezierEasing(0.4f, 0f, 0.2f, 1f)
 private val PrimaryPageParallaxOffset = 120.dp
 private val AlbumDetailTopBarButtonShape = CircleShape
 private val AlbumDetailBackTouchPassThroughWidth = 88.dp
@@ -1152,10 +1155,16 @@ fun MainContainer(
         val requestId = primaryNavigationRequestId
         if (targetPage >= 0 && currentPrimaryRoute != null) {
             pendingPrimaryNavigationRoute = route
+            UiFrameWorkCoordinator.markFrameCritical(
+                PrimaryPageSwitchDurationMs + PrimaryPageSwitchQuietTailMs
+            )
             primaryNavigationJob = scope.launch {
                 var completed = false
                 try {
                     primaryPagerState.stopScroll(MutatePriority.PreventUserInput)
+                    // 相邻页已由 Pager 保留在屏外。先提交 active/data-active 状态，让它在
+                    // 可见动画前完成一次状态恢复，避免数据订阅与动画首帧争抢主线程。
+                    withFrameNanos { }
                     val currentPage = primaryPagerState.currentPage
                     resolvePrimaryPagerApproachPage(
                         currentPage = currentPage,
@@ -1163,7 +1172,16 @@ fun MainContainer(
                     )?.let { approachPage ->
                         primaryPagerState.scrollToPage(approachPage)
                     }
-                    primaryPagerState.animateScrollToPage(targetPage)
+                    UiFrameWorkCoordinator.markFrameCritical(
+                        PrimaryPageSwitchDurationMs + PrimaryPageSwitchQuietTailMs
+                    )
+                    primaryPagerState.animateScrollToPage(
+                        page = targetPage,
+                        animationSpec = tween(
+                            durationMillis = PrimaryPageSwitchDurationMs,
+                            easing = PrimaryPageSwitchEasing
+                        )
+                    )
                     if (currentPrimaryRouteState.value != route) {
                         navController.navigatePrimaryRoute(route)
                     }
@@ -2111,8 +2129,15 @@ fun MainContainer(
                                     val primaryRouteDataActiveState = rememberUpdatedState(
                                         primaryRouteDataActive
                                     )
-                                    primaryContentStateHolder.SaveableStateProvider("primary_route:$route") {
-                                        when (route) {
+                                    Box(
+                                        modifier = Modifier
+                                            .fillMaxSize()
+                                            // 页面内容使用独立 RenderNode 保留 display list；Pager 滚动时
+                                            // 只更新图层位置，避免逐帧重录复杂列表和设置页的绘制命令。
+                                            .graphicsLayer { clip = false }
+                                    ) {
+                                        primaryContentStateHolder.SaveableStateProvider("primary_route:$route") {
+                                            when (route) {
                                         Routes.Library -> {
                                             LibraryScreen(
                                                 windowSizeClass = windowSizeClass,
@@ -2323,6 +2348,7 @@ fun MainContainer(
                                             )
                                         }
 
+                                        }
                                     }
                                 }
                             }

--- a/baselineprofile/src/main/java/com/asmr/player/baselineprofile/BenchmarkDriver.kt
+++ b/baselineprofile/src/main/java/com/asmr/player/baselineprofile/BenchmarkDriver.kt
@@ -181,6 +181,17 @@ internal fun UiDevice.performPrimaryNavigationProfile() {
     waitForPrimaryNavigation()
 }
 
+internal fun UiDevice.performPrimaryNavigationClickProfile() {
+    repeat(3) {
+        navigateBottomBarToSlot(1)
+        waitForPrimaryNavigation()
+        navigateBottomBarToSlot(2)
+        waitForPrimaryNavigation()
+        navigateBottomBarToSlot(0)
+        waitForPrimaryNavigation()
+    }
+}
+
 internal fun UiDevice.performSecondaryNavigationTransitionsProfile() {
     openFirstLibraryAlbum()
     performLongListScrollProfile()

--- a/baselineprofile/src/main/java/com/asmr/player/baselineprofile/LongListPerformanceBenchmark.kt
+++ b/baselineprofile/src/main/java/com/asmr/player/baselineprofile/LongListPerformanceBenchmark.kt
@@ -49,6 +49,22 @@ class LongListPerformanceBenchmark {
     }
 
     @Test
+    fun primaryNavigationClickTransitionsFrameTiming() {
+        benchmarkRule.measureRepeated(
+            packageName = PackageName,
+            metrics = listOf(FrameTimingGfxInfoMetric()),
+            compilationMode = CompilationMode.Partial(BaselineProfileMode.Require),
+            startupMode = null,
+            iterations = FrameTimingIterations,
+            setupBlock = {
+                startMainActivity()
+            }
+        ) {
+            device.performPrimaryNavigationClickProfile()
+        }
+    }
+
+    @Test
     fun secondaryNavigationTransitionsFrameTiming() {
         benchmarkRule.measureRepeated(
             packageName = PackageName,


### PR DESCRIPTION
## 变更内容

- 底部导航点击切页采用 320 ms ease-in-out 缓动，改善加速与收尾手感
- 在可见动画前恢复目标页状态，并让可延后的后台工作避开切页关键窗口
- 为页面增加独立 RenderNode 图层，减少 Pager 滚动时复杂页面 display list 重录
- 增加专门覆盖底栏点击切页的 Macrobenchmark 场景

## 验证

- `.\gradlew-local.bat :app:testReleaseUnitTest --tests com.asmr.player.MainNavigationSupportTest`
- `.\gradlew-local.bat :baselineprofile:connectedBenchmarkReleaseAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=com.asmr.player.baselineprofile.LongListPerformanceBenchmark#primaryNavigationClickTransitionsFrameTiming`
- `.\gradlew-local.bat :app:installRelease`

同设备对照的一轮中，P90/P95/P99 从 12/13/16 ms 降至 6.5/8.5/13 ms。MIUI 会在 60/120 Hz 间动态切换，因此当前结果不宣称已稳定达到 120 Hz 下 P99 ≤ 8.3 ms。