### PR TITLE
feat: 为迷你播放器添加播放反馈

### DIFF
--- a/app/src/main/java/com/asmr/player/main/MainContainer.kt
+++ b/app/src/main/java/com/asmr/player/main/MainContainer.kt
@@ -754,6 +754,7 @@ private fun PrimaryBottomChrome(
     lockedRoute: String?,
     miniPlayerVisible: Boolean,
     miniPlayerDisplayMode: MiniPlayerDisplayMode,
+    miniPlayerPlayFeedbackSignal: Long,
     onMiniPlayerDisplayModeChange: (MiniPlayerDisplayMode) -> Unit,
     onOpenNowPlaying: () -> Unit,
     onOpenQueue: () -> Unit,
@@ -784,6 +785,7 @@ private fun PrimaryBottomChrome(
         selectionProgresses = selectionProgresses,
         miniPlayerVisible = miniPlayerVisible,
         miniPlayerDisplayMode = miniPlayerDisplayMode,
+        miniPlayerPlayFeedbackSignal = miniPlayerPlayFeedbackSignal,
         onMiniPlayerDisplayModeChange = onMiniPlayerDisplayModeChange,
         onOpenNowPlaying = onOpenNowPlaying,
         onOpenQueue = onOpenQueue,
@@ -889,6 +891,10 @@ fun MainContainer(
         initialValue = MiniPlayerDisplayMode.CoverOnly.name
     )
     var miniPlayerDisplayMode by rememberSaveable { mutableStateOf(MiniPlayerDisplayMode.CoverOnly) }
+    var miniPlayerPlayFeedbackSignal by remember { mutableLongStateOf(0L) }
+    fun requestMiniPlayerPlayFeedback() {
+        miniPlayerPlayFeedbackSignal += 1L
+    }
     val primaryPagerRoutes = remember(bottomNavItems) { bottomNavItems.map { it.route } }
     val primaryPagerBeyondBoundsPageCount = remember(primaryPagerRoutes) {
         resolvePrimaryPagerBeyondBoundsPageCount(primaryPagerRoutes.size)
@@ -2154,7 +2160,9 @@ fun MainContainer(
                                                 },
                                                 onPlayTracks = { album, tracks, startTrack ->
                                                     scope.launch {
-                                                        playerViewModel.playTracksPrepared(album, tracks, startTrack)
+                                                        if (playerViewModel.playTracksPrepared(album, tracks, startTrack)) {
+                                                            requestMiniPlayerPlayFeedback()
+                                                        }
                                                     }
                                                 },
                                                 onOpenPlaylistPicker = { item ->
@@ -2265,7 +2273,11 @@ fun MainContainer(
                                                 scrollToTopSignal = favoritesScrollToTopSignal,
                                                 onPlayAll = { items, startItem ->
                                                     playerViewModel.playPlaylistItems(items, startItem)
-                                                    if (startItem.isVideoPlaybackItem()) openNowPlaying()
+                                                    if (startItem.isVideoPlaybackItem()) {
+                                                        openNowPlaying()
+                                                    } else {
+                                                        requestMiniPlayerPlayFeedback()
+                                                    }
                                                 },
                                                 viewModel = playlistsViewModel
                                             )
@@ -2566,12 +2578,19 @@ fun MainContainer(
                                 .toAlbumDetailInitialTab(),
                             onPlayTracks = { album, tracks, startTrack ->
                                 scope.launch {
-                                    playerViewModel.playTracksPrepared(album, tracks, startTrack)
+                                    if (playerViewModel.playTracksPrepared(album, tracks, startTrack)) {
+                                        requestMiniPlayerPlayFeedback()
+                                    }
                                 }
                             },
                             onPlayMediaItems = { items, startIndex ->
                                 playerViewModel.playMediaItems(items, startIndex)
-                                if (items.getOrNull(startIndex).isVideoPlaybackItem()) openNowPlaying()
+                                val startItem = items.getOrNull(startIndex)
+                                if (startItem.isVideoPlaybackItem()) {
+                                    openNowPlaying()
+                                } else if (startItem != null) {
+                                    requestMiniPlayerPlayFeedback()
+                                }
                             },
                             onAddToQueue = { album, track ->
                                 playerViewModel.addTrackToQueue(album, track)
@@ -2649,12 +2668,19 @@ fun MainContainer(
                                 .toAlbumDetailInitialTab(),
                             onPlayTracks = { album, tracks, startTrack ->
                                 scope.launch {
-                                    playerViewModel.playTracksPrepared(album, tracks, startTrack)
+                                    if (playerViewModel.playTracksPrepared(album, tracks, startTrack)) {
+                                        requestMiniPlayerPlayFeedback()
+                                    }
                                 }
                             },
                             onPlayMediaItems = { items, startIndex ->
                                 playerViewModel.playMediaItems(items, startIndex)
-                                if (items.getOrNull(startIndex).isVideoPlaybackItem()) openNowPlaying()
+                                val startItem = items.getOrNull(startIndex)
+                                if (startItem.isVideoPlaybackItem()) {
+                                    openNowPlaying()
+                                } else if (startItem != null) {
+                                    requestMiniPlayerPlayFeedback()
+                                }
                             },
                             onAddToQueue = { album, track ->
                                 playerViewModel.addTrackToQueue(album, track)
@@ -2720,12 +2746,19 @@ fun MainContainer(
                             rjCode = rj,
                             onPlayTracks = { album, tracks, startTrack ->
                                 scope.launch {
-                                    playerViewModel.playTracksPrepared(album, tracks, startTrack)
+                                    if (playerViewModel.playTracksPrepared(album, tracks, startTrack)) {
+                                        requestMiniPlayerPlayFeedback()
+                                    }
                                 }
                             },
                             onPlayMediaItems = { items, startIndex ->
                                 playerViewModel.playMediaItems(items, startIndex)
-                                if (items.getOrNull(startIndex).isVideoPlaybackItem()) openNowPlaying()
+                                val startItem = items.getOrNull(startIndex)
+                                if (startItem.isVideoPlaybackItem()) {
+                                    openNowPlaying()
+                                } else if (startItem != null) {
+                                    requestMiniPlayerPlayFeedback()
+                                }
                             },
                             onAddToQueue = { album, track ->
                                 playerViewModel.addTrackToQueue(album, track)
@@ -2795,7 +2828,12 @@ fun MainContainer(
                             title = groupName,
                             onPlayMediaItems = { items, startIndex ->
                                 playerViewModel.playMediaItems(items, startIndex)
-                                if (items.getOrNull(startIndex).isVideoPlaybackItem()) openNowPlaying()
+                                val startItem = items.getOrNull(startIndex)
+                                if (startItem.isVideoPlaybackItem()) {
+                                    openNowPlaying()
+                                } else if (startItem != null) {
+                                    requestMiniPlayerPlayFeedback()
+                                }
                             }
                         )
                     }
@@ -2833,7 +2871,11 @@ fun MainContainer(
                             title = playlistName,
                             onPlayAll = { items, startItem ->
                                 playerViewModel.playPlaylistItems(items, startItem)
-                                if (startItem.isVideoPlaybackItem()) openNowPlaying()
+                                if (startItem.isVideoPlaybackItem()) {
+                                    openNowPlaying()
+                                } else {
+                                    requestMiniPlayerPlayFeedback()
+                                }
                             }
                         )
                     }
@@ -2849,7 +2891,11 @@ fun MainContainer(
                                 windowSizeClass = windowSizeClass,
                                 onPlayAll = { items, startItem ->
                                     playerViewModel.playPlaylistItems(items, startItem)
-                                    if (startItem.isVideoPlaybackItem()) openNowPlaying()
+                                    if (startItem.isVideoPlaybackItem()) {
+                                        openNowPlaying()
+                                    } else {
+                                        requestMiniPlayerPlayFeedback()
+                                    }
                                 },
                                 viewModel = playlistsViewModel
                             )
@@ -2983,6 +3029,7 @@ fun MainContainer(
                         lockedRoute = pendingPrimaryNavigationRoute,
                         miniPlayerVisible = miniPlayerVisible,
                         miniPlayerDisplayMode = miniPlayerDisplayMode,
+                        miniPlayerPlayFeedbackSignal = miniPlayerPlayFeedbackSignal,
                         largeLayout = useLargeBottomChrome,
                         navItems = bottomNavItems,
                         onMiniPlayerDisplayModeChange = { nextMode ->

--- a/app/src/main/java/com/asmr/player/ui/nav/BottomChrome.kt
+++ b/app/src/main/java/com/asmr/player/ui/nav/BottomChrome.kt
@@ -532,6 +532,7 @@ fun BottomChrome(
     onOpenNowPlaying: () -> Unit,
     onOpenQueue: () -> Unit,
     onNavigate: (String) -> Unit,
+    miniPlayerPlayFeedbackSignal: Long = 0L,
     largeLayout: Boolean = false,
     modifier: Modifier = Modifier,
     navItems: List<BottomChromeNavItem> = bottomChromeNavItems(),
@@ -666,6 +667,7 @@ fun BottomChrome(
                             onDisplayModeChange = onMiniPlayerDisplayModeChange,
                             onOpenNowPlaying = onOpenNowPlaying,
                             onOpenQueue = onOpenQueue,
+                            playFeedbackSignal = miniPlayerPlayFeedbackSignal,
                             largeLayout = largeLayout,
                             compactScale = compactScale,
                             modifier = miniPlayerModifier

--- a/app/src/main/java/com/asmr/player/ui/player/MiniPlayer.kt
+++ b/app/src/main/java/com/asmr/player/ui/player/MiniPlayer.kt
@@ -2,6 +2,7 @@ package com.asmr.player.ui.player
 
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.SizeTransform
+import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.Spring
 import androidx.compose.animation.core.spring
 import androidx.compose.animation.fadeIn
@@ -66,6 +67,7 @@ import androidx.compose.ui.graphics.compositeOver
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.lerp
 import androidx.compose.ui.graphics.drawscope.clipRect
+import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.semantics.ProgressBarRangeInfo
 import androidx.compose.ui.semantics.progressBarRangeInfo
@@ -82,7 +84,9 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
+import kotlin.math.PI
 import kotlin.math.roundToInt
+import kotlin.math.sin
 
 enum class MiniPlayerDisplayMode {
     CoverOnly,
@@ -111,6 +115,11 @@ private fun sameMiniPlayerMediaItem(old: MediaItem?, new: MediaItem?): Boolean {
         old.mediaMetadata.artist?.toString() == new.mediaMetadata.artist?.toString()
 }
 
+internal fun miniPlayerPlayFeedbackEmphasis(progress: Float): Float {
+    val normalizedProgress = progress.coerceIn(0f, 1f)
+    return sin(normalizedProgress.toDouble() * PI).toFloat().coerceAtLeast(0f)
+}
+
 @Composable
 @OptIn(ExperimentalFoundationApi::class)
 fun MiniPlayer(
@@ -118,6 +127,7 @@ fun MiniPlayer(
     onDisplayModeChange: (MiniPlayerDisplayMode) -> Unit,
     onOpenNowPlaying: () -> Unit,
     onOpenQueue: () -> Unit,
+    playFeedbackSignal: Long = 0L,
     largeLayout: Boolean = false,
     compactScale: Float = 1f,
     modifier: Modifier = Modifier,
@@ -156,6 +166,20 @@ fun MiniPlayer(
         Color.White.copy(alpha = 0.14f)
     } else {
         colorScheme.primaryStrong.copy(alpha = 0.14f)
+    }
+    val playFeedbackProgress = remember { Animatable(1f) }
+
+    LaunchedEffect(playFeedbackSignal) {
+        if (playFeedbackSignal > 0L) {
+            playFeedbackProgress.snapTo(0f)
+            playFeedbackProgress.animateTo(
+                targetValue = 1f,
+                animationSpec = tween(
+                    durationMillis = 720,
+                    easing = FastOutSlowInEasing
+                )
+            )
+        }
     }
 
     var optimisticIsPlaying by remember { mutableStateOf<Boolean?>(null) }
@@ -199,6 +223,7 @@ fun MiniPlayer(
                 MiniPlayerCoverOnly(
                     artworkModel = metadata.artworkUri,
                     isPlaying = isPlayingEffective,
+                    playFeedbackProgress = { playFeedbackProgress.value },
                     onExpand = { onDisplayModeChange(MiniPlayerDisplayMode.Expanded) },
                     largeLayout = largeLayout,
                     compactScale = resolvedCompactScale
@@ -235,6 +260,42 @@ fun MiniPlayer(
                         modifier = Modifier
                             .fillMaxWidth()
                             .height(barHeight)
+                            .graphicsLayer {
+                                val emphasis = miniPlayerPlayFeedbackEmphasis(playFeedbackProgress.value)
+                                val scale = 1f + emphasis * 0.018f
+                                scaleX = scale
+                                scaleY = scale
+                            }
+                            .drawWithCache {
+                                val feedbackOutline = expandedShape.createOutline(
+                                    size = size,
+                                    layoutDirection = layoutDirection,
+                                    density = this
+                                )
+                                val feedbackPath = when (feedbackOutline) {
+                                    is Outline.Rectangle -> Path().apply { addRect(feedbackOutline.rect) }
+                                    is Outline.Rounded -> Path().apply { addRoundRect(feedbackOutline.roundRect) }
+                                    is Outline.Generic -> feedbackOutline.path
+                                }
+                                onDrawWithContent {
+                                    val progress = playFeedbackProgress.value.coerceIn(0f, 1f)
+                                    val fade = 1f - progress
+                                    if (fade > 0f) {
+                                        drawPath(
+                                            path = feedbackPath,
+                                            color = colorScheme.primary.copy(alpha = 0.14f * fade)
+                                        )
+                                    }
+                                    drawContent()
+                                    if (fade > 0f) {
+                                        drawPath(
+                                            path = feedbackPath,
+                                            color = colorScheme.primary.copy(alpha = 0.78f * fade),
+                                            style = Stroke(width = (2.5.dp + 1.5.dp * fade).toPx())
+                                        )
+                                    }
+                                }
+                            }
                     ) {
                         Box(
                             modifier = Modifier
@@ -439,6 +500,7 @@ fun MiniPlayer(
 private fun MiniPlayerCoverOnly(
     artworkModel: Any?,
     isPlaying: Boolean,
+    playFeedbackProgress: () -> Float,
     onExpand: () -> Unit,
     largeLayout: Boolean,
     compactScale: Float,
@@ -465,6 +527,35 @@ private fun MiniPlayerCoverOnly(
         Box(
             modifier = Modifier
                 .size(coverSize)
+                .graphicsLayer {
+                    val emphasis = miniPlayerPlayFeedbackEmphasis(playFeedbackProgress())
+                    val scale = 1f + emphasis * 0.045f
+                    scaleX = scale
+                    scaleY = scale
+                }
+                .drawWithCache {
+                    val baseRadius = size.minDimension / 2f
+                    val minimumExpansion = 2.dp.toPx()
+                    val maximumExpansion = 12.dp.toPx()
+                    val baseStrokeWidth = 2.5.dp.toPx()
+                    onDrawWithContent {
+                        val progress = playFeedbackProgress().coerceIn(0f, 1f)
+                        val fade = 1f - progress
+                        drawContent()
+                        if (fade > 0f) {
+                            drawCircle(
+                                color = colorScheme.primary.copy(alpha = 0.82f * fade),
+                                radius = baseRadius + minimumExpansion + maximumExpansion * progress,
+                                style = Stroke(width = baseStrokeWidth + 1.5.dp.toPx() * fade)
+                            )
+                            drawCircle(
+                                color = colorScheme.primary.copy(alpha = 0.72f * fade),
+                                radius = baseRadius - 1.dp.toPx(),
+                                style = Stroke(width = 2.dp.toPx())
+                            )
+                        }
+                    }
+                }
                 .clip(CircleShape)
                 .background(colorScheme.surface)
                 .border(width = 1.dp, color = miniPlayerBorderColor, shape = CircleShape)

--- a/app/src/test/java/com/asmr/player/ui/player/MiniPlayerPlayFeedbackTest.kt
+++ b/app/src/test/java/com/asmr/player/ui/player/MiniPlayerPlayFeedbackTest.kt
@@ -1,0 +1,21 @@
+package com.asmr.player.ui.player
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class MiniPlayerPlayFeedbackTest {
+
+    @Test
+    fun emphasisStartsAndEndsAtRestAndPeaksMidway() {
+        assertEquals(0f, miniPlayerPlayFeedbackEmphasis(0f), 0.0001f)
+        assertTrue(miniPlayerPlayFeedbackEmphasis(0.5f) > 0.99f)
+        assertEquals(0f, miniPlayerPlayFeedbackEmphasis(1f), 0.0001f)
+    }
+
+    @Test
+    fun emphasisClampsProgressOutsideAnimationRange() {
+        assertEquals(0f, miniPlayerPlayFeedbackEmphasis(-1f), 0.0001f)
+        assertEquals(0f, miniPlayerPlayFeedbackEmphasis(2f), 0.0001f)
+    }
+}


### PR DESCRIPTION
## 变更说明

- 在目录树、收藏和自建播放列表等音频播放入口发出显式反馈信号，首次播放、切换曲目及重复点击同一曲目均可触发。
- 迷你播放器封面态增加主题色外扩光环与轻微弹性聚焦；展开态增加主题色边框、底色闪现与轻微聚焦。
- 视频仍按原逻辑直接打开播放页，不触发迷你播放器反馈。
- 动画逐帧状态仅在绘制层和图形层读取，避免底部导航及页面逐帧重组或重测量。
- 增加反馈曲线单元测试，覆盖静止端点、峰值和越界输入。

## 验证

- `\.\gradlew-local.bat :app:testReleaseUnitTest --tests com.asmr.player.ui.player.MiniPlayerPlayFeedbackTest`
- 模拟器实测目录树与收藏列表点击，封面态和展开态反馈均正常且无裁剪。