### PR TITLE
feat: add portrait similar works recommendations

### DIFF
--- a/app/src/main/java/com/asmr/player/data/remote/scraper/DlsiteRecommendHtmlParser.kt
+++ b/app/src/main/java/com/asmr/player/data/remote/scraper/DlsiteRecommendHtmlParser.kt
@@ -5,6 +5,11 @@ import org.jsoup.nodes.Document
 import org.jsoup.nodes.Element
 import java.net.URI
 
+private val DlsiteResizedMainCoverPathRegex = Regex(
+    pattern = """^/resize/(images2/work/.+)_img_main_\d+x\d+\.(?:jpe?g|png|webp)$""",
+    option = RegexOption.IGNORE_CASE
+)
+
 internal fun dlsiteOriginalCoverUrlForWorkNo(rawWorkNo: String): String {
     val workNo = DlsiteWorkNo.extractWorkNo(rawWorkNo)
     val prefix = workNo.take(2)
@@ -27,6 +32,22 @@ internal fun resolveRecommendedWorkCoverUrl(
 ): String {
     return providedCoverUrl?.trim().orEmpty()
         .ifBlank { dlsiteOriginalCoverUrlForWorkNo(rawWorkNo) }
+}
+
+internal fun resolveRecommendedWorkHeroCoverUrl(
+    rawWorkNo: String,
+    providedCoverUrl: String?
+): String {
+    val provided = providedCoverUrl?.trim().orEmpty()
+    if (provided.isBlank()) return dlsiteOriginalCoverUrlForWorkNo(rawWorkNo)
+
+    val normalized = if (provided.startsWith("//")) "https:$provided" else provided
+    val uri = runCatching { URI(normalized) }.getOrNull() ?: return normalized
+    if (!uri.host.equals("img.dlsite.jp", ignoreCase = true)) return normalized
+
+    val resizedMainCover = DlsiteResizedMainCoverPathRegex
+        .matchEntire(uri.path.orEmpty()) ?: return normalized
+    return "https://img.dlsite.jp/modpub/${resizedMainCover.groupValues[1]}_img_main.jpg"
 }
 
 internal object DlsiteRecommendHtmlParser {

--- a/app/src/main/java/com/asmr/player/main/MainContainer.kt
+++ b/app/src/main/java/com/asmr/player/main/MainContainer.kt
@@ -83,7 +83,7 @@ import com.asmr.player.ui.library.LibraryFilterScreen
 import com.asmr.player.ui.library.LibraryScreen
 import com.asmr.player.ui.library.LibraryViewModel
 import com.asmr.player.ui.library.BulkPhase
-import com.asmr.player.data.remote.scraper.resolveRecommendedWorkCoverUrl
+import com.asmr.player.data.remote.scraper.resolveRecommendedWorkHeroCoverUrl
 import com.asmr.player.performance.UiFrameWorkCoordinator
 import com.asmr.player.ui.player.MiniPlayer
 import com.asmr.player.ui.player.NowPlayingMotionLayout
@@ -2611,7 +2611,7 @@ fun MainContainer(
                                     rjCode = targetRj,
                                     title = work?.title,
                                     circle = null,
-                                    coverUrl = resolveRecommendedWorkCoverUrl(targetRj, work?.coverUrl)
+                                    coverUrl = resolveRecommendedWorkHeroCoverUrl(targetRj, work?.coverUrl)
                                 )
                                 navigator.openAlbumDetailByRjStacked(targetRj)
                             },
@@ -2701,7 +2701,7 @@ fun MainContainer(
                                     rjCode = targetRj,
                                     title = work?.title,
                                     circle = null,
-                                    coverUrl = resolveRecommendedWorkCoverUrl(targetRj, work?.coverUrl)
+                                    coverUrl = resolveRecommendedWorkHeroCoverUrl(targetRj, work?.coverUrl)
                                 )
                                 navigator.openAlbumDetailByRjStacked(targetRj)
                             },
@@ -2773,7 +2773,7 @@ fun MainContainer(
                                     rjCode = targetRj,
                                     title = work?.title,
                                     circle = null,
-                                    coverUrl = resolveRecommendedWorkCoverUrl(targetRj, work?.coverUrl)
+                                    coverUrl = resolveRecommendedWorkHeroCoverUrl(targetRj, work?.coverUrl)
                                 )
                                 navigator.openAlbumDetailByRjStacked(targetRj)
                             },

--- a/app/src/main/java/com/asmr/player/ui/library/AlbumDetailScreen.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/AlbumDetailScreen.kt
@@ -1429,6 +1429,16 @@ fun AlbumDetailScreen(
                                             viewModel.persistListScrollPosition(asmrOneScrollStateKey, index, offset)
                                         },
                                         onListStateAvailable = { landscapeActiveListState = it },
+                                        showPortraitSimilarWorks = !useLandscapeArtworkTide,
+                                        portraitSimilarWorksContent = {
+                                            AlbumDetailPortraitSimilarWorksRow(
+                                                seedRjCode = model.baseRjCode.ifBlank { model.rjCode },
+                                                seedMetadata = model.dlsiteInfo ?: model.displayAlbum,
+                                                isRouteReady = isInitialRouteReady,
+                                                onOpenAlbumByRj = onOpenAlbumByRj,
+                                                viewModel = viewModel
+                                            )
+                                        },
                                         dlsiteRecommendations = model.dlsiteRecommendations,
                                         onOpenAlbumByRj = onOpenAlbumByRj,
                                         loadRemoteFileSize = { viewModel.loadRemoteFileSize(it) }
@@ -2493,6 +2503,112 @@ private fun AlbumDetailLandscapeSimilarWorksPane(
                                 }
                             )
                         }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun AlbumDetailPortraitSimilarWorksRow(
+    seedRjCode: String,
+    seedMetadata: Album,
+    isRouteReady: Boolean,
+    onOpenAlbumByRj: (String, DlsiteRecommendedWork?) -> Unit,
+    viewModel: AlbumDetailViewModel,
+    modifier: Modifier = Modifier,
+) {
+    val colorScheme = AsmrTheme.colorScheme
+    val state by viewModel.similarWorksState.collectAsStateWithLifecycle()
+    val seedFeatures = remember(
+        seedRjCode,
+        seedMetadata.circle,
+        seedMetadata.cv,
+        seedMetadata.tags
+    ) {
+        buildAlbumDetailRecommendationSeedFeatures(seedRjCode, seedMetadata)
+    }
+
+    LaunchedEffect(seedRjCode, seedFeatures, isRouteReady, viewModel) {
+        if (isRouteReady) {
+            viewModel.ensureSimilarWorksLoaded(
+                seedRjCode = seedRjCode,
+                seedFeatures = seedFeatures
+            )
+        }
+    }
+    DisposableEffect(seedRjCode, viewModel) {
+        onDispose(viewModel::cancelSimilarWorksLoad)
+    }
+
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(horizontal = AlbumDetailHorizontalPadding, vertical = 10.dp),
+        verticalArrangement = Arrangement.spacedBy(10.dp)
+    ) {
+        AlbumDetailSectionHeading(title = "相似作品推荐")
+        when {
+            (!isRouteReady && state.works.isEmpty()) ||
+                (state.isLoading && state.works.isEmpty()) -> {
+                DlsiteRecommendationLoadingCards()
+            }
+
+            state.works.isEmpty() -> {
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .heightIn(min = 76.dp),
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    verticalArrangement = Arrangement.Center
+                ) {
+                    Text(
+                        text = if (state.failed) "相似作品加载失败" else "暂时没有相似作品推荐",
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = colorScheme.textSecondary,
+                        textAlign = TextAlign.Center
+                    )
+                    if (state.failed) {
+                        TextButton(
+                            onClick = {
+                                viewModel.ensureSimilarWorksLoaded(
+                                    seedRjCode = seedRjCode,
+                                    seedFeatures = seedFeatures,
+                                    force = true
+                                )
+                            }
+                        ) {
+                            Text("重试")
+                        }
+                    }
+                }
+            }
+
+            else -> {
+                LazyRow(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(12.dp)
+                ) {
+                    items(
+                        items = state.works,
+                        key = AlbumDetailSimilarWork::rjCode
+                    ) { work ->
+                        val recommendedWork = DlsiteRecommendedWork(
+                            rjCode = work.rjCode,
+                            title = work.title,
+                            coverUrl = work.coverUrl
+                        )
+                        DlsiteRecommendedWorkCard(
+                            work = recommendedWork,
+                            displayRj = work.rjCode,
+                            onClick = {
+                                onOpenAlbumByRj(
+                                    work.rjCode,
+                                    recommendedWork
+                                )
+                            }
+                        )
                     }
                 }
             }

--- a/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailDlsiteTabs.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailDlsiteTabs.kt
@@ -872,34 +872,44 @@ private fun DlsiteRecommendationsLoadingBlocks() {
                     },
                     height = 18.dp
                 )
-                LazyRow(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
-                    items(listOf(0, 1, 2, 3), key = { it }, contentType = { "dlsiteRecommendationLoadingCard" }) {
-                        Surface(
-                            shape = RoundedCornerShape(12.dp),
-                            tonalElevation = 1.dp,
-                            color = AsmrTheme.colorScheme.surface.copy(alpha = 0.35f),
-                            modifier = Modifier.width(132.dp)
-                        ) {
-                            Column(
-                                modifier = Modifier.padding(bottom = 10.dp),
-                                verticalArrangement = Arrangement.spacedBy(10.dp)
-                            ) {
-                                AsmrShimmerPlaceholder(
-                                    modifier = Modifier
-                                        .fillMaxWidth()
-                                        .aspectRatio(1f),
-                                    cornerRadius = 14,
-                                    animateHighlight = false,
-                                )
-                                Column(
-                                    modifier = Modifier.padding(horizontal = 10.dp),
-                                    verticalArrangement = Arrangement.spacedBy(8.dp)
-                                ) {
-                                    DlsiteStaticPlaceholderLine(widthFraction = 0.88f, height = 12.dp)
-                                    DlsiteStaticPlaceholderLine(widthFraction = 0.46f, height = 10.dp)
-                                }
-                            }
-                        }
+                DlsiteRecommendationLoadingCards()
+            }
+        }
+    }
+}
+
+@Composable
+internal fun DlsiteRecommendationLoadingCards() {
+    val placeholders = remember { listOf(0, 1, 2, 3) }
+    LazyRow(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+        items(
+            items = placeholders,
+            key = { it },
+            contentType = { "dlsiteRecommendationLoadingCard" }
+        ) {
+            Surface(
+                shape = RoundedCornerShape(12.dp),
+                tonalElevation = 1.dp,
+                color = AsmrTheme.colorScheme.surface.copy(alpha = 0.35f),
+                modifier = Modifier.width(132.dp)
+            ) {
+                Column(
+                    modifier = Modifier.padding(bottom = 10.dp),
+                    verticalArrangement = Arrangement.spacedBy(10.dp)
+                ) {
+                    AsmrShimmerPlaceholder(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .aspectRatio(1f),
+                        cornerRadius = 14,
+                        animateHighlight = false,
+                    )
+                    Column(
+                        modifier = Modifier.padding(horizontal = 10.dp),
+                        verticalArrangement = Arrangement.spacedBy(8.dp)
+                    ) {
+                        DlsiteStaticPlaceholderLine(widthFraction = 0.88f, height = 12.dp)
+                        DlsiteStaticPlaceholderLine(widthFraction = 0.46f, height = 10.dp)
                     }
                 }
             }
@@ -1133,6 +1143,8 @@ internal fun AlbumDlsiteInfoBreadcrumbTabV2(
     onPersistCurrentPath: (String) -> Unit,
     initialScroll: Pair<Int, Int>,
     onPersistScroll: (Int, Int) -> Unit,
+    showPortraitSimilarWorks: Boolean,
+    portraitSimilarWorksContent: @Composable () -> Unit,
     dlsiteRecommendations: DlsiteRecommendations,
     onOpenAlbumByRj: (String, DlsiteRecommendedWork?) -> Unit,
     loadRemoteFileSize: suspend (String) -> Long?,
@@ -1578,6 +1590,13 @@ internal fun AlbumDlsiteInfoBreadcrumbTabV2(
                             onAddToPlaylist = { onAddToPlaylist(track) }
                         )
                     }
+                }
+            }
+        }
+        if (showPortraitSimilarWorks) {
+            item(key = "portrait-similar-works") {
+                Box(modifier = dlsiteAnimatedSectionModifier(Modifier.fillMaxWidth(), animateIntro)) {
+                    portraitSimilarWorksContent()
                 }
             }
         }

--- a/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailSharedSections.kt
+++ b/app/src/main/java/com/asmr/player/ui/library/albumdetail/AlbumDetailSharedSections.kt
@@ -339,7 +339,7 @@ private fun DlsiteRecommendationsBlock(
 }
 
 @Composable
-private fun DlsiteRecommendedWorkCard(
+internal fun DlsiteRecommendedWorkCard(
     work: DlsiteRecommendedWork,
     displayRj: String,
     onClick: () -> Unit

--- a/app/src/main/java/com/asmr/player/ui/nav/AlbumCoverHintStore.kt
+++ b/app/src/main/java/com/asmr/player/ui/nav/AlbumCoverHintStore.kt
@@ -6,8 +6,9 @@ import com.asmr.player.domain.model.Album
  * 轻量内存存储：在列表点击进入专辑详情时，记录列表已知的首屏信息，
  * 供详情页在网络解析完成前先种入标题、作品编号、社团、CV、标签、评分与封面。
  *
- * 这样 hero 封面与列表卡片使用完全相同的图片 model（同一 coverUrl + 同一 keyTag），
- * 跨尺寸缓存复用（peekAnySize）即可命中，避免重复发起网络请求。
+ * 这样 hero 可以立即使用调用方提供的封面；当封面 model 与列表一致时，
+ * 跨尺寸缓存复用（peekAnySize）仍可命中。推荐缩略图入口应先升级为原图 URL，
+ * 避免详情页将低分辨率图片固定为稳定 hero 封面。
  */
 object AlbumCoverHintStore {
     private const val MAX_ENTRIES = 64

--- a/app/src/test/java/com/asmr/player/data/remote/scraper/DlsiteRecommendHtmlParserTest.kt
+++ b/app/src/test/java/com/asmr/player/data/remote/scraper/DlsiteRecommendHtmlParserTest.kt
@@ -42,6 +42,31 @@ class DlsiteRecommendHtmlParserTest {
     }
 
     @Test
+    fun resolveRecommendedWorkHeroCoverUrl_prefersOriginalCoverOverRecommendationThumbnail() {
+        assertEquals(
+            "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01585000/RJ01584268_img_main.jpg",
+            resolveRecommendedWorkHeroCoverUrl(
+                rawWorkNo = "RJ01591284",
+                providedCoverUrl = "https://img.dlsite.jp/resize/images2/work/doujin/RJ01585000/RJ01584268_img_main_240x240.jpg"
+            )
+        )
+        assertEquals(
+            "https://api.example.com/recommendation-cover.jpg",
+            resolveRecommendedWorkHeroCoverUrl(
+                rawWorkNo = "RJ01499589",
+                providedCoverUrl = "https://api.example.com/recommendation-cover.jpg"
+            )
+        )
+        assertEquals(
+            dlsiteOriginalCoverUrlForWorkNo("RJ01499589"),
+            resolveRecommendedWorkHeroCoverUrl(
+                rawWorkNo = "RJ01499589",
+                providedCoverUrl = ""
+            )
+        )
+    }
+
+    @Test
     fun parse_imgWithFallbackCandidates_picksJpgAndNormalizesScheme() {
         val html = """
             <div class="recommend_work_item">


### PR DESCRIPTION
## Summary

- Add an EaraServer similar-works row above the existing three DLsite recommendation rows in portrait album detail.
- Reuse the existing DLsite recommendation card and loading skeleton so item sizing and styling stay identical; keep the landscape recommendation pane unchanged.
- Upgrade recommendation thumbnails to full-resolution hero covers while preserving the actual cover work path for translated editions.

## Verification

- .\gradlew-local.bat :app:testReleaseUnitTest --tests "com.asmr.player.ui.library.AlbumDetailSimilarWorksTest" --tests "com.asmr.player.ui.library.AlbumDetailLandscapeLayoutTest"
- .\gradlew-local.bat :app:testReleaseUnitTest --tests "com.asmr.player.data.remote.scraper.DlsiteRecommendHtmlParserTest"
- .\gradlew-local.bat :app:installRelease