### PR TITLE
fix: 移除部分封面加载动画

### DIFF
--- a/app/src/main/java/com/asmr/player/ui/library/AlbumDetailScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/AlbumDetailScreen.kt
@@ -166,6 +166,7 @@ import com.asmr.player.ui.common.DiscPlaceholder
 import com.asmr.player.ui.common.AsmrAsyncImage
 import com.asmr.player.ui.common.AsmrImageLoadingPlaceholder
 import com.asmr.player.ui.common.EaraLogoLoadingIndicator
+import com.asmr.player.ui.common.NoImageLoadingIndicator
 import com.asmr.player.ui.common.ImagePreviewDialog
 import com.asmr.player.ui.common.ImagePreviewRequest
 import com.asmr.player.ui.common.LocalBottomOverlayPadding
@@ -2533,6 +2534,7 @@ private fun AlbumDetailSimilarWorkCard(
             contentScale = ContentScale.Crop,
             placeholderCornerRadius = 0,
             peekAnySizeForInitial = true,
+            loading = NoImageLoadingIndicator,
             modifier = Modifier
                 .size(76.dp)
                 .clip(RoundedCornerShape(topStart = 10.dp, bottomStart = 10.dp))

--- a/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailDirectorySupport.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailDirectorySupport.kt
@@ -133,6 +133,7 @@ import com.asmr.player.ui.common.AudioItemSubtitleStampSpacing
 import com.asmr.player.ui.common.DiscPlaceholder
 import com.asmr.player.ui.common.AsmrAsyncImage
 import com.asmr.player.ui.common.AsmrShimmerPlaceholder
+import com.asmr.player.ui.common.NoImageLoadingIndicator
 import com.asmr.player.ui.common.CvChipsFlow
 import com.asmr.player.ui.common.EaraLogoLoadingIndicator
 import com.asmr.player.ui.common.ImagePreviewItem
@@ -3638,7 +3639,8 @@ internal fun DirectoryFileRow(
                             .size(42.dp)
                             .clip(RoundedCornerShape(8.dp)),
                         contentScale = ContentScale.Crop,
-                        placeholderCornerRadius = 8
+                        placeholderCornerRadius = 8,
+                        loading = NoImageLoadingIndicator
                     )
                 } else {
                     Box(
@@ -3976,6 +3978,7 @@ internal fun TreeFileRow(
                                 .clip(RoundedCornerShape(6.dp)),
                             contentScale = ContentScale.Crop,
                             placeholderCornerRadius = 6,
+                            loading = NoImageLoadingIndicator,
                         )
                     } else {
                         Icon(

--- a/app/src/main/java/com/asmr/player/ui/player/MiniPlayer.kt
+++ b/app/src/main/java/com/asmr/player/ui/player/MiniPlayer.kt
@@ -76,6 +76,7 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.media3.common.MediaItem
 import com.asmr.player.ui.common.AsmrAsyncImage
+import com.asmr.player.ui.common.NoImageLoadingIndicator
 import com.asmr.player.ui.theme.AsmrTheme
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.distinctUntilChanged
@@ -261,6 +262,7 @@ fun MiniPlayer(
                                         contentDescription = null,
                                         contentScale = ContentScale.Crop,
                                         placeholderCornerRadius = (52 * resolvedCompactScale).roundToInt(),
+                                        loading = NoImageLoadingIndicator,
                                         modifier = Modifier.fillMaxSize()
                                     )
                                 }
@@ -474,6 +476,7 @@ private fun MiniPlayerCoverOnly(
                 contentDescription = null,
                 contentScale = ContentScale.Crop,
                 placeholderCornerRadius = placeholderCornerRadius,
+                loading = NoImageLoadingIndicator,
                 modifier = Modifier.fillMaxSize()
             )
             MiniPlayerActivityBars(


### PR DESCRIPTION
## 改动

- 迷你播放器的展开与纯封面模式不再显示动态加载图标
- 横屏专辑详情页左侧相似作品封面改为纯渐入
- 目录树两套图片缩略图改为纯渐入
- 保留原有错误占位、裁剪、圆角和渐入行为

## 验证

- `git diff --check`
- `.\gradlew-local.bat :app:installRelease`
- 仅安装到 `Pixel_Tablet_API_34 / emulator-5554`
- `MainActivity` 冷启动成功，未发现 `AndroidRuntime/FATAL EXCEPTION`