### PR TITLE
fix(player): 统一播放页弹出式 Sheet 样式

### DIFF
--- a/app/src/main/java/com/asmr/player/MainActivity.kt
+++ b/app/src/main/java/com/asmr/player/MainActivity.kt
@@ -155,7 +155,7 @@ import com.asmr.player.data.settings.NowPlayingHomeLayoutMode
 import com.asmr.player.data.settings.NowPlayingLyricsSettings
 import com.asmr.player.util.MessageManager
 import com.asmr.player.ui.common.NonTouchableAppMessageOverlay
-import com.asmr.player.ui.common.StableWindowInsets
+import com.asmr.player.ui.common.PlayerModalSheet
 import com.asmr.player.ui.common.VisibleAppMessage
 import com.asmr.player.ui.theme.HuePalette
 import com.asmr.player.ui.theme.PlayerTheme
@@ -612,52 +612,26 @@ class MainActivity : ComponentActivity() {
                         )
                     }
                     
-                    val overlayConfiguration = LocalConfiguration.current
                     val activeOverlaySheet = overlaySheet
                     if (activeOverlaySheet != null) {
-                        Box(
-                            modifier = Modifier
-                                .fillMaxSize()
-                                .background(Color.Black.copy(alpha = 0.32f))
-                        )
-                        val sheetMaxHeight = overlayConfiguration.screenHeightDp.dp * 3 / 4
-                        key(
-                            activeOverlaySheet,
-                            overlayConfiguration.screenWidthDp,
-                            overlayConfiguration.screenHeightDp
-                        ) {
-                            val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
-                            ModalBottomSheet(
-                                onDismissRequest = { overlaySheet = null },
-                                sheetState = sheetState,
-                                containerColor = MaterialTheme.colorScheme.background,
-                                contentColor = MaterialTheme.colorScheme.onBackground,
-                                scrimColor = Color.Transparent,
-                                windowInsets = WindowInsets(0, 0, 0, 0)
-                            ) {
-                                Box(
-                                    modifier = Modifier
-                                        .fillMaxWidth()
-                                        .heightIn(max = sheetMaxHeight)
-                                        .windowInsetsPadding(StableWindowInsets.navigationBars)
-                                ) {
-                                    when (activeOverlaySheet) {
-                                        OverlaySheet.Queue -> QueueSheetContent(
-                                            viewModel = playerViewModel,
-                                            onDismiss = { overlaySheet = null },
-                                            modifier = Modifier
-                                                .fillMaxWidth()
-                                                .heightIn(max = sheetMaxHeight)
-                                        )
+                        key(activeOverlaySheet) {
+                            PlayerModalSheet(onDismissRequest = { overlaySheet = null }) { sheetMaxHeight ->
+                                when (activeOverlaySheet) {
+                                    OverlaySheet.Queue -> QueueSheetContent(
+                                        viewModel = playerViewModel,
+                                        onDismiss = { overlaySheet = null },
+                                        modifier = Modifier
+                                            .fillMaxWidth()
+                                            .heightIn(max = sheetMaxHeight)
+                                    )
 
-                                        OverlaySheet.SleepTimer -> SleepTimerSheetContent(
-                                            viewModel = playerViewModel,
-                                            onDismiss = { overlaySheet = null },
-                                            modifier = Modifier
-                                                .fillMaxWidth()
-                                                .heightIn(max = sheetMaxHeight)
-                                        )
-                                    }
+                                    OverlaySheet.SleepTimer -> SleepTimerSheetContent(
+                                        viewModel = playerViewModel,
+                                        onDismiss = { overlaySheet = null },
+                                        modifier = Modifier
+                                            .fillMaxWidth()
+                                            .heightIn(max = sheetMaxHeight)
+                                    )
                                 }
                             }
                         }

--- a/app/src/main/java/com/asmr/player/main/MainContainer.kt
+++ b/app/src/main/java/com/asmr/player/main/MainContainer.kt
@@ -133,6 +133,7 @@ import com.asmr.player.ui.common.FlatDialogAction
 import com.asmr.player.ui.common.FlatDialogActionTone
 import com.asmr.player.ui.common.FlatTextFieldDialog
 import com.asmr.player.ui.common.EdgeToEdgeFullHeightSheet
+import com.asmr.player.ui.common.PlayerModalSheet
 import com.asmr.player.ui.common.EaraTopBarContainer
 import com.asmr.player.ui.common.EaraMainTopBarHeight
 import com.asmr.player.ui.common.EaraTopBarIconButton
@@ -3092,17 +3093,8 @@ fun MainContainer(
                 )
                 nowPlayingPlaylistPickerRequest?.let { request ->
                     val playlistsViewModel: PlaylistsViewModel = hiltViewModel(activityViewModelStoreOwner)
-                    EdgeToEdgeFullHeightSheet(
-                        onDismissRequest = { nowPlayingPlaylistPickerRequest = null },
-                        containerColor = colorScheme.background.copy(alpha = 0.96f),
-                        contentColor = colorScheme.onBackground
-                    ) {
-                        Box(
-                            modifier = Modifier
-                                .fillMaxSize()
-                                .windowInsetsPadding(StableWindowInsets.statusBars)
-                                .windowInsetsPadding(StableWindowInsets.navigationBars)
-                        ) {
+                    PlayerModalSheet(onDismissRequest = { nowPlayingPlaylistPickerRequest = null }) { sheetMaxHeight ->
+                        Box(modifier = Modifier.fillMaxWidth().heightIn(max = sheetMaxHeight)) {
                             PlaylistPickerScreen(
                                 windowSizeClass = windowSizeClass,
                                 items = request.items,

--- a/app/src/main/java/com/asmr/player/ui/common/PlayerModalSheet.kt
+++ b/app/src/main/java/com/asmr/player/ui/common/PlayerModalSheet.kt
@@ -1,0 +1,63 @@
+package com.asmr.player.ui.common
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.key
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+
+private const val PlayerModalSheetMaxHeightFraction = 0.75f
+
+internal fun playerModalSheetMaxHeightDp(screenHeightDp: Int): Float =
+    screenHeightDp.coerceAtLeast(0) * PlayerModalSheetMaxHeightFraction
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+internal fun PlayerModalSheet(
+    onDismissRequest: () -> Unit,
+    containerColor: Color = MaterialTheme.colorScheme.background,
+    contentColor: Color = MaterialTheme.colorScheme.onBackground,
+    content: @Composable (maxHeight: Dp) -> Unit
+) {
+    val configuration = LocalConfiguration.current
+    val maxHeight = playerModalSheetMaxHeightDp(configuration.screenHeightDp).dp
+
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(Color.Black.copy(alpha = 0.32f))
+    )
+
+    key(configuration.screenWidthDp, configuration.screenHeightDp) {
+        ModalBottomSheet(
+            onDismissRequest = onDismissRequest,
+            sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true),
+            containerColor = containerColor,
+            contentColor = contentColor,
+            scrimColor = Color.Transparent,
+            windowInsets = WindowInsets(0, 0, 0, 0)
+        ) {
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .heightIn(max = maxHeight)
+                    .windowInsetsPadding(StableWindowInsets.navigationBars)
+            ) {
+                content(maxHeight)
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/asmr/player/ui/player/NowPlayingScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/player/NowPlayingScreen.kt
@@ -100,6 +100,7 @@ import com.asmr.player.ui.common.AppVolumeWarningSessionState
 import com.asmr.player.playback.AppVolume
 import com.asmr.player.playback.PlaybackSnapshot
 import com.asmr.player.ui.common.EqualizerPanel
+import com.asmr.player.ui.common.PlayerModalSheet
 import com.asmr.player.ui.common.rememberProtectedAppVolumeChangeState
 import com.asmr.player.ui.common.DiscPlaceholder
 import com.asmr.player.ui.common.smoothScrollToIndex
@@ -2551,19 +2552,11 @@ internal fun NowPlayingScreen(
         }
 
         if (showSliceSheet) {
-            val sheetMinHeight = (configuration.screenHeightDp.dp * 0.66f).coerceAtLeast(320.dp)
-            ModalBottomSheet(
-                onDismissRequest = dismissSliceSheet,
-                sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true),
-                containerColor = colorScheme.surface,
-                contentColor = colorScheme.onSurface,
-                windowInsets = WindowInsets(0, 0, 0, 0)
-            ) {
+            PlayerModalSheet(onDismissRequest = dismissSliceSheet) { sheetMaxHeight ->
                 Column(
                     modifier = Modifier
                         .fillMaxWidth()
-                        .heightIn(min = sheetMinHeight)
-                        .windowInsetsPadding(WindowInsets.navigationBars)
+                        .heightIn(max = sheetMaxHeight)
                         .padding(horizontal = 16.dp, vertical = 12.dp)
                 ) {
                     Row(
@@ -2750,18 +2743,12 @@ internal fun NowPlayingScreen(
                     equalizerVolumeOverlayBounds = null
                 }
             }
-            ModalBottomSheet(
-                onDismissRequest = { showEqualizer = false },
-                sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true),
-                containerColor = colorScheme.surface,
-                contentColor = colorScheme.onSurface,
-                windowInsets = WindowInsets(0, 0, 0, 0)
-            ) {
+            PlayerModalSheet(onDismissRequest = { showEqualizer = false }) { sheetMaxHeight ->
                 val scrollState = rememberScrollState()
                 Box(
                     modifier = Modifier
-                        .fillMaxHeight()
-                        .windowInsetsPadding(WindowInsets.navigationBars)
+                        .fillMaxWidth()
+                        .heightIn(max = sheetMaxHeight)
                         .focusRequester(equalizerFocusRequester)
                         .focusable()
                         .onPreviewKeyEvent { event ->

--- a/app/src/test/java/com/asmr/player/ui/common/PlayerModalSheetTest.kt
+++ b/app/src/test/java/com/asmr/player/ui/common/PlayerModalSheetTest.kt
@@ -1,0 +1,17 @@
+package com.asmr.player.ui.common
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class PlayerModalSheetTest {
+    @Test
+    fun maxHeight_matchesQueueStyleInPortraitAndLandscape() {
+        assertEquals(600f, playerModalSheetMaxHeightDp(screenHeightDp = 800), 0.001f)
+        assertEquals(308.25f, playerModalSheetMaxHeightDp(screenHeightDp = 411), 0.001f)
+    }
+
+    @Test
+    fun maxHeight_doesNotBecomeNegativeForInvalidConfiguration() {
+        assertEquals(0f, playerModalSheetMaxHeightDp(screenHeightDp = -1), 0.001f)
+    }
+}


### PR DESCRIPTION
## 变更说明

- 抽取播放相关弹出页共用的 `PlayerModalSheet`，统一为当前播放队列的最大高度、圆角、拖拽柄、主题颜色与遮罩样式。
- 将添加到播放列表、音效面板和切片管理接入统一容器；播放队列与定时关闭也复用同一实现。
- 使用全窗口遮罩覆盖横屏系统导航区域，修复添加到播放列表和音效面板右侧露出播放主页的细条。
- 保留各面板原有的滚动、音量键、输入和业务交互。