### PR TITLE
feat: 优化 Gallery 图片预览、分享与保存

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -11,6 +11,9 @@
     <uses-permission android:name="android.permission.WAKE_LOCK" />
     <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS" />
     <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW" />
+    <uses-permission
+        android:name="android.permission.WRITE_EXTERNAL_STORAGE"
+        android:maxSdkVersion="28" />
 
     <application
         android:name=".AsmrApp"

--- a/app/src/main/java/com/asmr/player/ui/common/ImagePreviewDialog.kt
+++ b/app/src/main/java/com/asmr/player/ui/common/ImagePreviewDialog.kt
@@ -1,47 +1,55 @@
 package com.asmr.player.ui.common
 
+import android.Manifest
+import android.content.ActivityNotFoundException
+import android.content.ClipData
 import android.content.Intent
-import android.net.Uri
-import android.webkit.MimeTypeMap
+import android.content.pm.PackageManager
+import android.graphics.drawable.ColorDrawable
+import android.os.Build
+import android.view.Window
+import android.view.WindowManager
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.gestures.detectTransformGestures
-import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.rounded.OpenInNew
 import androidx.compose.material.icons.rounded.ChevronLeft
 import androidx.compose.material.icons.rounded.ChevronRight
+import androidx.compose.material.icons.rounded.Check
 import androidx.compose.material.icons.rounded.Close
 import androidx.compose.material.icons.rounded.ImageNotSupported
-import androidx.compose.material3.Card
-import androidx.compose.material3.CardDefaults
-import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material.icons.rounded.SaveAlt
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.IconButtonDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.mutableStateMapOf
 import androidx.compose.runtime.produceState
 import androidx.compose.runtime.remember
@@ -54,41 +62,58 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
-import androidx.core.content.FileProvider
+import androidx.compose.ui.window.DialogWindowProvider
+import androidx.core.content.ContextCompat
+import androidx.core.view.WindowCompat
+import com.asmr.player.AsmrApp
 import com.asmr.player.ui.theme.AsmrTheme
 import com.asmr.player.util.MessageManager
-import java.io.File
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 
 internal const val IMAGE_PREVIEW_DIALOG_TAG = "image_preview_dialog"
 internal const val IMAGE_PREVIEW_CLOSE_TAG = "image_preview_close"
-internal const val IMAGE_PREVIEW_OUTSIDE_TAG = "image_preview_outside"
 internal const val IMAGE_PREVIEW_PAGER_TAG = "image_preview_pager"
 internal const val IMAGE_PREVIEW_COUNT_TAG = "image_preview_count"
 internal const val IMAGE_PREVIEW_PREV_TAG = "image_preview_prev"
 internal const val IMAGE_PREVIEW_NEXT_TAG = "image_preview_next"
 internal const val IMAGE_PREVIEW_OPEN_EXTERNAL_TAG = "image_preview_open_external"
+internal const val IMAGE_PREVIEW_SAVE_TO_GALLERY_TAG = "image_preview_save_to_gallery"
+internal val ImagePreviewOverlayColor = Color(0xFF202124)
 
 internal data class ImagePreviewLayoutSpec(
-    val widthFraction: Float = 0.92f,
-    val maxWidthDp: Int = 760,
-    val heightFraction: Float = 0.66f,
-    val minHeightDp: Int = 260,
-    val maxHeightDp: Int = 680,
     val imageViewportPaddingDp: Int = 6,
     val toolbarVerticalPaddingDp: Int = 8,
     val footerVerticalPaddingDp: Int = 8
 )
 
 internal val DefaultImagePreviewLayoutSpec = ImagePreviewLayoutSpec()
+
+@Suppress("DEPRECATION")
+private fun Window.applyImagePreviewSystemBarStyle() {
+    val overlayColor = ImagePreviewOverlayColor.toArgb()
+    setLayout(WindowManager.LayoutParams.MATCH_PARENT, WindowManager.LayoutParams.MATCH_PARENT)
+    setBackgroundDrawable(ColorDrawable(overlayColor))
+    decorView.setBackgroundColor(overlayColor)
+    statusBarColor = overlayColor
+    navigationBarColor = overlayColor
+    WindowCompat.setDecorFitsSystemWindows(this, false)
+    WindowCompat.getInsetsController(this, decorView).apply {
+        isAppearanceLightStatusBars = false
+        isAppearanceLightNavigationBars = false
+    }
+}
 
 internal data class ImagePreviewItem(
     val key: String,
@@ -134,56 +159,134 @@ internal fun ImagePreviewDialog(
     val normalizedRequest = remember(request) { request.normalized() } ?: return
     val items = normalizedRequest.items
     val context = LocalContext.current
-    val colorScheme = AsmrTheme.colorScheme
     val layoutSpec = DefaultImagePreviewLayoutSpec
     val scope = rememberCoroutineScope()
+    val actionColors = IconButtonDefaults.iconButtonColors(
+        containerColor = Color.White.copy(alpha = 0.10f),
+        contentColor = Color.White,
+        disabledContainerColor = Color.White.copy(alpha = 0.05f),
+        disabledContentColor = Color.White.copy(alpha = 0.38f)
+    )
     val pagerState = rememberPagerState(
         initialPage = normalizedRequest.initialIndex,
         pageCount = { items.size }
     )
     val pageTransforms = remember(items) { mutableStateMapOf<String, ImagePreviewTransformState>() }
     val resolvedItems = remember(items) { mutableStateMapOf<String, ImagePreviewPreparedItem>() }
+    var openingExternalImageKey by remember { mutableStateOf<String?>(null) }
+    var savingImageKey by remember { mutableStateOf<String?>(null) }
+    var savedImageKey by remember { mutableStateOf<String?>(null) }
+    var pendingSavePermissionRequest by remember { mutableStateOf<PreviewImageSaveRequest?>(null) }
     val currentItem = items.getOrElse(pagerState.currentPage) { items.first() }
+    val currentPreparedItem = resolvedItems[currentItem.key]
     val currentTransform = pageTransforms.getOrPut(currentItem.key) { ImagePreviewTransformState() }
     val canNavigate = items.size > 1
     val allowPaging = currentTransform.isAtRest
+    val isCurrentImagePreparing = currentPreparedItem == null &&
+        currentItem.imageModel == null &&
+        currentItem.prepareImage != null
+
+    fun currentImageRequest(): PreviewImageSaveRequest {
+        val prepared = resolvedItems[currentItem.key]
+        return PreviewImageSaveRequest(
+            key = currentItem.key,
+            title = currentItem.title,
+            imageModel = prepared?.imageModel ?: currentItem.imageModel,
+            openPathOrUrl = prepared?.openPathOrUrl ?: currentItem.openPathOrUrl
+        )
+    }
+
+    fun saveImage(request: PreviewImageSaveRequest) {
+        if (savingImageKey != null) return
+        savingImageKey = request.key
+        scope.launch {
+            try {
+                val app = context.applicationContext as? AsmrApp
+                    ?: error("Image client is unavailable")
+                savePreviewImageToGallery(
+                    context = context.applicationContext,
+                    request = request,
+                    httpClient = app.imageOkHttpClient
+                )
+                savingImageKey = null
+                savedImageKey = request.key
+                messageManager.showSuccess("已保存到相册")
+                delay(1_500)
+                if (savedImageKey == request.key) savedImageKey = null
+            } catch (cancellation: CancellationException) {
+                throw cancellation
+            } catch (_: Exception) {
+                messageManager.showError("保存到相册失败")
+            } finally {
+                savingImageKey = null
+            }
+        }
+    }
+
+    val savePermissionLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.RequestPermission()
+    ) { granted ->
+        val pendingRequest = pendingSavePermissionRequest
+        pendingSavePermissionRequest = null
+        if (granted && pendingRequest != null) {
+            saveImage(pendingRequest)
+        } else if (!granted) {
+            messageManager.showWarning("需要存储权限才能保存到相册")
+        }
+    }
+
+    fun saveCurrentToGallery() {
+        val saveRequest = currentImageRequest()
+        val needsLegacyPermission = Build.VERSION.SDK_INT <= Build.VERSION_CODES.P &&
+            ContextCompat.checkSelfPermission(
+                context,
+                Manifest.permission.WRITE_EXTERNAL_STORAGE
+            ) != PackageManager.PERMISSION_GRANTED
+        if (needsLegacyPermission) {
+            pendingSavePermissionRequest = saveRequest
+            savePermissionLauncher.launch(Manifest.permission.WRITE_EXTERNAL_STORAGE)
+        } else {
+            saveImage(saveRequest)
+        }
+    }
 
     fun openCurrentWithOtherApp() {
-        val path = (resolvedItems[currentItem.key]?.openPathOrUrl ?: currentItem.openPathOrUrl).trim()
-        if (path.isBlank()) {
+        if (openingExternalImageKey != null) return
+        val openRequest = currentImageRequest()
+        if (resolvePreviewImageSaveSource(openRequest).location.isBlank()) {
             messageManager.showError("无法打开：路径为空")
             return
         }
 
-        runCatching {
-            val uri = when {
-                path.startsWith("content://", ignoreCase = true) -> Uri.parse(path)
-                path.startsWith("http://", ignoreCase = true) || path.startsWith("https://", ignoreCase = true) -> Uri.parse(path)
-                else -> {
-                    val file = File(path)
-                    if (!file.exists()) throw java.io.FileNotFoundException(path)
-                    FileProvider.getUriForFile(
-                        context,
-                        "${context.packageName}.fileprovider",
-                        file
-                    )
+        openingExternalImageKey = openRequest.key
+        scope.launch {
+            try {
+                val app = context.applicationContext as? AsmrApp
+                    ?: error("Image client is unavailable")
+                val prepared = preparePreviewImageForExternalOpen(
+                    context = context.applicationContext,
+                    request = openRequest,
+                    httpClient = app.imageOkHttpClient
+                )
+                val viewIntent = Intent(Intent.ACTION_VIEW).apply {
+                    setDataAndType(prepared.uri, prepared.mimeType)
+                    clipData = ClipData.newRawUri("image", prepared.uri)
+                    addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
                 }
-            }
-            val mimeType = runCatching { context.contentResolver.getType(uri) }.getOrNull()
-                ?: path.substringAfterLast('.', "").lowercase().takeIf { it.isNotBlank() }?.let { ext ->
-                    MimeTypeMap.getSingleton().getMimeTypeFromExtension(ext)
+                val chooser = Intent.createChooser(viewIntent, "打开图片").apply {
+                    addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
                 }
-                ?: "image/*"
-            val intent = Intent(Intent.ACTION_VIEW).apply {
-                setDataAndType(uri, mimeType)
-                addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
-            }
-            context.startActivity(Intent.createChooser(intent, "打开图片"))
-        }.onFailure { throwable ->
-            when (throwable) {
-                is android.content.ActivityNotFoundException -> messageManager.showInfo("未找到可打开的应用")
-                is java.io.FileNotFoundException -> messageManager.showError("文件不存在")
-                else -> messageManager.showError("无法打开该图片")
+                context.startActivity(chooser)
+            } catch (cancellation: CancellationException) {
+                throw cancellation
+            } catch (_: ActivityNotFoundException) {
+                messageManager.showInfo("未找到可打开的应用")
+            } catch (_: java.io.FileNotFoundException) {
+                messageManager.showError("文件不存在")
+            } catch (_: Exception) {
+                messageManager.showError("无法打开该图片")
+            } finally {
+                openingExternalImageKey = null
             }
         }
     }
@@ -199,144 +302,165 @@ internal fun ImagePreviewDialog(
 
     Dialog(
         onDismissRequest = onDismiss,
-        properties = DialogProperties(usePlatformDefaultWidth = false)
+        properties = DialogProperties(
+            usePlatformDefaultWidth = false,
+            decorFitsSystemWindows = false
+        )
     ) {
+        val dialogView = LocalView.current
+        DisposableEffect(dialogView) {
+            (dialogView.parent as? DialogWindowProvider)?.window?.applyImagePreviewSystemBarStyle()
+            onDispose {}
+        }
         Box(
             modifier = Modifier
                 .fillMaxSize()
-                .testTag(IMAGE_PREVIEW_OUTSIDE_TAG)
-                .background(Color.Black.copy(alpha = 0.74f))
-                .clickable(onClick = onDismiss),
-            contentAlignment = Alignment.Center
+                .background(ImagePreviewOverlayColor)
+                .testTag(IMAGE_PREVIEW_DIALOG_TAG)
         ) {
-            Card(
+            Column(
                 modifier = Modifier
-                    .fillMaxWidth(layoutSpec.widthFraction)
-                    .widthIn(max = layoutSpec.maxWidthDp.dp)
-                    .fillMaxHeight(layoutSpec.heightFraction)
-                    .heightIn(min = layoutSpec.minHeightDp.dp, max = layoutSpec.maxHeightDp.dp)
-                    .testTag(IMAGE_PREVIEW_DIALOG_TAG),
-                shape = RoundedCornerShape(24.dp),
-                colors = CardDefaults.cardColors(containerColor = colorScheme.surface)
+                    .fillMaxSize()
+                    .windowInsetsPadding(WindowInsets.safeDrawing)
             ) {
-                Column(
+                Row(
                     modifier = Modifier
-                        .fillMaxSize()
-                        .clickable(
-                            indication = null,
-                            interactionSource = remember { MutableInteractionSource() },
-                            onClick = {}
-                        )
+                        .fillMaxWidth()
+                        .padding(horizontal = 12.dp, vertical = layoutSpec.toolbarVerticalPaddingDp.dp),
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    verticalAlignment = Alignment.CenterVertically
                 ) {
-                    Row(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(horizontal = 12.dp, vertical = layoutSpec.toolbarVerticalPaddingDp.dp),
-                        horizontalArrangement = Arrangement.spacedBy(8.dp),
-                        verticalAlignment = Alignment.CenterVertically
+                    Text(
+                        text = currentItem.title.ifBlank { currentItem.openPathOrUrl.substringAfterLast('/').substringAfterLast('\\') },
+                        modifier = Modifier.weight(1f),
+                        style = MaterialTheme.typography.titleMedium,
+                        color = Color.White,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis
+                    )
+                    IconButton(
+                        onClick = ::openCurrentWithOtherApp,
+                        enabled = openingExternalImageKey == null &&
+                            savingImageKey == null &&
+                            !isCurrentImagePreparing,
+                        colors = actionColors,
+                        modifier = Modifier.testTag(IMAGE_PREVIEW_OPEN_EXTERNAL_TAG)
                     ) {
-                        Text(
-                            text = currentItem.title.ifBlank { currentItem.openPathOrUrl.substringAfterLast('/').substringAfterLast('\\') },
-                            modifier = Modifier.weight(1f),
-                            style = MaterialTheme.typography.titleMedium,
-                            color = colorScheme.textPrimary,
-                            maxLines = 1,
-                            overflow = TextOverflow.Ellipsis
-                        )
-                        IconButton(
-                            onClick = ::openCurrentWithOtherApp,
-                            modifier = Modifier.testTag(IMAGE_PREVIEW_OPEN_EXTERNAL_TAG)
-                        ) {
-                            Icon(Icons.AutoMirrored.Rounded.OpenInNew, contentDescription = "打开")
-                        }
-                        IconButton(
-                            onClick = onDismiss,
-                            modifier = Modifier.testTag(IMAGE_PREVIEW_CLOSE_TAG)
-                        ) {
-                            Icon(Icons.Rounded.Close, contentDescription = "关闭")
+                        if (openingExternalImageKey != null) {
+                            CircularProgressIndicator(
+                                modifier = Modifier.size(20.dp),
+                                color = Color.White,
+                                strokeWidth = 2.dp
+                            )
+                        } else {
+                            Icon(Icons.AutoMirrored.Rounded.OpenInNew, contentDescription = "使用其他应用打开")
                         }
                     }
+                    IconButton(
+                        onClick = ::saveCurrentToGallery,
+                        enabled = savingImageKey == null &&
+                            openingExternalImageKey == null &&
+                            savedImageKey != currentItem.key &&
+                            !isCurrentImagePreparing,
+                        colors = actionColors,
+                        modifier = Modifier.testTag(IMAGE_PREVIEW_SAVE_TO_GALLERY_TAG)
+                    ) {
+                        if (savingImageKey != null) {
+                            CircularProgressIndicator(
+                                modifier = Modifier.size(20.dp),
+                                color = Color.White,
+                                strokeWidth = 2.dp
+                            )
+                        } else if (savedImageKey == currentItem.key) {
+                            Icon(Icons.Rounded.Check, contentDescription = "已保存到相册")
+                        } else {
+                            Icon(Icons.Rounded.SaveAlt, contentDescription = "保存到相册")
+                        }
+                    }
+                    IconButton(
+                        onClick = onDismiss,
+                        colors = actionColors,
+                        modifier = Modifier.testTag(IMAGE_PREVIEW_CLOSE_TAG)
+                    ) {
+                        Icon(Icons.Rounded.Close, contentDescription = "关闭")
+                    }
+                }
 
-                    HorizontalDivider(color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.08f))
-
-                    Box(
+                Box(
+                    modifier = Modifier
+                        .weight(1f)
+                        .fillMaxWidth()
+                        .clipToBounds(),
+                    contentAlignment = Alignment.Center
+                ) {
+                    HorizontalPager(
+                        state = pagerState,
                         modifier = Modifier
-                            .weight(1f)
-                            .fillMaxWidth()
+                            .fillMaxSize()
                             .clipToBounds()
-                            .background(Color(0xFF13161A)),
-                        contentAlignment = Alignment.Center
-                    ) {
-                        HorizontalPager(
-                            state = pagerState,
-                            modifier = Modifier
-                                .fillMaxSize()
-                                .clipToBounds()
-                                .testTag(IMAGE_PREVIEW_PAGER_TAG),
-                            beyondViewportPageCount = 0,
-                            userScrollEnabled = canNavigate && allowPaging,
-                            key = { index -> items[index].key }
-                        ) { page ->
-                            val item = items[page]
-                            val transformState = pageTransforms.getOrPut(item.key) { ImagePreviewTransformState() }
-                            ImagePreviewPageHost(
-                                item = item,
-                                cachedPrepared = resolvedItems[item.key],
-                                onPrepared = { prepared -> resolvedItems[item.key] = prepared },
-                                state = transformState,
-                                onStateChange = { pageTransforms[item.key] = it },
-                                pageContent = pageContent
-                            )
-                        }
-
-                        if (canNavigate && allowPaging) {
-                            PreviewNavButton(
-                                modifier = Modifier
-                                    .align(Alignment.CenterStart)
-                                    .padding(start = 12.dp)
-                                    .testTag(IMAGE_PREVIEW_PREV_TAG),
-                                onClick = {
-                                    if (pagerState.currentPage > 0) {
-                                        pageTransforms[currentItem.key] = ImagePreviewTransformState()
-                                        scope.launch {
-                                            pagerState.animateScrollToPage(pagerState.currentPage - 1)
-                                        }
-                                    }
-                                },
-                                icon = Icons.Rounded.ChevronLeft,
-                                enabled = pagerState.currentPage > 0
-                            )
-                            PreviewNavButton(
-                                modifier = Modifier
-                                    .align(Alignment.CenterEnd)
-                                    .padding(end = 12.dp)
-                                    .testTag(IMAGE_PREVIEW_NEXT_TAG),
-                                onClick = {
-                                    if (pagerState.currentPage < items.lastIndex) {
-                                        pageTransforms[currentItem.key] = ImagePreviewTransformState()
-                                        scope.launch {
-                                            pagerState.animateScrollToPage(pagerState.currentPage + 1)
-                                        }
-                                    }
-                                },
-                                icon = Icons.Rounded.ChevronRight,
-                                enabled = pagerState.currentPage < items.lastIndex
-                            )
-                        }
-                    }
-
-                    if (canNavigate) {
-                        HorizontalDivider(color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.08f))
-                        Text(
-                            text = "${pagerState.currentPage + 1} / ${items.size}",
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .padding(horizontal = 16.dp, vertical = layoutSpec.footerVerticalPaddingDp.dp)
-                                .testTag(IMAGE_PREVIEW_COUNT_TAG),
-                            style = MaterialTheme.typography.labelLarge,
-                            color = colorScheme.textSecondary
+                            .testTag(IMAGE_PREVIEW_PAGER_TAG),
+                        beyondViewportPageCount = 0,
+                        userScrollEnabled = canNavigate && allowPaging,
+                        key = { index -> items[index].key }
+                    ) { page ->
+                        val item = items[page]
+                        val transformState = pageTransforms.getOrPut(item.key) { ImagePreviewTransformState() }
+                        ImagePreviewPageHost(
+                            item = item,
+                            cachedPrepared = resolvedItems[item.key],
+                            onPrepared = { prepared -> resolvedItems[item.key] = prepared },
+                            state = transformState,
+                            onStateChange = { pageTransforms[item.key] = it },
+                            pageContent = pageContent
                         )
                     }
+
+                    if (canNavigate && allowPaging) {
+                        PreviewNavButton(
+                            modifier = Modifier
+                                .align(Alignment.CenterStart)
+                                .padding(start = 12.dp)
+                                .testTag(IMAGE_PREVIEW_PREV_TAG),
+                            onClick = {
+                                if (pagerState.currentPage > 0) {
+                                    pageTransforms[currentItem.key] = ImagePreviewTransformState()
+                                    scope.launch {
+                                        pagerState.animateScrollToPage(pagerState.currentPage - 1)
+                                    }
+                                }
+                            },
+                            icon = Icons.Rounded.ChevronLeft,
+                            enabled = pagerState.currentPage > 0
+                        )
+                        PreviewNavButton(
+                            modifier = Modifier
+                                .align(Alignment.CenterEnd)
+                                .padding(end = 12.dp)
+                                .testTag(IMAGE_PREVIEW_NEXT_TAG),
+                            onClick = {
+                                if (pagerState.currentPage < items.lastIndex) {
+                                    pageTransforms[currentItem.key] = ImagePreviewTransformState()
+                                    scope.launch {
+                                        pagerState.animateScrollToPage(pagerState.currentPage + 1)
+                                    }
+                                }
+                            },
+                            icon = Icons.Rounded.ChevronRight,
+                            enabled = pagerState.currentPage < items.lastIndex
+                        )
+                    }
+                }
+
+                if (canNavigate) {
+                    Text(
+                        text = "${pagerState.currentPage + 1} / ${items.size}",
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 16.dp, vertical = layoutSpec.footerVerticalPaddingDp.dp)
+                            .testTag(IMAGE_PREVIEW_COUNT_TAG),
+                        style = MaterialTheme.typography.labelLarge,
+                        color = Color.White.copy(alpha = 0.72f)
+                    )
                 }
             }
         }

--- a/app/src/main/java/com/asmr/player/ui/common/PreviewImageGallerySaver.kt
+++ b/app/src/main/java/com/asmr/player/ui/common/PreviewImageGallerySaver.kt
@@ -1,0 +1,385 @@
+package com.asmr.player.ui.common
+
+import android.content.ContentValues
+import android.content.Context
+import android.media.MediaScannerConnection
+import android.net.Uri
+import android.os.Build
+import android.os.Environment
+import android.provider.MediaStore
+import android.webkit.MimeTypeMap
+import androidx.core.content.FileProvider
+import com.asmr.player.cache.CacheImageModel
+import com.asmr.player.util.Formatting
+import java.io.File
+import java.io.FileInputStream
+import java.io.FileOutputStream
+import java.io.IOException
+import java.io.InputStream
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import okhttp3.OkHttpClient
+import okhttp3.Request
+
+internal data class PreviewImageSaveRequest(
+    val key: String,
+    val title: String,
+    val imageModel: Any?,
+    val openPathOrUrl: String
+)
+
+internal data class PreviewImageSaveSource(
+    val location: String,
+    val headers: Map<String, String>
+)
+
+internal data class PreparedExternalPreviewImage(
+    val uri: Uri,
+    val mimeType: String
+)
+
+internal fun resolvePreviewImageSaveSource(request: PreviewImageSaveRequest): PreviewImageSaveSource {
+    val cacheModel = request.imageModel as? CacheImageModel
+    val modelData = cacheModel?.data ?: request.imageModel
+    val modelLocation = when (modelData) {
+        is Uri -> modelData.toString()
+        is File -> modelData.absolutePath
+        is String -> modelData
+        else -> ""
+    }.trim()
+    return PreviewImageSaveSource(
+        location = modelLocation.ifBlank { request.openPathOrUrl.trim() },
+        headers = cacheModel?.headers.orEmpty()
+    )
+}
+
+internal fun buildPreviewImageDisplayName(
+    title: String,
+    sourceLocation: String,
+    mimeType: String,
+    fallbackId: Long = System.currentTimeMillis()
+): String {
+    val sourceName = runCatching { Uri.parse(sourceLocation).lastPathSegment.orEmpty() }
+        .getOrDefault("")
+        .substringAfterLast('/')
+        .substringAfterLast('\\')
+    val safeTitle = Formatting.sanitizeFilename(title.substringAfterLast('/').substringAfterLast('\\'))
+        .trim()
+        .trim('.')
+    val safeSourceName = Formatting.sanitizeFilename(sourceName).trim().trim('.')
+    val candidate = safeTitle.ifBlank { safeSourceName }.ifBlank { "Eara_$fallbackId" }
+    val candidateExtension = candidate.substringAfterLast('.', "").lowercase()
+    val sourceExtension = sourceLocation.substringBefore('?').substringAfterLast('.', "").lowercase()
+    val extension = when {
+        imageMimeTypeForExtension(candidateExtension) != null -> candidateExtension
+        imageMimeTypeForExtension(sourceExtension) != null -> sourceExtension
+        else -> imageExtensionForMimeType(mimeType).orEmpty()
+    }.let { if (it.equals("jpeg", ignoreCase = true)) "jpg" else it.lowercase() }
+        .ifBlank { "jpg" }
+    val baseName = if (imageMimeTypeForExtension(candidateExtension) != null) {
+        candidate.substringBeforeLast('.').ifBlank { "Eara_$fallbackId" }
+    } else {
+        candidate
+    }
+    return "$baseName.$extension"
+}
+
+internal suspend fun savePreviewImageToGallery(
+    context: Context,
+    request: PreviewImageSaveRequest,
+    httpClient: OkHttpClient
+): Uri = withContext(Dispatchers.IO) {
+    val source = resolvePreviewImageSaveSource(request)
+    if (source.location.isBlank()) throw IOException("图片来源为空")
+    withPreviewImageInput(context, source, httpClient) { input, sourceMimeType ->
+        val mimeType = normalizeImageMimeType(sourceMimeType)
+            ?: imageMimeTypeForLocation(source.location)
+            ?: "image/jpeg"
+        val displayName = buildPreviewImageDisplayName(
+            title = request.title,
+            sourceLocation = source.location,
+            mimeType = mimeType
+        )
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            savePreviewImageWithMediaStore(context, input, displayName, mimeType)
+        } else {
+            savePreviewImageToLegacyPictures(context, input, displayName, mimeType)
+        }
+    }
+}
+
+internal suspend fun preparePreviewImageForExternalOpen(
+    context: Context,
+    request: PreviewImageSaveRequest,
+    httpClient: OkHttpClient,
+    contentUriForFile: (Context, File) -> Uri = ::previewImageContentUriForFile
+): PreparedExternalPreviewImage = withContext(Dispatchers.IO) {
+    val source = resolvePreviewImageSaveSource(request)
+    if (source.location.isBlank()) throw IOException("图片来源为空")
+
+    when {
+        source.location.startsWith("content://", ignoreCase = true) -> {
+            val uri = Uri.parse(source.location)
+            PreparedExternalPreviewImage(
+                uri = uri,
+                mimeType = normalizeImageMimeType(context.contentResolver.getType(uri))
+                    ?: imageMimeTypeForLocation(source.location)
+                    ?: "image/*"
+            )
+        }
+        source.location.startsWith("file://", ignoreCase = true) -> {
+            val path = Uri.parse(source.location).path ?: throw IOException("图片路径无效")
+            prepareLocalPreviewImageForExternalOpen(context, File(path), contentUriForFile)
+        }
+        source.location.startsWith("http://", ignoreCase = true) ||
+            source.location.startsWith("https://", ignoreCase = true) -> {
+            stageRemotePreviewImage(context, request, source, httpClient, contentUriForFile)
+        }
+        else -> prepareLocalPreviewImageForExternalOpen(context, File(source.location), contentUriForFile)
+    }
+}
+
+private fun prepareLocalPreviewImageForExternalOpen(
+    context: Context,
+    file: File,
+    contentUriForFile: (Context, File) -> Uri
+): PreparedExternalPreviewImage {
+    if (!file.isFile) throw java.io.FileNotFoundException(file.absolutePath)
+    return PreparedExternalPreviewImage(
+        uri = contentUriForFile(context, file),
+        mimeType = imageMimeTypeForLocation(file.name) ?: "image/*"
+    )
+}
+
+private fun stageRemotePreviewImage(
+    context: Context,
+    request: PreviewImageSaveRequest,
+    source: PreviewImageSaveSource,
+    httpClient: OkHttpClient,
+    contentUriForFile: (Context, File) -> Uri
+): PreparedExternalPreviewImage {
+    return withPreviewImageInput(context, source, httpClient) { input, sourceMimeType ->
+        val mimeType = normalizeImageMimeType(sourceMimeType)
+            ?: imageMimeTypeForLocation(source.location)
+            ?: "image/jpeg"
+        val displayName = buildPreviewImageDisplayName(
+            title = request.title,
+            sourceLocation = source.location,
+            mimeType = mimeType
+        )
+        val cacheDirectory = File(context.cacheDir, PREVIEW_IMAGE_SHARE_CACHE_DIRECTORY)
+        if (!cacheDirectory.isDirectory && !cacheDirectory.mkdirs()) {
+            throw IOException("无法创建图片分享缓存")
+        }
+        cleanupExpiredPreviewImageShares(cacheDirectory)
+
+        val sourceIdentity = buildString {
+            append(request.key)
+            append('\u0000')
+            append(source.location)
+            source.headers.toSortedMap().forEach { (name, value) ->
+                append('\u0000')
+                append(name)
+                append('=')
+                append(value)
+            }
+        }
+        val target = File(
+            cacheDirectory,
+            "${Integer.toHexString(sourceIdentity.hashCode())}_$displayName"
+        )
+        val temporary = File(cacheDirectory, ".${target.name}.${System.nanoTime()}.tmp")
+        try {
+            FileOutputStream(temporary).use { output -> input.copyTo(output) }
+            if (target.exists() && !target.delete()) {
+                throw IOException("无法更新图片分享缓存")
+            }
+            if (!temporary.renameTo(target)) {
+                temporary.copyTo(target, overwrite = true)
+                temporary.delete()
+            }
+        } catch (throwable: Throwable) {
+            temporary.delete()
+            throw throwable
+        }
+        PreparedExternalPreviewImage(
+            uri = contentUriForFile(context, target),
+            mimeType = mimeType
+        )
+    }
+}
+
+private fun previewImageContentUriForFile(context: Context, file: File): Uri {
+    return FileProvider.getUriForFile(
+        context,
+        "${context.packageName}.fileprovider",
+        file
+    )
+}
+
+private fun cleanupExpiredPreviewImageShares(directory: File) {
+    val expiresBefore = System.currentTimeMillis() - PREVIEW_IMAGE_SHARE_CACHE_MAX_AGE_MS
+    directory.listFiles()?.forEach { file ->
+        if (file.isFile && file.lastModified() < expiresBefore) file.delete()
+    }
+}
+
+private const val PREVIEW_IMAGE_SHARE_CACHE_DIRECTORY = "shared_preview_images"
+private const val PREVIEW_IMAGE_SHARE_CACHE_MAX_AGE_MS = 24L * 60L * 60L * 1_000L
+
+private fun <T> withPreviewImageInput(
+    context: Context,
+    source: PreviewImageSaveSource,
+    httpClient: OkHttpClient,
+    block: (InputStream, String?) -> T
+): T {
+    val location = source.location
+    return when {
+        location.startsWith("http://", ignoreCase = true) || location.startsWith("https://", ignoreCase = true) -> {
+            val requestBuilder = Request.Builder().url(location)
+            source.headers.forEach { (name, value) -> requestBuilder.header(name, value) }
+            httpClient.newCall(requestBuilder.build()).execute().use { response ->
+                if (!response.isSuccessful) throw IOException("图片下载失败：HTTP ${response.code}")
+                val body = response.body ?: throw IOException("图片下载结果为空")
+                body.byteStream().use { input ->
+                    block(input, body.contentType()?.toString())
+                }
+            }
+        }
+        location.startsWith("content://", ignoreCase = true) -> {
+            val uri = Uri.parse(location)
+            val input = context.contentResolver.openInputStream(uri)
+                ?: throw IOException("无法读取图片")
+            input.use { block(it, context.contentResolver.getType(uri)) }
+        }
+        location.startsWith("file://", ignoreCase = true) -> {
+            val path = Uri.parse(location).path ?: throw IOException("图片路径无效")
+            FileInputStream(File(path)).use { block(it, imageMimeTypeForLocation(path)) }
+        }
+        else -> {
+            FileInputStream(File(location)).use { block(it, imageMimeTypeForLocation(location)) }
+        }
+    }
+}
+
+private fun savePreviewImageWithMediaStore(
+    context: Context,
+    input: InputStream,
+    displayName: String,
+    mimeType: String
+): Uri {
+    val resolver = context.contentResolver
+    val collection = MediaStore.Images.Media.getContentUri(MediaStore.VOLUME_EXTERNAL_PRIMARY)
+    val values = ContentValues().apply {
+        put(MediaStore.Images.Media.DISPLAY_NAME, displayName)
+        put(MediaStore.Images.Media.MIME_TYPE, mimeType)
+        put(MediaStore.Images.Media.RELATIVE_PATH, "${Environment.DIRECTORY_PICTURES}/Eara")
+        put(MediaStore.Images.Media.IS_PENDING, 1)
+    }
+    val uri = resolver.insert(collection, values) ?: throw IOException("无法创建相册文件")
+    return try {
+        resolver.openOutputStream(uri, "w")?.use { output -> input.copyTo(output) }
+            ?: throw IOException("无法写入相册文件")
+        resolver.update(
+            uri,
+            ContentValues().apply { put(MediaStore.Images.Media.IS_PENDING, 0) },
+            null,
+            null
+        )
+        uri
+    } catch (throwable: Throwable) {
+        resolver.delete(uri, null, null)
+        throw throwable
+    }
+}
+
+@Suppress("DEPRECATION")
+private fun savePreviewImageToLegacyPictures(
+    context: Context,
+    input: InputStream,
+    displayName: String,
+    mimeType: String
+): Uri {
+    val directory = File(
+        Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_PICTURES),
+        "Eara"
+    )
+    if (!directory.isDirectory && !directory.mkdirs()) throw IOException("无法创建相册目录")
+    val target = uniqueLegacyGalleryFile(directory, displayName)
+    try {
+        FileOutputStream(target).use { output -> input.copyTo(output) }
+    } catch (throwable: Throwable) {
+        target.delete()
+        throw throwable
+    }
+    MediaScannerConnection.scanFile(
+        context,
+        arrayOf(target.absolutePath),
+        arrayOf(mimeType),
+        null
+    )
+    return Uri.fromFile(target)
+}
+
+private fun uniqueLegacyGalleryFile(directory: File, displayName: String): File {
+    val initial = File(directory, displayName)
+    if (!initial.exists()) return initial
+    val extension = displayName.substringAfterLast('.', "")
+    val baseName = displayName.substringBeforeLast('.', displayName)
+    var suffix = 2
+    while (true) {
+        val candidateName = if (extension.isBlank()) "$baseName ($suffix)" else "$baseName ($suffix).$extension"
+        val candidate = File(directory, candidateName)
+        if (!candidate.exists()) return candidate
+        suffix += 1
+    }
+}
+
+private fun normalizeImageMimeType(value: String?): String? {
+    return value
+        ?.substringBefore(';')
+        ?.trim()
+        ?.lowercase()
+        ?.takeIf { it.startsWith("image/") }
+}
+
+private fun imageMimeTypeForLocation(location: String): String? {
+    val extension = location.substringBefore('?').substringAfterLast('.', "").lowercase()
+    return imageMimeTypeForExtension(extension)
+}
+
+private fun imageMimeTypeForExtension(extension: String): String? {
+    if (extension.isBlank()) return null
+    return MimeTypeMap.getSingleton().getMimeTypeFromExtension(extension)
+        ?.takeIf { it.startsWith("image/") }
+        ?: when (extension.lowercase()) {
+            "jpg", "jpeg", "jfif" -> "image/jpeg"
+            "png" -> "image/png"
+            "webp" -> "image/webp"
+            "gif" -> "image/gif"
+            "bmp" -> "image/bmp"
+            "heic" -> "image/heic"
+            "heif" -> "image/heif"
+            "avif" -> "image/avif"
+            "svg" -> "image/svg+xml"
+            "ico" -> "image/x-icon"
+            else -> null
+        }
+}
+
+private fun imageExtensionForMimeType(mimeType: String): String? {
+    return MimeTypeMap.getSingleton().getExtensionFromMimeType(mimeType)
+        ?: when (mimeType.lowercase()) {
+            "image/jpeg" -> "jpg"
+            "image/png" -> "png"
+            "image/webp" -> "webp"
+            "image/gif" -> "gif"
+            "image/bmp" -> "bmp"
+            "image/heic" -> "heic"
+            "image/heif" -> "heif"
+            "image/avif" -> "avif"
+            "image/svg+xml" -> "svg"
+            "image/x-icon" -> "ico"
+            else -> null
+        }
+}

--- a/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailDirectorySupport.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailDirectorySupport.kt
@@ -511,15 +511,13 @@ internal fun buildDirectoryImagePreviewRequest(
 }
 
 internal fun buildGalleryImagePreviewRequest(
-    galleryUrls: List<String>,
-    clickedUrl: String,
-    toPreviewItem: (String) -> ImagePreviewItem?
+    galleryItems: List<ImagePreviewItem>,
+    clickedKey: String
 ): ImagePreviewRequest? {
-    val items = galleryUrls.mapNotNull(toPreviewItem)
-    if (items.isEmpty()) return null
-    val initialIndex = galleryUrls.indexOfFirst { it == clickedUrl }
+    if (galleryItems.isEmpty()) return null
+    val initialIndex = galleryItems.indexOfFirst { it.key == clickedKey }
     if (initialIndex < 0) return null
-    return ImagePreviewRequest(items = items, initialIndex = initialIndex)
+    return ImagePreviewRequest(items = galleryItems, initialIndex = initialIndex)
 }
 
 internal fun buildBreadcrumbSegments(currentPath: String): List<DirectoryBreadcrumbSegment> {
@@ -1200,6 +1198,50 @@ internal fun buildRemoteTreeIndex(
     return RemoteTreeIndex(root = root)
 }
 
+private fun RemoteTreeNode.toDirectoryFileItem(): DirectoryFileItem {
+    return DirectoryFileItem(
+        path = path,
+        title = name.substringBeforeLast('.'),
+        fileType = fileType,
+        isPlayable = fileType == TreeFileType.Audio || fileType == TreeFileType.Video,
+        isOnline = true,
+        durationSeconds = durationSeconds,
+        sizeSource = if (url.isNotBlank()) FileSizeSource.Remote(url) else FileSizeSource.None,
+        absolutePath = url,
+        url = url,
+        playlistTarget = playlistTarget,
+        subtitleSources = subtitleSources,
+        showSubtitleStamp = subtitleSources.isNotEmpty(),
+        dlsitePlayImageCrypt = dlsitePlayImageCrypt,
+        dlsitePlayImageWidth = dlsitePlayImageWidth,
+        dlsitePlayImageHeight = dlsitePlayImageHeight,
+        dlsitePlayOptimizedName = dlsitePlayOptimizedName
+    )
+}
+
+internal fun collectRemoteTreeImageFiles(index: RemoteTreeIndex): List<DirectoryFileItem> {
+    val images = mutableListOf<DirectoryFileItem>()
+
+    fun collect(node: RemoteTreeNode) {
+        val children = node.children.values
+        children.asSequence()
+            .filter { it.children.isNotEmpty() }
+            .sortedBy { SmartSortKey.of(it.name) }
+            .forEach(::collect)
+        children.asSequence()
+            .filter { child ->
+                child.children.isEmpty() &&
+                    child.fileType == TreeFileType.Image &&
+                    child.url.isNotBlank()
+            }
+            .sortedBy { SmartSortKey.of(it.name) }
+            .mapTo(images) { it.toDirectoryFileItem() }
+    }
+
+    collect(index.root)
+    return images
+}
+
 internal fun buildRemoteDirectoryBrowser(
     index: RemoteTreeIndex,
     currentPath: String
@@ -1221,26 +1263,7 @@ internal fun buildRemoteDirectoryBrowser(
         .asSequence()
         .filter { it.children.isEmpty() && it.url.isNotBlank() && it.fileType != TreeFileType.Subtitle && it.fileType != TreeFileType.Other }
         .sortedBy { SmartSortKey.of(it.name) }
-        .map { child ->
-            DirectoryFileItem(
-                path = child.path,
-                title = child.name.substringBeforeLast('.'),
-                fileType = child.fileType,
-                isPlayable = child.fileType == TreeFileType.Audio || child.fileType == TreeFileType.Video,
-                isOnline = true,
-                durationSeconds = child.durationSeconds,
-                sizeSource = if (child.url.isNotBlank()) FileSizeSource.Remote(child.url) else FileSizeSource.None,
-                absolutePath = child.url,
-                url = child.url,
-                playlistTarget = child.playlistTarget,
-                subtitleSources = child.subtitleSources,
-                showSubtitleStamp = child.subtitleSources.isNotEmpty(),
-                dlsitePlayImageCrypt = child.dlsitePlayImageCrypt,
-                dlsitePlayImageWidth = child.dlsitePlayImageWidth,
-                dlsitePlayImageHeight = child.dlsitePlayImageHeight,
-                dlsitePlayOptimizedName = child.dlsitePlayOptimizedName
-            )
-        }
+        .map(RemoteTreeNode::toDirectoryFileItem)
         .toList()
     return DirectoryBrowserResult(
         currentPath = normalizedPath,

--- a/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailDlsiteTabs.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailDlsiteTabs.kt
@@ -73,6 +73,7 @@ import androidx.compose.ui.semantics.stateDescription
 import androidx.compose.ui.state.ToggleableState
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.IntSize
@@ -154,22 +155,106 @@ private val DlsiteGalleryThumbGap = 10.dp
 private val DlsiteGallerySectionHeight = 120.dp
 private const val DlsiteGalleryThumbCornerRadius = 12
 
+private enum class DlsiteGalleryImageSource {
+    Dlsite,
+    Directory
+}
+
+private data class DlsiteGalleryImage(
+    val key: String,
+    val title: String,
+    val url: String,
+    val source: DlsiteGalleryImageSource
+) {
+    fun imageModel(): Any {
+        if (source == DlsiteGalleryImageSource.Directory) return url
+        val headers = DlsiteAntiHotlink.headersForImageUrl(url)
+        return if (headers.isEmpty()) url else CacheImageModel(data = url, headers = headers, keyTag = "dlsite")
+    }
+
+    fun toPreviewItem(): ImagePreviewItem {
+        return ImagePreviewItem(
+            key = key,
+            title = title,
+            imageModel = imageModel(),
+            openPathOrUrl = url
+        )
+    }
+}
+
+private data class DlsiteInfoRemoteTreeData(
+    val index: RemoteTreeIndex,
+    val imageFiles: List<DirectoryFileItem>
+)
+
+private fun buildDlsiteGalleryImages(
+    galleryUrls: List<String>,
+    directoryImages: List<DirectoryFileItem>
+): List<DlsiteGalleryImage> {
+    val seenUrls = hashSetOf<String>()
+    return buildList {
+        galleryUrls.forEach { rawUrl ->
+            val url = rawUrl.trim()
+            if (url.isBlank() || !seenUrls.add(url)) return@forEach
+            add(
+                DlsiteGalleryImage(
+                    key = "dlsite:$url",
+                    title = url.substringBefore('?').substringAfterLast('/').ifBlank { "Gallery" },
+                    url = url,
+                    source = DlsiteGalleryImageSource.Dlsite
+                )
+            )
+        }
+        directoryImages.forEach { file ->
+            val url = file.url.trim()
+            if (url.isBlank() || !seenUrls.add(url)) return@forEach
+            add(
+                DlsiteGalleryImage(
+                    key = "directory:${file.path}",
+                    title = file.title.ifBlank { file.path.substringAfterLast('/') },
+                    url = url,
+                    source = DlsiteGalleryImageSource.Directory
+                )
+            )
+        }
+    }
+}
+
 @Composable
-private fun DlsiteGalleryLoadingRow() {
-    val placeholders = remember { listOf(0, 1, 2, 3) }
-    LazyRow(
+private fun DlsiteGalleryAwaitingPreview(
+    galleryCount: Int?
+) {
+    val colorScheme = AsmrTheme.colorScheme
+    Surface(
         modifier = Modifier
             .fillMaxWidth()
             .height(DlsiteGallerySectionHeight)
-            .padding(horizontal = AlbumDetailHorizontalPadding),
-        horizontalArrangement = Arrangement.spacedBy(DlsiteGalleryThumbGap),
-        contentPadding = PaddingValues(vertical = 10.dp)
+            .padding(horizontal = AlbumDetailHorizontalPadding, vertical = 10.dp),
+        shape = RoundedCornerShape(DlsiteGalleryThumbCornerRadius.dp),
+        color = colorScheme.surfaceVariant.copy(alpha = if (colorScheme.isDark) 0.24f else 0.48f),
+        border = BorderStroke(1.dp, colorScheme.primary.copy(alpha = 0.24f))
     ) {
-        items(placeholders, key = { it }, contentType = { "galleryLoadingThumb" }) {
-            AsmrShimmerPlaceholder(
-                modifier = Modifier.size(width = DlsiteGalleryThumbWidth, height = DlsiteGalleryThumbHeight),
-                cornerRadius = DlsiteGalleryThumbCornerRadius,
-                animateHighlight = false,
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(horizontal = 20.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center
+        ) {
+            Text(
+                text = "样图未加载",
+                style = MaterialTheme.typography.titleSmall,
+                color = colorScheme.textPrimary,
+                fontWeight = FontWeight.SemiBold
+            )
+            Text(
+                text = galleryCount
+                    ?.let { count -> "共 $count 张 · 点击右上角“预览”后加载到本地" }
+                    ?: "获取到样图链接后，可点击右上角“预览”加载",
+                modifier = Modifier.padding(top = 6.dp),
+                style = MaterialTheme.typography.bodySmall,
+                color = colorScheme.textSecondary,
+                textAlign = TextAlign.Center
             )
         }
     }
@@ -1059,6 +1144,7 @@ internal fun AlbumDlsiteInfoBreadcrumbTabV2(
         contentColor = colorScheme.textPrimary,
         disabledContentColor = colorScheme.textTertiary.copy(alpha = 0.7f)
     )
+    var isGalleryPreviewRequested by rememberSaveable(treeStateKey) { mutableStateOf(false) }
     var currentPath by rememberSaveable(treeStateKey) { mutableStateOf(initialCurrentPath.trim().trim('/')) }
     val asmrLeafTracks by produceState(initialValue = emptyList<AsmrOneLeafUi>(), key1 = asmrOneTree) {
         value = withContext(Dispatchers.Default) { flattenAsmrOneTracksForUi(asmrOneTree) }
@@ -1066,15 +1152,22 @@ internal fun AlbumDlsiteInfoBreadcrumbTabV2(
     val asmrLeafByRelPath by produceState(initialValue = emptyMap<String, AsmrOneLeafUi>(), key1 = asmrLeafTracks) {
         value = withContext(Dispatchers.Default) { asmrLeafTracks.associateBy { it.relativePath } }
     }
-    val remoteIndex by produceState<RemoteTreeIndex?>(
+    val remoteTreeData by produceState<DlsiteInfoRemoteTreeData?>(
         initialValue = null,
         asmrOneTree,
         album.id,
         album.coverPath,
         album.coverUrl,
     ) {
-        value = withContext(Dispatchers.Default) { buildRemoteTreeIndex(asmrOneTree, album) }
+        value = withContext(Dispatchers.Default) {
+            val index = buildRemoteTreeIndex(asmrOneTree, album)
+            DlsiteInfoRemoteTreeData(
+                index = index,
+                imageFiles = collectRemoteTreeImageFiles(index)
+            )
+        }
     }
+    val remoteIndex = remoteTreeData?.index
     val browser by produceState<DirectoryBrowserResult?>(initialValue = null, key1 = remoteIndex, key2 = currentPath) {
         value = remoteIndex?.let { index ->
             withContext(Dispatchers.Default) { buildRemoteDirectoryBrowser(index, currentPath) }
@@ -1103,10 +1196,13 @@ internal fun AlbumDlsiteInfoBreadcrumbTabV2(
         hasAsmrOneTree = asmrOneTree.isNotEmpty(),
         hasDirectoryBrowser = browser != null
     )
-    val galleryPanelTarget: DlsiteContentPanel<List<String>> = when {
-        galleryUrls.isEmpty() && isInitialDlsiteLoading -> DlsiteContentPanel(DlsiteContentKind.Loading)
-        galleryUrls.isEmpty() -> DlsiteContentPanel(DlsiteContentKind.Empty)
-        else -> DlsiteContentPanel(DlsiteContentKind.Content, galleryUrls)
+    val galleryImages = remember(galleryUrls, remoteTreeData) {
+        buildDlsiteGalleryImages(galleryUrls, remoteTreeData?.imageFiles.orEmpty())
+    }
+    val galleryPanelTarget: DlsiteContentPanel<List<DlsiteGalleryImage>> = when {
+        galleryImages.isNotEmpty() -> DlsiteContentPanel(DlsiteContentKind.Content, galleryImages)
+        isInitialDlsiteLoading || isAsmrOnePending -> DlsiteContentPanel(DlsiteContentKind.Loading)
+        else -> DlsiteContentPanel(DlsiteContentKind.Empty)
     }
     val galleryFadeState = rememberDlsiteContentFadeState(galleryPanelTarget, treeStateKey)
     val trialPanelTarget: DlsiteContentPanel<List<Track>> = when {
@@ -1296,7 +1392,30 @@ internal fun AlbumDlsiteInfoBreadcrumbTabV2(
             Column(modifier = dlsiteAnimatedSectionModifier(Modifier.fillMaxWidth(), animateIntro)) {
                 AlbumDetailSectionHeading(
                     title = "Gallery",
-                    modifier = Modifier.padding(horizontal = AlbumDetailHorizontalPadding, vertical = 8.dp)
+                    modifier = Modifier.padding(horizontal = AlbumDetailHorizontalPadding, vertical = 8.dp),
+                    actions = {
+                        OutlinedButton(
+                            onClick = { isGalleryPreviewRequested = true },
+                            enabled = galleryFadeState.panel.kind == DlsiteContentKind.Content &&
+                                galleryFadeState.panel.value.orEmpty().isNotEmpty() &&
+                                !isGalleryPreviewRequested,
+                            colors = ButtonDefaults.outlinedButtonColors(
+                                contentColor = colorScheme.primary,
+                                disabledContentColor = colorScheme.textTertiary.copy(alpha = 0.72f)
+                            ),
+                            border = BorderStroke(
+                                width = 1.dp,
+                                color = if (galleryFadeState.panel.kind == DlsiteContentKind.Content && !isGalleryPreviewRequested) {
+                                    colorScheme.primary.copy(alpha = 0.52f)
+                                } else {
+                                    colorScheme.textTertiary.copy(alpha = 0.22f)
+                                }
+                            ),
+                            contentPadding = PaddingValues(horizontal = 14.dp, vertical = 6.dp)
+                        ) {
+                            Text("预览")
+                        }
+                    }
                 )
                 Box(
                     modifier = Modifier
@@ -1306,7 +1425,7 @@ internal fun AlbumDlsiteInfoBreadcrumbTabV2(
                     contentAlignment = Alignment.Center
                 ) {
                     when (galleryFadeState.panel.kind) {
-                        DlsiteContentKind.Loading -> DlsiteGalleryLoadingRow()
+                        DlsiteContentKind.Loading -> DlsiteGalleryAwaitingPreview(galleryCount = null)
                         DlsiteContentKind.Empty -> {
                             DlsiteSectionEmptyState(
                                 text = "暂无样图",
@@ -1315,49 +1434,38 @@ internal fun AlbumDlsiteInfoBreadcrumbTabV2(
                             )
                         }
                         DlsiteContentKind.Content -> {
-                            val displayedGalleryUrls = galleryFadeState.panel.value.orEmpty()
-                            LazyRow(
-                                modifier = Modifier.fillMaxWidth().padding(horizontal = AlbumDetailHorizontalPadding),
-                                horizontalArrangement = Arrangement.spacedBy(DlsiteGalleryThumbGap),
-                                contentPadding = PaddingValues(vertical = 10.dp)
-                            ) {
-                                items(items = displayedGalleryUrls, key = { it }, contentType = { "galleryThumb" }) { url ->
-                                    val model = remember(url) {
-                                        val headers = DlsiteAntiHotlink.headersForImageUrl(url)
-                                        if (headers.isEmpty()) url else CacheImageModel(data = url, headers = headers, keyTag = "dlsite")
-                                    }
-                                    Card(
-                                        modifier = Modifier.size(width = DlsiteGalleryThumbWidth, height = DlsiteGalleryThumbHeight).clickable {
-                                            buildGalleryImagePreviewRequest(
-                                                galleryUrls = displayedGalleryUrls,
-                                                clickedUrl = url,
-                                                toPreviewItem = { galleryUrl ->
-                                                    val headers = DlsiteAntiHotlink.headersForImageUrl(galleryUrl)
-                                                    val previewModel: Any = if (headers.isEmpty()) {
-                                                        galleryUrl
-                                                    } else {
-                                                        CacheImageModel(data = galleryUrl, headers = headers, keyTag = "dlsite")
-                                                    }
-                                                    ImagePreviewItem(
-                                                        key = galleryUrl,
-                                                        title = galleryUrl.substringBefore('?').substringAfterLast('/').ifBlank { "Gallery" },
-                                                        imageModel = previewModel,
-                                                        openPathOrUrl = galleryUrl
-                                                    )
-                                                }
-                                            )?.let(onPreviewImages)
-                                        },
-                                        shape = RoundedCornerShape(10.dp),
-                                        colors = CardDefaults.cardColors(containerColor = Color.Transparent)
-                                    ) {
-                                        AsmrAsyncImage(
-                                            model = model,
-                                            contentDescription = null,
-                                            contentScale = ContentScale.Crop,
-                                            placeholderCornerRadius = DlsiteGalleryThumbCornerRadius,
-                                            loading = NoImageLoadingIndicator,
-                                            modifier = Modifier.fillMaxSize()
-                                        )
+                            val displayedGalleryImages = galleryFadeState.panel.value.orEmpty()
+                            if (!isGalleryPreviewRequested) {
+                                DlsiteGalleryAwaitingPreview(galleryCount = displayedGalleryImages.size)
+                            } else {
+                                val galleryPreviewItems = remember(displayedGalleryImages) {
+                                    displayedGalleryImages.map(DlsiteGalleryImage::toPreviewItem)
+                                }
+                                LazyRow(
+                                    modifier = Modifier.fillMaxWidth().padding(horizontal = AlbumDetailHorizontalPadding),
+                                    horizontalArrangement = Arrangement.spacedBy(DlsiteGalleryThumbGap),
+                                    contentPadding = PaddingValues(vertical = 10.dp)
+                                ) {
+                                    items(items = galleryPreviewItems, key = { it.key }, contentType = { "galleryThumb" }) { image ->
+                                        Card(
+                                            modifier = Modifier.size(width = DlsiteGalleryThumbWidth, height = DlsiteGalleryThumbHeight).clickable {
+                                                buildGalleryImagePreviewRequest(
+                                                    galleryItems = galleryPreviewItems,
+                                                    clickedKey = image.key
+                                                )?.let(onPreviewImages)
+                                            },
+                                            shape = RoundedCornerShape(10.dp),
+                                            colors = CardDefaults.cardColors(containerColor = Color.Transparent)
+                                        ) {
+                                            AsmrAsyncImage(
+                                                model = image.imageModel,
+                                                contentDescription = null,
+                                                contentScale = ContentScale.Crop,
+                                                placeholderCornerRadius = DlsiteGalleryThumbCornerRadius,
+                                                loading = NoImageLoadingIndicator,
+                                                modifier = Modifier.fillMaxSize()
+                                            )
+                                        }
                                     }
                                 }
                             }

--- a/app/src/test/java/com/asmr/player/ui/common/ImagePreviewDialogTest.kt
+++ b/app/src/test/java/com/asmr/player/ui/common/ImagePreviewDialogTest.kt
@@ -8,16 +8,15 @@ import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.semantics.SemanticsProperties
 import androidx.compose.ui.test.SemanticsMatcher
 import androidx.compose.ui.test.assert
 import androidx.compose.ui.test.assertCountEquals
-import androidx.compose.ui.test.click
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
-import androidx.compose.ui.test.performTouchInput
 import com.asmr.player.ui.theme.AsmrPlayerTheme
 import com.asmr.player.util.MessageManager
 import org.junit.Assert.assertEquals
@@ -33,7 +32,7 @@ class ImagePreviewDialogTest {
     val composeRule = createComposeRule()
 
     @Test
-    fun singleImage_hidesNavigationAndClosesFromButtonsAndOverlay() {
+    fun singleImage_hidesNavigationAndClosesFromTopRight() {
         var dismissCount = 0
 
         composeRule.setContent {
@@ -54,12 +53,16 @@ class ImagePreviewDialogTest {
         composeRule.onAllNodesWithTag(IMAGE_PREVIEW_COUNT_TAG).assertCountEquals(0)
         composeRule.onAllNodesWithTag(IMAGE_PREVIEW_PREV_TAG).assertCountEquals(0)
         composeRule.onAllNodesWithTag(IMAGE_PREVIEW_NEXT_TAG).assertCountEquals(0)
+        composeRule.onNodeWithTag(IMAGE_PREVIEW_OPEN_EXTERNAL_TAG, useUnmergedTree = true).assert(
+            SemanticsMatcher.expectValue(SemanticsProperties.TestTag, IMAGE_PREVIEW_OPEN_EXTERNAL_TAG)
+        )
+        composeRule.onNodeWithTag(IMAGE_PREVIEW_SAVE_TO_GALLERY_TAG, useUnmergedTree = true).assert(
+            SemanticsMatcher.expectValue(SemanticsProperties.TestTag, IMAGE_PREVIEW_SAVE_TO_GALLERY_TAG)
+        )
 
         composeRule.onNodeWithTag(IMAGE_PREVIEW_CLOSE_TAG, useUnmergedTree = true).performClick()
-        composeRule.onNodeWithTag(IMAGE_PREVIEW_OUTSIDE_TAG, useUnmergedTree = true)
-            .performTouchInput { click(Offset(1f, 1f)) }
 
-        assertEquals(2, dismissCount)
+        assertEquals(1, dismissCount)
     }
 
     @Test
@@ -92,12 +95,11 @@ class ImagePreviewDialogTest {
     }
 
     @Test
-    fun layoutSpec_matchesPlannedBounds() {
-        assertEquals(0.92f, DefaultImagePreviewLayoutSpec.widthFraction)
-        assertEquals(760, DefaultImagePreviewLayoutSpec.maxWidthDp)
-        assertEquals(0.66f, DefaultImagePreviewLayoutSpec.heightFraction)
-        assertEquals(260, DefaultImagePreviewLayoutSpec.minHeightDp)
-        assertEquals(680, DefaultImagePreviewLayoutSpec.maxHeightDp)
+    fun fullscreenLayout_usesDeepGrayOverlayAndStableSpacing() {
+        assertEquals(Color(0xFF202124), ImagePreviewOverlayColor)
+        assertEquals(6, DefaultImagePreviewLayoutSpec.imageViewportPaddingDp)
+        assertEquals(8, DefaultImagePreviewLayoutSpec.toolbarVerticalPaddingDp)
+        assertEquals(8, DefaultImagePreviewLayoutSpec.footerVerticalPaddingDp)
     }
 
     @Test

--- a/app/src/test/java/com/asmr/player/ui/common/PreviewImageGallerySaverTest.kt
+++ b/app/src/test/java/com/asmr/player/ui/common/PreviewImageGallerySaverTest.kt
@@ -1,0 +1,116 @@
+package com.asmr.player.ui.common
+
+import android.content.Context
+import android.net.Uri
+import androidx.test.core.app.ApplicationProvider
+import com.asmr.player.cache.CacheImageModel
+import java.util.Base64
+import kotlinx.coroutines.runBlocking
+import okhttp3.OkHttpClient
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class PreviewImageGallerySaverTest {
+
+    @Test
+    fun resolveSource_usesCacheModelDataAndHeaders() {
+        val source = resolvePreviewImageSaveSource(
+            PreviewImageSaveRequest(
+                key = "gallery:1",
+                title = "样图",
+                imageModel = CacheImageModel(
+                    data = "https://img.example.com/sample.jpg",
+                    headers = mapOf("Referer" to "https://www.dlsite.com/")
+                ),
+                openPathOrUrl = "https://fallback.example.com/sample.jpg"
+            )
+        )
+
+        assertEquals("https://img.example.com/sample.jpg", source.location)
+        assertEquals(mapOf("Referer" to "https://www.dlsite.com/"), source.headers)
+    }
+
+    @Test
+    fun resolveSource_fallsBackToOpenPathForUnsupportedModel() {
+        val source = resolvePreviewImageSaveSource(
+            PreviewImageSaveRequest(
+                key = "local:1",
+                title = "封面",
+                imageModel = Any(),
+                openPathOrUrl = "/storage/emulated/0/Music/cover.png"
+            )
+        )
+
+        assertEquals("/storage/emulated/0/Music/cover.png", source.location)
+        assertEquals(emptyMap<String, String>(), source.headers)
+    }
+
+    @Test
+    fun displayName_keepsReadableChineseAndUsesImageExtension() {
+        assertEquals(
+            "封面测试.webp",
+            buildPreviewImageDisplayName(
+                title = "封面:测试",
+                sourceLocation = "https://img.example.com/raw.webp?token=1",
+                mimeType = "image/webp",
+                fallbackId = 42L
+            )
+        )
+        assertEquals(
+            "Eara_42.jpg",
+            buildPreviewImageDisplayName(
+                title = "",
+                sourceLocation = "https://img.example.com/",
+                mimeType = "image/jpeg",
+                fallbackId = 42L
+            )
+        )
+    }
+
+    @Test
+    fun prepareRemoteImage_downloadsOriginalBytesWithHeadersAndReturnsContentUri() = runBlocking {
+        val server = MockWebServer().apply { start() }
+        val imageBytes = Base64.getDecoder().decode(
+            "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII="
+        )
+        try {
+            server.enqueue(
+                MockResponse()
+                    .setHeader("Content-Type", "image/png")
+                    .setBody(okio.Buffer().write(imageBytes))
+            )
+            val context = ApplicationProvider.getApplicationContext<Context>()
+            var stagedFile: java.io.File? = null
+            val prepared = preparePreviewImageForExternalOpen(
+                context = context,
+                request = PreviewImageSaveRequest(
+                    key = "gallery:remote",
+                    title = "远程样图",
+                    imageModel = CacheImageModel(
+                        data = server.url("/protected/sample").toString(),
+                        headers = mapOf("Referer" to "https://www.dlsite.com/")
+                    ),
+                    openPathOrUrl = ""
+                ),
+                httpClient = OkHttpClient(),
+                contentUriForFile = { _, file ->
+                    stagedFile = file
+                    Uri.parse("content://com.asmr.player.fileprovider/shared/${file.name}")
+                }
+            )
+
+            assertEquals("content", prepared.uri.scheme)
+            assertEquals("image/png", prepared.mimeType)
+            assertArrayEquals(imageBytes, stagedFile!!.readBytes())
+            assertEquals("https://www.dlsite.com/", server.takeRequest().getHeader("Referer"))
+        } finally {
+            server.shutdown()
+        }
+    }
+}

--- a/app/src/test/java/com/asmr/player/ui/library/AlbumDetailDirectorySupportTest.kt
+++ b/app/src/test/java/com/asmr/player/ui/library/AlbumDetailDirectorySupportTest.kt
@@ -322,6 +322,47 @@ class AlbumDetailDirectorySupportTest {
     }
 
     @Test
+    fun collectRemoteTreeImageFiles_includesImagesFromEveryDirectory() {
+        val album = Album(
+            id = 8L,
+            title = "Album",
+            path = "web://rj/RJ000001",
+            rjCode = "RJ000001"
+        )
+        val tree = listOf(
+            AsmrOneTrackNodeResponse(
+                title = "booklet",
+                children = listOf(
+                    AsmrOneTrackNodeResponse(
+                        title = "page02.png",
+                        mediaDownloadUrl = "https://example.com/booklet/page02.png"
+                    ),
+                    AsmrOneTrackNodeResponse(
+                        title = "page01.webp",
+                        mediaDownloadUrl = "https://example.com/booklet/page01.webp"
+                    ),
+                    AsmrOneTrackNodeResponse(
+                        title = "track.mp3",
+                        mediaDownloadUrl = "https://example.com/booklet/track.mp3"
+                    )
+                )
+            ),
+            AsmrOneTrackNodeResponse(
+                title = "cover.jpg",
+                mediaDownloadUrl = "https://example.com/cover.jpg"
+            )
+        )
+
+        val images = collectRemoteTreeImageFiles(buildRemoteTreeIndex(tree, album))
+
+        assertEquals(
+            listOf("booklet/page01.webp", "booklet/page02.png", "cover.jpg"),
+            images.map { it.path }
+        )
+        assertTrue(images.all { it.fileType == TreeFileType.Image && it.isOnline })
+    }
+
+    @Test
     fun buildDlsiteTrialDownloadTree_keepsOnlyPlayableMediaWithStableNames() {
         val tree = buildDlsiteTrialDownloadTree(
             listOf(

--- a/app/src/test/java/com/asmr/player/ui/library/ImagePreviewSupportTest.kt
+++ b/app/src/test/java/com/asmr/player/ui/library/ImagePreviewSupportTest.kt
@@ -64,16 +64,15 @@ class ImagePreviewSupportTest {
         )
 
         val result = buildGalleryImagePreviewRequest(
-            galleryUrls = urls,
-            clickedUrl = "https://img.example/2.jpg",
-            toPreviewItem = { url ->
+            galleryItems = urls.map { url ->
                 ImagePreviewItem(
                     key = url,
                     title = url.substringAfterLast('/'),
                     imageModel = url,
                     openPathOrUrl = url
                 )
-            }
+            },
+            clickedKey = "https://img.example/2.jpg"
         )
 
         requireNotNull(result)


### PR DESCRIPTION
## 变更内容

- Gallery 改为用户点击“预览”后才加载图片，未加载时展示专用占位容器
- Gallery 合并展示 DLSite 样图与目录树中的图片，并进行去重和后台索引
- 图片预览改为全屏深灰遮罩，覆盖状态栏与导航栏区域
- 新增“保存到相册”，兼容 Android 7–16
- 修复远程图片交给系统相册时被误报“文件已损坏”：携带原请求头下载原始字节到缓存，再通过 FileProvider URI 分享
- 为打开、保存和延迟准备过程补充加载状态、错误处理与缓存清理

## 验证

- `:app:testDebugUnitTest` 指定的图片预览与 Gallery 测试全部通过
- `:app:installRelease` 构建成功，并安装到 Android 16 真机和 Android 14 模拟器